### PR TITLE
Fix Improper Neutralization of Argument Delimiters in a argument Injection 

### DIFF
--- a/test/e2e/mock-cdn/update-mock-cdn-files.js
+++ b/test/e2e/mock-cdn/update-mock-cdn-files.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const { writeFileSync } = require('fs');
 
-const exec = util.promisify(require('node:child_process').exec);
+const execFile = util.promisify(require('node:child_process').execFile);
 
 const PPOM_VERSION_URL =
   'https://static.cx.metamask.io/api/v1/confirmations/ppom/ppom_version.json';
@@ -122,11 +122,9 @@ async function updateMockCdnFiles() {
   );
 
   // exporting the brotli data to files
-  exec(`curl ${PPOM_CONFIG_URL}${mainnetConfigVersion} -o ${CDN_CONFIG_PATH}`);
-  exec(`curl ${PPOM_STALE_URL}${mainnetStaleVersion} -o ${CDN_STALE_PATH}`);
-  exec(
-    `curl ${PPOM_STALE_DIFF_URL}${mainnetStaleDiffVersion} -o ${CDN_STALE_DIFF_PATH}`,
-  );
+  await execFile('curl', [ `${PPOM_CONFIG_URL}${mainnetConfigVersion}`, '-o', CDN_CONFIG_PATH ]);
+  await execFile('curl', [ `${PPOM_STALE_URL}${mainnetStaleVersion}`, '-o', CDN_STALE_PATH ]);
+  await execFile('curl', [ `${PPOM_STALE_DIFF_URL}${mainnetStaleDiffVersion}`, '-o', CDN_STALE_DIFF_PATH ]);
 }
 
 updateMockCdnFiles();


### PR DESCRIPTION

fix is to avoid interpolating untrusted data into a shell command string executed via the shell. Instead, use the safer API `child_process.execFile` (or its promisified version) which does not invoke a shell, and accepts command and arguments separately as an array. This prevents any shell-special characters in external data from influencing command behavior. Several commands are constructed with interpolated data; replace all uses of `exec` with `execFile`, passing each CLI argument (url, flags, filenames) as individual array elements. Add `require('node:child_process').execFile` and create a promisified version if needed (via `util.promisify`).  
Specifically, change lines 125-129 to use `execFile` in place of `exec`, splitting the command into array arguments.  
No external libraries are required, just standard `child_process.execFile` and `util.promisify`.

#### References
[npm shell-quote](https://www.npmjs.com/package/shell-quote)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
