### PR TITLE
feat: remove INJECT_ONCE - make it self-contained instead

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -52,20 +52,4 @@ const start = () => {
   }
 };
 
-(function () {
-  let once = false;
-  Object.defineProperty(document, 'INJECT_ONCE', {
-    value: (textContent) => {
-      if (once) {
-        return;
-      }
-      once = true;
-      const d = document;
-      const s = d.createElement('script');
-      s.textContent = textContent;
-      d.documentElement.appendChild(s).remove();
-    },
-  });
-})();
-
 start();

--- a/development/webpack/utils/plugins/SelfInjectPlugin/index.ts
+++ b/development/webpack/utils/plugins/SelfInjectPlugin/index.ts
@@ -144,9 +144,9 @@ export class SelfInjectPlugin {
 
     // generate the new self-injecting source code:
     const newSource = new ConcatSource();
-    newSource.add(`;(function (d, textContent)  {
+    newSource.add(`;(function (d, code)  {
   const s = d.createElement('script');
-  s.textContent = textContent;
+  s.textContent = code;
   d.documentElement.appendChild(s).remove();
 })(document,`);
     newSource.add(this.escapeJs(source + sourceMappingURLComment));

--- a/development/webpack/utils/plugins/SelfInjectPlugin/index.ts
+++ b/development/webpack/utils/plugins/SelfInjectPlugin/index.ts
@@ -144,7 +144,11 @@ export class SelfInjectPlugin {
 
     // generate the new self-injecting source code:
     const newSource = new ConcatSource();
-    newSource.add(`document.INJECT_ONCE(`);
+    newSource.add(`;(function (d, textContent)  {
+  const s = d.createElement('script');
+  s.textContent = textContent;
+  d.documentElement.appendChild(s).remove();
+})(document,`);
     newSource.add(this.escapeJs(source + sourceMappingURLComment));
     newSource.add(`);`);
 

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -102,7 +102,6 @@ const cache = args.cache
 // #region plugins
 const commitHash = isDevelopment ? getLatestCommit().hash() : null;
 const plugins: WebpackPluginInstance[] = [
-  new SelfInjectPlugin({ test: /^scripts\/inpage\.js$/u }),
   // HtmlBundlerPlugin treats HTML files as entry points
   new HtmlBundlerPlugin({
     preprocessorOptions: { useWith: false },
@@ -177,6 +176,13 @@ const plugins: WebpackPluginInstance[] = [
     ],
   }),
 ];
+if (MANIFEST_VERSION === 2) {
+  plugins.push(
+    new SelfInjectPlugin({
+      test: /^scripts\/inpage\.js$/u,
+    }),
+  );
+}
 if (args.lavamoat) {
   const { lavamoatPlugin } = require('./utils/plugins/LavamoatPlugin');
   plugins.push(lavamoatPlugin(args));


### PR DESCRIPTION
never really needed it?

might be a fix for #35465 

TODO:
- [x] handle selectively using the SelfInject only for mv2 (either by splitting the output file names or making the plugin conditional on manifest version
