### PR TITLE
feat: add trezor swap e2e tests

### DIFF
--- a/test/e2e/tests/hardware-wallets/ledger/mocks.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/mocks.ts
@@ -46,32 +46,17 @@ async function mockLedgerIframeBridge(mockServer: MockttpServer) {
 
 export async function mockLedgerTransactionRequests(mockServer: MockttpServer) {
   await mockTransactionRequestsBase(mockServer);
-
   await mockEthDaiTrade(mockServer);
-
-  // Mock essential swap API endpoints
   await mockSwapNetworkInfo(mockServer);
-  // Using mockSwapTokens instead of complex mockTokenInfo
-  // Removed mockTransactionFees - not needed for basic swap test
-
-  // Mock critical swap API endpoints that are missing
   await mockSwapFeatureFlags(mockServer);
   await mockSwapTokens(mockServer);
   await mockSwapTopAssets(mockServer);
   await mockSwapAggregatorMetadata(mockServer);
   await mockSwapGasPrices(mockServer);
   await mockSuggestedGasFees(mockServer);
-  // Using mockLedgerEthDaiTrade instead of complex mockSwapTrades
-
-  // Mock price APIs - critical for swap functionality
   await mockPriceAPIs(mockServer);
-
-  // Mock Ledger iframe bridge - minimal mock to prevent catch-all redirect
   await mockLedgerIframeBridge(mockServer);
-
-  // Note: Smart Transaction APIs are NOT mocked because Smart Transactions are disabled in the test
-
-  // Mock external accounts API for activity list - CRITICAL for activity list display
   await mockExternalAccountsAPI(mockServer);
   await mockIcon(mockServer);
+  // Note: Smart Transaction APIs are NOT mocked because Smart Transactions are disabled in the test
 }

--- a/test/e2e/tests/hardware-wallets/ledger/mocks.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/mocks.ts
@@ -1,283 +1,18 @@
 import { MockttpServer } from 'mockttp';
 import {
-  AGGREGATOR_METADATA_API_MOCK_RESULT,
-  GAS_PRICE_API_MOCK_RESULT,
-  TOP_ASSETS_API_MOCK_RESULT,
-} from '../../../../data/mock-data';
-import { mockMultiNetworkBalancePolling } from '../../../mock-balance-polling/mock-balance-polling';
-
-// Simplified ETH->DAI trade mock with only essential data for ledger swap test
-const LEDGER_SWAP_ETH_DAI_TRADES_MOCK = [
-  {
-    // Primary successful trade option (airswapV4)
-    trade: {
-      data: '0x5f575529', // Simplified swap function selector
-      from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
-      value: '2000000000000000000', // 2 ETH
-      to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
-    },
-    hasRoute: false,
-    sourceAmount: '2000000000000000000',
-    destinationAmount: '4650000000000000000000', // ~4650 DAI
-    error: null,
-    sourceToken: '0x0000000000000000000000000000000000000000', // ETH
-    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
-    maxGas: 300000,
-    averageGas: 150000,
-    estimatedRefund: 0,
-    approvalNeeded: null,
-    fetchTime: 500,
-    aggregator: 'airswapV4',
-    aggType: 'RFQ',
-    fee: 0.875,
-    quoteRefreshSeconds: 30,
-    gasMultiplier: 1,
-    sourceTokenRate: 1,
-    destinationTokenRate: 0.0004256,
-    priceSlippage: {
-      ratio: 1.01,
-      calculationError: '',
-      bucket: 'low',
-      sourceAmountInUSD: 4700,
-      destinationAmountInUSD: 4650,
-      sourceAmountInNativeCurrency: 2,
-      destinationAmountInNativeCurrency: 1.98,
-      sourceAmountInETH: 2,
-      destinationAmountInETH: 1.98,
-    },
-  },
-  {
-    // Secondary successful trade option (oneInchV5)
-    trade: {
-      data: '0x5f575529',
-      from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
-      value: '2000000000000000000',
-      to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
-    },
-    hasRoute: false,
-    sourceAmount: '2000000000000000000',
-    destinationAmount: '4640000000000000000000', // ~4640 DAI
-    error: null,
-    sourceToken: '0x0000000000000000000000000000000000000000',
-    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
-    maxGas: 1000000,
-    averageGas: 560000,
-    estimatedRefund: 0,
-    approvalNeeded: null,
-    fetchTime: 400,
-    aggregator: 'oneInchV5',
-    aggType: 'AGG',
-    fee: 0.875,
-    quoteRefreshSeconds: 30,
-    gasMultiplier: 1.06,
-    sourceTokenRate: 1,
-    destinationTokenRate: 0.0004256,
-    priceSlippage: {
-      ratio: 1.015,
-      calculationError: '',
-      bucket: 'low',
-      sourceAmountInUSD: 4700,
-      destinationAmountInUSD: 4640,
-      sourceAmountInNativeCurrency: 2,
-      destinationAmountInNativeCurrency: 1.97,
-      sourceAmountInETH: 2,
-      destinationAmountInETH: 1.97,
-    },
-  },
-  {
-    // Failed trade option to show realistic aggregator mix
-    trade: null,
-    hasRoute: false,
-    maxGas: 2750000,
-    averageGas: 637198,
-    estimatedRefund: 0,
-    sourceToken: '0x0000000000000000000000000000000000000000',
-    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
-    sourceAmount: '2000000000000000000',
-    destinationAmount: null,
-    error: 'Request failed with status code 403',
-    approvalNeeded: null,
-    fetchTime: 25,
-    aggregator: 'paraswap',
-    aggType: 'AGG',
-    fee: 0.875,
-    quoteRefreshSeconds: 30,
-    gasMultiplier: 1.05,
-    sourceTokenRate: 1,
-    destinationTokenRate: 0.0004256,
-    priceSlippage: {
-      ratio: null,
-      calculationError: 'No trade data to calculate price slippage',
-      bucket: 'high',
-      sourceAmountInUSD: null,
-      destinationAmountInUSD: null,
-      sourceAmountInNativeCurrency: null,
-      destinationAmountInNativeCurrency: null,
-      sourceAmountInETH: null,
-      destinationAmountInETH: null,
-    },
-  },
-];
-
-export async function mockLedgerEthDaiTrade(mockServer: MockttpServer) {
-  return [
-    await mockServer
-      .forGet('https://bridge.api.cx.metamask.io/networks/1/trades')
-      .thenCallback(() => {
-        return {
-          statusCode: 200,
-          json: LEDGER_SWAP_ETH_DAI_TRADES_MOCK,
-        };
-      }),
-  ];
-}
-
-export async function mockLedgerTransactionRequests(mockServer: MockttpServer) {
-  await mockLedgerTransactionRequestsBase(mockServer);
-
-  await mockLedgerEthDaiTrade(mockServer);
-
-  // Mock essential swap API endpoints
-  await mockSwapNetworkInfo(mockServer);
-  // Using mockSwapTokens instead of complex mockTokenInfo
-  // Removed mockTransactionFees - not needed for basic swap test
-
-  // Mock critical swap API endpoints that are missing
-  await mockSwapFeatureFlags(mockServer);
-  await mockSwapTokens(mockServer);
-  await mockSwapTopAssets(mockServer);
-  await mockSwapAggregatorMetadata(mockServer);
-  await mockSwapGasPrices(mockServer);
-  await mockSuggestedGasFees(mockServer);
-  // Using mockLedgerEthDaiTrade instead of complex mockSwapTrades
-
-  // Mock price APIs - critical for swap functionality
-  await mockPriceAPIs(mockServer);
-
-  // Mock Ledger iframe bridge - minimal mock to prevent catch-all redirect
-  await mockLedgerIframeBridge(mockServer);
-
-  // Note: Smart Transaction APIs are NOT mocked because Smart Transactions are disabled in the test
-
-  // Mock external accounts API for activity list - CRITICAL for activity list display
-  await mockExternalAccountsAPI(mockServer);
-
-  // Simplified token icon mocks for localhost chain (1337) and mainnet (1)
-  const tokenIconResponse = {
-    statusCode: 200,
-    body: 'fake-image-data',
-    headers: { 'content-type': 'image/png' },
-  };
-
-  // Generic catch-all for any token icons on any chain - covers ETH, DAI, and others
-  await mockServer
-    .forGet(
-      /https:\/\/static\.cx\.metamask\.io\/api\/v1\/tokenIcons\/\d+\/0x[a-fA-F0-9]{40}\.png/u,
-    )
-    .thenCallback(() => tokenIconResponse);
-
-  // Removed Smart Transactions submitTransactions mock since Smart Transactions are disabled
-}
-
-// Mock network information for swap API
-async function mockSwapNetworkInfo(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://bridge.api.cx.metamask.io/networks/1')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {
-        active: true,
-        networkId: 1,
-        chainId: 1,
-        chainName: 'Ethereum',
-        nativeCurrency: {
-          name: 'Ether',
-          symbol: 'ETH',
-          decimals: 18,
-          address: '0x0000000000000000000000000000000000000000',
-        },
-        iconUrl: 'https://s3.amazonaws.com/airswap-token-images/ETH.png',
-        blockExplorerUrl: 'https://etherscan.io',
-        networkType: 'L1',
-        aggregators: [
-          'airswapV3',
-          'airswapV4',
-          'oneInchV4',
-          'oneInchV5',
-          'paraswap',
-          'pmm',
-          'zeroEx',
-          'openOcean',
-          'hashFlow',
-          'wrappedNative',
-          'kyberSwap',
-        ],
-        refreshRates: {
-          quotes: 30,
-          quotesPrefetching: 30,
-          stxGetTransactions: 10,
-          stxBatchStatus: 1,
-          stxStatusDeadline: 160,
-          stxMaxFeeMultiplier: 2,
-        },
-      },
-    }));
-}
-
-// Removed complex mockTokenInfo function - using simple mockSwapTokens instead
-
-// Removed complex mockTransactionFees function - not needed for basic swap test
-
-// Mock price APIs - essential for swap page to load
-async function mockPriceAPIs(mockServer: MockttpServer) {
-  // Mock empty spot prices for mainnet
-  await mockServer
-    .forGet('https://price.api.cx.metamask.io/v2/chains/1/spot-prices')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {},
-    }));
-
-  // Mock historical prices for ETH (0x000...000)
-  await mockServer
-    .forGet(
-      'https://price.api.cx.metamask.io/v1/1/historical-prices/0x0000000000000000000000000000000000000000',
-    )
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {},
-    }));
-
-  // Mock historical prices for DAI
-  await mockServer
-    .forGet(
-      'https://price.api.cx.metamask.io/v1/1/historical-prices/0x6B175474E89094C44Da98b954EedeAC495271d0F',
-    )
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {},
-    }));
-
-  // Generic spot-prices with query params
-  await mockServer
-    .forGet(
-      /https:\/\/price\.api\.cx\.metamask\.io\/v2\/chains\/1\/spot-prices\?.*/u,
-    )
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {},
-    }));
-
-  // Generic historical prices for any token
-  await mockServer
-    .forGet(
-      /https:\/\/price\.api\.cx\.metamask\.io\/v1\/1\/historical-prices\/0x[a-fA-F0-9]{40}/u,
-    )
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {},
-    }));
-}
+  mockEthDaiTrade,
+  mockExternalAccountsAPI,
+  mockIcon,
+  mockPriceAPIs,
+  mockSuggestedGasFees,
+  mockSwapAggregatorMetadata,
+  mockSwapFeatureFlags,
+  mockSwapGasPrices,
+  mockSwapNetworkInfo,
+  mockSwapTokens,
+  mockSwapTopAssets,
+  mockTransactionRequestsBase,
+} from '../swap-mocks';
 
 // Minimal Ledger iframe bridge mock - just to prevent catch-all redirect
 // The actual signing is handled by FakeLedgerBridge in background.js
