### PR TITLE
test: fix Upload Artifacts step if the spec has a long name

### DIFF
--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -375,7 +375,7 @@ describe('Multichain API', function () {
             await testDapp.openTestDappPage();
             await testDapp.checkPageIsLoaded();
             await testDapp.connectExternallyConnectable(extensionId);
-            await testDapp.initCreateSessionScopes(['eip155:13f37']);
+            await testDapp.initCreateSessionScopes(['eip155:1337']);
 
             const connectAccountConfirmation = new ConnectAccountConfirmation(
               driver,

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -375,7 +375,7 @@ describe('Multichain API', function () {
             await testDapp.openTestDappPage();
             await testDapp.checkPageIsLoaded();
             await testDapp.connectExternallyConnectable(extensionId);
-            await testDapp.initCreateSessionScopes(['eip155:1337']);
+            await testDapp.initCreateSessionScopes(['eip155:13f37']);
 
             const connectAccountConfirmation = new ConnectAccountConfirmation(
               driver,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1650,7 +1650,10 @@ function collectMetrics() {
  * @param {string} testTitle - The title of the test
  */
 function sanitizeTestTitle(testTitle) {
-  return testTitle
+  // Maximum length for directory names (conservative limit to avoid filesystem issues)
+  const MAX_DIR_NAME_LENGTH = 200;
+
+  let sanitized = testTitle
     .toLowerCase()
     .replace(/[<>:"/\\|?*\r\n]/gu, '') // Remove invalid characters
     .trim()
@@ -1658,6 +1661,22 @@ function sanitizeTestTitle(testTitle) {
     .replace(/[^a-z0-9-]+/gu, '-') // Replace non-alphanumerics (excluding dash) with dash
     .replace(/--+/gu, '-') // Collapse multiple dashes
     .replace(/^-+|-+$/gu, ''); // Trim leading/trailing dashes
+
+  // Truncate if too long, but try to break at word boundaries (dashes)
+  if (sanitized.length > MAX_DIR_NAME_LENGTH) {
+    let truncated = sanitized.substring(0, MAX_DIR_NAME_LENGTH);
+
+    // Try to find the last dash to break at a word boundary
+    const lastDashIndex = truncated.lastIndexOf('-');
+    if (lastDashIndex > MAX_DIR_NAME_LENGTH * 0.7) { // Only use dash if it's not too far back
+      truncated = truncated.substring(0, lastDashIndex);
+    }
+
+    // Clean up any trailing dashes
+    sanitized = truncated.replace(/-+$/gu, '');
+  }
+
+  return sanitized;
 }
 
 module.exports = { Driver, PAGES, errorMessages };

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1667,8 +1667,9 @@ function sanitizeTestTitle(testTitle) {
     let truncated = sanitized.substring(0, MAX_DIR_NAME_LENGTH);
 
     // Try to find the last dash to break at a word boundary
+    // and only use dash if it's not too far back
     const lastDashIndex = truncated.lastIndexOf('-');
-    if (lastDashIndex > MAX_DIR_NAME_LENGTH * 0.7) { // Only use dash if it's not too far back
+    if (lastDashIndex > MAX_DIR_NAME_LENGTH * 0.7) {
       truncated = truncated.substring(0, lastDashIndex);
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Whenever there's a spec that has a long name, if that spec fails, we cannot upload the artifacts due to the file system limitation of a long directory:

`Error: ENAMETOOLONG: name too long, mkdir './test-artifacts/chrome/multichain-api-dapp-has-existing-session-with-2-scopes-and-1-account-and-then-calls-wallet-createsession-with-different-scopes-and-accounts-should-include-old-session-permissions-as-pre-selected-in-the-connection-screen-along-with-those-requested-in-the-new-wallet-createsession-request'`


See example of failure [here](https://github.com/MetaMask/metamask-extension/actions/runs/17385999453/job/49352835527) (you need to unfold the Run e2e steps and look for the error)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35612?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35585

## **Manual testing steps**

1. See run with long failing test

https://github.com/MetaMask/metamask-extension/actions/runs/17432293983/job/49494178862?pr=35612

go to Artifacts download them and see that you have a folder correctly created (with shortened name)


<img width="912" height="277" alt="Screenshot from 2025-09-03 13-58-03" src="https://github.com/user-attachments/assets/5e58e2c2-b418-4c3a-ac9d-72aa39db1f40" />

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="2425" height="548" alt="Screenshot from 2025-09-03 13-26-28" src="https://github.com/user-attachments/assets/8fb96929-0318-4a55-9cc9-6462e88f9370" />


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
