### PR TITLE
fix: cp-13.2.0 Make SnapsNameProvider respect the chainIds caveat

### DIFF
--- a/app/scripts/lib/SnapsNameProvider.test.ts
+++ b/app/scripts/lib/SnapsNameProvider.test.ts
@@ -1,5 +1,5 @@
 import { NameType } from '@metamask/name-controller';
-import { HandlerType } from '@metamask/snaps-utils';
+import { HandlerType, SnapCaveatType } from '@metamask/snaps-utils';
 import {
   GetAllSnaps,
   GetSnap,
@@ -39,6 +39,13 @@ const SNAP_MOCK_3 = {
   },
 };
 
+const SNAP_MOCK_4 = {
+  id: 'testSnap4',
+  manifest: {
+    proposedName: 'Test Snap 4',
+  },
+};
+
 function createMockMessenger({
   getAllSnaps,
   getSnap,
@@ -56,7 +63,9 @@ function createMockMessenger({
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getAllSnaps ||
-    jest.fn().mockReturnValue([SNAP_MOCK, SNAP_MOCK_2, SNAP_MOCK_3]);
+    jest
+      .fn()
+      .mockReturnValue([SNAP_MOCK, SNAP_MOCK_2, SNAP_MOCK_3, SNAP_MOCK_4]);
 
   const getSnapMock =
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
@@ -65,7 +74,9 @@ function createMockMessenger({
     jest
       .fn()
       .mockImplementation((snapId) =>
-        [SNAP_MOCK, SNAP_MOCK_2, SNAP_MOCK_3].find(({ id }) => id === snapId),
+        [SNAP_MOCK, SNAP_MOCK_2, SNAP_MOCK_3, SNAP_MOCK_4].find(
+          ({ id }) => id === snapId,
+        ),
       );
 
   const handleSnapRequestMock =
@@ -79,9 +90,21 @@ function createMockMessenger({
     getPermissionControllerState ||
     jest.fn().mockReturnValue({
       subjects: {
-        [SNAP_MOCK.id]: { permissions: { 'endowment:name-lookup': true } },
-        [SNAP_MOCK_2.id]: { permissions: { 'endowment:name-lookup': true } },
+        [SNAP_MOCK.id]: { permissions: { 'endowment:name-lookup': {} } },
+        [SNAP_MOCK_2.id]: { permissions: { 'endowment:name-lookup': {} } },
         [SNAP_MOCK_3.id]: { permissions: {} },
+        [SNAP_MOCK_4.id]: {
+          permissions: {
+            'endowment:name-lookup': {
+              caveats: [
+                {
+                  type: SnapCaveatType.ChainIds,
+                  value: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+                },
+              ],
+            },
+          },
+        },
       },
     });
 
@@ -122,12 +145,17 @@ describe('SnapsNameProvider', () => {
       const { sourceIds, sourceLabels } = metadata;
 
       expect(sourceIds).toStrictEqual({
-        [NameType.ETHEREUM_ADDRESS]: [SNAP_MOCK.id, SNAP_MOCK_2.id],
+        [NameType.ETHEREUM_ADDRESS]: [
+          SNAP_MOCK.id,
+          SNAP_MOCK_2.id,
+          SNAP_MOCK_4.id,
+        ],
       });
 
       expect(sourceLabels).toStrictEqual({
         [SNAP_MOCK.id]: SNAP_MOCK.manifest.proposedName,
         [SNAP_MOCK_2.id]: SNAP_MOCK_2.manifest.proposedName,
+        [SNAP_MOCK_4.id]: SNAP_MOCK_4.manifest.proposedName,
       });
     });
   });

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -2,6 +2,7 @@
   "accounts.api.cx.metamask.io",
   "acl.execution.metamask.io",
   "api.devnet.solana.com",
+  "api.etherscan.io",
   "api.lens.dev",
   "api.segment.io",
   "api.simplehash.com",

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -113,7 +113,7 @@ describe('Petnames - Signatures', function (this: Suite) {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         await confirmation.checkProposedNames('0xCD2a3...DD826', [
           ['test.lens', 'Lens Protocol'],
-          ['cd2.1337.test.domain', 'Name Lookup Example Snap'],
+          ['cd2.1.test.domain', 'Name Lookup Example Snap'],
         ]);
       },
     );

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -94,6 +94,7 @@ describe('Petnames - Signatures', function (this: Suite) {
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withNoNames()
+          .withNetworkControllerOnMainnet()
           .build(),
         testSpecificMock: mockLookupSnap,
         title: this.test?.fullTitle(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously the SnapsNameProvider would not respect the `chainIds` caveat when specified by the Snap, this would result in calls to the Snap that it is not expecting and could crash it. In production this crashes the Solana Snap.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35477?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35473
Fixes: https://github.com/MetaMask/metamask-extension/issues/35364