@@ -309,201 +44,34 @@ async function mockLedgerIframeBridge(mockServer: MockttpServer) {
     }));
 }
 
-// Mock swap feature flags API
-async function mockSwapFeatureFlags(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://bridge.api.cx.metamask.io/featureFlags')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {
-        ethereum: {
-          mobileActive: true,
-          extensionActive: true,
-          smartTransactions: {
-            expectedDeadline: 45,
-            maxDeadline: 150,
-            returnTxHashAsap: false,
-          },
-        },
-        smartTransactions: {
-          expectedDeadline: 45,
-          maxDeadline: 150,
-          returnTxHashAsap: false,
-        },
-      },
-    }));
-}
+export async function mockLedgerTransactionRequests(mockServer: MockttpServer) {
+  await mockTransactionRequestsBase(mockServer);
 
-// Mock swap tokens API
-async function mockSwapTokens(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://bridge.api.cx.metamask.io/networks/1/tokens')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: [
-        {
-          symbol: 'ETH',
-          name: 'Ether',
-          address: '0x0000000000000000000000000000000000000000',
-          decimals: 18,
-          iconUrl:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/eth_28.png',
-          aggregators: [
-            'metamask',
-            'aave',
-            'coinGecko',
-            'oneInch',
-            'pmm',
-            'zerion',
-          ],
-          occurrences: 6,
-        },
-        {
-          symbol: 'DAI',
-          name: 'Dai Stablecoin',
-          address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-          decimals: 18,
-          iconUrl:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/dai.svg',
-          aggregators: [
-            'metamask',
-            'aave',
-            'coinGecko',
-            'oneInch',
-            'pmm',
-            'zerion',
-          ],
-          occurrences: 6,
-        },
-      ],
-    }));
-}
+  await mockEthDaiTrade(mockServer);
 
