### PR TITLE
test: allow test build that can reach real servers

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -111,7 +111,7 @@ global.stateHooks.getMostRecentPersistedState = () =>
   persistenceManager.mostRecentRetrievedState;
 
 // Read the infuraProjectId from manifestFlags at this startup state
-process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS =
+globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS =
   getManifestFlags().testing?.infuraProjectId;
 
 /**
@@ -1039,7 +1039,7 @@ export function setupController(
   //
   controller = new MetamaskController({
     infuraProjectId:
-      process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
+      globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
       process.env.INFURA_PROJECT_ID,
     // User confirmation callbacks:
     showUserConfirmation: triggerUi,

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -110,6 +110,10 @@ const persistenceManager = new PersistenceManager({ localStore });
 global.stateHooks.getMostRecentPersistedState = () =>
   persistenceManager.mostRecentRetrievedState;
 
+// Read the infuraProjectId from manifestFlags at this startup state
+process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS =
+  getManifestFlags().testing?.infuraProjectId;
+
 /**
  * A helper function to log the current state of the vault. Useful for debugging
  * purposes, to, in the case of database corruption, an possible way for an end
@@ -1034,7 +1038,9 @@ export function setupController(
   // MetaMask Controller
   //
   controller = new MetamaskController({
-    infuraProjectId: process.env.INFURA_PROJECT_ID,
+    infuraProjectId:
+      process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
+      process.env.INFURA_PROJECT_ID,
     // User confirmation callbacks:
     showUserConfirmation: triggerUi,
     // initial state

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -8,6 +8,9 @@
 // It must be run first in case an error is thrown later during initialization.
 import './lib/setup-initial-state-hooks';
 
+// Import this very early, so globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS is always defined
+import '../../shared/constants/infura-project-id';
+
 import { finished } from 'readable-stream';
 import log from 'loglevel';
 import browser from 'webextension-polyfill';
@@ -109,10 +112,6 @@ const persistenceManager = new PersistenceManager({ localStore });
 // Setup global hook for improved Sentry state snapshots during initialization
 global.stateHooks.getMostRecentPersistedState = () =>
   persistenceManager.mostRecentRetrievedState;
-
-// Read the infuraProjectId from manifestFlags at this startup state
-globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS =
-  getManifestFlags().testing?.infuraProjectId;
 
 /**
  * A helper function to log the current state of the vault. Useful for debugging
@@ -1038,9 +1037,7 @@ export function setupController(
   // MetaMask Controller
   //
   controller = new MetamaskController({
-    infuraProjectId:
-      globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
-      process.env.INFURA_PROJECT_ID,
+    infuraProjectId: globalThis.INFURA_PROJECT_ID,
     // User confirmation callbacks:
     showUserConfirmation: triggerUi,
     // initial state

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -12,6 +12,9 @@ import '@lavamoat/lavadome-react';
 import './lib/setup-initial-state-hooks';
 import '../../development/wdyr';
 
+// Import this very early, so globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS is always defined
+import '../../shared/constants/infura-project-id';
+
 import * as reactDevtoolsCore from 'react-devtools-core';
 
 if (reactDevtoolsCore && process.env.METAMASK_REACT_REDUX_DEVTOOLS) {

--- a/shared/constants/infura-project-id.ts
+++ b/shared/constants/infura-project-id.ts
@@ -1,0 +1,7 @@
+import { getManifestFlags } from '../lib/manifestFlags';
+
+const INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS =
+  getManifestFlags().testing?.infuraProjectId;
+
+globalThis.INFURA_PROJECT_ID =
+  INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ?? process.env.INFURA_PROJECT_ID;

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -356,7 +356,9 @@ export const ACALA_TESTNET_DISPLAY_NAME = 'Acala Testnet';
 export const KARURA_DISPLAY_NAME = 'Karura';
 
 export const infuraProjectId =
-  process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore: yarn test:api-specs-multichain complains "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature"
+  globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
   process.env.INFURA_PROJECT_ID;
 
 export const getRpcUrl = ({

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -355,11 +355,12 @@ export const ACALA_DISPLAY_NAME = 'Acala';
 export const ACALA_TESTNET_DISPLAY_NAME = 'Acala Testnet';
 export const KARURA_DISPLAY_NAME = 'Karura';
 
+// If `network.ts` is being run in the Node.js environment, `infura-project-id.ts` will not be imported,
+// so we need to look at process.env.INFURA_PROJECT_ID instead.
 export const infuraProjectId =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore: yarn test:api-specs-multichain complains "Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature"
-  globalThis.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
-  process.env.INFURA_PROJECT_ID;
+  globalThis.INFURA_PROJECT_ID ?? process.env.INFURA_PROJECT_ID;
 
 export const getRpcUrl = ({
   network,

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -355,7 +355,10 @@ export const ACALA_DISPLAY_NAME = 'Acala';
 export const ACALA_TESTNET_DISPLAY_NAME = 'Acala Testnet';
 export const KARURA_DISPLAY_NAME = 'Karura';
 
-export const infuraProjectId = process.env.INFURA_PROJECT_ID;
+export const infuraProjectId =
+  process.env.INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS ??
+  process.env.INFURA_PROJECT_ID;
+
 export const getRpcUrl = ({
   network,
   excludeProjectId = false,

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -91,6 +91,10 @@ export type ManifestFlags = {
      * Whether to simulate an unresponsive background by ignoring connections from the UI
      */
     simulateUnresponsiveBackground?: boolean;
