### PR TITLE
fix: multichain account name in the account picker

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -333,6 +333,39 @@ const state = {
     isInitialized: true,
     isUnlocked: true,
     rpcUrl: 'https://rawtestrpc.metamask.io/',
+    "accountTree": {
+      "selectedAccountGroup": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+      "wallets": {
+        "entropy:01JKAF3DSGM3AB87EM9N0K41AJ": {
+          "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ",
+          "type": "entropy",
+          "groups": {
+            "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0": {
+              "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+              "type": "multichain-account",
+              "accounts": [
+                "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3",
+                "07c2cfec-36c9-46c4-8115-3836d3ac9047"
+              ],
+              "metadata": {
+                "name": "Account 1",
+                "entropy": {
+                  "groupIndex": 0
+                },
+                "hidden": false,
+                "pinned": false
+              }
+            }
+          },
+          "metadata": {
+            "name": "Wallet 1",
+            "entropy": {
+              "id": "01JKAF3DSGM3AB87EM9N0K41AJ"
+            }
+          }
+        }
+      }
+    },
     internalAccounts: {
       accounts: {
         'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -164,6 +164,39 @@
         ]
       }
     },
+    "accountTree": {
+      "selectedAccountGroup": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+      "wallets": {
+        "entropy:01JKAF3DSGM3AB87EM9N0K41AJ": {
+          "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ",
+          "type": "entropy",
+          "groups": {
+            "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0": {
+              "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+              "type": "multichain-account",
+              "accounts": [
+                "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3",
+                "07c2cfec-36c9-46c4-8115-3836d3ac9047"
+              ],
+              "metadata": {
+                "name": "Account 1",
+                "entropy": {
+                  "groupIndex": 0
+                },
+                "hidden": false,
+                "pinned": false
+              }
+            }
+          },
+          "metadata": {
+            "name": "Wallet 1",
+            "entropy": {
+              "id": "01JKAF3DSGM3AB87EM9N0K41AJ"
+            }
+          }
+        }
+      }
+    },
     "internalAccounts": {
       "accounts": {
         "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3": {

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -1,4 +1,37 @@
 {
+  "accountTree": {
+    "selectedAccountGroup": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+    "wallets": {
+      "entropy:01JKAF3DSGM3AB87EM9N0K41AJ": {
+        "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ",
+        "type": "entropy",
+        "groups": {
+          "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0": {
+            "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+            "type": "multichain-account",
+            "accounts": [
+              "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3",
+              "07c2cfec-36c9-46c4-8115-3836d3ac9047"
+            ],
+            "metadata": {
+              "name": "Account 1",
+              "entropy": {
+                "groupIndex": 0
+              },
+              "hidden": false,
+              "pinned": false
+            }
+          }
+        },
+        "metadata": {
+          "name": "Wallet 1",
+          "entropy": {
+            "id": "01JKAF3DSGM3AB87EM9N0K41AJ"
+          }
+        }
+      }
+    }
+  },
   "accounts": {
     "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc": {
       "balance": "0x346ba7725f412cbfdb",

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -1,4 +1,37 @@
 {
+  "accountTree": {
+    "selectedAccountGroup": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+    "wallets": {
+      "entropy:01JKAF3DSGM3AB87EM9N0K41AJ": {
+        "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ",
+        "type": "entropy",
+        "groups": {
+          "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0": {
+            "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+            "type": "multichain-account",
+            "accounts": [
+              "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3",
+              "07c2cfec-36c9-46c4-8115-3836d3ac9047"
+            ],
+            "metadata": {
+              "name": "Account 1",
+              "entropy": {
+                "groupIndex": 0
+              },
+              "hidden": false,
+              "pinned": false
+            }
+          }
+        },
+        "metadata": {
+          "name": "Wallet 1",
+          "entropy": {
+            "id": "01JKAF3DSGM3AB87EM9N0K41AJ"
+          }
+        }
+      }
+    }
+  },
   "accounts": { "0x03cf1158b58ccdfc04dd518f11f85c3ee7fa0189": {} },
   "accountsByChainId": {},
   "addSnapAccountEnabled": false,

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -69,6 +69,10 @@ import {
   setShowCopyAddressToast,
 } from '../../../ducks/app/app';
 import { PreferredAvatar } from '../../app/preferred-avatar';
+import {
+  getMultichainAccountGroupById,
+  getSelectedAccountGroup,
+} from '../../../selectors/multichain-accounts/account-tree';
 
 type AppHeaderUnlockedContentProps = {
   disableAccountPicker: boolean;
@@ -88,12 +92,19 @@ export const AppHeaderUnlockedContent = ({
   const isMultichainAccountsState2Enabled = useSelector(
     getIsMultichainAccountsState2Enabled,
   );
+  const selectedMultichainAccountId = useSelector(getSelectedAccountGroup);
+  const selectedMultichainAccount = useSelector((state) =>
+    getMultichainAccountGroupById(state, selectedMultichainAccountId),
+  );
 
   // Used for account picker
   const internalAccount = useSelector(getSelectedInternalAccount);
   const shortenedAddress =
     internalAccount &&
     shortenAddress(normalizeSafeAddress(internalAccount.address));
+  const accountName = isMultichainAccountsState2Enabled
+    ? selectedMultichainAccount.metadata.name
+    : internalAccount.metadata.name;
 
   // During onboarding there is no selected internal account
   const currentAddress = internalAccount?.address;
@@ -211,7 +222,7 @@ export const AppHeaderUnlockedContent = ({
           >
             <AccountPicker
               address={internalAccount.address}
-              name={internalAccount.metadata.name}
+              name={accountName}
               showAvatarAccount={false}
               onClick={() => {
                 handleAccountMenuClick();


### PR DESCRIPTION
## **Description**
This PR adds fix for multichain account names used in the account picker. Previous implementation was getting name from the internal accounts. This change is isolated by multichain accounts state 2 feature flag and does not affect current UI/UX in production.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35478?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed source for multichain account names in account picker

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-423

## **Manual testing steps**
1. Build extension with multichain accounts state 2 feature flag enabled.
2. Open extension and look at the header.
3. Click on the account picker, change accounts and make sure that the names are correct and as expected.

## **Screenshots/Recordings**
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Multichain account names were still displayed correctly before, because of the synchronization between internal and multichain accounts, so nothing is a visible difference.

https://github.com/user-attachments/assets/bfd4bb00-44a4-4f94-88b0-3bba66cdb2e8

### **After**

https://github.com/user-attachments/assets/364ea259-f0ea-4f24-b8a4-b3ab0a971b33

Here is also a video of the production version when multichain accounts state 2 is disabled. So we can confirm that nothing is affected by this change:

https://github.com/user-attachments/assets/8d5db75d-581c-4279-9f64-3b63a116e66b

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.