### PR TITLE
fix: Prevent critical error screen from being replaced

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -510,11 +510,18 @@ const corruptionHandler = new CorruptionHandler();
  * @param {browser.Runtime.Port} port - The port provided by a new context.
  */
 const handleOnConnect = async (port) => {
-  if (
-    inTest &&
-    getManifestFlags().testing?.simulateUnresponsiveBackground === true
-  ) {
-    return;
+  if (inTest) {
+    const simulatedDelay =
+      getManifestFlags().testing?.simulateDelayedBackgroundResponse;
+    if (simulatedDelay === true) {
+      return;
+    } else if (typeof simulatedDelay === 'number') {
+      await new Promise((resolve) => setTimeout(resolve, simulatedDelay));
+    } else {
+      log.error(
+        `Unrecognized value for 'simulateDelayedBackgroundResponse': '${simulatedDelay}'`,
+      );
+    }
   }
 
   try {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -517,7 +517,7 @@ const handleOnConnect = async (port) => {
       return;
     } else if (typeof simulatedDelay === 'number') {
       await new Promise((resolve) => setTimeout(resolve, simulatedDelay));
-    } else {
+    } else if (simulatedDelay !== undefined) {
       log.error(
         `Unrecognized value for 'simulateDelayedBackgroundResponse': '${simulatedDelay}'`,
       );

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -32,7 +32,7 @@ import { ExtensionPortStream } from 'extension-port-stream';
 import launchMetaMaskUi, {
   CriticalStartupErrorHandler,
   connectToBackground,
-  displayCriticalError,
+  displayCriticalErrorMessage,
   CriticalErrorTranslationKey,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
@@ -254,7 +254,7 @@ async function initializeUiWithTab(
       global.platform.openExtensionInBrowser();
     }
   } catch (error) {
-    await displayCriticalError(
+    await displayCriticalErrorMessage(
       container,
       CriticalErrorTranslationKey.TroubleStarting,
       error,

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -96,9 +96,10 @@ export type ManifestFlags = {
      */
     disableSync?: boolean;
     /**
-     * Whether to simulate an unresponsive background by ignoring connections from the UI
+     * Simulate a delay to how quickly the background responds to the UI. Set this to `true` to
+     * make the background completely unresponsive.
      */
-    simulateUnresponsiveBackground?: boolean;
+    simulateDelayedBackgroundResponse?: number | boolean;
     /**
      * Number of milliseconds to wait before resolving the simulated slow
      * background loading promise.

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -99,7 +99,7 @@ export type ManifestFlags = {
      * Simulate a delay to how quickly the background responds to the UI. Set this to `true` to
      * make the background completely unresponsive.
      */
-    simulateDelayedBackgroundResponse?: number | boolean;
+    simulateDelayedBackgroundResponse?: number | true;
     /**
      * Number of milliseconds to wait before resolving the simulated slow
      * background loading promise.

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -6,6 +6,8 @@ import { PAGES } from '../../webdriver/driver';
 import LoginPage from '../../page-objects/pages/login-page';
 import { getManifestVersion } from '../../set-manifest-flags';
 
+const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
+
 describe('Critical errors', function (this: Suite) {
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
@@ -14,7 +16,8 @@ describe('Critical errors', function (this: Suite) {
         ignoredConsoleErrors: ['Background connection unresponsive'],
         manifestFlags: {
           testing: {
-            simulateUnresponsiveBackground: true,
+            // Simulate completely unresponsive background
+            simulateDelayedBackgroundResponse: true,
           },
         },
         title: this.test?.fullTitle(),
@@ -22,8 +25,40 @@ describe('Critical errors', function (this: Suite) {
       async ({ driver }) => {
         await driver.navigate(PAGES.HOME, { waitForControllers: false });
 
-        // Wait until 15 second timer expires
-        await driver.delay(15_000);
+        // Wait until timeout expires
+        await driver.delay(BACKGROUND_CONNECTION_TIMEOUT);
+
+        const criticalErrorPage = new CriticalErrorPage(driver);
+        await criticalErrorPage.checkPageIsLoaded();
+        await criticalErrorPage.validateTroubleStartingDescription();
+        await criticalErrorPage.validateErrorMessage(
+          'Background connection unresponsive',
+        );
+      },
+    );
+  });
+
+  it('shows critical error screen when background takes over 15 seconds to respond', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ignoredConsoleErrors: ['Background connection unresponsive'],
+        manifestFlags: {
+          testing: {
+            // Delay for 100ms longer than timeout, simulating a very slow background response
+            simulateDelayedBackgroundResponse:
+              BACKGROUND_CONNECTION_TIMEOUT + 100,
+          },
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate(PAGES.HOME, { waitForControllers: false });
+
+        // Wait one additional second after timeout to ensure background has had time to respond,
+        // to ensure that the critical error screen remains in place even after the background
+        // responds.
+        await driver.delay(BACKGROUND_CONNECTION_TIMEOUT + 1_000);
 
         const criticalErrorPage = new CriticalErrorPage(driver);
         await criticalErrorPage.checkPageIsLoaded();

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -34,7 +34,7 @@ html[data-theme] {
 }
 
 /* stylelint-disable */
-#app-content {
+#app-content, #critical-error-content {
   overflow-x: hidden;
   height: 100%;
   display: flex;

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../shared/constants/start-up-errors';
 import { displayStateCorruptionError } from './state-corruption-html';
 import {
-  displayCriticalError,
+  displayCriticalErrorMessage,
   CriticalErrorTranslationKey,
 } from './display-critical-error';
 
@@ -67,7 +67,7 @@ export class CriticalStartupErrorHandler {
     try {
       await Promise.race([livenessCheck, timeoutPromise]);
     } catch (error) {
-      await displayCriticalError(
+      await displayCriticalErrorMessage(
         this.#container,
         CriticalErrorTranslationKey.TroubleStarting,
         // This cast is safe because `livenessCheck` can't throw, and `timeoutPromise` only throws an
@@ -103,7 +103,7 @@ export class CriticalStartupErrorHandler {
       if (this.#onLivenessCheckCompleted) {
         this.#onLivenessCheckCompleted();
       } else {
-        await displayCriticalError(
+        await displayCriticalErrorMessage(
           this.#container,
           CriticalErrorTranslationKey.TroubleStarting,
           new Error('Unreachable error, liveness check not initialized'),
@@ -146,7 +146,7 @@ export class CriticalStartupErrorHandler {
         error: ErrorLike;
         currentLocale?: string;
       };
-      await displayCriticalError(
+      await displayCriticalErrorMessage(
         this.#container,
         CriticalErrorTranslationKey.TroubleStarting,
         error as ErrorLike,

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -2,7 +2,7 @@ import browser from 'webextension-polyfill';
 import { act } from 'react-dom/test-utils';
 import * as errorUtils from '../../../shared/lib/error-utils';
 import {
-  displayCriticalError,
+  displayCriticalErrorMessage,
   CriticalErrorTranslationKey,
   extractEnvelopeUrlFromDsn,
 } from './display-critical-error';
@@ -77,7 +77,7 @@ describe('displayCriticalError', () => {
     const error = new Error(MOCK_ERROR_MESSAGE);
 
     await expect(
-      displayCriticalError(
+      displayCriticalErrorMessage(
         container,
         CriticalErrorTranslationKey.TroubleStarting,
         error,
@@ -98,7 +98,7 @@ describe('displayCriticalError', () => {
     const error = new Error(MOCK_ERROR_MESSAGE);
 
     await expect(
-      displayCriticalError(
+      displayCriticalErrorMessage(
         container,
         CriticalErrorTranslationKey.TroubleStarting,
         error,
@@ -202,7 +202,7 @@ describe('displayCriticalError', () => {
     const error = new Error(MOCK_ERROR_MESSAGE);
 
     await expect(
-      displayCriticalError(
+      displayCriticalErrorMessage(
         container,
         CriticalErrorTranslationKey.SomethingIsWrong,
         error,

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -81,7 +81,7 @@ describe('displayCriticalError', () => {
     jest.clearAllMocks();
   });
 
-  it('renders critical error html into container', async () => {
+  it('renders critical error html into parent of container', async () => {
     const error = new Error(MOCK_ERROR_MESSAGE);
 
     await expect(

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -40,6 +40,7 @@ jest.mock('../../../shared/lib/manifestFlags', () => ({
 }));
 
 describe('displayCriticalError', () => {
+  let rootContainer: HTMLElement;
   let container: HTMLElement;
   const MOCK_ERROR_MESSAGE = 'test error';
   const EXPECTED_ENVELOPE_URL = extractEnvelopeUrlFromDsn(MOCK_SENTRY_DSN_DEV);
@@ -50,6 +51,13 @@ describe('displayCriticalError', () => {
 
   beforeEach(() => {
     container = document.createElement('div');
+    // When a critical error is displayed, the main application container is removed from the DOM.
+    // We use `container.parentElement` to determine whether the container has been removed yet or
+    // not. The mock container starts with a parent so that it looks like no error has occurred
+    // yet.
+    rootContainer = document.createElement('div');
+    rootContainer.appendChild(container);
+
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
     } as Response);
@@ -91,7 +99,9 @@ describe('displayCriticalError', () => {
       { preferredLocale: 'en', t: expect.any(Function) },
       expect.any(String),
     );
-    expect(container.innerHTML).toContain('critical-error-button');
+    expect(
+      rootContainer.querySelector('#critical-error-content')?.innerHTML,
+    ).toContain('critical-error-button');
   });
 
   it('clicking restart button calls fetch and reload if checkbox checked', async () => {
@@ -106,10 +116,10 @@ describe('displayCriticalError', () => {
       ),
     ).rejects.toThrow(error);
 
-    const restartButton = container.querySelector<HTMLButtonElement>(
+    const restartButton = rootContainer.querySelector<HTMLButtonElement>(
       '#critical-error-button',
     );
-    const checkbox = container.querySelector<HTMLInputElement>(
+    const checkbox = rootContainer.querySelector<HTMLInputElement>(
       '#critical-error-checkbox',
     );
 
@@ -210,10 +220,10 @@ describe('displayCriticalError', () => {
       ),
     ).rejects.toThrow(error);
 
-    const restartButton = container.querySelector<HTMLButtonElement>(
+    const restartButton = rootContainer.querySelector<HTMLButtonElement>(
       '#critical-error-button',
     );
-    const checkbox = container.querySelector<HTMLInputElement>(
+    const checkbox = rootContainer.querySelector<HTMLInputElement>(
       '#critical-error-checkbox',
     );
 

--- a/ui/helpers/utils/display-critical-error.ts
+++ b/ui/helpers/utils/display-critical-error.ts
@@ -155,7 +155,7 @@ export async function displayCriticalErrorMessage(
   errorKey: CriticalErrorTranslationKey,
   error: ErrorLike,
   currentLocale?: string,
-) {
+): Promise<never> {
   const localeContext = await maybeGetLocaleContext(currentLocale);
   const html = getErrorHtml(errorKey, error, localeContext, SUPPORT_LINK);
 

--- a/ui/helpers/utils/display-critical-error.ts
+++ b/ui/helpers/utils/display-critical-error.ts
@@ -161,12 +161,14 @@ export async function displayCriticalErrorMessage(
 
   const criticalErrorContainer = displayCriticalErrorPage(container, html);
   if (criticalErrorContainer) {
-    const restartButton = container.querySelector<HTMLButtonElement>(
-      '#critical-error-button',
-    );
-    const reportCheckbox = container.querySelector<HTMLInputElement>(
-      '#critical-error-checkbox',
-    );
+    const restartButton =
+      criticalErrorContainer.querySelector<HTMLButtonElement>(
+        '#critical-error-button',
+      );
+    const reportCheckbox =
+      criticalErrorContainer.querySelector<HTMLInputElement>(
+        '#critical-error-checkbox',
+      );
 
     // Restart button: report error and restart MetaMask
     restartButton?.addEventListener('click', async () => {

--- a/ui/helpers/utils/state-corruption-html.ts
+++ b/ui/helpers/utils/state-corruption-html.ts
@@ -11,6 +11,7 @@ import { switchDirectionForPreferredLocale } from '../../../shared/lib/switch-di
 import getFirstPreferredLangCode from '../../../shared/lib/get-first-preferred-lang-code';
 import { METHOD_REPAIR_DATABASE } from '../../../shared/constants/state-corruption';
 import { t, updateCurrentLocale } from '../../../shared/lib/translate';
+import { displayCriticalErrorPage } from './display-critical-error';
 
 export async function getStateCorruptionErrorHtml(
   vaultRecoveryLink: string,
@@ -118,9 +119,12 @@ export async function displayStateCorruptionError(
     currentLocale,
     SUPPORT_LINK,
   );
-  container.innerHTML = html;
+  const errorPageContainer = displayCriticalErrorPage(container, html);
+  if (!errorPageContainer) {
+    return;
+  }
 
-  const button = container.querySelector<HTMLButtonElement>(
+  const button = errorPageContainer.querySelector<HTMLButtonElement>(
     '#critical-error-button',
   );
   if (button) {

--- a/ui/index.js
+++ b/ui/index.js
@@ -49,7 +49,7 @@ import { SEEDLESS_PASSWORD_OUTDATED_CHECK_INTERVAL_MS } from './constants';
 
 export { CriticalStartupErrorHandler } from './helpers/utils/critical-startup-error-handler';
 export {
-  displayCriticalError,
+  displayCriticalErrorMessage,
   CriticalErrorTranslationKey,
 } from './helpers/utils/display-critical-error';
 


### PR DESCRIPTION
## **Description**

Previously the critical error screen could get overwritten by React, or replaced with another critical error screen. This would be jarring and confusing for users, and might obscure important errors from being reported to us.

The critical error screen has been updated to use an alternative root element, deleting the original root app element the first time it's rendered. Later critical error screens will only render if the app root is still present. This ensures the error screen will remain even if the app somehow recovers, or if another error occurs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35441?quickstart=1)

## **Changelog**

CHANGELOG entry: null

We could say something like "Ensure critical errors cannot be overwritten", but I don't think it's necessary given that we don't know for sure users _would_ experience this issue, particularly not on older versions. And it's a bit confusing to explain anyway.

## **Related issues**

Fixes #35440

## **Manual testing steps**

We don't know of any manual reproduction steps. But the E2E test that has been added does simulate a scenario where this problem would occur.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens critical error handling and testability.
> 
> - Introduces `displayCriticalErrorPage` and switches to `displayCriticalErrorMessage`, rendering errors into a new `#critical-error-content` container and removing `#app-content` to prevent overwrite; updates imports/usages across UI and startup handler
> - Styles `#critical-error-content` alongside `#app-content` in base CSS
> - Replaces manifest flag `simulateUnresponsiveBackground` with `testing.simulateDelayedBackgroundResponse` (number | true) and handles delays in `background.js` `handleOnConnect`
> - Adds/updates E2E and unit tests for unresponsive/slow background scenarios and error page behavior (including 15s timeout persistence)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0640919a4692219731deb4f13730258a88c58136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->