### PR TITLE
feat: Add SRP backup to Multichain Account Details

### DIFF
--- a/ui/components/multichain-accounts/account-details-row/account-details-row.tsx
+++ b/ui/components/multichain-accounts/account-details-row/account-details-row.tsx
@@ -34,7 +34,7 @@ export const AccountDetailsRow = ({
 
   return (
     <Box
-      backgroundColor={BackgroundColor.backgroundAlternative}
+      backgroundColor={BackgroundColor.backgroundMuted}
       display={Display.Flex}
       justifyContent={JustifyContent.spaceBetween}
       style={style}

--- a/ui/components/multichain-accounts/account-details-row/index.scss
+++ b/ui/components/multichain-accounts/account-details-row/index.scss
@@ -25,5 +25,6 @@
 
   &__value {
     max-width: 150px;
+    font-weight: 600;
   }
 }

--- a/ui/components/multichain-accounts/multichain-accounts.scss
+++ b/ui/components/multichain-accounts/multichain-accounts.scss
@@ -3,3 +3,4 @@
 @import "multichain-account-menu-items";
 @import "account-details-row";
 @import "add-multichain-account";
+@import "multichain-srp-backup";

--- a/ui/components/multichain-accounts/multichain-srp-backup/index.scss
+++ b/ui/components/multichain-accounts/multichain-srp-backup/index.scss
@@ -1,0 +1,5 @@
+.multichain-srp-backup {
+  p {
+    font-weight: 600;
+  }
+}

--- a/ui/components/multichain-accounts/multichain-srp-backup/index.ts
+++ b/ui/components/multichain-accounts/multichain-srp-backup/index.ts
@@ -1,0 +1,1 @@
+export { MultichainSrpBackup } from './multichain-srp-backup';

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import { MultichainSrpBackup } from './multichain-srp-backup';
+
+const meta: Meta<typeof MultichainSrpBackup> = {
+  title: 'Components/MultichainAccounts/MultichainSrpBackup',
+  component: MultichainSrpBackup,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A component that displays a Secret Recovery Phrase backup button.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      const store = configureStore({
+        metamask: {
+          ...mockState.metamask,
+        },
+      });
+
+      return (
+        <Provider store={store}>
+          <MemoryRouter>
+            <div style={{ maxWidth: '600px', margin: '0 auto' }}>
+              <Story />
+            </div>
+          </MemoryRouter>
+        </Provider>
+      );
+    },
+  ],
+  argTypes: {
+    shouldShowBackupReminder: {
+      control: 'boolean',
+      description: 'When true, displays a backup reminder with error styling',
+      defaultValue: false,
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS class names',
+    },
+    keyringId: {
+      control: 'text',
+      description: 'ID of the keyring for SRP quiz modal',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MultichainSrpBackup>;
+
+export const Default: Story = {
+  args: {
+    shouldShowBackupReminder: false,
+    keyringId: 'test-keyring-id',
+  },
+};
+
+export const WithBackupReminder: Story = {
+  args: {
+    shouldShowBackupReminder: true,
+    keyringId: 'test-keyring-id',
+  },
+};

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -50,16 +50,6 @@ describe('MultichainSrpBackup', () => {
     expect(buttonElement).toHaveClass('custom-class');
   });
 
-  it('displays "Backup" text with error color when shouldShowBackupReminder is true', () => {
-    renderComponent({ shouldShowBackupReminder: true });
-
-    const backupText = screen.getByText('Backup');
-
-    expect(backupText).toBeInTheDocument();
-    expect(backupText).toHaveClass('mm-box--color-error-default');
-    expect(screen.queryByText('Back up')).not.toBeInTheDocument();
-  });
-
   it('displays "Back up" text when shouldShowBackupReminder is false', () => {
     renderComponent({ shouldShowBackupReminder: false });
 

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
+import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
+import { MultichainSrpBackup } from './multichain-srp-backup';
+
+const mockHistoryPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+const srpBackupRowTestId = 'multichain-srp-backup';
+const srpQuizHeaderTestId = 'srp-quiz-header';
+
+describe('MultichainSrpBackup', () => {
+  const renderComponent = (props = {}) => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    return renderWithProvider(<MultichainSrpBackup {...props} />, store);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default props', () => {
+    renderComponent();
+
+    expect(screen.getByText('Secret Recovery Phrase')).toBeInTheDocument();
+    expect(screen.getByText('Back up')).toBeInTheDocument();
+
+    const buttonElement = screen.getByTestId(srpBackupRowTestId);
+    expect(buttonElement).toHaveClass('multichain-srp-backup');
+  });
+
+  it('applies custom className when provided', () => {
+    renderComponent({ className: 'custom-class' });
+
+    const buttonElement = screen.getByTestId(srpBackupRowTestId);
+    expect(buttonElement).toHaveClass('multichain-srp-backup');
+    expect(buttonElement).toHaveClass('custom-class');
+  });
+
+  it('displays "Backup" text with error color when shouldShowBackupReminder is true', () => {
+    renderComponent({ shouldShowBackupReminder: true });
+
+    const backupText = screen.getByText('Backup');
+
+    expect(backupText).toBeInTheDocument();
+    expect(backupText).toHaveClass('mm-box--color-error-default');
+    expect(screen.queryByText('Back up')).not.toBeInTheDocument();
+  });
+
+  it('displays "Back up" text when shouldShowBackupReminder is false', () => {
+    renderComponent({ shouldShowBackupReminder: false });
+
+    expect(screen.getByText('Back up')).toBeInTheDocument();
+    expect(screen.queryByText('Backup')).not.toBeInTheDocument();
+  });
+
+  it('navigates to SRP review route when shouldShowBackupReminder is true', () => {
+    renderComponent({ shouldShowBackupReminder: true });
+
+    fireEvent.click(screen.getByTestId(srpBackupRowTestId));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith(
+      `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`,
+    );
+  });
+
+  it('opens SRP quiz modal when shouldShowBackupReminder is false', async () => {
+    renderComponent({
+      shouldShowBackupReminder: false,
+      keyringId: 'test-keyring-id',
+    });
+
+    fireEvent.click(screen.getByTestId(srpBackupRowTestId));
+
+    await waitFor(() => {
+      expect(screen.getByText('Security quiz')).toBeInTheDocument();
+    });
+
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+  });
+
+  it('closes SRP quiz modal when close button is clicked', async () => {
+    renderComponent({
+      shouldShowBackupReminder: false,
+      keyringId: 'test-keyring-id',
+    });
+
+    fireEvent.click(screen.getByTestId(srpBackupRowTestId));
+    await waitFor(() => {
+      expect(screen.getByText('Security quiz')).toBeInTheDocument();
+    });
+
+    const closeButton = screen
+      .getByTestId(srpQuizHeaderTestId)
+      .querySelector('button');
+
+    if (closeButton) {
+      fireEvent.click(closeButton);
+    } else {
+      throw new Error('Close button not found in the modal header');
+    }
+
+    await waitFor(() => {
+      expect(screen.queryByText('Security quiz')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -71,21 +71,12 @@ export const MultichainSrpBackup: React.FC<MultichainSrpBackupProps> = ({
           </Text>
         </Box>
         <Box display={Display.Flex} alignItems={AlignItems.center} gap={2}>
-          {shouldShowBackupReminder ? (
-            <Text
-              variant={TextVariant.bodyMdMedium}
-              color={TextColor.errorDefault}
-            >
-              {t('backup')}
-            </Text>
-          ) : (
-            <Text
-              variant={TextVariant.bodyMdMedium}
-              color={TextColor.textAlternative}
-            >
-              {t('accountDetailsSrpBackUpMessage')}
-            </Text>
-          )}
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.textAlternative}
+          >
+            {t('accountDetailsSrpBackUpMessage')}
+          </Text>
           <Icon
             name={IconName.ArrowRight}
             size={IconSize.Sm}

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import classnames from 'classnames';
+import { IconSize } from '@metamask/design-system-react';
+import { Box, Icon, IconName, Text } from '../../component-library';
+import {
+  AlignItems,
+  BackgroundColor,
+  BlockSize,
+  Display,
+  IconColor,
+  JustifyContent,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
+import SRPQuiz from '../../app/srp-quiz-modal';
+
+export type MultichainSrpBackupProps = {
+  shouldShowBackupReminder?: boolean;
+  className?: string | Record<string, boolean>;
+  keyringId?: string;
+};
+
+export const MultichainSrpBackup: React.FC<MultichainSrpBackupProps> = ({
+  shouldShowBackupReminder = false,
+  className = '',
+  keyringId,
+}) => {
+  const t = useI18nContext();
+  const history = useHistory();
+  const [srpQuizModalVisible, setSrpQuizModalVisible] = useState(false);
+
+  const handleSrpBackupClick = () => {
+    if (shouldShowBackupReminder) {
+      const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
+      history.push(backUpSRPRoute);
+    } else {
+      setSrpQuizModalVisible(true);
+    }
+  };
+
+  const handleQuizModalClose = () => {
+    setSrpQuizModalVisible(false);
+  };
+
+  const finalClassName = classnames('multichain-srp-backup', className);
+
+  return (
+    <>
+      <Box
+        className={finalClassName}
+        padding={4}
+        width={BlockSize.Full}
+        textAlign={TextAlign.Left}
+        display={Display.Flex}
+        justifyContent={JustifyContent.spaceBetween}
+        alignItems={AlignItems.center}
+        backgroundColor={BackgroundColor.backgroundMuted}
+        onClick={handleSrpBackupClick}
+        data-testid="multichain-srp-backup"
+      >
+        <Box>
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.textDefault}
+          >
+            {t('secretRecoveryPhrase')}
+          </Text>
+        </Box>
+        <Box display={Display.Flex} alignItems={AlignItems.center} gap={2}>
+          {shouldShowBackupReminder ? (
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.errorDefault}
+            >
+              {t('backup')}
+            </Text>
+          ) : (
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.textAlternative}
+            >
+              {t('accountDetailsSrpBackUpMessage')}
+            </Text>
+          )}
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            color={IconColor.iconAlternative}
+          />
+        </Box>
+      </Box>
+      {srpQuizModalVisible && keyringId && (
+        <SRPQuiz
+          keyringId={keyringId}
+          isOpen={srpQuizModalVisible}
+          onClose={handleQuizModalClose}
+          closeAfterCompleting
+        />
+      )}
+    </>
+  );
+};

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { IconSize } from '@metamask/design-system-react';
@@ -33,18 +33,18 @@ export const MultichainSrpBackup: React.FC<MultichainSrpBackupProps> = ({
   const history = useHistory();
   const [srpQuizModalVisible, setSrpQuizModalVisible] = useState(false);
 
-  const handleSrpBackupClick = () => {
+  const handleSrpBackupClick = useCallback(() => {
     if (shouldShowBackupReminder) {
       const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
       history.push(backUpSRPRoute);
     } else {
       setSrpQuizModalVisible(true);
     }
-  };
+  }, [shouldShowBackupReminder, history, setSrpQuizModalVisible]);
 
-  const handleQuizModalClose = () => {
+  const handleQuizModalClose = useCallback(() => {
     setSrpQuizModalVisible(false);
-  };
+  }, [setSrpQuizModalVisible]);
 
   const finalClassName = classnames('multichain-srp-backup', className);
 

--- a/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/index.scss
@@ -1,4 +1,4 @@
-.multichain-account-details {
+.multichain-account-details-page {
   max-width: 600px;
 
   &__section {
@@ -16,6 +16,13 @@
         margin-bottom: 0;
       }
     }
+  }
+
+  &__srp-button {
+    cursor: pointer;
+    border: none;
+    padding-left: 12px;
+    padding-right: 20px;
   }
 
   &__remove-button {

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
@@ -12,8 +12,7 @@ const accountDetailsRowNetworksTestId = 'account-details-row-networks';
 const accountDetailsRowPrivateKeysTestId = 'account-details-row-private-keys';
 const accountDetailsRowSmartAccountTestId = 'account-details-row-smart-account';
 const accountDetailsRowWalletTestId = 'account-details-row-wallet';
-const accountDetailsRowSecretRecoveryPhraseTestId =
-  'account-details-row-secret-recovery-phrase';
+const accountDetailsRowSecretRecoveryPhraseTestId = 'multichain-srp-backup';
 
 const mockHistoryPush = jest.fn();
 const mockHistoryGoBack = jest.fn();

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -17,7 +17,6 @@ import {
   Page,
 } from '../../../components/multichain/pages/page';
 import {
-  BackgroundColor,
   IconColor,
   TextColor,
   TextVariant,
@@ -58,6 +57,12 @@ export const MultichainAccountDetailsPage = () => {
 
   const isEntropyWallet = wallet?.type === AccountWalletType.Entropy;
   const shouldShowBackupReminder = isSRPBackedUp === false;
+
+  const handleAddressesClick = () => {
+    history.push(
+      `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`,
+    );
+  };
 
   return (
     <Page className="multichain-account-details-page">
@@ -105,6 +110,7 @@ export const MultichainAccountDetailsPage = () => {
           <AccountDetailsRow
             label={t('networks')}
             value={`${addressCount} ${addressCount > 1 ? t('addressesLabel') : t('addressLabel')}`}
+            onClick={handleAddressesClick}
             endAccessory={
               <ButtonIcon
                 iconName={IconName.ArrowRight}
@@ -113,11 +119,6 @@ export const MultichainAccountDetailsPage = () => {
                 ariaLabel={t('addresses')}
                 marginLeft={2}
                 data-testid="network-addresses-link"
-                onClick={() => {
-                  history.push(
-                    `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`,
-                  );
-                }}
               />
             }
           />

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { AccountGroupId, AccountWalletType } from '@metamask/account-api';
+import classnames from 'classnames';
 import {
   AvatarAccount,
   AvatarAccountSize,
@@ -16,6 +17,7 @@ import {
   Page,
 } from '../../../components/multichain/pages/page';
 import {
+  BackgroundColor,
   IconColor,
   TextColor,
   TextVariant,
@@ -32,6 +34,8 @@ import {
   MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE,
   MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
+import { MultichainSrpBackup } from '../../../components/multichain-accounts/multichain-srp-backup';
+import { useWalletInfo } from '../../../hooks/multichain-accounts/useWalletInfo';
 
 export const MultichainAccountDetailsPage = () => {
   const t = useI18nContext();
@@ -43,6 +47,7 @@ export const MultichainAccountDetailsPage = () => {
   );
   const walletId = extractWalletIdFromGroupId(accountGroupId);
   const wallet = useSelector((state) => getWallet(state, walletId));
+  const { keyringId, isSRPBackedUp } = useWalletInfo(walletId);
   const walletRoute = `${MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE}/${encodeURIComponent(walletId)}`;
   const isRemovable =
     wallet?.type !== AccountWalletType.Entropy &&
@@ -51,8 +56,11 @@ export const MultichainAccountDetailsPage = () => {
     getNetworkAddressCount(state, accountGroupId),
   );
 
+  const isEntropyWallet = wallet?.type === AccountWalletType.Entropy;
+  const shouldShowBackupReminder = isSRPBackedUp === false;
+
   return (
-    <Page className="multichain-account-details">
+    <Page className="multichain-account-details-page">
       <Header
         textProps={{
           variant: TextVariant.headingSm,
@@ -70,7 +78,7 @@ export const MultichainAccountDetailsPage = () => {
         {t('accountDetails')}
       </Header>
       <Content
-        className="multichain-account-details__content"
+        className="multichain-account-details-page__content"
         paddingTop={3}
         gap={4}
       >
@@ -79,7 +87,7 @@ export const MultichainAccountDetailsPage = () => {
           size={AvatarAccountSize.Xl}
           style={{ margin: '0 auto' }}
         />
-        <Box className="multichain-account-details__section">
+        <Box className="multichain-account-details-page__section">
           <AccountDetailsRow
             label={t('accountName')}
             value={multichainAccount.metadata.name}
@@ -87,7 +95,7 @@ export const MultichainAccountDetailsPage = () => {
               <ButtonIcon
                 iconName={IconName.ArrowRight}
                 color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
+                size={ButtonIconSize.Sm}
                 ariaLabel={t('accountName')}
                 marginLeft={2}
                 data-testid="account-name-action"
@@ -101,7 +109,7 @@ export const MultichainAccountDetailsPage = () => {
               <ButtonIcon
                 iconName={IconName.ArrowRight}
                 color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
+                size={ButtonIconSize.Sm}
                 ariaLabel={t('addresses')}
                 marginLeft={2}
                 data-testid="network-addresses-link"
@@ -120,7 +128,7 @@ export const MultichainAccountDetailsPage = () => {
               <ButtonIcon
                 iconName={IconName.ArrowRight}
                 color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
+                size={ButtonIconSize.Sm}
                 ariaLabel={t('privateKeys')}
                 marginLeft={2}
                 data-testid="private-keys-action"
@@ -134,7 +142,7 @@ export const MultichainAccountDetailsPage = () => {
               <ButtonIcon
                 iconName={IconName.ArrowRight}
                 color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
+                size={ButtonIconSize.Sm}
                 ariaLabel={t('smartAccountLabel')}
                 marginLeft={2}
                 data-testid="smart-account-action"
@@ -142,7 +150,7 @@ export const MultichainAccountDetailsPage = () => {
             }
           />
         </Box>
-        <Box className="multichain-account-details__section">
+        <Box className="multichain-account-details-page__section">
           <AccountDetailsRow
             label={t('wallet')}
             value={wallet.metadata.name}
@@ -150,7 +158,7 @@ export const MultichainAccountDetailsPage = () => {
               <ButtonIcon
                 iconName={IconName.ArrowRight}
                 color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
+                size={ButtonIconSize.Sm}
                 ariaLabel={t('wallet')}
                 marginLeft={2}
                 data-testid="wallet-details-link"
@@ -160,23 +168,19 @@ export const MultichainAccountDetailsPage = () => {
               history.push(walletRoute);
             }}
           />
-          <AccountDetailsRow
-            label={t('secretRecoveryPhrase')}
-            value={t('accountDetailsSrpBackUpMessage')}
-            endAccessory={
-              <ButtonIcon
-                iconName={IconName.ArrowRight}
-                color={IconColor.iconAlternative}
-                size={ButtonIconSize.Md}
-                ariaLabel={t('accountDetailsSrpBackUpMessage')}
-                marginLeft={2}
-                data-testid="srp-backup-action"
-              />
-            }
-          />
+          {isEntropyWallet ? (
+            <MultichainSrpBackup
+              className={classnames(
+                'multichain-account-details__row',
+                'multichain-account-details-page__srp-button',
+              )}
+              shouldShowBackupReminder={shouldShowBackupReminder}
+              keyringId={keyringId}
+            />
+          ) : null}
         </Box>
         {isRemovable && (
-          <Box className="multichain-account-details__section">
+          <Box className="multichain-account-details-page__section">
             <AccountDetailsRow
               label={t('removeAccount')}
               labelColor={TextColor.errorDefault}

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
@@ -11,21 +11,16 @@ import {
   Box,
   ButtonIcon,
   ButtonIconSize,
-  Icon,
   IconName,
-  IconSize,
   Text,
 } from '../../../components/component-library';
 import {
   AlignItems,
   BackgroundColor,
-  BlockSize,
   BorderRadius,
   Display,
   FlexDirection,
-  IconColor,
   JustifyContent,
-  TextAlign,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -36,14 +31,11 @@ import {
 } from '../../../components/multichain/pages/page';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getWalletsWithAccounts } from '../../../selectors/multichain-accounts/account-tree';
-import SRPQuiz from '../../../components/app/srp-quiz-modal';
-import {
-  ACCOUNT_LIST_PAGE_ROUTE,
-  ONBOARDING_REVIEW_SRP_ROUTE,
-} from '../../../helpers/constants/routes';
+import { ACCOUNT_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
 import { MultichainAccountCell } from '../../../components/multichain-accounts/multichain-account-cell';
 import { AddMultichainAccount } from '../../../components/multichain-accounts/add-multichain-account';
 import { useWalletInfo } from '../../../hooks/multichain-accounts/useWalletInfo';
+import { MultichainSrpBackup } from '../../../components/multichain-accounts/multichain-srp-backup';
 
 export const WalletDetailsPage = () => {
   const t = useI18nContext();
@@ -51,7 +43,6 @@ export const WalletDetailsPage = () => {
   const { id } = useParams();
   const walletId = decodeURIComponent(id as string) as AccountWalletId;
   const walletsWithAccounts = useSelector(getWalletsWithAccounts);
-  const [srpQuizModalVisible, setSrpQuizModalVisible] = useState(false);
   const wallet = walletsWithAccounts[walletId as AccountWalletId];
   const { multichainAccounts, keyringId, isSRPBackedUp } =
     useWalletInfo(walletId);
@@ -74,15 +65,6 @@ export const WalletDetailsPage = () => {
 
   const handleBack = () => {
     history.goBack();
-  };
-
-  const handleSrpBackupClick = () => {
-    if (shouldShowBackupReminder) {
-      const backUpSRPRoute = `${ONBOARDING_REVIEW_SRP_ROUTE}/?isFromReminder=true`;
-      history.push(backUpSRPRoute);
-    } else {
-      setSrpQuizModalVisible(true);
-    }
   };
 
   const multichainAccountCells = useMemo(
@@ -163,50 +145,17 @@ export const WalletDetailsPage = () => {
             </Text>
           </Box>
           {isEntropyWallet ? (
-            <Box
+            <MultichainSrpBackup
               className={classnames(
                 'multichain-wallet-details-page__row',
                 'multichain-wallet-details-page__row--last',
                 'multichain-wallet-details-page__srp-button',
               )}
-              padding={4}
-              width={BlockSize.Full}
-              textAlign={TextAlign.Left}
-              {...rowStylesProps}
-              as="button"
-              onClick={handleSrpBackupClick}
-            >
-              <Box>
-                <Text
-                  variant={TextVariant.bodyMdMedium}
-                  color={TextColor.textDefault}
-                >
-                  {t('secretRecoveryPhrase')}
-                </Text>
-              </Box>
-              <Box
-                display={Display.Flex}
-                alignItems={AlignItems.center}
-                gap={2}
-              >
-                {shouldShowBackupReminder ? (
-                  <Text
-                    variant={TextVariant.bodyMdMedium}
-                    color={TextColor.errorDefault}
-                  >
-                    {t('backup')}
-                  </Text>
-                ) : null}
-                <Icon
-                  name={IconName.ArrowRight}
-                  size={IconSize.Sm}
-                  color={IconColor.iconAlternative}
-                />
-              </Box>
-            </Box>
+              shouldShowBackupReminder={shouldShowBackupReminder}
+              keyringId={keyringId}
+            />
           ) : null}
         </Box>
-
         <Box
           display={Display.Flex}
           flexDirection={FlexDirection.Column}
@@ -217,14 +166,6 @@ export const WalletDetailsPage = () => {
           {isEntropyWallet && <AddMultichainAccount walletId={walletId} />}
         </Box>
       </Content>
-      {isEntropyWallet && srpQuizModalVisible && (
-        <SRPQuiz
-          keyringId={keyringId}
-          isOpen={srpQuizModalVisible}
-          onClose={() => setSrpQuizModalVisible(false)}
-          closeAfterCompleting
-        />
-      )}
     </Page>
   );
 };


### PR DESCRIPTION
## **Description**
This PR adds SRP reveal/backup item to the Multichain Account List page.

Notes:
- Reveal SRP process and JSX template is extracted into a new component to reduce code duplication.
- Some minor refactoring is done to Wallet Details and Account Details pages to improve maintainability.
- Some minor UI adjustments are done in order to match the design specification from [Figma](https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=0-1&p=f&m=dev).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35518?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added SRP backup process to Multichain Account Details

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-701

## **Manual testing steps**
1. Build extension with multichain accounts state 2 feature flag enabled.
2. Open extension > account list > account details.
3. Check that account details contains SRP backup row.
4. Use SRP backup process by clicking on the SRP backup row and test.
5. Check the same process on wallet details.
6. Check the same process for new fresh wallet (single wallet) for which backup of SRP is skipped on creation. Make sure that backup text is red and the process links to the SRP backup page instead to a modal.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
SRP reveal/backup was not available on the account details page before, so nothing important to show here. Please have a look at the "After" section and confirm that everything is as expected and by design.

### **After**

https://github.com/user-attachments/assets/d4922256-7746-402f-bfea-2e6e6f14d7fd


https://github.com/user-attachments/assets/1e9eb1b4-0f6a-4437-bb49-a1767962df82


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.