+    /**
+     * The Infura project ID to use for API requests, useful to inject into a test build that doesn't have one
+     */
+    infuraProjectId?: string;
   };
 };
 

--- a/test/e2e/mock-e2e-pass-through.ts
+++ b/test/e2e/mock-e2e-pass-through.ts
@@ -10,11 +10,15 @@ type SetupMockReturn = {
  *
  * @param server - The mock server used for network mocks.
  * @param testSpecificMock - Function for setting up test-specific network mocks.
+ * @param _options - Not used in this version
+ * @param _withSolanaWebSocket - Not used in this version
  * @returns SetupMockReturn
  */
 export async function setupMockingPassThrough(
   server: Mockttp,
   testSpecificMock: (server: Mockttp) => Promise<MockedEndpoint[]>,
+  _options = undefined,
+  _withSolanaWebSocket = undefined,
 ): Promise<SetupMockReturn> {
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {

--- a/test/e2e/mock-e2e-pass-through.ts
+++ b/test/e2e/mock-e2e-pass-through.ts
@@ -1,0 +1,36 @@
+import type { Mockttp, MockedEndpoint } from 'mockttp';
+
+type SetupMockReturn = {
+  mockedEndpoint: MockedEndpoint[];
+  getPrivacyReport: () => string[];
+};
+
+/**
+ * Setup E2E network mocks that just passes through requests
+ *
+ * @param server - The mock server used for network mocks.
+ * @param testSpecificMock - Function for setting up test-specific network mocks.
+ * @returns SetupMockReturn
+ */
+export async function setupMockingPassThrough(
+  server: Mockttp,
+  testSpecificMock: (server: Mockttp) => Promise<MockedEndpoint[]>,
+): Promise<SetupMockReturn> {
+  await server.forAnyRequest().thenPassThrough({
+    beforeRequest: (req) => {
+      console.log('Request going to a live server ============', req.url);
+      return {};
+    },
+  });
+
+  const mockedEndpoint = await testSpecificMock(server);
+
+  return { mockedEndpoint, getPrivacyReport };
+}
+
+/**
+ * This version does not support a privacy report.
+ */
+function getPrivacyReport(): string[] {
+  return [];
+}

--- a/test/e2e/tests/power-user/power-user.spec.ts
+++ b/test/e2e/tests/power-user/power-user.spec.ts
@@ -1,6 +1,6 @@
 import { generateWalletState } from '../../../../app/scripts/fixtures/generate-wallet-state';
 import { withFixtures } from '../../helpers';
-import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import { Driver } from '../../webdriver/driver';
@@ -22,11 +22,16 @@ describe('Power user persona', function () {
         title: this.test?.fullTitle(),
         fixtures: (await generateWalletState(withState, true)).build(),
         manifestFlags: {
-          testing: { disableSync: true },
+          testing: {
+            disableSync: true,
+            infuraProjectId: process.env.INFURA_PROJECT_ID,
+          },
         },
+        useMockingPassThrough: true,
+        disableServerMochaToBackground: true,
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithBalanceValidation(driver);
+        await loginWithoutBalanceValidation(driver);
 
         // Confirm the number of accounts in the account list
         new HeaderNavbar(driver).openAccountMenu();

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -300,7 +300,7 @@ export declare global {
 
   var browser: Browser;
 
-  var INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS: string | undefined;
+  var INFURA_PROJECT_ID: string | undefined;
 
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -300,6 +300,8 @@ export declare global {
 
   var browser: Browser;
 
+  var INFURA_PROJECT_ID_FROM_MANIFEST_FLAGS: string | undefined;
+
   namespace jest {
     // The interface is being used for declaration merging, which is an acceptable exception to this rule.
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860


### PR DESCRIPTION
## **Description**

Allow a pre-built test build without an Infura key to:

- Use a real Infura key injected from manifestFlags
- Make the mocking server pass through all requests

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Resolves: MetaMask/MetaMask-planning#5701

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->