### PR TITLE
refactor: Refactor app state and preferences controller to modular init pattern

### DIFF
--- a/app/scripts/controller-init/app-state-controller-init.test.ts
+++ b/app/scripts/controller-init/app-state-controller-init.test.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/base-controller';
+import { AppStateController } from '../controllers/app-state-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAppStateControllerMessenger,
+  AppStateControllerMessenger,
+} from './messengers';
+import { AppStateControllerInit } from './app-state-controller-init';
+
+jest.mock('../controllers/app-state-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AppStateControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAppStateControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AppStateControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AppStateControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AppStateController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AppStateControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AppStateController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      extension: expect.any(Object),
+      onInactiveTimeout: expect.any(Function),
+    });
+  });
+});

--- a/app/scripts/controller-init/app-state-controller-init.ts
+++ b/app/scripts/controller-init/app-state-controller-init.ts
@@ -1,0 +1,31 @@
+import {
+  AppStateController,
+  AppStateControllerMessenger,
+} from '../controllers/app-state-controller';
+import { ControllerInitFunction } from './types';
+
+/**
+ * Initialize the appState controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the extension.
+ * @param request.setLocked - Function to set the app as locked.
+ * @param request.extension - The extension browser API.
+ * @returns The initialized controller.
+ */
+export const AppStateControllerInit: ControllerInitFunction<
+  AppStateController,
+  AppStateControllerMessenger
+> = ({ controllerMessenger, persistedState, setLocked, extension }) => {
+  const controller = new AppStateController({
+    messenger: controllerMessenger,
+    state: persistedState.AppStateController,
+    onInactiveTimeout: () => setLocked(),
+    extension,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/app-state-controller-init.ts
+++ b/app/scripts/controller-init/app-state-controller-init.ts
@@ -5,7 +5,7 @@ import {
 import { ControllerInitFunction } from './types';
 
 /**
- * Initialize the appState controller.
+ * Initialize the app state controller.
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.

--- a/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
@@ -57,7 +57,7 @@ function buildInitRequestMock(): jest.Mocked<
 
   baseControllerMessenger.registerActionHandler(
     'PreferencesController:getState',
-    jest.fn().mockResolvedValue({ useCurrencyRateCheck: true }),
+    jest.fn().mockReturnValue({ useCurrencyRateCheck: true }),
   );
 
   const requestMock = {

--- a/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
@@ -2,7 +2,7 @@ import {
   TokenRatesController,
   TokenRatesControllerMessenger,
 } from '@metamask/assets-controllers';
-import { Messenger } from '@metamask/base-controller';
+import { ActionConstraint, Messenger } from '@metamask/base-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ControllerInitRequest } from '../types';
@@ -11,6 +11,7 @@ import {
   getTokenRatesControllerMessenger,
   TokenRatesControllerInitMessenger,
 } from '../messengers/assets';
+import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { TokenRatesControllerInit } from './token-rates-controller-init';
 
 jest.mock('@metamask/assets-controllers');
@@ -49,7 +50,15 @@ function buildInitRequestMock(): jest.Mocked<
     TokenRatesControllerInitMessenger
   >
 > {
-  const baseControllerMessenger = new Messenger();
+  const baseControllerMessenger = new Messenger<
+    PreferencesControllerGetStateAction | ActionConstraint,
+    never
+  >();
+
+  baseControllerMessenger.registerActionHandler(
+    'PreferencesController:getState',
+    jest.fn().mockResolvedValue({ useCurrencyRateCheck: true }),
+  );
 
   const requestMock = {
     ...buildControllerInitRequestMock(),

--- a/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/controller-init/assets/token-rates-controller-init.test.ts
@@ -6,7 +6,11 @@ import { Messenger } from '@metamask/base-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ControllerInitRequest } from '../types';
-import { getTokenRatesControllerMessenger } from '../messengers/assets';
+import {
+  getTokenRatesControllerInitMessenger,
+  getTokenRatesControllerMessenger,
+  TokenRatesControllerInitMessenger,
+} from '../messengers/assets';
 import { TokenRatesControllerInit } from './token-rates-controller-init';
 
 jest.mock('@metamask/assets-controllers');
@@ -40,7 +44,10 @@ function buildControllerMock(
  * stubbed PreferencesController.
  */
 function buildInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<TokenRatesControllerMessenger>
+  ControllerInitRequest<
+    TokenRatesControllerMessenger,
+    TokenRatesControllerInitMessenger
+  >
 > {
   const baseControllerMessenger = new Messenger();
 
@@ -49,7 +56,9 @@ function buildInitRequestMock(): jest.Mocked<
     controllerMessenger: getTokenRatesControllerMessenger(
       baseControllerMessenger,
     ),
-    initMessenger: undefined,
+    initMessenger: getTokenRatesControllerInitMessenger(
+      baseControllerMessenger,
+    ),
   };
 
   // @ts-expect-error Incomplete mock, just includes properties used by code-under-test.

--- a/app/scripts/controller-init/assets/token-rates-controller-init.ts
+++ b/app/scripts/controller-init/assets/token-rates-controller-init.ts
@@ -3,7 +3,11 @@ import {
   TokenRatesController,
 } from '@metamask/assets-controllers';
 import { ControllerInitFunction } from '../types';
-import { TokenRatesControllerMessenger } from '../messengers/assets';
+import {
+  TokenRatesControllerMessenger,
+  TokenRatesControllerInitMessenger,
+} from '../messengers/assets';
+import { previousValueComparator } from '../../lib/util';
 
 /**
  * Initialize the Token Rates controller.
@@ -15,17 +19,33 @@ import { TokenRatesControllerMessenger } from '../messengers/assets';
  */
 export const TokenRatesControllerInit: ControllerInitFunction<
   TokenRatesController,
-  TokenRatesControllerMessenger
+  TokenRatesControllerMessenger,
+  TokenRatesControllerInitMessenger
 > = (request) => {
-  const { controllerMessenger, getController, persistedState } = request;
-  const preferencesController = () => getController('PreferencesController');
+  const { controllerMessenger, initMessenger, persistedState } = request;
+  const preferencesState = initMessenger.call('PreferencesController:getState');
 
   const controller = new TokenRatesController({
     messenger: controllerMessenger,
     state: persistedState.TokenRatesController,
     tokenPricesService: new CodefiTokenPricesServiceV2(),
-    disabled: !preferencesController().state?.useCurrencyRateCheck,
+    disabled: !preferencesState.useCurrencyRateCheck,
   });
+
+  initMessenger.subscribe(
+    'PreferencesController:stateChange',
+    previousValueComparator((prevState, currState) => {
+      const { useCurrencyRateCheck: prevUseCurrencyRateCheck } = prevState;
+      const { useCurrencyRateCheck: currUseCurrencyRateCheck } = currState;
+      if (currUseCurrencyRateCheck && !prevUseCurrencyRateCheck) {
+        controller.enable();
+      } else if (!currUseCurrencyRateCheck && prevUseCurrencyRateCheck) {
+        controller.disable();
+      }
+
+      return true;
+    }, preferencesState),
+  );
 
   return {
     controller,

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -69,12 +69,14 @@ import OAuthService from '../services/oauth/oauth-service';
 import MetaMetricsController from '../controllers/metametrics-controller';
 import { SnapsNameProvider } from '../lib/SnapsNameProvider';
 import AccountTrackerController from '../controllers/account-tracker-controller';
+import { AppStateController } from '../controllers/app-state-controller';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
  */
 export type Controller =
   | AccountTrackerController
+  | AppStateController
   | AuthenticationController
   | BridgeController
   | BridgeStatusController
@@ -141,6 +143,7 @@ export type Controller =
  */
 export type ControllerFlatState = AccountsController['state'] &
   AccountTreeController['state'] &
+  AppStateController['state'] &
   AuthenticationController['state'] &
   BridgeController['state'] &
   BridgeStatusController['state'] &

--- a/app/scripts/controller-init/messengers/accounts/index.ts
+++ b/app/scripts/controller-init/messengers/accounts/index.ts
@@ -12,5 +12,8 @@ export type {
   AccountTreeControllerMessenger,
   AccountTreeControllerInitMessenger,
 } from './account-tree-controller-messenger';
-export type { MultichainAccountServiceMessenger } from './multichain-account-service-messenger';
+export type {
+  MultichainAccountServiceMessenger,
+  MultichainAccountServiceInitMessenger,
+} from './multichain-account-service-messenger';
 export type { InstitutionalSnapControllerMessenger } from './institutional-snap-controller-messenger';

--- a/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.test.ts
@@ -1,5 +1,8 @@
 import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
-import { getMultichainAccountServiceMessenger } from './multichain-account-service-messenger';
+import {
+  getMultichainAccountServiceInitMessenger,
+  getMultichainAccountServiceMessenger,
+} from './multichain-account-service-messenger';
 
 describe('getMultichainAccountServiceMessenger', () => {
   it('returns a restricted messenger', () => {
@@ -8,6 +11,18 @@ describe('getMultichainAccountServiceMessenger', () => {
       getMultichainAccountServiceMessenger(messenger);
 
     expect(multichainAccountServiceMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});
+
+describe('getMultichainAccountServiceInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const multichainAccountServiceInitMessenger =
+      getMultichainAccountServiceInitMessenger(messenger);
+
+    expect(multichainAccountServiceInitMessenger).toBeInstanceOf(
       RestrictedMessenger,
     );
   });

--- a/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -18,6 +18,10 @@ import {
   NetworkControllerFindNetworkClientIdByChainIdAction,
   NetworkControllerGetNetworkClientByIdAction,
 } from '@metamask/network-controller';
+import {
+  PreferencesControllerGetStateAction,
+  PreferencesControllerStateChangeEvent,
+} from '../../../controllers/preferences-controller';
 
 type Actions =
   | AccountsControllerListMultichainAccountsAction
@@ -72,6 +76,14 @@ export function getMultichainAccountServiceMessenger(
   });
 }
 
+type AllowedInitializationActions = PreferencesControllerGetStateAction;
+
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+
+export type MultichainAccountServiceInitMessenger = ReturnType<
+  typeof getMultichainAccountServiceInitMessenger
+>;
+
 /**
  * Get a restricted messenger for the account wallet controller. This is scoped to the
  * actions and events that this controller is allowed to handle.
@@ -80,9 +92,14 @@ export function getMultichainAccountServiceMessenger(
  * @returns The restricted controller messenger.
  */
 export function getMultichainAccountServiceInitMessenger(
-  messenger: Messenger<Actions, Events>,
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
 ) {
-  // Our `init` method needs the same actions, so just re-use the same messenger
-  // function here.
-  return getMultichainAccountServiceMessenger(messenger);
+  return messenger.getRestricted({
+    name: 'MultichainAccountServiceInit',
+    allowedActions: ['PreferencesController:getState'],
+    allowedEvents: ['PreferencesController:stateChange'],
+  });
 }

--- a/app/scripts/controller-init/messengers/app-state-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/app-state-controller-messenger.test.ts
@@ -1,0 +1,14 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getAppStateControllerMessenger,
+} from './app-state-controller-messenger';
+
+describe('getAppStateControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const appStateControllerMessenger =
+      getAppStateControllerMessenger(messenger);
+
+    expect(appStateControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/app-state-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/app-state-controller-messenger.test.ts
@@ -1,7 +1,5 @@
 import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
-import {
-  getAppStateControllerMessenger,
-} from './app-state-controller-messenger';
+import { getAppStateControllerMessenger } from './app-state-controller-messenger';
 
 describe('getAppStateControllerMessenger', () => {
   it('returns a restricted messenger', () => {

--- a/app/scripts/controller-init/messengers/app-state-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/app-state-controller-messenger.ts
@@ -1,0 +1,34 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/app-state-controller';
+
+export type AppStateControllerMessenger = ReturnType<
+  typeof getAppStateControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * gas fee controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAppStateControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'AppStateController',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'ApprovalController:acceptRequest',
+      'KeyringController:getState',
+      'PreferencesController:getState',
+    ],
+    allowedEvents: [
+      'KeyringController:unlock',
+      'PreferencesController:stateChange',
+    ],
+  });
+}

--- a/app/scripts/controller-init/messengers/app-state-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/app-state-controller-messenger.ts
@@ -10,7 +10,7 @@ export type AppStateControllerMessenger = ReturnType<
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
- * gas fee controller.
+ * app state controller.
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.

--- a/app/scripts/controller-init/messengers/assets/index.ts
+++ b/app/scripts/controller-init/messengers/assets/index.ts
@@ -1,5 +1,11 @@
-export { getTokenRatesControllerMessenger } from './token-rates-controller-messenger';
-export type { TokenRatesControllerMessenger } from './token-rates-controller-messenger';
+export {
+  getTokenRatesControllerMessenger,
+  getTokenRatesControllerInitMessenger,
+} from './token-rates-controller-messenger';
+export type {
+  TokenRatesControllerMessenger,
+  TokenRatesControllerInitMessenger,
+} from './token-rates-controller-messenger';
 
 export {
   getNftControllerMessenger,

--- a/app/scripts/controller-init/messengers/assets/token-rates-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/assets/token-rates-controller-messenger.test.ts
@@ -1,5 +1,8 @@
 import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
-import { getTokenRatesControllerMessenger } from './token-rates-controller-messenger';
+import {
+  getTokenRatesControllerInitMessenger,
+  getTokenRatesControllerMessenger,
+} from './token-rates-controller-messenger';
 
 describe('getTokenRatesControllerMessenger', () => {
   it('returns a restricted messenger', () => {
@@ -8,5 +11,17 @@ describe('getTokenRatesControllerMessenger', () => {
       getTokenRatesControllerMessenger(messenger);
 
     expect(tokenRatesControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getTokenRatesControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const tokenRatesControllerInitMessenger =
+      getTokenRatesControllerInitMessenger(messenger);
+
+    expect(tokenRatesControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
   });
 });

--- a/app/scripts/controller-init/messengers/assets/token-rates-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/assets/token-rates-controller-messenger.ts
@@ -9,11 +9,14 @@ import {
   AccountsControllerGetAccountAction,
   AccountsControllerSelectedEvmAccountChangeEvent,
 } from '@metamask/accounts-controller';
-import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
 import {
   TokensControllerGetStateAction,
   TokensControllerStateChangeEvent,
 } from '@metamask/assets-controllers';
+import {
+  PreferencesControllerGetStateAction,
+  PreferencesControllerStateChangeEvent,
+} from '../../../controllers/preferences-controller';
 
 type Actions =
   | TokensControllerGetStateAction
@@ -57,5 +60,34 @@ export function getTokenRatesControllerMessenger(
       'PreferencesController:stateChange',
       'TokensController:stateChange',
     ],
+  });
+}
+
+type AllowedInitializationActions = PreferencesControllerGetStateAction;
+
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+
+export type TokenRatesControllerInitMessenger = ReturnType<
+  typeof getTokenRatesControllerInitMessenger
+>;
+
+/**
+ * Get a restricted messenger for the token rates controller initialization.
+ * This is scoped to the actions and events that the initialization is allowed
+ * to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getTokenRatesControllerInitMessenger(
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  return messenger.getRestricted({
+    name: 'TokenRatesControllerInit',
+    allowedActions: ['PreferencesController:getState'],
+    allowedEvents: ['PreferencesController:stateChange'],
   });
 }

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -39,6 +39,7 @@ import {
   getNftControllerInitMessenger,
   getNftControllerMessenger,
   getNftDetectionControllerMessenger,
+  getTokenRatesControllerInitMessenger,
   getTokenRatesControllerMessenger,
 } from './assets';
 import {
@@ -55,6 +56,7 @@ import {
   getAccountTreeControllerMessenger,
   getAccountTreeControllerInitMessenger,
   getMultichainAccountServiceMessenger,
+  getMultichainAccountServiceInitMessenger,
 } from './accounts';
 import {
   getOAuthServiceMessenger,
@@ -128,6 +130,8 @@ import {
   getBridgeControllerMessenger,
 } from './bridge-controller-messenger';
 import { getBridgeStatusControllerMessenger } from './bridge-status-controller-messenger';
+import { getPreferencesControllerMessenger } from './preferences-controller-messenger';
+import { getAppStateControllerMessenger } from './app-state-controller-messenger';
 
 export type {
   AccountTrackerControllerMessenger,
@@ -137,6 +141,8 @@ export {
   getAccountTrackerControllerMessenger,
   getAccountTrackerControllerInitMessenger,
 } from './account-tracker-controller-messenger';
+export type { AppStateControllerMessenger } from './app-state-controller-messenger';
+export { getAppStateControllerMessenger } from './app-state-controller-messenger';
 export type {
   BridgeControllerMessenger,
   BridgeControllerInitMessenger,
@@ -185,6 +191,8 @@ export {
 } from './name-controller-messenger';
 export type { OnboardingControllerMessenger } from './onboarding-controller-messenger';
 export { getOnboardingControllerMessenger } from './onboarding-controller-messenger';
+export type { PreferencesControllerMessenger } from './preferences-controller-messenger';
+export { getPreferencesControllerMessenger } from './preferences-controller-messenger';
 export type {
   RemoteFeatureFlagControllerMessenger,
   RemoteFeatureFlagControllerInitMessenger,
@@ -240,6 +248,10 @@ export const CONTROLLER_MESSENGERS = {
   AccountTrackerController: {
     getMessenger: getAccountTrackerControllerMessenger,
     getInitMessenger: getAccountTrackerControllerInitMessenger,
+  },
+  AppStateController: {
+    getMessenger: getAppStateControllerMessenger,
+    getInitMessenger: noop,
   },
   AuthenticationController: {
     getMessenger: getAuthenticationControllerMessenger,
@@ -389,6 +401,10 @@ export const CONTROLLER_MESSENGERS = {
     getMessenger: getPPOMControllerMessenger,
     getInitMessenger: getPPOMControllerInitMessenger,
   },
+  PreferencesController: {
+    getMessenger: getPreferencesControllerMessenger,
+    getInitMessenger: noop,
+  },
   TokenBalancesController: {
     getMessenger: getTokenBalancesControllerMessenger,
     getInitMessenger: getTokenBalancesControllerInitMessenger,
@@ -415,7 +431,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   TokenRatesController: {
     getMessenger: getTokenRatesControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getTokenRatesControllerInitMessenger,
   },
   NftController: {
     getMessenger: getNftControllerMessenger,
@@ -443,7 +459,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   MultichainAccountService: {
     getMessenger: getMultichainAccountServiceMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getMultichainAccountServiceInitMessenger,
   },
   NetworkOrderController: {
     getMessenger: getNetworkOrderControllerMessenger,

--- a/app/scripts/controller-init/messengers/preferences-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/preferences-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getPreferencesControllerMessenger } from './preferences-controller-messenger';
+
+describe('getPreferencesControllerMessenger', () => {
+  it('returns a restricted controller messenger', () => {
+    const controllerMessenger = new Messenger<never, never>();
+    const preferencesControllerMessenger =
+      getPreferencesControllerMessenger(controllerMessenger);
+
+    expect(preferencesControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/preferences-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/preferences-controller-messenger.ts
@@ -1,0 +1,32 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/preferences-controller';
+
+export type PreferencesControllerMessenger = ReturnType<
+  typeof getPreferencesControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * preferences controller.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getPreferencesControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'PreferencesController',
+    allowedActions: [
+      'AccountsController:setSelectedAccount',
+      'AccountsController:getSelectedAccount',
+      'AccountsController:getAccountByAddress',
+      'AccountsController:setAccountName',
+      'NetworkController:getState',
+    ],
+    allowedEvents: ['AccountsController:stateChange'],
+  });
+}

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -1,26 +1,42 @@
 import { MultichainAccountService } from '@metamask/multichain-account-service';
-import { Messenger } from '@metamask/base-controller';
+import { ActionConstraint, Messenger } from '@metamask/base-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ControllerInitRequest } from '../types';
 import {
+  getMultichainAccountServiceInitMessenger,
   getMultichainAccountServiceMessenger,
+  MultichainAccountServiceInitMessenger,
   MultichainAccountServiceMessenger,
 } from '../messengers/accounts';
+import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { MultichainAccountServiceInit } from './multichain-account-service-init';
 
 jest.mock('@metamask/multichain-account-service');
 
 function buildInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<MultichainAccountServiceMessenger>
+  ControllerInitRequest<
+    MultichainAccountServiceMessenger,
+    MultichainAccountServiceInitMessenger
+  >
 > {
-  const baseControllerMessenger = new Messenger();
+  const baseControllerMessenger = new Messenger<
+    PreferencesControllerGetStateAction | ActionConstraint,
+    never
+  >();
+
+  baseControllerMessenger.registerActionHandler(
+    'PreferencesController:getState',
+    jest.fn().mockResolvedValue({}),
+  );
 
   return {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getMultichainAccountServiceMessenger(
       baseControllerMessenger,
     ),
-    initMessenger: undefined,
+    initMessenger: getMultichainAccountServiceInitMessenger(
+      baseControllerMessenger,
+    ),
   };
 }
 

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -26,7 +26,7 @@ function buildInitRequestMock(): jest.Mocked<
 
   baseControllerMessenger.registerActionHandler(
     'PreferencesController:getState',
-    jest.fn().mockResolvedValue({}),
+    jest.fn().mockReturnValue({}),
   );
 
   return {

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -1,21 +1,51 @@
 import { MultichainAccountService } from '@metamask/multichain-account-service';
 import { ControllerInitFunction } from '../types';
-import { MultichainAccountServiceMessenger } from '../messengers/accounts';
+import {
+  MultichainAccountServiceMessenger,
+  MultichainAccountServiceInitMessenger,
+} from '../messengers/accounts';
+import { previousValueComparator } from '../../lib/util';
 
 /**
  * Initialize the multichain account service.
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.initMessenger - The messenger to use for initialization.
  * @returns The initialized service.
  */
 export const MultichainAccountServiceInit: ControllerInitFunction<
   MultichainAccountService,
-  MultichainAccountServiceMessenger
-> = ({ controllerMessenger }) => {
+  MultichainAccountServiceMessenger,
+  MultichainAccountServiceInitMessenger
+> = ({ controllerMessenger, initMessenger }) => {
   const controller = new MultichainAccountService({
     messenger: controllerMessenger,
   });
+
+  const preferencesState = initMessenger.call('PreferencesController:getState');
+
+  initMessenger.subscribe(
+    'PreferencesController:stateChange',
+    previousValueComparator((prevState, currState) => {
+      const { useExternalServices: prevUseExternalServices } = prevState;
+      const { useExternalServices: currUseExternalServices } = currState;
+      if (prevUseExternalServices !== currUseExternalServices) {
+        // Set basic functionality and trigger alignment when enabled
+        // This single call handles both provider disable/enable and alignment.
+        controller
+          .setBasicFunctionality(currUseExternalServices)
+          .catch((error) => {
+            console.error(
+              'Failed to set basic functionality on MultichainAccountService:',
+              error,
+            );
+          });
+      }
+
+      return true;
+    }, preferencesState),
+  );
 
   return {
     memStateKey: null,

--- a/app/scripts/controller-init/preferences-controller-init.test.ts
+++ b/app/scripts/controller-init/preferences-controller-init.test.ts
@@ -1,0 +1,45 @@
+import { Messenger } from '@metamask/base-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getPreferencesControllerMessenger,
+  PreferencesControllerMessenger,
+} from './messengers';
+import { PreferencesController } from '../controllers/preferences-controller';
+import { PreferencesControllerInit } from './preferences-controller-init';
+
+jest.mock('../controllers/preferences-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<PreferencesControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getPreferencesControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+    initLangCode: 'en-US',
+  };
+
+  return requestMock;
+}
+
+describe('PreferencesControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = PreferencesControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(PreferencesController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    PreferencesControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(PreferencesController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: {
+        currentLocale: 'en-US',
+      },
+    });
+  });
+});

--- a/app/scripts/controller-init/preferences-controller-init.test.ts
+++ b/app/scripts/controller-init/preferences-controller-init.test.ts
@@ -1,11 +1,11 @@
 import { Messenger } from '@metamask/base-controller';
+import { PreferencesController } from '../controllers/preferences-controller';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import {
   getPreferencesControllerMessenger,
   PreferencesControllerMessenger,
 } from './messengers';
-import { PreferencesController } from '../controllers/preferences-controller';
 import { PreferencesControllerInit } from './preferences-controller-init';
 
 jest.mock('../controllers/preferences-controller');

--- a/app/scripts/controller-init/preferences-controller-init.ts
+++ b/app/scripts/controller-init/preferences-controller-init.ts
@@ -1,0 +1,31 @@
+import { ControllerInitFunction } from './types';
+import {
+  PreferencesController,
+  PreferencesControllerMessenger,
+} from '../controllers/preferences-controller';
+
+/**
+ * Initialize the preferences controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the extension.
+ * @param request.initLangCode
+ * @returns The initialized controller.
+ */
+export const PreferencesControllerInit: ControllerInitFunction<
+  PreferencesController,
+  PreferencesControllerMessenger
+> = ({ controllerMessenger, persistedState, initLangCode }) => {
+  const controller = new PreferencesController({
+    state: {
+      currentLocale: initLangCode ?? '',
+      ...persistedState,
+    },
+    messenger: controllerMessenger,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/preferences-controller-init.ts
+++ b/app/scripts/controller-init/preferences-controller-init.ts
@@ -1,8 +1,8 @@
-import { ControllerInitFunction } from './types';
 import {
   PreferencesController,
   PreferencesControllerMessenger,
 } from '../controllers/preferences-controller';
+import { ControllerInitFunction } from './types';
 
 /**
  * Initialize the preferences controller.

--- a/app/scripts/controller-init/preferences-controller-init.ts
+++ b/app/scripts/controller-init/preferences-controller-init.ts
@@ -20,7 +20,7 @@ export const PreferencesControllerInit: ControllerInitFunction<
   const controller = new PreferencesController({
     state: {
       currentLocale: initLangCode ?? '',
-      ...persistedState,
+      ...persistedState.PreferencesController,
     },
     messenger: controllerMessenger,
   });

--- a/app/scripts/controller-init/test/utils.ts
+++ b/app/scripts/controller-init/test/utils.ts
@@ -29,6 +29,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
     persistedState: {},
     removeAllConnections: jest.fn(),
     setupUntrustedCommunicationEip1193: jest.fn(),
+    setLocked: jest.fn(),
     showNotification: jest.fn(),
     preinstalledSnaps: [],
   };

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -170,6 +170,11 @@ export type ControllerInitRequest<
   }): void;
 
   /**
+   * Lock the extension.
+   */
+  setLocked(): void;
+
+  /**
    * Show a native notification.
    *
    * @param title - The title of the notification.
@@ -194,6 +199,11 @@ export type ControllerInitRequest<
   initMessenger: InitMessengerType;
 
   getCronjobControllerStorageManager: () => CronjobControllerStorageManager;
+
+  /**
+   * The user's preferred language code, if any.
+   */
+  initLangCode: string | null;
 };
 
 /**

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -1,8 +1,4 @@
 import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
-import type {
-  AcceptRequest,
-  AddApprovalRequest,
-} from '@metamask/approval-controller';
 import { Browser } from 'webextension-polyfill';
 import {
   ENVIRONMENT_TYPE_POPUP,
@@ -11,18 +7,18 @@ import {
 } from '../../../shared/constants/app';
 import { AccountOverviewTabKey } from '../../../shared/constants/app-state';
 import { MINUTE } from '../../../shared/constants/time';
-import { AppStateController } from './app-state-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+  AppStateController,
+} from './app-state-controller';
 import type {
   AppStateControllerActions,
   AppStateControllerEvents,
   AppStateControllerOptions,
   AppStateControllerState,
 } from './app-state-controller';
-import type {
-  PreferencesControllerState,
-  PreferencesControllerGetStateAction,
-  PreferencesControllerStateChangeEvent,
-} from './preferences-controller';
+import type { PreferencesControllerState } from './preferences-controller';
 
 jest.mock('webextension-polyfill');
 
@@ -75,35 +71,39 @@ describe('AppStateController', () => {
 
   describe('getUnlockPromise', () => {
     it('waits for unlock if the extension is locked', async () => {
-      await withController(({ controller }) => {
-        const isUnlockedMock = jest
-          .spyOn(controller, 'isUnlocked')
-          .mockReturnValue(false);
+      await withController(async ({ controller, controllerMessenger }) => {
+        controllerMessenger.registerActionHandler(
+          'KeyringController:getState',
+          jest.fn().mockReturnValue({ isUnlocked: false }),
+        );
+
         expect(controller.waitingForUnlock).toHaveLength(0);
 
         controller.getUnlockPromise(true);
-        expect(isUnlockedMock).toHaveBeenCalled();
         expect(controller.waitingForUnlock).toHaveLength(1);
       });
     });
 
     it('resolves immediately if the extension is already unlocked', async () => {
-      await withController(async ({ controller }) => {
-        const isUnlockedMock = jest
-          .spyOn(controller, 'isUnlocked')
-          .mockReturnValue(true);
+      await withController(async ({ controller, controllerMessenger }) => {
+        controllerMessenger.registerActionHandler(
+          'KeyringController:getState',
+          jest.fn().mockReturnValue({ isUnlocked: true }),
+        );
 
         await expect(
           controller.getUnlockPromise(false),
         ).resolves.toBeUndefined();
-
-        expect(isUnlockedMock).toHaveBeenCalled();
       });
     });
 
     it('publishes an unlock change event when isUnlocked is set to false', async () => {
       await withController(async ({ controller, controllerMessenger }) => {
-        jest.spyOn(controller, 'isUnlocked').mockReturnValue(false);
+        controllerMessenger.registerActionHandler(
+          'KeyringController:getState',
+          jest.fn().mockReturnValue({ isUnlocked: false }),
+        );
+
         const unlockChangeSpy = jest.fn();
         controllerMessenger.subscribe(
           'AppStateController:unlockChange',
@@ -125,37 +125,41 @@ describe('AppStateController', () => {
 
     it('creates approval request when waitForUnlock is called with shouldShowUnlockRequest as true', async () => {
       const addRequestMock = jest.fn().mockResolvedValue(undefined);
-      await withController({ addRequestMock }, async ({ controller }) => {
-        jest.spyOn(controller, 'isUnlocked').mockReturnValue(false);
+      await withController(
+        { addRequestMock },
+        async ({ controller, controllerMessenger }) => {
+          controllerMessenger.registerActionHandler(
+            'KeyringController:getState',
+            jest.fn().mockReturnValue({ isUnlocked: false }),
+          );
 
-        controller.getUnlockPromise(true);
+          controller.getUnlockPromise(true);
 
-        expect(addRequestMock).toHaveBeenCalled();
-        expect(addRequestMock).toHaveBeenCalledWith(
-          {
-            id: expect.any(String),
-            origin: ORIGIN_METAMASK,
-            type: 'unlock',
-          },
-          true,
-        );
-      });
+          expect(addRequestMock).toHaveBeenCalled();
+          expect(addRequestMock).toHaveBeenCalledWith(
+            {
+              id: expect.any(String),
+              origin: ORIGIN_METAMASK,
+              type: 'unlock',
+            },
+            true,
+          );
+        },
+      );
     });
 
     it('accepts approval request revolving all the related promises', async () => {
-      let unlockListener: () => void;
       const addRequestMock = jest.fn().mockResolvedValue(undefined);
       await withController(
         {
           addRequestMock,
-          options: {
-            addUnlockListener: (listener) => {
-              unlockListener = listener;
-            },
-          },
         },
         ({ controller, controllerMessenger }) => {
-          jest.spyOn(controller, 'isUnlocked').mockReturnValue(false);
+          controllerMessenger.registerActionHandler(
+            'KeyringController:getState',
+            jest.fn().mockReturnValue({ isUnlocked: false }),
+          );
+
           const unlockChangeSpy = jest.fn();
           controllerMessenger.subscribe(
             'AppStateController:unlockChange',
@@ -163,8 +167,6 @@ describe('AppStateController', () => {
           );
 
           controller.getUnlockPromise(true);
-
-          unlockListener();
 
           expect(unlockChangeSpy).toHaveBeenCalled();
           expect(addRequestMock).toHaveBeenCalled();
@@ -1002,11 +1004,8 @@ type WithControllerCallback<ReturnValue> = ({
 }: {
   controller: AppStateController;
   controllerMessenger: Messenger<
-    | AppStateControllerActions
-    | AddApprovalRequest
-    | AcceptRequest
-    | PreferencesControllerGetStateAction,
-    AppStateControllerEvents | PreferencesControllerStateChangeEvent
+    AppStateControllerActions | AllowedActions,
+    AppStateControllerEvents | AllowedEvents
   >;
 }) => ReturnValue;
 
@@ -1021,21 +1020,23 @@ async function withController<ReturnValue>(
   const { addRequestMock, state, options = {} } = rest;
 
   const controllerMessenger = new Messenger<
-    | AppStateControllerActions
-    | AddApprovalRequest
-    | AcceptRequest
-    | PreferencesControllerGetStateAction,
-    AppStateControllerEvents | PreferencesControllerStateChangeEvent
+    AppStateControllerActions | AllowedActions,
+    AppStateControllerEvents | AllowedEvents
   >();
   const appStateMessenger = controllerMessenger.getRestricted({
     name: 'AppStateController',
     allowedActions: [
-      `ApprovalController:addRequest`,
-      `ApprovalController:acceptRequest`,
-      `PreferencesController:getState`,
+      'ApprovalController:addRequest',
+      'ApprovalController:acceptRequest',
+      'KeyringController:getState',
+      'PreferencesController:getState',
     ],
-    allowedEvents: [`PreferencesController:stateChange`],
+    allowedEvents: [
+      'PreferencesController:stateChange',
+      'KeyringController:unlock',
+    ],
   });
+
   controllerMessenger.registerActionHandler(
     'PreferencesController:getState',
     jest.fn().mockReturnValue({
@@ -1044,6 +1045,7 @@ async function withController<ReturnValue>(
       },
     }),
   );
+
   controllerMessenger.registerActionHandler(
     'ApprovalController:addRequest',
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
@@ -1053,8 +1055,6 @@ async function withController<ReturnValue>(
 
   return fn({
     controller: new AppStateController({
-      addUnlockListener: jest.fn(),
-      isUnlocked: jest.fn(() => true),
       onInactiveTimeout: jest.fn(),
       messenger: appStateMessenger,
       extension: extensionMock,

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -14,6 +14,10 @@ import {
 import { DeferredPromise, Json, createDeferredPromise } from '@metamask/utils';
 import type { QrScanRequest, SerializedUR } from '@metamask/eth-qr-keyring';
 import { Browser } from 'webextension-polyfill';
+import {
+  KeyringControllerGetStateAction,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
 import { MINUTE } from '../../../shared/constants/time';
 import { AUTO_LOCK_TIMEOUT_ALARM } from '../../../shared/constants/alarms';
 import { isManifestV3 } from '../../../shared/modules/mv3.utils';
@@ -111,6 +115,11 @@ export type AppStateControllerGetStateAction = ControllerGetStateAction<
   AppStateControllerState
 >;
 
+export type AppStateControllerGetUnlockPromiseAction = {
+  type: 'AppStateController:getUnlockPromise';
+  handler: (shouldShowUnlockRequest: boolean) => Promise<void>;
+};
+
 export type AppStateControllerRequestQrCodeScanAction = {
   type: 'AppStateController:requestQrCodeScan';
   handler: (request: QrScanRequest) => Promise<SerializedUR>;
@@ -121,14 +130,16 @@ export type AppStateControllerRequestQrCodeScanAction = {
  */
 export type AppStateControllerActions =
   | AppStateControllerGetStateAction
+  | AppStateControllerGetUnlockPromiseAction
   | AppStateControllerRequestQrCodeScanAction;
 
 /**
  * Actions that this controller is allowed to call.
  */
-type AllowedActions =
+export type AllowedActions =
   | AddApprovalRequest
   | AcceptRequest
+  | KeyringControllerGetStateAction
   | PreferencesControllerGetStateAction;
 
 /**
@@ -154,7 +165,9 @@ export type AppStateControllerEvents =
 /**
  * Events that this controller is allowed to subscribe.
  */
-type AllowedEvents = PreferencesControllerStateChangeEvent;
+export type AllowedEvents =
+  | KeyringControllerUnlockEvent
+  | PreferencesControllerStateChangeEvent;
 
 export type AppStateControllerMessenger = RestrictedMessenger<
   typeof controllerName,
@@ -180,8 +193,6 @@ type AppStateControllerInitState = Partial<
 >;
 
 export type AppStateControllerOptions = {
-  addUnlockListener: (callback: () => void) => void;
-  isUnlocked: () => boolean;
   state?: AppStateControllerInitState;
   onInactiveTimeout?: () => void;
   messenger: AppStateControllerMessenger;
@@ -527,8 +538,6 @@ export class AppStateController extends BaseController<
 
   #timer: NodeJS.Timeout | null;
 
-  isUnlocked: () => boolean;
-
   readonly waitingForUnlock: { resolve: () => void }[];
 
   #approvalRequestId: string | null;
@@ -538,8 +547,6 @@ export class AppStateController extends BaseController<
   constructor({
     state = {},
     messenger,
-    addUnlockListener,
-    isUnlocked,
     onInactiveTimeout,
     extension,
   }: AppStateControllerOptions) {
@@ -560,9 +567,12 @@ export class AppStateController extends BaseController<
     this.#onInactiveTimeout = onInactiveTimeout || (() => undefined);
     this.#timer = null;
 
-    this.isUnlocked = isUnlocked;
     this.waitingForUnlock = [];
-    addUnlockListener(this.#handleUnlock.bind(this));
+
+    messenger.subscribe(
+      'KeyringController:unlock',
+      this.#handleUnlock.bind(this),
+    );
 
     messenger.subscribe(
       'PreferencesController:stateChange',
@@ -583,6 +593,11 @@ export class AppStateController extends BaseController<
     }
 
     this.messagingSystem.registerActionHandler(
+      'AppStateController:getUnlockPromise',
+      this.getUnlockPromise.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
       'AppStateController:requestQrCodeScan',
       this.#requestQrCodeScan.bind(this),
     );
@@ -601,7 +616,11 @@ export class AppStateController extends BaseController<
    */
   getUnlockPromise(shouldShowUnlockRequest: boolean): Promise<void> {
     return new Promise((resolve) => {
-      if (this.isUnlocked()) {
+      const { isUnlocked } = this.messagingSystem.call(
+        'KeyringController:getState',
+      );
+
+      if (isUnlocked) {
         resolve();
       } else {
         this.#waitForUnlock(resolve, shouldShowUnlockRequest);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7413,7 +7413,7 @@ export default class MetamaskController extends EventEmitter {
           RestrictedMethods.wallet_snap,
         ),
         getIsLocked: () => {
-          const { isUnlocked } = this.messagingSystem.call(
+          const { isUnlocked } = this.controllerMessenger.call(
             'KeyringController:getState',
           );
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -275,8 +275,6 @@ import createTabIdMiddleware from './lib/createTabIdMiddleware';
 import { AccountOrderController } from './controllers/account-order';
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware';
 import { isStreamWritable, setupMultiplex } from './lib/stream-utils';
-import { PreferencesController } from './controllers/preferences-controller';
-import { AppStateController } from './controllers/app-state-controller';
 import { AlertController } from './controllers/alert-controller';
 import Backup from './lib/backup';
 import DecryptMessageController from './controllers/decrypt-message';
@@ -423,6 +421,8 @@ import { RemoteFeatureFlagControllerInit } from './controller-init/remote-featur
 import { SwapsControllerInit } from './controller-init/swaps-controller-init';
 import { BridgeControllerInit } from './controller-init/bridge-controller-init';
 import { BridgeStatusControllerInit } from './controller-init/bridge-status-controller-init';
+import { PreferencesControllerInit } from './controller-init/preferences-controller-init';
+import { AppStateControllerInit } from './controller-init/app-state-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -799,26 +799,6 @@ export default class MetamaskController extends EventEmitter {
       state: initState.AccountsController,
     });
 
-    const preferencesMessenger = this.controllerMessenger.getRestricted({
-      name: 'PreferencesController',
-      allowedActions: [
-        'AccountsController:setSelectedAccount',
-        'AccountsController:getSelectedAccount',
-        'AccountsController:getAccountByAddress',
-        'AccountsController:setAccountName',
-        'NetworkController:getState',
-      ],
-      allowedEvents: ['AccountsController:stateChange'],
-    });
-
-    this.preferencesController = new PreferencesController({
-      state: {
-        currentLocale: opts.initLangCode ?? '',
-        ...initState.PreferencesController,
-      },
-      messenger: preferencesMessenger,
-    });
-
     const dataDeletionService = new DataDeletionService();
     const metaMetricsDataDeletionMessenger =
       this.controllerMessenger.getRestricted({
@@ -832,24 +812,6 @@ export default class MetamaskController extends EventEmitter {
         messenger: metaMetricsDataDeletionMessenger,
         state: initState.metaMetricsDataDeletionController,
       });
-
-    const appStateControllerMessenger = this.controllerMessenger.getRestricted({
-      name: 'AppStateController',
-      allowedActions: [
-        `${this.approvalController.name}:addRequest`,
-        `${this.approvalController.name}:acceptRequest`,
-        `PreferencesController:getState`,
-      ],
-      allowedEvents: ['PreferencesController:stateChange'],
-    });
-    this.appStateController = new AppStateController({
-      addUnlockListener: this.on.bind(this, 'unlock'),
-      isUnlocked: this.isUnlocked.bind(this),
-      state: initState.AppStateController,
-      onInactiveTimeout: () => this.setLocked(),
-      messenger: appStateControllerMessenger,
-      extension: this.extension,
-    });
 
     const phishingControllerMessenger = this.controllerMessenger.getRestricted({
       name: 'PhishingController',
@@ -880,19 +842,6 @@ export default class MetamaskController extends EventEmitter {
       state: initState.AccountOrderController,
     });
 
-    this.controllerMessenger.subscribe(
-      'PreferencesController:stateChange',
-      previousValueComparator((prevState, currState) => {
-        const { useCurrencyRateCheck: prevUseCurrencyRateCheck } = prevState;
-        const { useCurrencyRateCheck: currUseCurrencyRateCheck } = currState;
-        if (currUseCurrencyRateCheck && !prevUseCurrencyRateCheck) {
-          this.tokenRatesController.enable();
-        } else if (!currUseCurrencyRateCheck && prevUseCurrencyRateCheck) {
-          this.tokenRatesController.disable();
-        }
-      }, this.preferencesController.state),
-    );
-
     const keyringOverrides = this.opts.overrides?.keyrings;
 
     const additionalKeyrings = [
@@ -901,7 +850,7 @@ export default class MetamaskController extends EventEmitter {
         keyringOverrides?.qrBridge || QrKeyringScannerBridge,
         {
           requestScan: async (request) =>
-            appStateControllerMessenger.call(
+            this.controllerMessenger.call(
               'AppStateController:requestQrCodeScan',
               request,
             ),
@@ -1125,17 +1074,6 @@ export default class MetamaskController extends EventEmitter {
       }),
     });
 
-    this.backup = new Backup({
-      preferencesController: this.preferencesController,
-      addressBookController: this.addressBookController,
-      accountsController: this.accountsController,
-      networkController: this.networkController,
-      trackMetaMetricsEvent: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'MetaMetricsController:trackEvent',
-      ),
-    });
-
     // This gets used as a ...spread parameter in two places: new TransactionController() and createRPCMethodTrackingMiddleware()
     this.snapAndHardwareMetricsParams = {
       getSelectedAccount: this.accountsController.getSelectedAccount.bind(
@@ -1277,42 +1215,16 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
-    // MultichainAccountService has subscription for preferences changes
-    this.controllerMessenger.subscribe(
-      'PreferencesController:stateChange',
-      previousValueComparator((prevState, currState) => {
-        const { useExternalServices: prevUseExternalServices } = prevState;
-        const { useExternalServices: currUseExternalServices } = currState;
-        if (prevUseExternalServices !== currUseExternalServices) {
-          // Set basic functionality and trigger alignment when enabled
-          // This single call handles both provider disable/enable and alignment
-          // Only call if MultichainAccountService is available (multichain builds)
-          if (this.multichainAccountService) {
-            this.controllerMessenger
-              .call(
-                'MultichainAccountService:setBasicFunctionality',
-                currUseExternalServices,
-              )
-              .catch((error) => {
-                console.error(
-                  'Failed to set basic functionality on MultichainAccountService:',
-                  error,
-                );
-              });
-          }
-        }
-      }, this.preferencesController.state),
-    );
-
     const existingControllers = [
       this.networkController,
-      this.preferencesController,
       this.keyringController,
       this.accountsController,
     ];
 
     /** @type {import('./controller-init/utils').InitFunctions} */
     const controllerInitFunctions = {
+      PreferencesController: PreferencesControllerInit,
+      AppStateController: AppStateControllerInit,
       MetaMetricsController: MetaMetricsControllerInit,
       RemoteFeatureFlagController: RemoteFeatureFlagControllerInit,
       GasFeeController: GasFeeControllerInit,
@@ -1388,6 +1300,8 @@ export default class MetamaskController extends EventEmitter {
     this.controllersByName = controllersByName;
 
     // Backwards compatibility for existing references
+    this.preferencesController = controllersByName.PreferencesController;
+    this.appStateController = controllersByName.AppStateController;
     this.metaMetricsController = controllersByName.MetaMetricsController;
     this.remoteFeatureFlagController =
       controllersByName.RemoteFeatureFlagController;
@@ -1451,6 +1365,17 @@ export default class MetamaskController extends EventEmitter {
       controllersByName.GatorPermissionsController;
     this.ensController = controllersByName.EnsController;
     this.nameController = controllersByName.NameController;
+
+    this.backup = new Backup({
+      preferencesController: this.preferencesController,
+      addressBookController: this.addressBookController,
+      accountsController: this.accountsController,
+      networkController: this.networkController,
+      trackMetaMetricsEvent: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'MetaMetricsController:trackEvent',
+      ),
+    });
 
     this.on('update', (update) => {
       this.metaMetricsController.handleMetaMaskStateUpdate(update);
@@ -1787,7 +1712,6 @@ export default class MetamaskController extends EventEmitter {
       AppStateController: this.appStateController,
       AppMetadataController: this.appMetadataController,
       KeyringController: this.keyringController,
-      PreferencesController: this.preferencesController,
       MetaMetricsController: this.metaMetricsController,
       MetaMetricsDataDeletionController: this.metaMetricsDataDeletionController,
       AddressBookController: this.addressBookController,
@@ -2235,8 +2159,9 @@ export default class MetamaskController extends EventEmitter {
               throw new Error(`Entropy source with ID "${source}" not found.`);
             }
           },
-          getUnlockPromise: this.appStateController.getUnlockPromise.bind(
-            this.appStateController,
+          getUnlockPromise: this.controllerMessenger.call.bind(
+            this.controllerMessenger,
+            'AppStateController:getUnlockPromise',
           ),
           getSnap: this.controllerMessenger.call.bind(
             this.controllerMessenger,
@@ -7444,8 +7369,9 @@ export default class MetamaskController extends EventEmitter {
           'SnapController:clearSnapState',
           origin,
         ),
-        getUnlockPromise: this.appStateController.getUnlockPromise.bind(
-          this.appStateController,
+        getUnlockPromise: this.controllerMessenger.call.bind(
+          this.controllerMessenger,
+          'AppStateController:getUnlockPromise',
         ),
         getSnaps: this.controllerMessenger.call.bind(
           this.controllerMessenger,
@@ -9185,6 +9111,7 @@ export default class MetamaskController extends EventEmitter {
       getStateUI: this._getMetaMaskState.bind(this),
       getTransactionMetricsRequest:
         this.getTransactionMetricsRequest.bind(this),
+      initLangCode: this.opts.initLangCode,
       updateAccountBalanceForTransactionNetwork:
         this.updateAccountBalanceForTransactionNetwork.bind(this),
       offscreenPromise: this.offscreenPromise,
@@ -9193,6 +9120,7 @@ export default class MetamaskController extends EventEmitter {
       removeAllConnections: this.removeAllConnections.bind(this),
       setupUntrustedCommunicationEip1193:
         this.setupUntrustedCommunicationEip1193.bind(this),
+      setLocked: this.setLocked.bind(this),
       showNotification: this.platform._showNotification,
       getAccountType: this.getAccountType.bind(this),
       getDeviceModel: this.getDeviceModel.bind(this),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1712,6 +1712,7 @@ export default class MetamaskController extends EventEmitter {
       AppStateController: this.appStateController,
       AppMetadataController: this.appMetadataController,
       KeyringController: this.keyringController,
+      PreferencesController: this.preferencesController,
       MetaMetricsController: this.metaMetricsController,
       MetaMetricsDataDeletionController: this.metaMetricsDataDeletionController,
       AddressBookController: this.addressBookController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7413,7 +7413,11 @@ export default class MetamaskController extends EventEmitter {
           RestrictedMethods.wallet_snap,
         ),
         getIsLocked: () => {
-          return !this.appStateController.isUnlocked();
+          const { isUnlocked } = this.messagingSystem.call(
+            'KeyringController:getState',
+          );
+
+          return !isUnlocked;
         },
         getIsActive: () => {
           return this._isClientOpen;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This migrates the app state and preferences controller to use the modular init pattern. In addition, I removed a lot of direct references to either of these controllers, to make this refactor possible. Where possible, a reference was replaced to use the messenger instead.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35610?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: #29530.

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