-// Mock swap top assets API
-async function mockSwapTopAssets(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1/topAssets')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: TOP_ASSETS_API_MOCK_RESULT,
-    }));
-}
+  // Mock essential swap API endpoints
+  await mockSwapNetworkInfo(mockServer);
+  // Using mockSwapTokens instead of complex mockTokenInfo
+  // Removed mockTransactionFees - not needed for basic swap test
 
-// Mock swap aggregator metadata API
-async function mockSwapAggregatorMetadata(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1/aggregatorMetadata')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: AGGREGATOR_METADATA_API_MOCK_RESULT,
-    }));
-}
+  // Mock critical swap API endpoints that are missing
+  await mockSwapFeatureFlags(mockServer);
+  await mockSwapTokens(mockServer);
+  await mockSwapTopAssets(mockServer);
+  await mockSwapAggregatorMetadata(mockServer);
+  await mockSwapGasPrices(mockServer);
+  await mockSuggestedGasFees(mockServer);
+  // Using mockLedgerEthDaiTrade instead of complex mockSwapTrades
 
-// Mock swap gas prices API
-async function mockSwapGasPrices(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://gas.api.cx.metamask.io/networks/1/gasPrices')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: GAS_PRICE_API_MOCK_RESULT,
-    }));
-}
+  // Mock price APIs - critical for swap functionality
+  await mockPriceAPIs(mockServer);
 
-// Mock suggested gas fees API for chainId 1337 (localhost)
-async function mockSuggestedGasFees(mockServer: MockttpServer) {
-  return await mockServer
-    .forGet('https://gas.api.cx.metamask.io/networks/1337/suggestedGasFees')
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: {
-        low: {
-          suggestedMaxPriorityFeePerGas: '1',
-          suggestedMaxFeePerGas: '20',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 30000,
-        },
-        medium: {
-          suggestedMaxPriorityFeePerGas: '1.5',
-          suggestedMaxFeePerGas: '25',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 30000,
-        },
-        high: {
-          suggestedMaxPriorityFeePerGas: '2',
-          suggestedMaxFeePerGas: '30',
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 30000,
-        },
-        estimatedBaseFee: '18',
-        networkCongestion: 0.5,
-        latestPriorityFeeRange: ['1', '2'],
-        historicalPriorityFeeRange: ['1', '3'],
-        historicalBaseFeeRange: ['15', '25'],
-        priorityFeeTrend: 'stable',
-        baseFeeTrend: 'stable',
-      },
-    }));
-}
+  // Mock Ledger iframe bridge - minimal mock to prevent catch-all redirect
+  await mockLedgerIframeBridge(mockServer);
 
-async function mockLedgerTransactionRequestsBase(mockServer: MockttpServer) {
-  await mockMultiNetworkBalancePolling(mockServer);
-}
+  // Note: Smart Transaction APIs are NOT mocked because Smart Transactions are disabled in the test
 
