### PR TITLE
feat: Add entry points for Add Wallet modal from account list page

### DIFF
--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
@@ -3,11 +3,28 @@ import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
 import { AddWalletModal } from './add-wallet-modal';
 
+const mockHistoryPush = jest.fn();
+const mockOpenExtensionInBrowser = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
 describe('AddWalletModal', () => {
   const mockOnClose = jest.fn();
 
   beforeEach(() => {
     mockOnClose.mockClear();
+    mockHistoryPush.mockClear();
+    mockOpenExtensionInBrowser.mockClear();
+
+    // @ts-expect-error mocking platform
+    global.platform = {
+      openExtensionInBrowser: mockOpenExtensionInBrowser,
+    };
   });
 
   it('renders the modal when isOpen is true', () => {
@@ -24,12 +41,47 @@ describe('AddWalletModal', () => {
     expect(screen.getByText('Add a hardware wallet')).toBeInTheDocument();
   });
 
-  it('calls onClose when a wallet option is clicked', () => {
+  it('calls onClose and navigates when import wallet option is clicked', () => {
     renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
 
     fireEvent.click(screen.getByText('Import a wallet'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockHistoryPush).toHaveBeenCalledWith('/import-srp');
+  });
+
+  it('calls onClose and navigates when import account option is clicked', () => {
+    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByText('Import an account'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockHistoryPush).toHaveBeenCalledWith('/new-account');
+  });
+
+  it('calls onClose and opens hardware wallet route in expanded view', () => {
+    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByText('Add a hardware wallet'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOpenExtensionInBrowser).toHaveBeenCalledWith(
+      '/new-account/connect',
+    );
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+  });
+
+  it('falls back to history.push when openExtensionInBrowser is not available for hardware wallet', () => {
+    // @ts-expect-error mocking platform
+    global.platform = {};
+
+    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByText('Add a hardware wallet'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOpenExtensionInBrowser).not.toHaveBeenCalled();
+    expect(mockHistoryPush).toHaveBeenCalledWith('/new-account/connect');
   });
 
   it('does not render when isOpen is false', () => {

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
@@ -6,7 +6,6 @@ import {
   CONNECT_HARDWARE_ROUTE,
   IMPORT_SRP_ROUTE,
 } from '../../../helpers/constants/routes';
-import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { AddWalletModal } from './add-wallet-modal';
 
 const mockHistoryPush = jest.fn();

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
+import {
+  ADD_WALLET_PAGE_ROUTE,
+  CONNECT_HARDWARE_ROUTE,
+  IMPORT_SRP_ROUTE,
+} from '../../../helpers/constants/routes';
 import { AddWalletModal } from './add-wallet-modal';
 
 const mockHistoryPush = jest.fn();
@@ -47,7 +52,7 @@ describe('AddWalletModal', () => {
     fireEvent.click(screen.getByText('Import a wallet'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
-    expect(mockHistoryPush).toHaveBeenCalledWith('/import-srp');
+    expect(mockHistoryPush).toHaveBeenCalledWith(IMPORT_SRP_ROUTE);
   });
 
   it('calls onClose and navigates when import account option is clicked', () => {
@@ -56,7 +61,7 @@ describe('AddWalletModal', () => {
     fireEvent.click(screen.getByText('Import an account'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
-    expect(mockHistoryPush).toHaveBeenCalledWith('/new-account');
+    expect(mockHistoryPush).toHaveBeenCalledWith(ADD_WALLET_PAGE_ROUTE);
   });
 
   it('calls onClose and opens hardware wallet route in expanded view', () => {
@@ -66,22 +71,9 @@ describe('AddWalletModal', () => {
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
     expect(mockOpenExtensionInBrowser).toHaveBeenCalledWith(
-      '/new-account/connect',
+      CONNECT_HARDWARE_ROUTE,
     );
     expect(mockHistoryPush).not.toHaveBeenCalled();
-  });
-
-  it('falls back to history.push when openExtensionInBrowser is not available for hardware wallet', () => {
-    // @ts-expect-error mocking platform
-    global.platform = {};
-
-    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
-
-    fireEvent.click(screen.getByText('Add a hardware wallet'));
-
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
-    expect(mockOpenExtensionInBrowser).not.toHaveBeenCalled();
-    expect(mockHistoryPush).toHaveBeenCalledWith('/new-account/connect');
   });
 
   it('does not render when isOpen is false', () => {

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
@@ -6,6 +6,7 @@ import {
   CONNECT_HARDWARE_ROUTE,
   IMPORT_SRP_ROUTE,
 } from '../../../helpers/constants/routes';
+import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { AddWalletModal } from './add-wallet-modal';
 
 const mockHistoryPush = jest.fn();
@@ -16,6 +17,11 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     push: mockHistoryPush,
   }),
+}));
+
+jest.mock('../../../../app/scripts/lib/util', () => ({
+  ...jest.requireActual('../../../../app/scripts/lib/util'),
+  getEnvironmentType: () => 'popup',
 }));
 
 describe('AddWalletModal', () => {

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   Box,
   BoxAlignItems,
@@ -25,6 +26,11 @@ import {
 import type { ModalProps } from '../../component-library';
 import { FlexDirection } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  CONNECT_HARDWARE_ROUTE,
+  IMPORT_SRP_ROUTE,
+  NEW_ACCOUNT_ROUTE,
+} from '../../../helpers/constants/routes';
 
 export type AddWalletModalProps = Omit<
   ModalProps,
@@ -38,6 +44,7 @@ type WalletOption = {
   id: string;
   titleKey: string;
   iconName: IconName;
+  route: string;
 };
 
 export const AddWalletModal: React.FC<AddWalletModalProps> = ({
@@ -46,28 +53,32 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
   ...props
 }) => {
   const t = useI18nContext();
+  const history = useHistory();
 
   const walletOptions: WalletOption[] = [
     {
       id: 'import-wallet',
       titleKey: 'importAWallet',
       iconName: IconName.Wallet,
+      route: IMPORT_SRP_ROUTE,
     },
     {
       id: 'import-account',
       titleKey: 'importAnAccount',
       iconName: IconName.Download,
+      route: NEW_ACCOUNT_ROUTE,
     },
     {
       id: 'hardware-wallet',
       titleKey: 'addAHardwareWallet',
       iconName: IconName.Hardware,
+      route: CONNECT_HARDWARE_ROUTE,
     },
   ];
 
-  const handleOptionClick = () => {
-    // TODO Handle optionId selection logic here in subsequent PR
+  const handleOptionClick = (option: WalletOption) => {
     onClose?.();
+    history.push(option.route);
   };
 
   return (
@@ -84,11 +95,11 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
           {walletOptions.map((option) => (
             <Box
               key={option.id}
-              onClick={() => handleOptionClick()}
+              onClick={() => handleOptionClick(option)}
               onKeyDown={(e: React.KeyboardEvent) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  handleOptionClick();
+                  handleOptionClick(option);
                 }
               }}
               alignItems={BoxAlignItems.Center}

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -32,6 +32,8 @@ import {
   ADD_WALLET_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 
 export type AddWalletModalProps = Omit<

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -78,7 +78,17 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
 
   const handleOptionClick = (option: WalletOption) => {
     onClose?.();
-    history.push(option.route);
+    
+    // Hardware wallet connections require expanded view
+    if (option.id === 'hardware-wallet') {
+      if (global.platform.openExtensionInBrowser) {
+        global.platform.openExtensionInBrowser(option.route);
+      } else {
+        history.push(option.route);
+      }
+    } else {
+      history.push(option.route);
+    }
   };
 
   return (

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -31,6 +31,8 @@ import {
   IMPORT_SRP_ROUTE,
   ADD_WALLET_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
+import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 
 export type AddWalletModalProps = Omit<
   ModalProps,
@@ -81,8 +83,8 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
 
     // Hardware wallet connections require expanded view
     if (option.id === 'hardware-wallet') {
-      if (global.platform.openExtensionInBrowser) {
-        global.platform.openExtensionInBrowser(option.route);
+      if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
+        global.platform.openExtensionInBrowser?.(option.route);
       } else {
         history.push(option.route);
       }

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -29,7 +29,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   CONNECT_HARDWARE_ROUTE,
   IMPORT_SRP_ROUTE,
-  NEW_ACCOUNT_ROUTE,
+  ADD_WALLET_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
 
 export type AddWalletModalProps = Omit<
@@ -66,7 +66,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
       id: 'import-account',
       titleKey: 'importAnAccount',
       iconName: IconName.Download,
-      route: NEW_ACCOUNT_ROUTE,
+      route: ADD_WALLET_PAGE_ROUTE,
     },
     {
       id: 'hardware-wallet',
@@ -78,7 +78,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
 
   const handleOptionClick = (option: WalletOption) => {
     onClose?.();
-    
+
     // Hardware wallet connections require expanded view
     if (option.id === 'hardware-wallet') {
       if (global.platform.openExtensionInBrowser) {

--- a/ui/components/multichain/pages/page/components/content/index.scss
+++ b/ui/components/multichain/pages/page/components/content/index.scss
@@ -1,3 +1,18 @@
 .multichain-page-content {
   overflow: auto;
+  // Scroll bar styles
+  // Firefox
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-icon-muted) transparent;
+
+  // Webkit: Chrome, Brave
+  ::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    -webkit-border-radius: 8px;
+    border-radius: 8px;
+    background: var(--color-icon-muted);
+  }
 }

--- a/ui/pages/multichain-accounts/account-list/account-list.test.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.test.tsx
@@ -65,17 +65,6 @@ describe('AccountList', () => {
           },
         },
       },
-      localeMessages: {
-        currentLocale: 'en',
-        current: {
-          back: 'Back',
-          accounts: 'Accounts',
-          addWallet: 'Add wallet',
-          importAWallet: 'Import a wallet',
-          importAnAccount: 'Import an account',
-          addAHardwareWallet: 'Add a hardware wallet',
-        },
-      },
     });
 
     return renderWithProvider(<AccountList />, store);

--- a/ui/pages/multichain-accounts/account-list/account-list.test.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.test.tsx
@@ -20,8 +20,6 @@ jest.mock('react-router-dom', () => ({
 describe('AccountList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Disable reselect dev mode checks for testing
-    process.env.NODE_ENV = 'production';
   });
 
   const renderComponent = () => {

--- a/ui/pages/multichain-accounts/account-list/account-list.test.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.test.tsx
@@ -7,17 +7,21 @@ import configureStore from '../../../store/store';
 import { AccountList } from './account-list';
 
 const mockHistoryGoBack = jest.fn();
+const mockHistoryPush = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     goBack: mockHistoryGoBack,
+    push: mockHistoryPush,
   }),
 }));
 
 describe('AccountList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Disable reselect dev mode checks for testing
+    process.env.NODE_ENV = 'production';
   });
 
   const renderComponent = () => {
@@ -68,6 +72,10 @@ describe('AccountList', () => {
         current: {
           back: 'Back',
           accounts: 'Accounts',
+          addWallet: 'Add wallet',
+          importAWallet: 'Import a wallet',
+          importAnAccount: 'Import an account',
+          addAHardwareWallet: 'Add a hardware wallet',
         },
       },
     });
@@ -99,5 +107,20 @@ describe('AccountList', () => {
     fireEvent.click(backButton);
 
     expect(mockHistoryGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the add wallet modal when the add wallet button is clicked', () => {
+    renderComponent();
+
+    // First, let's verify the button is rendered by looking for it with role
+    const addWalletButton = screen.getByRole('button', { name: 'Add wallet' });
+    expect(addWalletButton).toBeInTheDocument();
+
+    fireEvent.click(addWalletButton);
+
+    // The modal renders with portal, so we need to look for modal content
+    expect(screen.getByText('Import a wallet')).toBeInTheDocument();
+    expect(screen.getByText('Import an account')).toBeInTheDocument();
+    expect(screen.getByText('Add a hardware wallet')).toBeInTheDocument();
   });
 });

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -11,7 +11,6 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
-  Text,
 } from '@metamask/design-system-react';
 import {
   Content,
@@ -19,11 +18,7 @@ import {
   Header,
   Page,
 } from '../../../components/multichain/pages/page';
-import {
-  Display,
-  FlexDirection,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
+import { TextVariant } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MultichainAccountList } from '../../../components/multichain-accounts/multichain-account-list';
 import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
@@ -33,13 +33,13 @@ export const AccountList = () => {
 
   const [isAddWalletModalOpen, setIsAddWalletModalOpen] = useState(false);
 
-  const handleOpenAddWalletModal = () => {
+  const handleOpenAddWalletModal = useCallback(() => {
     setIsAddWalletModalOpen(true);
-  };
+  }, [setIsAddWalletModalOpen]);
 
-  const handleCloseAddWalletModal = () => {
+  const handleCloseAddWalletModal = useCallback(() => {
     setIsAddWalletModalOpen(false);
-  };
+  }, [setIsAddWalletModalOpen]);
 
   return (
     <Page className="account-list-page">

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -6,13 +6,13 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-} from '@metamask/design-system-react';
-import {
   Box,
+  BoxFlexDirection,
   ButtonIcon,
   ButtonIconSize,
   IconName,
-} from '../../../components/component-library';
+  Text,
+} from '@metamask/design-system-react';
 import {
   Content,
   Footer,
@@ -64,13 +64,12 @@ export const AccountList = () => {
         {t('accounts')}
       </Header>
       <Content className="account-list-page__content">
-        <Box className="flex flex-col">
+        <Box flexDirection={BoxFlexDirection.Column}>
           <MultichainAccountList
             wallets={wallets}
             selectedAccountGroups={[selectedAccountGroup]}
           />
         </Box>
-        <Box paddingLeft={4} paddingRight={4} paddingBottom={4}></Box>
       </Content>
       <Footer className="shadow-sm">
         <Button

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { Button, ButtonSize, ButtonVariant } from '@metamask/design-system-react';
 import {
   Box,
   ButtonIcon,
@@ -21,6 +22,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MultichainAccountList } from '../../../components/multichain-accounts/multichain-account-list';
 import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';
+import { AddWalletModal } from '../../../components/multichain-accounts/add-wallet-modal';
 
 export const AccountList = () => {
   const t = useI18nContext();
@@ -28,6 +30,16 @@ export const AccountList = () => {
   const accountTree = useSelector(getAccountTree);
   const { wallets } = accountTree;
   const { selectedAccountGroup } = accountTree;
+  
+  const [isAddWalletModalOpen, setIsAddWalletModalOpen] = useState(false);
+
+  const handleOpenAddWalletModal = () => {
+    setIsAddWalletModalOpen(true);
+  };
+
+  const handleCloseAddWalletModal = () => {
+    setIsAddWalletModalOpen(false);
+  };
 
   return (
     <Page className="account-list-page">
@@ -52,8 +64,16 @@ export const AccountList = () => {
             wallets={wallets}
             selectedAccountGroups={[selectedAccountGroup]}
           />
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Lg}
+            onClick={handleOpenAddWalletModal}
+          >
+            {t('addWallet')}
+          </Button>
         </Box>
       </Content>
+      <AddWalletModal isOpen={isAddWalletModalOpen} onClose={handleCloseAddWalletModal} />
     </Page>
   );
 };

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { Button, ButtonSize, ButtonVariant } from '@metamask/design-system-react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
 import {
   Box,
   ButtonIcon,
@@ -11,6 +15,7 @@ import {
 } from '../../../components/component-library';
 import {
   Content,
+  Footer,
   Header,
   Page,
 } from '../../../components/multichain/pages/page';
@@ -30,7 +35,7 @@ export const AccountList = () => {
   const accountTree = useSelector(getAccountTree);
   const { wallets } = accountTree;
   const { selectedAccountGroup } = accountTree;
-  
+
   const [isAddWalletModalOpen, setIsAddWalletModalOpen] = useState(false);
 
   const handleOpenAddWalletModal = () => {
@@ -59,21 +64,28 @@ export const AccountList = () => {
         {t('accounts')}
       </Header>
       <Content className="account-list-page__content">
-        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+        <Box className="flex flex-col">
           <MultichainAccountList
             wallets={wallets}
             selectedAccountGroups={[selectedAccountGroup]}
           />
-          <Button
-            variant={ButtonVariant.Secondary}
-            size={ButtonSize.Lg}
-            onClick={handleOpenAddWalletModal}
-          >
-            {t('addWallet')}
-          </Button>
         </Box>
+        <Box paddingLeft={4} paddingRight={4} paddingBottom={4}></Box>
       </Content>
-      <AddWalletModal isOpen={isAddWalletModalOpen} onClose={handleCloseAddWalletModal} />
+      <Footer className="shadow-sm">
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onClick={handleOpenAddWalletModal}
+          isFullWidth
+        >
+          {t('addWallet')}
+        </Button>
+      </Footer>
+      <AddWalletModal
+        isOpen={isAddWalletModalOpen}
+        onClose={handleCloseAddWalletModal}
+      />
     </Page>
   );
 };


### PR DESCRIPTION
## **Description**

This PR adds functional entry points for the Add Wallet modal component from the main account list page. The modal was previously created but not integrated into the user interface. This change provides users with a centralized way to access wallet and account import functionality.

### What is the reason for the change?
The Add Wallet modal component existed but was not accessible from the main account list UI, preventing users from easily discovering and using wallet/account import features.

### What is the improvement/solution?
- Integrated the Add Wallet modal into the account list page with a prominent footer button
- Connected modal options to existing MetaMask routes for wallet import, account import, and hardware wallet connection
- Added proper state management and user interaction handling
- Enhanced the modal with routing functionality to navigate to appropriate pages

## **Changelog**

CHANGELOG entry: Added Add Wallet button to account list page that opens modal with import options

## **Related issues**

Fixes: N/A - This is a feature enhancement for existing modal component

## **Manual testing steps**

1. Go to the account list page (/account-list)
2. Scroll to the bottom of the page
3. Click the "Add Wallet" button in the footer
4. Verify the modal opens with three options:
   - Import a wallet (should navigate to /import-srp)
   - Import an account (should navigate to /add-wallet-page)
   - Add a hardware wallet (should navigate to /new-account/connect)
5. Test that clicking each option closes the modal and navigates to the correct page
6. Test that clicking outside the modal or the X button closes it without navigation
7. Verify keyboard navigation works (Enter/Space on options)

## **Screenshots/Recordings**

### **Before**
- Add Wallet modal existed but was not accessible from any UI
- Account list page had no way to access wallet/account import features

### **After**
- Account list page now has "Add Wallet" button in footer
- Modal opens with three categorized import options
- Each option navigates to existing MetaMask import flows

https://github.com/user-attachments/assets/f481a1bf-74ad-4bab-8bf4-8fef3ae00985

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.