### PR TITLE
fix: updating rpc should not switch dapp connected network

### DIFF
--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
@@ -27,9 +27,11 @@ import { getMultichainNetworkConfigurationsByChainId } from '../../../../selecto
 export const SelectRpcUrlModal = ({
   networkConfiguration,
   onNetworkChange,
+  isAccessedFromDappConnectedSitePopover = false,
 }: {
   networkConfiguration?: NetworkConfiguration;
   onNetworkChange: (chainId: CaipChainId, networkClientId: string) => void;
+  isAccessedFromDappConnectedSitePopover?: boolean;
 }) => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -82,17 +84,21 @@ export const SelectRpcUrlModal = ({
           paddingRight={4}
           display={Display.Flex}
           key={rpcEndpoint.url}
-          onClick={() => {
+          onClick={async () => {
             const network = {
               ...networkConfigurationToUse,
               defaultRpcEndpointIndex: index,
             };
-            dispatch(updateNetwork(network));
+
+            await dispatch(updateNetwork(network, {}));
             dispatch(setEditedNetwork());
-            onNetworkChange(
-              toEvmCaipChainId(network.chainId),
-              rpcEndpoint.networkClientId,
-            );
+
+            if (!isAccessedFromDappConnectedSitePopover) {
+              onNetworkChange(
+                toEvmCaipChainId(network.chainId),
+                rpcEndpoint.networkClientId,
+              );
+            }
           }}
           className={classnames('select-rpc-url__item', {
             'select-rpc-url__item--selected':

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -284,12 +284,9 @@ export const NetworksForm = ({
         };
 
         if (existingNetwork) {
-          const options = {
-            replacementSelectedRpcEndpointIndex:
-              chainIdHex === existingNetwork.chainId
-                ? rpcUrls?.defaultRpcEndpointIndex
-                : undefined,
-          };
+          // Don't automatically update dapp connections when editing RPC URLs
+          // Users should manually switch networks if they want dapps to use different RPCs
+          const options = {};
           await dispatch(updateNetwork(networkPayload, options));
           if (Object.keys(tokenNetworkFilter).length === 1) {
             await dispatch(


### PR DESCRIPTION
This PR ensures that editing a rpc url should not switch the dapp connected network

CHANGELOG entry:

## **Related issues**

Fixes: #35481

## **Manual testing steps**

1. Connect dapp to MM
2. Add a new RPC url
3. Check the dapp connected network should stay the same

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**




https://github.com/user-attachments/assets/20b8dcd1-9fb9-4878-9ebb-c93456095bbe

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