-// Mock external accounts API for activity list display
-async function mockExternalAccountsAPI(mockServer: MockttpServer) {
-  // Mock the external accounts API that provides transaction history for activity list
-  // This API is called when user clicks on Activity tab
-  // Use the ACTUAL address that the test is using (from the API call logs)
-  await mockServer
-    .forGet(
-      'https://accounts.api.cx.metamask.io/v1/accounts/0xF68464152d7289D7eA9a2bEC2E0035c45188223c/transactions',
-    )
-    .withQuery({
-      networks: '0x1,0x89,0x38,0xe708,0x2105,0xa,0xa4b1,0x82750,0x531',
-      sortDirection: 'DESC',
-    })
-    .thenJson(200, {
-      data: [
-        {
-          hash: '0xe3e223b9725765a7de557effdb2b507ace3534bcff2c1fe3a857e0791e56a518',
-          chainId: 1337, // localhost chainId
-          from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
-          to: '0x881d40237659c251811cec9c364ef91dc08d300c',
-          value: '2000000000000000000', // 2 ETH
-          blockNumber: 1,
-          blockHash:
-            '0x1111111111111111111111111111111111111111111111111111111111111111',
-          transactionIndex: 0,
-          gasUsed: '21000',
-          gasPrice: '10000000000',
-          status: 'confirmed',
-          timestamp: Date.now(),
-          type: 'swap',
-        },
-      ],
-    });
-
-  // Also mock without query parameters as fallback
-  await mockServer
-    .forGet(
-      'https://accounts.api.cx.metamask.io/v1/accounts/0xF68464152d7289D7eA9a2bEC2E0035c45188223c/transactions',
-    )
-    .thenJson(200, [
-      {
-        hash: '0xe3e223b9725765a7de557effdb2b507ace3534bcff2c1fe3a857e0791e56a518',
-        chainId: 1337,
-        from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
-        to: '0x881d40237659c251811cec9c364ef91dc08d300c',
-        value: '2000000000000000000',
-        blockNumber: 1,
-        blockHash:
-          '0x1111111111111111111111111111111111111111111111111111111111111111',
-        transactionIndex: 0,
-        gasUsed: '21000',
-        gasPrice: '10000000000',
-        status: 'confirmed',
-        timestamp: Date.now(),
-        type: 'swap',
-      },
-    ]);
+  // Mock external accounts API for activity list - CRITICAL for activity list display
+  await mockExternalAccountsAPI(mockServer);
+  await mockIcon(mockServer);
 }

