### PR TITLE
feat: add Trezor e2e tests for legacy and EIP1559 transactions

### DIFF
--- a/test/e2e/tests/hardware-wallets/trezor/trezor-send.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-send.spec.ts
@@ -1,13 +1,13 @@
 import { Suite } from 'mocha';
 import { Driver } from '../../../webdriver/driver';
-import { Ganache } from '../../../seeder/ganache';
+import { Anvil } from '../../../seeder/anvil';
 import FixtureBuilder from '../../../fixture-builder';
 import { withFixtures } from '../../../helpers';
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../../stub/keyring-bridge';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import { sendRedesignedTransactionToAddress } from '../../../page-objects/flows/send-transaction.flow';
-import { loginWithoutBalanceValidation } from '../../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 
 const RECIPIENT = '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3';
 
@@ -30,16 +30,20 @@ describe('Trezor Hardware', function (this: Suite) {
           localNodes,
         }: {
           driver: Driver;
-          localNodes: Ganache[] | undefined[];
+          localNodes: Anvil[] | undefined[];
         }) => {
           // Seed the Trezor account with balance
           (await localNodes?.[0]?.setAccountBalance(
-            KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+            KNOWN_PUBLIC_KEY_ADDRESSES[0].address as `0x${string}`,
             '0x100000000000000000000',
           )) ?? console.error('localNodes is undefined or empty');
-          await loginWithoutBalanceValidation(driver);
+          await loginWithBalanceValidation(
+            driver,
+            localNodes?.[0],
+            undefined,
+            '1208925.8196',
+          );
           const homePage = new HomePage(driver);
-          await homePage.checkExpectedBalanceIsDisplayed('1208925.8196');
           await sendRedesignedTransactionToAddress({
             driver,
             recipientAddress: RECIPIENT,

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-send.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-send.spec.ts
@@ -12,40 +12,45 @@ import { loginWithoutBalanceValidation } from '../../../page-objects/flows/login
 const RECIPIENT = '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3';
 
 describe('Trezor Hardware', function (this: Suite) {
-  it('send ETH', async function () {
-    await withFixtures(
-      {
-        fixtures: new FixtureBuilder().withTrezorAccount().build(),
-        localNodeOptions: {
-          hardfork: 'muirGlacier',
+  for (const testCase of [
+    { hardfork: 'london', type: 'EIP-1559' },
+    { hardfork: 'muirGlacier', type: 'legacy' },
+  ]) {
+    it(`send ETH with ${testCase.type} transaction`, async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilder().withTrezorAccount().build(),
+          localNodeOptions: {
+            hardfork: testCase.hardfork,
+          },
+          title: this.test?.fullTitle(),
         },
-        title: this.test?.fullTitle(),
-      },
-      async ({
-        driver,
-        localNodes,
-      }: {
-        driver: Driver;
-        localNodes: Ganache[] | undefined[];
-      }) => {
-        // Seed the Trezor account with balance
-        (await localNodes?.[0]?.setAccountBalance(
-          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
-          '0x100000000000000000000',
-        )) ?? console.error('localNodes is undefined or empty');
-        await loginWithoutBalanceValidation(driver);
-        const homePage = new HomePage(driver);
-        await homePage.checkExpectedBalanceIsDisplayed('1208925.8196');
-        await sendRedesignedTransactionToAddress({
+        async ({
           driver,
-          recipientAddress: RECIPIENT,
-          amount: '1',
-        });
-        await homePage.checkPageIsLoaded();
-        const activityList = new ActivityListPage(driver);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity();
-        await activityList.checkTxAmountInActivity();
-      },
-    );
-  });
+          localNodes,
+        }: {
+          driver: Driver;
+          localNodes: Ganache[] | undefined[];
+        }) => {
+          // Seed the Trezor account with balance
+          (await localNodes?.[0]?.setAccountBalance(
+            KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+            '0x100000000000000000000',
+          )) ?? console.error('localNodes is undefined or empty');
+          await loginWithoutBalanceValidation(driver);
+          const homePage = new HomePage(driver);
+          await homePage.checkExpectedBalanceIsDisplayed('1208925.8196');
+          await sendRedesignedTransactionToAddress({
+            driver,
+            recipientAddress: RECIPIENT,
+            amount: '1',
+          });
+          await homePage.checkPageIsLoaded();
+          const activityList = new ActivityListPage(driver);
+          await activityList.checkConfirmedTxNumberDisplayedInActivity();
+          await activityList.checkTxAmountInActivity();
+        },
+      );
+    });
+  }
 });

--- a/test/stub/keyring-bridge.js
+++ b/test/stub/keyring-bridge.js
@@ -111,6 +111,22 @@ export class FakeTrezorBridge extends FakeKeyringBridge {
   }
 
   async ethereumSignTransaction({ transaction }) {
+    const txType = Number(transaction.type);
+    let hardfork;
+    switch (txType) {
+      case 0:
+        hardfork = 'muirGlacier';
+        break;
+      case 1:
+        throw new Error(
+          'Unsupported transaction type: EIP-2930 (type 1) not yet implemented in FakeLedgerBridge.',
+        );
+      case 2:
+        hardfork = 'london';
+        break;
+      default:
+        throw new Error(`Unsupported transaction type: ${txType}`);
+    }
     const common = Common.custom({
       chain: {
         name: 'localhost',
@@ -118,7 +134,7 @@ export class FakeTrezorBridge extends FakeKeyringBridge {
         networkId: transaction.chainId,
       },
       chainId: transaction.chainId,
-      hardfork: 'istanbul',
+      hardfork,
     });
 
     const signedTransaction = TransactionFactory.fromTxData(transaction, {

--- a/test/stub/keyring-bridge.js
+++ b/test/stub/keyring-bridge.js
@@ -119,7 +119,7 @@ export class FakeTrezorBridge extends FakeKeyringBridge {
         break;
       case 1:
         throw new Error(
-          'Unsupported transaction type: EIP-2930 (type 1) not yet implemented in FakeLedgerBridge.',
+          'Unsupported transaction type: EIP-2930 (type 1) not yet implemented in FakeTrezorBridge.',
         );
       case 2:
         hardfork = 'london';


### PR DESCRIPTION
## **Description**

Adds legacy and EIP-1559 transaction test cases for Trezor related e2e tests

Fixes: https://github.com/MetaMask/accounts-planning/issues/962?issue=MetaMask%7Caccounts-planning%7C972

## **Manual testing steps**

Local testing
1. run `yarn && yarn start:test` in one terminal tab and wait for build end
2. run `yarn test:e2e:single test/e2e/tests/hardware-wallets/trezor/trezor-send.spec.ts` on another terminal tab

Otherwise check this PR CI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
