### PR TITLE
fix: remove non-existent round prop from IconButton

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -439,7 +439,6 @@ const CoinButtons = ({
           tooltipRender={(contents: React.ReactElement) =>
             generateTooltip('buyButton', contents)
           }
-          round={!displayNewIconButtons}
         />
       }
       <IconButton
@@ -471,7 +470,6 @@ const CoinButtons = ({
         tooltipRender={(contents: React.ReactElement) =>
           generateTooltip('swapButton', contents)
         }
-        round={!displayNewIconButtons}
       />
       {/* the bridge button is redundant if unified ui is enabled, testnet or non-bridge chain (unsupported) */}
       {isUnifiedUIEnabled ||
@@ -507,7 +505,6 @@ const CoinButtons = ({
           tooltipRender={(contents: React.ReactElement) =>
             generateTooltip('bridgeButton', contents)
           }
-          round={!displayNewIconButtons}
         />
       )}
       <IconButton
@@ -535,7 +532,6 @@ const CoinButtons = ({
         tooltipRender={(contents: React.ReactElement) =>
           generateTooltip('sendButton', contents)
         }
-        round={!displayNewIconButtons}
       />
       {
         <>
@@ -566,7 +562,6 @@ const CoinButtons = ({
             label={t('receive')}
             width={BlockSize.Full}
             onClick={handleReceiveOnClick}
-            round={!displayNewIconButtons}
           />
         </>
       }

--- a/ui/components/ui/icon-button/icon-button.tsx
+++ b/ui/components/ui/icon-button/icon-button.tsx
@@ -20,7 +20,6 @@ export type IconButtonProps = ButtonBaseProps<'button'> & {
   label: string;
   className?: string;
   tooltipRender?: (content: React.ReactElement) => React.ReactElement;
-  round?: boolean;
 };
 
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(


### PR DESCRIPTION
## **Description**

This PR fixes a React warning by removing the non-existent `round` prop from IconButton components in the CoinButtons component. The `round` prop was being passed with a boolean value `false` to IconButton components that don't support this attribute, causing console warnings.

The changes remove the `round={!displayNewIconButtons}` prop from all IconButton instances in the coin-buttons.tsx file.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes console warnings for non-boolean attribute `round` in coin buttons.

## **Manual testing steps**

1. Open the MetaMask extension
2. Navigate to the wallet overview page where coin buttons are displayed
3. Open browser dev tools and check console
4. Verify no warnings about non-existent `round` prop are displayed
5. Verify coin buttons still function correctly (Buy, Swap, Bridge, Send, Receive)

## **Screenshots/Recordings**

N/A - This is a console warning fix with no visual changes.

### Before

<img width="1504" height="865" alt="Screenshot 2025-08-29 at 1 43 07 PM" src="https://github.com/user-attachments/assets/2f145263-9115-47c2-b13c-e75f637096fd" />

### After

<img width="1510" height="863" alt="Screenshot 2025-08-29 at 1 47 28 PM" src="https://github.com/user-attachments/assets/d251b559-63eb-429a-9d90-eb1bdef3c237" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.ai/code)