--- a/test/e2e/tests/hardware-wallets/swap-mocks.ts
+++ b/test/e2e/tests/hardware-wallets/swap-mocks.ts
@@ -1,0 +1,428 @@
+import { MockttpServer } from 'mockttp';
+import {
+  AGGREGATOR_METADATA_API_MOCK_RESULT,
+  GAS_PRICE_API_MOCK_RESULT,
+  TOP_ASSETS_API_MOCK_RESULT,
+} from '../../../data/mock-data';
+import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-balance-polling';
+
+// Simplified ETH->DAI trade mock with only essential data for hardware wallet swap test
+export const SWAP_ETH_DAI_TRADES_MOCK = [
+  {
+    // Primary successful trade option (airswapV4)
+    trade: {
+      data: '0x5f575529', // Simplified swap function selector
+      from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
+      value: '2000000000000000000', // 2 ETH
+      to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
+    },
+    hasRoute: false,
+    sourceAmount: '2000000000000000000',
+    destinationAmount: '4650000000000000000000', // ~4650 DAI
+    error: null,
+    sourceToken: '0x0000000000000000000000000000000000000000', // ETH
+    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+    maxGas: 300000,
+    averageGas: 150000,
+    estimatedRefund: 0,
+    approvalNeeded: null,
+    fetchTime: 500,
+    aggregator: 'airswapV4',
+    aggType: 'RFQ',
+    fee: 0.875,
+    quoteRefreshSeconds: 30,
+    gasMultiplier: 1,
+    sourceTokenRate: 1,
+    destinationTokenRate: 0.0004256,
+    priceSlippage: {
+      ratio: 1.01,
+      calculationError: '',
+      bucket: 'low',
+      sourceAmountInUSD: 4700,
+      destinationAmountInUSD: 4650,
+      sourceAmountInNativeCurrency: 2,
+      destinationAmountInNativeCurrency: 1.98,
+      sourceAmountInETH: 2,
+      destinationAmountInETH: 1.98,
+    },
+  },
+  {
+    // Secondary successful trade option (oneInchV5)
+    trade: {
+      data: '0x5f575529',
+      from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
+      value: '2000000000000000000',
+      to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
+    },
+    hasRoute: false,
+    sourceAmount: '2000000000000000000',
+    destinationAmount: '4640000000000000000000', // ~4640 DAI
+    error: null,
+    sourceToken: '0x0000000000000000000000000000000000000000',
+    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    maxGas: 1000000,
+    averageGas: 560000,
+    estimatedRefund: 0,
+    approvalNeeded: null,
+    fetchTime: 400,
+    aggregator: 'oneInchV5',
+    aggType: 'AGG',
+    fee: 0.875,
+    quoteRefreshSeconds: 30,
+    gasMultiplier: 1.06,
+    sourceTokenRate: 1,
+    destinationTokenRate: 0.0004256,
+    priceSlippage: {
+      ratio: 1.015,
+      calculationError: '',
+      bucket: 'low',
+      sourceAmountInUSD: 4700,
+      destinationAmountInUSD: 4640,
+      sourceAmountInNativeCurrency: 2,
+      destinationAmountInNativeCurrency: 1.97,
+      sourceAmountInETH: 2,
+      destinationAmountInETH: 1.97,
+    },
+  },
+  {
+    // Failed trade option to show realistic aggregator mix
+    trade: null,
+    hasRoute: false,
+    maxGas: 2750000,
+    averageGas: 637198,
+    estimatedRefund: 0,
+    sourceToken: '0x0000000000000000000000000000000000000000',
+    destinationToken: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    sourceAmount: '2000000000000000000',
+    destinationAmount: null,
+    error: 'Request failed with status code 403',
+    approvalNeeded: null,
+    fetchTime: 25,
+    aggregator: 'paraswap',
+    aggType: 'AGG',
+    fee: 0.875,
+    quoteRefreshSeconds: 30,
+    gasMultiplier: 1.05,
+    sourceTokenRate: 1,
+    destinationTokenRate: 0.0004256,
+    priceSlippage: {
+      ratio: null,
+      calculationError: 'No trade data to calculate price slippage',
+      bucket: 'high',
+      sourceAmountInUSD: null,
+      destinationAmountInUSD: null,
+      sourceAmountInNativeCurrency: null,
+      destinationAmountInNativeCurrency: null,
+      sourceAmountInETH: null,
+      destinationAmountInETH: null,
+    },
+  },
+];
+
+export async function mockEthDaiTrade(mockServer: MockttpServer) {
+  return [
+    await mockServer
+      .forGet('https://swap.api.cx.metamask.io/networks/1/trades')
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+          json: SWAP_ETH_DAI_TRADES_MOCK,
+        };
+      }),
+  ];
+}
+
+export async function mockTransactionRequestsBase(mockServer: MockttpServer) {
+  await mockMultiNetworkBalancePolling(mockServer);
+}
+
+// Mock external accounts API for activity list display
+export async function mockExternalAccountsAPI(mockServer: MockttpServer) {
+  // Mock the external accounts API that provides transaction history for activity list
+  // This API is called when user clicks on Activity tab
+  // Use the ACTUAL address that the test is using (from the API call logs)
+  await mockServer
+    .forGet(
+      'https://accounts.api.cx.metamask.io/v1/accounts/0xF68464152d7289D7eA9a2bEC2E0035c45188223c/transactions',
+    )
+    .withQuery({
+      networks: '0x1,0x89,0x38,0xe708,0x2105,0xa,0xa4b1,0x82750,0x531',
+      sortDirection: 'DESC',
+    })
+    .thenJson(200, {
+      data: [
+        {
+          hash: '0xe3e223b9725765a7de557effdb2b507ace3534bcff2c1fe3a857e0791e56a518',
+          chainId: 1337, // localhost chainId
+          from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
+          to: '0x881d40237659c251811cec9c364ef91dc08d300c',
+          value: '2000000000000000000', // 2 ETH
+          blockNumber: 1,
+          blockHash:
+            '0x1111111111111111111111111111111111111111111111111111111111111111',
+          transactionIndex: 0,
+          gasUsed: '21000',
+          gasPrice: '10000000000',
+          status: 'confirmed',
+          timestamp: Date.now(),
+          type: 'swap',
+        },
+      ],
+    });
+
+  // Also mock without query parameters as fallback
+  await mockServer
+    .forGet(
+      'https://accounts.api.cx.metamask.io/v1/accounts/0xF68464152d7289D7eA9a2bEC2E0035c45188223c/transactions',
+    )
+    .thenJson(200, [
+      {
+        hash: '0xe3e223b9725765a7de557effdb2b507ace3534bcff2c1fe3a857e0791e56a518',
+        chainId: 1337,
+        from: '0xF68464152d7289D7eA9a2bEC2E0035c45188223c',
+        to: '0x881d40237659c251811cec9c364ef91dc08d300c',
+        value: '2000000000000000000',
+        blockNumber: 1,
+        blockHash:
+          '0x1111111111111111111111111111111111111111111111111111111111111111',
+        transactionIndex: 0,
+        gasUsed: '21000',
+        gasPrice: '10000000000',
+        status: 'confirmed',
+        timestamp: Date.now(),
+        type: 'swap',
+      },
+    ]);
+}
+
+// Mock swap feature flags API
+export async function mockSwapFeatureFlags(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://swap.api.cx.metamask.io/featureFlags')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        ethereum: {
+          mobileActive: true,
+          extensionActive: true,
+          smartTransactions: {
+            expectedDeadline: 45,
+            maxDeadline: 150,
+            returnTxHashAsap: false,
+          },
+        },
+        smartTransactions: {
+          expectedDeadline: 45,
+          maxDeadline: 150,
+          returnTxHashAsap: false,
+        },
+      },
+    }));
+}
+
+// Mock swap tokens API
+export async function mockSwapTokens(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://swap.api.cx.metamask.io/networks/1/tokens')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: [
+        {
+          symbol: 'ETH',
+          name: 'Ether',
+          address: '0x0000000000000000000000000000000000000000',
+          decimals: 18,
+          iconUrl:
+            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/eth_28.png',
+          aggregators: [
+            'metamask',
+            'aave',
+            'coinGecko',
+            'oneInch',
+            'pmm',
+            'zerion',
+          ],
+          occurrences: 6,
+        },
+        {
+          symbol: 'DAI',
+          name: 'Dai Stablecoin',
+          address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          decimals: 18,
+          iconUrl:
+            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/dai.svg',
+          aggregators: [
+            'metamask',
+            'aave',
+            'coinGecko',
+            'oneInch',
+            'pmm',
+            'zerion',
+          ],
+          occurrences: 6,
+        },
+      ],
+    }));
+}
+
+// Mock swap top assets API
+export async function mockSwapTopAssets(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://swap.api.cx.metamask.io/networks/1/topAssets')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TOP_ASSETS_API_MOCK_RESULT,
+    }));
+}
+
+// Mock swap aggregator metadata API
+export async function mockSwapAggregatorMetadata(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://swap.api.cx.metamask.io/networks/1/aggregatorMetadata')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: AGGREGATOR_METADATA_API_MOCK_RESULT,
+    }));
+}
+
+// Mock swap gas prices API
+export async function mockSwapGasPrices(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://gas.api.cx.metamask.io/networks/1/gasPrices')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: GAS_PRICE_API_MOCK_RESULT,
+    }));
+}
+
+// Mock network information for swap API
+export async function mockSwapNetworkInfo(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://swap.api.cx.metamask.io/networks/1')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        active: true,
+        networkId: 1,
+        chainId: 1,
+        chainName: 'Ethereum Mainnet',
+        nativeCurrency: {
+          name: 'Ether',
+          symbol: 'ETH',
+          decimals: 18,
+          address: '0x0000000000000000000000000000000000000000',
+        },
+        iconUrl: 'https://s3.amazonaws.com/airswap-token-images/ETH.png',
+        blockExplorerUrl: 'https://etherscan.io',
+        networkType: 'L1',
+        aggregators: [
+          'airswapV3',
+          'airswapV4',
+          'oneInchV4',
+          'oneInchV5',
+          'paraswap',
+          'pmm',
+          'zeroEx',
+          'openOcean',
+          'hashFlow',
+          'wrappedNative',
+          'kyberSwap',
+        ],
+        refreshRates: {
+          quotes: 30,
+          quotesPrefetching: 30,
+          stxGetTransactions: 10,
+          stxBatchStatus: 1,
+          stxStatusDeadline: 160,
+          stxMaxFeeMultiplier: 2,
+        },
+      },
+    }));
+}
+
+// Mock suggested gas fees API for chainId 1337 (localhost)
+export async function mockSuggestedGasFees(mockServer: MockttpServer) {
+  return await mockServer
+    .forGet('https://gas.api.cx.metamask.io/networks/1337/suggestedGasFees')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        low: {
+          suggestedMaxPriorityFeePerGas: '1',
+          suggestedMaxFeePerGas: '20',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        medium: {
+          suggestedMaxPriorityFeePerGas: '1.5',
+          suggestedMaxFeePerGas: '25',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        high: {
+          suggestedMaxPriorityFeePerGas: '2',
+          suggestedMaxFeePerGas: '30',
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        estimatedBaseFee: '18',
+        networkCongestion: 0.5,
+        latestPriorityFeeRange: ['1', '2'],
+        historicalPriorityFeeRange: ['1', '3'],
+        historicalBaseFeeRange: ['15', '25'],
+        priorityFeeTrend: 'stable',
+        baseFeeTrend: 'stable',
+      },
+    }));
+}
+
+// Mock price APIs - essential for swap page to load
+export async function mockPriceAPIs(mockServer: MockttpServer) {
+  // Mock empty spot prices for mainnet
+  await mockServer
+    .forGet('https://price.api.cx.metamask.io/v2/chains/1/spot-prices')
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+
+  // Mock historical prices for ETH (0x000...000)
+  await mockServer
+    .forGet(
+      'https://price.api.cx.metamask.io/v1/1/historical-prices/0x0000000000000000000000000000000000000000',
+    )
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+
+  // Mock historical prices for DAI
+  await mockServer
+    .forGet(
+      'https://price.api.cx.metamask.io/v1/1/historical-prices/0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    )
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+
+  // Generic spot-prices with query params
+  await mockServer
+    .forGet(
+      /https:\/\/price\.api\.cx\.metamask\.io\/v2\/chains\/1\/spot-prices\?.*/u,
+    )
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+
+  // Generic historical prices for any token
+  await mockServer
+    .forGet(
+      /https:\/\/price\.api\.cx\.metamask\.io\/v1\/1\/historical-prices\/0x[a-fA-F0-9]{40}/u,
+    )
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+}

--- a/test/e2e/tests/hardware-wallets/swap-mocks.ts
+++ b/test/e2e/tests/hardware-wallets/swap-mocks.ts
@@ -7,7 +7,7 @@ import {
 import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-balance-polling';
 
 // Simplified ETH->DAI trade mock with only essential data for hardware wallet swap test
-export const SWAP_ETH_DAI_TRADES_MOCK = [
+const SWAP_ETH_DAI_TRADES_MOCK = [
   {
     // Primary successful trade option (airswapV4)
     trade: {
@@ -119,10 +119,25 @@ export const SWAP_ETH_DAI_TRADES_MOCK = [
   },
 ];
 
+// Generic catch-all for any token icons on any chain - covers ETH, DAI, and others
+export async function mockIcon(mockServer: MockttpServer) {
+  const tokenIconResponse = {
+    statusCode: 200,
+    body: 'fake-image-data',
+    headers: { 'content-type': 'image/png' },
+  };
+
+  await mockServer
+    .forGet(
+      /https:\/\/static\.cx\.metamask\.io\/api\/v1\/tokenIcons\/\d+\/0x[a-fA-F0-9]{40}\.png/u,
+    )
+    .thenCallback(() => tokenIconResponse);
+}
+
 export async function mockEthDaiTrade(mockServer: MockttpServer) {
   return [
     await mockServer
-      .forGet('https://swap.api.cx.metamask.io/networks/1/trades')
+      .forGet('https://bridge.api.cx.metamask.io/networks/1/trades')
       .thenCallback(() => {
         return {
           statusCode: 200,
@@ -136,11 +151,10 @@ export async function mockTransactionRequestsBase(mockServer: MockttpServer) {
   await mockMultiNetworkBalancePolling(mockServer);
 }
 
-// Mock external accounts API for activity list display
+// Mock the external accounts API that provides transaction history for activity list
+// This API is called when user clicks on Activity tab
+// Use the ACTUAL address that the test is using (from the API call logs)
 export async function mockExternalAccountsAPI(mockServer: MockttpServer) {
-  // Mock the external accounts API that provides transaction history for activity list
-  // This API is called when user clicks on Activity tab
-  // Use the ACTUAL address that the test is using (from the API call logs)
   await mockServer
     .forGet(
       'https://accounts.api.cx.metamask.io/v1/accounts/0xF68464152d7289D7eA9a2bEC2E0035c45188223c/transactions',
@@ -198,7 +212,7 @@ export async function mockExternalAccountsAPI(mockServer: MockttpServer) {
 // Mock swap feature flags API
 export async function mockSwapFeatureFlags(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/featureFlags')
+    .forGet('https://bridge.api.cx.metamask.io/featureFlags')
     .thenCallback(() => ({
       statusCode: 200,
       json: {
@@ -223,7 +237,7 @@ export async function mockSwapFeatureFlags(mockServer: MockttpServer) {
 // Mock swap tokens API
 export async function mockSwapTokens(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1/tokens')
+    .forGet('https://bridge.api.cx.metamask.io/networks/1/tokens')
     .thenCallback(() => ({
       statusCode: 200,
       json: [
@@ -298,14 +312,14 @@ export async function mockSwapGasPrices(mockServer: MockttpServer) {
 // Mock network information for swap API
 export async function mockSwapNetworkInfo(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1')
+    .forGet('https://bridge.api.cx.metamask.io/networks/1')
     .thenCallback(() => ({
       statusCode: 200,
       json: {
         active: true,
         networkId: 1,
         chainId: 1,
-        chainName: 'Ethereum Mainnet',
+        chainName: 'Ethereum',
         nativeCurrency: {
           name: 'Ether',
           symbol: 'ETH',

--- a/test/e2e/tests/hardware-wallets/trezor/mocks.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/mocks.ts
@@ -1,0 +1,39 @@
+import { MockttpServer } from 'mockttp';
+import {
+  mockEthDaiTrade,
+  mockExternalAccountsAPI,
+  mockPriceAPIs,
+  mockSuggestedGasFees,
+  mockSwapAggregatorMetadata,
+  mockSwapFeatureFlags,
+  mockSwapGasPrices,
+  mockSwapNetworkInfo,
+  mockSwapTokens,
+  mockSwapTopAssets,
+  mockTransactionRequestsBase,
+} from '../swap-mocks';
+
+export async function mockTrezorTransactionRequests(mockServer: MockttpServer) {
+  await mockTransactionRequestsBase(mockServer);
+  await mockEthDaiTrade(mockServer);
+  await mockSwapNetworkInfo(mockServer);
+  await mockSwapFeatureFlags(mockServer);
+  await mockSwapTokens(mockServer);
+  await mockSwapTopAssets(mockServer);
+  await mockSwapAggregatorMetadata(mockServer);
+  await mockSwapGasPrices(mockServer);
+  await mockSuggestedGasFees(mockServer);
+  await mockPriceAPIs(mockServer);
+  await mockExternalAccountsAPI(mockServer);
+
+  const tokenIconResponse = {
+    statusCode: 200,
+    body: 'fake-image-data',
+    headers: { 'content-type': 'image/png' },
+  };
+  await mockServer
+    .forGet(
+      /https:\/\/static\.cx\.metamask\.io\/api\/v1\/tokenIcons\/\d+\/0x[a-fA-F0-9]{40}\.png/u,
+    )
+    .thenCallback(() => tokenIconResponse);
+}

--- a/test/e2e/tests/hardware-wallets/trezor/mocks.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/mocks.ts
@@ -2,6 +2,7 @@ import { MockttpServer } from 'mockttp';
 import {
   mockEthDaiTrade,
   mockExternalAccountsAPI,
+  mockIcon,
   mockPriceAPIs,
   mockSuggestedGasFees,
   mockSwapAggregatorMetadata,
@@ -16,24 +17,17 @@ import {
 export async function mockTrezorTransactionRequests(mockServer: MockttpServer) {
   await mockTransactionRequestsBase(mockServer);
   await mockEthDaiTrade(mockServer);
+
   await mockSwapNetworkInfo(mockServer);
   await mockSwapFeatureFlags(mockServer);
   await mockSwapTokens(mockServer);
   await mockSwapTopAssets(mockServer);
   await mockSwapAggregatorMetadata(mockServer);
   await mockSwapGasPrices(mockServer);
+
   await mockSuggestedGasFees(mockServer);
   await mockPriceAPIs(mockServer);
-  await mockExternalAccountsAPI(mockServer);
 
-  const tokenIconResponse = {
-    statusCode: 200,
-    body: 'fake-image-data',
-    headers: { 'content-type': 'image/png' },
-  };
-  await mockServer
-    .forGet(
-      /https:\/\/static\.cx\.metamask\.io\/api\/v1\/tokenIcons\/\d+\/0x[a-fA-F0-9]{40}\.png/u,
-    )
-    .thenCallback(() => tokenIconResponse);
+  await mockExternalAccountsAPI(mockServer);
+  await mockIcon(mockServer);
 }

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
@@ -1,0 +1,92 @@
+import { Browser } from 'selenium-webdriver';
+import FixtureBuilder from '../../../fixture-builder';
+import { WINDOW_TITLES, withFixtures } from '../../../helpers';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
+import HeaderNavbar from '../../../page-objects/pages/header-navbar';
+import SettingsPage from '../../../page-objects/pages/settings/settings-page';
+import { checkActivityTransaction } from '../../swaps/shared';
+
+import HomePage from '../../../page-objects/pages/home/homepage';
+import AdvancedSettings from '../../../page-objects/pages/settings/advanced-settings';
+import SwapPage from '../../../page-objects/pages/swap/swap-page';
+
+import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../../stub/keyring-bridge';
+import { mockTrezorTransactionRequests } from './mocks';
+
+const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
+
+describe('Trezor Swap', function () {
+  it('swaps ETH to DAI', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().withTrezorAccount().build(),
+        localNodeOptions: {
+          loadState: './test/e2e/seeder/network-states/with50Dai.json',
+        },
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockTrezorTransactionRequests,
+      },
+      async ({ driver, localNodes }) => {
+        (await localNodes?.[0]?.setAccountBalance(
+          KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
+          '0x1158e460913d00000',
+        )) ?? console.error('localNodes is undefined or empty');
+
+        await loginWithBalanceValidation(driver, undefined, undefined, '20');
+
+        const homePage = new HomePage(driver);
+
+        // disable smart transactions
+        const headerNavbar = new HeaderNavbar(driver);
+        await headerNavbar.checkPageIsLoaded();
+        await headerNavbar.openSettingsPage();
+        const settingsPage = new SettingsPage(driver);
+
+        await settingsPage.checkPageIsLoaded();
+        await settingsPage.clickAdvancedTab();
+        const advancedSettingsPage = new AdvancedSettings(driver);
+        await advancedSettingsPage.checkPageIsLoaded();
+        await advancedSettingsPage.toggleSmartTransactions();
+        await settingsPage.closeSettingsPage();
+
+        await homePage.checkIfSwapButtonIsClickable();
+
+        await homePage.startSwapFlow();
+
+        if (isFirefox) {
+          // firefox will open swap page in another tab with same name, so we need to close it
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
+          await driver.closeWindow();
+        }
+
+        // switch to the swap page tab
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        const swapPage = new SwapPage(driver);
+        await swapPage.checkPageIsLoaded();
+        await swapPage.enterSwapAmount('2');
+        await swapPage.selectDestinationToken('DAI');
+        await swapPage.dismissManualTokenWarning();
+
+        await swapPage.checkSwapButtonIsEnabled();
+        await swapPage.submitSwap();
+
+        await swapPage.waitForTransactionToComplete();
+
+        // check activity list
+        await homePage.goToActivityList();
+
+        await checkActivityTransaction(driver, {
+          index: 0,
+          amount: '2',
+          swapFrom: 'TESTETH',
+          swapTo: 'DAI',
+        });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
@@ -68,6 +68,10 @@ describe('Trezor Swap', function () {
 
         const swapPage = new SwapPage(driver);
         await swapPage.checkPageIsLoaded();
+
+        //  Occasionally, source token is not set automatically in e2e tests for some reason, so we need to do it manually
+        await swapPage.selectSourceToken('TESTETH');
+
         await swapPage.enterSwapAmount('2');
         await swapPage.selectDestinationToken('DAI');
         await swapPage.dismissManualTokenWarning();
@@ -77,6 +81,11 @@ describe('Trezor Swap', function () {
 
         await swapPage.waitForTransactionToComplete();
 
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        await homePage.checkPageIsLoaded();
         // check activity list
         await homePage.goToActivityList();
 

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts
@@ -2,14 +2,9 @@ import { Browser } from 'selenium-webdriver';
 import FixtureBuilder from '../../../fixture-builder';
 import { WINDOW_TITLES, withFixtures } from '../../../helpers';
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
-import HeaderNavbar from '../../../page-objects/pages/header-navbar';
-import SettingsPage from '../../../page-objects/pages/settings/settings-page';
 import { checkActivityTransaction } from '../../swaps/shared';
-
 import HomePage from '../../../page-objects/pages/home/homepage';
-import AdvancedSettings from '../../../page-objects/pages/settings/advanced-settings';
 import SwapPage from '../../../page-objects/pages/swap/swap-page';
-
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../../stub/keyring-bridge';
 import { mockTrezorTransactionRequests } from './mocks';
 
@@ -19,9 +14,15 @@ describe('Trezor Swap', function () {
   it('swaps ETH to DAI', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().withTrezorAccount().build(),
+        fixtures: new FixtureBuilder()
+          .withPreferencesControllerSmartTransactionsOptedOut()
+          .withTrezorAccount()
+          .build(),
         localNodeOptions: {
           loadState: './test/e2e/seeder/network-states/with50Dai.json',
+        },
+        manifestFlags: {
+          testing: { disableSmartTransactionsOverride: true },
         },
         title: this.test?.fullTitle(),
         testSpecificMock: mockTrezorTransactionRequests,
@@ -33,24 +34,8 @@ describe('Trezor Swap', function () {
         )) ?? console.error('localNodes is undefined or empty');
 
         await loginWithBalanceValidation(driver, undefined, undefined, '20');
-
         const homePage = new HomePage(driver);
-
-        // disable smart transactions
-        const headerNavbar = new HeaderNavbar(driver);
-        await headerNavbar.checkPageIsLoaded();
-        await headerNavbar.openSettingsPage();
-        const settingsPage = new SettingsPage(driver);
-
-        await settingsPage.checkPageIsLoaded();
-        await settingsPage.clickAdvancedTab();
-        const advancedSettingsPage = new AdvancedSettings(driver);
-        await advancedSettingsPage.checkPageIsLoaded();
-        await advancedSettingsPage.toggleSmartTransactions();
-        await settingsPage.closeSettingsPage();
-
         await homePage.checkIfSwapButtonIsClickable();
-
         await homePage.startSwapFlow();
 
         if (isFirefox) {
@@ -74,16 +59,14 @@ describe('Trezor Swap', function () {
 
         await swapPage.enterSwapAmount('2');
         await swapPage.selectDestinationToken('DAI');
-        await swapPage.dismissManualTokenWarning();
+        // await swapPage.dismissManualTokenWarning();
 
         await swapPage.checkSwapButtonIsEnabled();
+        // To mitigate flakiness where the Swap page is re-rendered after submitting the swap (#36501)
+        await driver.delay(5000);
         await swapPage.submitSwap();
 
         await swapPage.waitForTransactionToComplete();
-
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
 
         await homePage.checkPageIsLoaded();
         // check activity list


### PR DESCRIPTION
## **Description**

Adds legacy and EIP-1559 transaction test cases for Trezor related e2e tests

Fixes: https://github.com/MetaMask/accounts-planning/issues/962?issue=MetaMask%7Caccounts-planning%7C970

## **Manual testing steps**

Local testing
1. run `yarn && yarn start:test` in one terminal tab and wait for build end
2. run `yarn test:e2e:single test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts` on another terminal tab

Otherwise check this PR CI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Trezor ETH→DAI swap e2e test and consolidates swap API mocks into a shared module used by both Trezor and Ledger tests.
> 
> - **Tests**:
>   - Add `test/e2e/tests/hardware-wallets/trezor/trezor-swap.spec.ts` to validate ETH→DAI swap flow for Trezor.
> - **Mocks (shared)**:
>   - Introduce `test/e2e/tests/hardware-wallets/swap-mocks.ts` with reusable mocks: `mockEthDaiTrade`, `mockSwapNetworkInfo`, `mockSwapTokens`, `mockSwapTopAssets`, `mockSwapAggregatorMetadata`, `mockSwapGasPrices`, `mockSuggestedGasFees`, `mockPriceAPIs`, `mockExternalAccountsAPI`, `mockTransactionRequestsBase`, `mockIcon`.
> - **Ledger**:
>   - Simplify `ledger/mocks.ts` to import and use shared swap mocks; keep minimal Ledger iframe bridge mock; add `mockIcon` usage.
> - **Trezor**:
>   - Add `trezor/mocks.ts` composing the shared swap mocks for Trezor test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6a34f4cd3d36f448fcbc62133b0031024b0d67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->