### PR TITLE
DOD NOT MERGE. Webpack lavamoat experiments

### DIFF
--- a/app/background.html
+++ b/app/background.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <script src="/bootstrap.js" defer></script>
+    <script src="./scripts/load/bootstrap.ts" defer></script>
     <script src="./scripts/load/background.ts" defer></script>
   </body>
 </html>

--- a/app/partial-body.html
+++ b/app/partial-body.html
@@ -14,5 +14,5 @@
   <div class="loading-timeout-message" aria-live="polite" role="status"></div>
 </div>
 <div id="popover-content"></div>
-<script src="/bootstrap.js" defer></script>
+<script src="./scripts/load/bootstrap.ts" defer></script>
 <script src="./scripts/load/ui.ts" defer></script>

--- a/development/webpack/build.ts
+++ b/development/webpack/build.ts
@@ -1,7 +1,7 @@
 import { webpack } from 'webpack';
 import type WebpackDevServerType from 'webpack-dev-server';
 import { noop, logStats, __HMR_READY__ } from './utils/helpers';
-import configs from './webpack.config';
+import config from './webpack.config';
 
 // disable browserslist stats as it needlessly traverses the filesystem multiple
 // times looking for a stats file that doesn't exist.
@@ -13,9 +13,9 @@ require('browserslist/node').getStat = noop;
  * @param onComplete
  */
 export function build(onComplete: () => void = noop) {
-  const isDevelopment = configs[0].mode === 'development';
-  const { watch, ...options } = configs[0];
-  const compiler = webpack(configs);
+  const isDevelopment = config.mode === 'development';
+  const { watch, ...options } = config;
+  const compiler = webpack(config);
   if (__HMR_READY__ && watch) {
     // DISABLED BECAUSE WE AREN'T `__HMR_READY__` YET
     // Use `webpack-dev-server` to enable HMR
@@ -44,13 +44,13 @@ export function build(onComplete: () => void = noop) {
     console.error(`🦊 Running ${options.mode} build…`);
     if (watch) {
       // once HMR is ready (__HMR_READY__ variable), this section should be removed.
-      compiler.watch(options.watchOptions, (err, multiStats) => {
-        logStats(err ?? undefined, multiStats?.stats[0]);
+      compiler.watch(options.watchOptions, (err, stats) => {
+        logStats(err ?? undefined, stats);
         console.error('🦊 Watching for changes…');
       });
     } else {
-      compiler.run((err, multiStats) => {
-        logStats(err ?? undefined, multiStats?.stats[0]);
+      compiler.run((err, stats) => {
+        logStats(err ?? undefined, stats);
         // `onComplete` must be called synchronously _before_ `compiler.close`
         // or the caller might observe output from the `close` command.
         onComplete();

--- a/lavamoat/webpack/policy.json
+++ b/lavamoat/webpack/policy.json
@@ -2467,6 +2467,181 @@
         "@segment/loosely-validate-event>join-component": true
       }
     },
+    "@sentry/browser>@sentry-internal/browser-utils": {
+      "globals": {
+        "PerformanceEventTiming.prototype": true,
+        "PerformanceObserver": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "addEventListener": true,
+        "clearTimeout": true,
+        "performance": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "__SENTRY_DEBUG__": true,
+        "cancelAnimationFrame": true,
+        "clearTimeout": true,
+        "document.createElement": true,
+        "document.createElementNS": true,
+        "document.createTextNode": true,
+        "isSecureContext": true,
+        "requestAnimationFrame": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay-canvas": {
+      "globals": {
+        "Blob": true,
+        "HTMLCanvasElement": true,
+        "HTMLImageElement": true,
+        "ImageData": true,
+        "URL.createObjectURL": true,
+        "WeakRef": true,
+        "Worker": true,
+        "cancelAnimationFrame": true,
+        "console.error": true,
+        "createImageBitmap": true,
+        "document": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/replay": {
+      "globals": {
+        "Blob": true,
+        "CSSConditionRule": true,
+        "CSSGroupingRule": true,
+        "CSSMediaRule": true,
+        "CSSRule": true,
+        "CSSSupportsRule": true,
+        "Document": true,
+        "DragEvent": true,
+        "Element": true,
+        "FormData": true,
+        "HTMLElement": true,
+        "HTMLFormElement": true,
+        "Headers": true,
+        "MouseEvent": true,
+        "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.prototype.contains": true,
+        "PointerEvent": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "Worker": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
+        "__rrMutationObserver": true,
+        "addEventListener": true,
+        "clearTimeout": true,
+        "console.debug": true,
+        "console.error": true,
+        "console.warn": true,
+        "customElements.get": true,
+        "document": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "location.href": true,
+        "location.origin": true,
+        "parent": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser": {
+      "globals": {
+        "PerformanceObserver.supportedEntryTypes": true,
+        "Request": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "addEventListener": true,
+        "console.error": true,
+        "indexedDB.open": true,
+        "performance.timeOrigin": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry-internal/browser-utils": true,
+        "@sentry/browser>@sentry-internal/feedback": true,
+        "@sentry/browser>@sentry-internal/replay-canvas": true,
+        "@sentry/browser>@sentry-internal/replay": true,
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core": {
+      "globals": {
+        "Headers": true,
+        "Request": true,
+        "URL": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_TRACING__": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "HTMLElement": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "module": true,
+        "process": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "process": true
+      }
+    },
     "@solana/addresses": {
       "globals": {
         "Intl.Collator": true,

--- a/repro/app.js
+++ b/repro/app.js
@@ -1,0 +1,3 @@
+import './common.js';
+
+console.log('this is the app entry point');

--- a/repro/bootstrap.js
+++ b/repro/bootstrap.js
@@ -1,0 +1,3 @@
+import './common.js';
+console.log(new URL("./common.js", import.meta.url));
+console.log('this is the bootstrap entry point');

--- a/repro/common.js
+++ b/repro/common.js
@@ -1,0 +1,5 @@
+// const process = require('process');
+
+console.log('this is the common file');
+// console.log('process.platform:', process.platform);
+// console.log('process.env.NODE_ENV:', process.env.NODE_ENV);

--- a/repro/index.html
+++ b/repro/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Webpack LavaMoat Demo</title>
+  </head>
+  <body>
+    <h1>Webpack LavaMoat Demo</h1>
+    <p>Check the console for output from both entry points.</p>
+
+    <!-- Load bootstrap.js first, then app.js -->
+    <script src="runtime.js"></script>
+    <script src="bootstrap.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/repro/webpack.config.js
+++ b/repro/webpack.config.js
@@ -1,0 +1,142 @@
+const path = require('path');
+const { ProvidePlugin } = require('webpack');
+const CopyPlugin = require('copy-webpack-plugin');
+const LavaMoatPlugin = require('@lavamoat/webpack');
+
+module.exports = {
+  mode: 'development',
+  entry: {
+    app: './repro/app.js',
+    bootstrap: {
+      import: './repro/bootstrap.js',
+      layer: 'bootstrap',
+    },
+  },
+  devtool: false,
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+  },
+  optimization: {
+    splitChunks: {
+      maxSize: 24,
+      minSize: 1,
+    },
+    runtimeChunk: {
+      name: (chunk) => {
+        if(chunk.name === "bootstrap") return false;
+        return "runtime";
+      }
+    },
+  },
+  plugins: [
+    new LavaMoatPlugin({
+      readableResourceIds: true,
+      inlineLockdown: /^runtime\.js/u,
+      rootDir: __dirname + '/../',
+      diagnosticsVerbosity: 2,
+      generatePolicy: true,
+      runChecks: true, // Candidate to disable later for performance. useful in debugging invalid JS errors, but unless the audit proves me wrong this is probably not improving security.
+      readableResourceIds: true,
+      inlineLockdown: /^runtime\.js/u,
+      debugRuntime: false,
+      lockdown: {
+        consoleTaming: 'unsafe',
+        errorTaming: 'unsafe',
+        stackFiltering: 'verbose',
+        overrideTaming: 'severe',
+        localeTaming: 'unsafe',
+        errorTrapping: 'none',
+        reporting: 'none',
+      },
+      scuttleGlobalThis: {
+        enabled: true,
+        // TODO(34913): support snow and scuttler
+        // scuttlerName: 'SCUTTLER',
+        exceptions: [
+          // globals used by different mm deps outside of lm compartment
+          'Proxy',
+          'toString',
+          'getComputedStyle',
+          'addEventListener',
+          'removeEventListener',
+          'ShadowRoot',
+          'HTMLElement',
+          'Element',
+          'pageXOffset',
+          'pageYOffset',
+          'visualViewport',
+          'Reflect',
+          'Set',
+          'Object',
+          'navigator',
+          'harden',
+          'console',
+          'WeakSet',
+          'Event',
+          'Image', // Used by browser to generate notifications
+          'fetch', // Used by browser to generate notifications
+          'AbortController',
+          'OffscreenCanvas', // Used by browser to generate notifications
+          // globals chromedriver needs to function
+          // @ts-expect-error - regex is not included in the types for some reason
+          /cdc_[a-zA-Z0-9]+_[a-zA-Z]+/iu,
+          'name',
+          'performance',
+          'parseFloat',
+          'innerWidth',
+          'innerHeight',
+          'Symbol',
+          'Math',
+          'DOMRect',
+          'Number',
+          'Array',
+          'crypto',
+          'Function',
+          'Uint8Array',
+          'String',
+          'Promise',
+          'JSON',
+          'Date',
+          'setTimeout',
+          'clearTimeout',
+          'ret_nodes',
+          // globals sentry needs to function
+          '__SENTRY__',
+          'appState',
+          'extra',
+          'stateHooks',
+          'sentryHooks',
+          'sentry',
+          // e2e
+          'HTMLFormElement',
+          'getSelection',
+          'EventTarget',
+          'browser',
+          'chrome',
+          'indexedDB',
+        ],
+      },
+    }),
+    new ProvidePlugin({
+      process: 'process/browser.js',
+    }),
+    new CopyPlugin({
+      patterns: [{ from: './repro/index.html', to: 'index.html' }],
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        issuerLayer: 'bootstrap',
+        use: LavaMoatPlugin.exclude,
+      },
+      {
+        dependency: 'url',
+        type: 'asset/resource',
+      },
+    ],
+  },
+  experiments: {
+    layers: true,
+  },
+};


### PR DESCRIPTION
Experiements using webpack `layer`. I like this approach better because:

1. the bootstrap file linked in our HTML _actually exists_.
2. we don't have an entirely separate compilation config to maintain for this path.
3. its idiomatic. webpack (experimental) `layer` feature was built for use cases like this
4. it doesn't encourage others to hack in their own build config for their own files ... eventually recreating the browserify system we have now.
5. It can be implemented in a way that is more modular than a config