### PR TITLE
feat: Add search functionality to the Multichain Account List page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5197,6 +5197,10 @@
   "searchTokensByNameOrAddress": {
     "message": "Search tokens by name or address"
   },
+  "searchYourAccounts": {
+    "message": "Search your accounts",
+    "description": "Placeholder in a searchbar. Used on multichain account list page."
+  },
   "secretRecoveryPhrase": {
     "message": "Secret Recovery Phrase"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5197,6 +5197,10 @@
   "searchTokensByNameOrAddress": {
     "message": "Search tokens by name or address"
   },
+  "searchYourAccounts": {
+    "message": "Search your accounts",
+    "description": "Placeholder in a searchbar. Used on multichain account list page."
+  },
   "secretRecoveryPhrase": {
     "message": "Secret Recovery Phrase"
   },

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -153,6 +153,22 @@ describe('MultichainAccountList', () => {
     expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
   });
 
+  it('does not render wallet headers based on prop', () => {
+    renderComponent({ displayWalletHeader: false });
+
+    expect(screen.queryByText('Wallet 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Wallet 2')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Account 1 from wallet 1')).toBeInTheDocument();
+    expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
+  });
+
   it('marks only the selected account with a check icon and dispatches action on click', () => {
     renderComponent();
 
@@ -237,7 +253,7 @@ describe('MultichainAccountList', () => {
     renderComponent({ wallets: multiGroupWallets });
 
     expect(
-      screen.getAllByTestId('multichain-account-tree-wallet-header'),
+      screen.queryAllByTestId('multichain-account-tree-wallet-header'),
     ).toHaveLength(1);
     expect(
       screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -42,7 +42,7 @@ export type MultichainAccountListProps = {
   selectedAccountGroups: AccountGroupId[];
   handleAccountClick?: (accountGroupId: AccountGroupId) => void;
   isInSearchMode?: boolean;
-  hasMultipleWallets?: boolean;
+  displayWalletHeader?: boolean;
 };
 
 export const MultichainAccountList = ({
@@ -50,7 +50,7 @@ export const MultichainAccountList = ({
   selectedAccountGroups,
   handleAccountClick,
   isInSearchMode = false,
-  hasMultipleWallets,
+  displayWalletHeader = true,
 }: MultichainAccountListProps) => {
   const dispatch = useDispatch();
   const history = useHistory();
@@ -159,7 +159,7 @@ export const MultichainAccountList = ({
 
         return [
           ...walletsAccumulator,
-          hasMultipleWallets ? walletHeader : null,
+          displayWalletHeader ? walletHeader : null,
           ...groupsItems,
         ];
       },

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -173,6 +173,8 @@ export const MultichainAccountList = ({
     defaultHomeActiveTabName,
     dispatch,
     history,
+    isInSearchMode,
+    displayWalletHeader,
     selectedAccountGroupsSet,
   ]);
 

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -41,12 +41,16 @@ export type MultichainAccountListProps = {
   wallets: AccountTreeWallets;
   selectedAccountGroups: AccountGroupId[];
   handleAccountClick?: (accountGroupId: AccountGroupId) => void;
+  isInSearchMode?: boolean;
+  hasMultipleWallets?: boolean;
 };
 
 export const MultichainAccountList = ({
   wallets,
   selectedAccountGroups,
   handleAccountClick,
+  isInSearchMode = false,
+  hasMultipleWallets,
 }: MultichainAccountListProps) => {
   const dispatch = useDispatch();
   const history = useHistory();
@@ -144,7 +148,7 @@ export const MultichainAccountList = ({
           },
         );
 
-        if (walletData.type === AccountWalletType.Entropy) {
+        if (!isInSearchMode && walletData.type === AccountWalletType.Entropy) {
           groupsItems.push(
             <AddMultichainAccount
               walletId={walletId as AccountWalletId}
@@ -153,7 +157,11 @@ export const MultichainAccountList = ({
           );
         }
 
-        return [...walletsAccumulator, walletHeader, ...groupsItems];
+        return [
+          ...walletsAccumulator,
+          hasMultipleWallets ? walletHeader : null,
+          ...groupsItems,
+        ];
       },
       [] as React.ReactNode[],
     );

--- a/ui/pages/multichain-accounts/account-list/account-list.test.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.test.tsx
@@ -26,44 +26,6 @@ describe('AccountList', () => {
     const store = configureStore({
       metamask: {
         ...mockState.metamask,
-        accountTree: {
-          selectedAccountGroup: '01JKAF3DSGM3AB87EM9N0K41AJ:default',
-          wallets: {
-            '01JKAF3DSGM3AB87EM9N0K41AJ': {
-              id: '01JKAF3DSGM3AB87EM9N0K41AJ',
-              metadata: {
-                name: 'Wallet 1',
-              },
-              groups: {
-                '01JKAF3DSGM3AB87EM9N0K41AJ:default': {
-                  id: '01JKAF3DSGM3AB87EM9N0K41AJ:default',
-                  metadata: {
-                    name: 'Account 1 from wallet 1',
-                  },
-                  accounts: [
-                    'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-                    '07c2cfec-36c9-46c4-8115-3836d3ac9047',
-                  ],
-                },
-              },
-            },
-            '01JKAF3PJ247KAM6C03G5Q0NP8': {
-              id: '01JKAF3PJ247KAM6C03G5Q0NP8',
-              metadata: {
-                name: 'Wallet 2',
-              },
-              groups: {
-                '01JKAF3PJ247KAM6C03G5Q0NP8:default': {
-                  id: '01JKAF3PJ247KAM6C03G5Q0NP8:default',
-                  metadata: {
-                    name: 'Account 1 from wallet 2',
-                  },
-                  accounts: ['784225f4-d30b-4e77-a900-c8bbce735b88'],
-                },
-              },
-            },
-          },
-        },
       },
     });
 
@@ -80,11 +42,11 @@ describe('AccountList', () => {
       'multichain-account-tree-wallet-header',
     );
 
-    expect(walletHeaders.length).toBe(2);
+    expect(walletHeaders.length).toBe(5);
     expect(screen.getByText('Wallet 1')).toBeInTheDocument();
     expect(screen.getByText('Wallet 2')).toBeInTheDocument();
-    expect(screen.getByText('Account 1 from wallet 1')).toBeInTheDocument();
-    expect(screen.getByText('Account 1 from wallet 2')).toBeInTheDocument();
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(screen.getByText('Account 2')).toBeInTheDocument();
   });
 
   it('calls history.goBack when back button is clicked', () => {

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -23,6 +23,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MultichainAccountList } from '../../../components/multichain-accounts/multichain-account-list';
 import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';
 import { AddWalletModal } from '../../../components/multichain-accounts/add-wallet-modal';
+import { filterWalletsByGroupName } from './utils';
 
 export const AccountList = () => {
   const t = useI18nContext();
@@ -30,6 +31,17 @@ export const AccountList = () => {
   const accountTree = useSelector(getAccountTree);
   const { wallets } = accountTree;
   const { selectedAccountGroup } = accountTree;
+  const [searchPattern, setSearchPattern] = useState<string>('');
+
+  const onSearchBarChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setSearchPattern(e.target.value),
+    [],
+  );
+
+  const filteredWallets = useMemo(() => {
+    return filterWalletsByGroupName(wallets, searchPattern);
+  }, [wallets, searchPattern]);
 
   const [isAddWalletModalOpen, setIsAddWalletModalOpen] = useState(false);
 
@@ -59,11 +71,47 @@ export const AccountList = () => {
         {t('accounts')}
       </Header>
       <Content className="account-list-page__content">
-        <Box flexDirection={BoxFlexDirection.Column}>
-          <MultichainAccountList
-            wallets={wallets}
-            selectedAccountGroups={[selectedAccountGroup]}
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          paddingLeft={4}
+          paddingRight={4}
+          paddingBottom={2}
+        >
+          <TextFieldSearch
+            size={TextFieldSearchSize.Lg}
+            placeholder={t('searchYourAccounts')}
+            value={searchPattern}
+            onChange={onSearchBarChange}
+            clearButtonOnClick={() => setSearchPattern('')}
+            width={BlockSize.Full}
+            borderWidth={0}
+            backgroundColor={BackgroundColor.backgroundMuted}
+            borderRadius={BorderRadius.LG}
+            data-testid="multichain-account-list-search"
           />
+        </Box>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          height={BlockSize.Full}
+        >
+          {Object.keys(filteredWallets).length > 0 ? (
+            <MultichainAccountList
+              wallets={filteredWallets}
+              selectedAccountGroups={[selectedAccountGroup]}
+            />
+          ) : (
+            <Box
+              display={Display.Flex}
+              justifyContent={JustifyContent.center}
+              alignItems={AlignItems.center}
+              width={BlockSize.Full}
+              height={BlockSize.Full}
+            >
+              <Text>{t('noAccountsFound')}</Text>
+            </Box>
+          )}
         </Box>
       </Content>
       <Footer className="shadow-sm">

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
@@ -6,8 +6,6 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-  Box,
-  BoxFlexDirection,
   ButtonIcon,
   ButtonIconSize,
   IconName,
@@ -18,11 +16,26 @@ import {
   Header,
   Page,
 } from '../../../components/multichain/pages/page';
-import { TextVariant } from '../../../helpers/constants/design-system';
+import {
+  AlignItems,
+  BackgroundColor,
+  BlockSize,
+  BorderRadius,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MultichainAccountList } from '../../../components/multichain-accounts/multichain-account-list';
 import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';
 import { AddWalletModal } from '../../../components/multichain-accounts/add-wallet-modal';
+import {
+  TextFieldSearch,
+  TextFieldSearchSize,
+  Text,
+  Box,
+} from '../../../components/component-library';
 import { filterWalletsByGroupName } from './utils';
 
 export const AccountList = () => {
@@ -72,7 +85,6 @@ export const AccountList = () => {
       </Header>
       <Content className="account-list-page__content">
         <Box
-          display={Display.Flex}
           flexDirection={FlexDirection.Column}
           paddingLeft={4}
           paddingRight={4}
@@ -93,8 +105,8 @@ export const AccountList = () => {
         </Box>
         <Box
           display={Display.Flex}
-          flexDirection={FlexDirection.Column}
           height={BlockSize.Full}
+          flexDirection={FlexDirection.Column}
         >
           {Object.keys(filteredWallets).length > 0 ? (
             <MultichainAccountList

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -47,6 +47,11 @@ export const AccountList = () => {
   const { selectedAccountGroup } = accountTree;
   const [searchPattern, setSearchPattern] = useState<string>('');
 
+  const hasMultipleWallets = useMemo(
+    () => Object.keys(wallets).length > 1,
+    [wallets],
+  );
+
   const onSearchBarChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) =>
       setSearchPattern(e.target.value),
@@ -118,6 +123,8 @@ export const AccountList = () => {
             <MultichainAccountList
               wallets={filteredWallets}
               selectedAccountGroups={[selectedAccountGroup]}
+              isInSearchMode={Boolean(searchPattern)}
+              hasMultipleWallets={hasMultipleWallets}
             />
           ) : (
             <Box

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -24,6 +24,7 @@ import {
   Display,
   FlexDirection,
   JustifyContent,
+  TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -55,6 +56,11 @@ export const AccountList = () => {
   const filteredWallets = useMemo(() => {
     return filterWalletsByGroupName(wallets, searchPattern);
   }, [wallets, searchPattern]);
+
+  const hasFilteredWallets = useMemo(
+    () => Object.keys(filteredWallets).length > 0,
+    [filteredWallets],
+  );
 
   const [isAddWalletModalOpen, setIsAddWalletModalOpen] = useState(false);
 
@@ -108,7 +114,7 @@ export const AccountList = () => {
           height={BlockSize.Full}
           flexDirection={FlexDirection.Column}
         >
-          {Object.keys(filteredWallets).length > 0 ? (
+          {hasFilteredWallets ? (
             <MultichainAccountList
               wallets={filteredWallets}
               selectedAccountGroups={[selectedAccountGroup]}
@@ -121,7 +127,12 @@ export const AccountList = () => {
               width={BlockSize.Full}
               height={BlockSize.Full}
             >
-              <Text>{t('noAccountsFound')}</Text>
+              <Text
+                color={TextColor.textAlternative}
+                variant={TextVariant.bodyMdMedium}
+              >
+                {t('noAccountsFound')}
+              </Text>
             </Box>
           )}
         </Box>

--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -124,7 +124,7 @@ export const AccountList = () => {
               wallets={filteredWallets}
               selectedAccountGroups={[selectedAccountGroup]}
               isInSearchMode={Boolean(searchPattern)}
-              hasMultipleWallets={hasMultipleWallets}
+              displayWalletHeader={hasMultipleWallets}
             />
           ) : (
             <Box

--- a/ui/pages/multichain-accounts/account-list/utils.test.ts
+++ b/ui/pages/multichain-accounts/account-list/utils.test.ts
@@ -1,0 +1,65 @@
+import mockState from '../../../../test/data/mock-state.json';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+import { filterWalletsByGroupName } from './utils';
+
+describe('filterWalletsByGroupName', () => {
+  const mockWallets: AccountTreeWallets = mockState.metamask.accountTree
+    .wallets as unknown as AccountTreeWallets;
+
+  it('should return original wallets when search pattern is empty', () => {
+    const result = filterWalletsByGroupName(mockWallets, '');
+    expect(result).toBe(mockWallets);
+
+    const resultWithSpaces = filterWalletsByGroupName(mockWallets, '   ');
+    expect(resultWithSpaces).toBe(mockWallets);
+  });
+
+  it('should filter wallets to only include groups with matching names', () => {
+    const result = filterWalletsByGroupName(mockWallets, 'Account 2');
+
+    expect(Object.keys(result)).toHaveLength(1);
+    expect(result['entropy:01JKAF3PJ247KAM6C03G5Q0NP8']).toBeDefined();
+
+    const wallet = result['entropy:01JKAF3PJ247KAM6C03G5Q0NP8'];
+    expect(Object.keys(wallet.groups)).toHaveLength(1);
+    expect(wallet.groups['entropy:01JKAF3PJ247KAM6C03G5Q0NP8/0']).toBeDefined();
+  });
+
+  it('should filter wallets to only include groups with partially matching names', () => {
+    const result = filterWalletsByGroupName(mockWallets, 'Account');
+
+    expect(Object.keys(result)).toHaveLength(5);
+  });
+
+  it('should handle case-insensitive search', () => {
+    const result1 = filterWalletsByGroupName(mockWallets, 'ACCOUNT 2');
+    const result2 = filterWalletsByGroupName(mockWallets, 'account 2');
+
+    expect(Object.keys(result1)).toEqual(Object.keys(result2));
+    expect(result1).toEqual(result2);
+    expect(Object.keys(result1)).toHaveLength(1);
+  });
+
+  it('should trim search pattern before matching', () => {
+    const result = filterWalletsByGroupName(mockWallets, '  Account 2  ');
+
+    expect(Object.keys(result)).toHaveLength(1);
+    expect(result['entropy:01JKAF3PJ247KAM6C03G5Q0NP8']).toBeDefined();
+  });
+
+  it('should return empty object when no matches are found', () => {
+    const result = filterWalletsByGroupName(mockWallets, 'nonexistent');
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should preserve wallet properties in filtered results', () => {
+    const result = filterWalletsByGroupName(mockWallets, 'Account 1');
+    const originalWallet = mockWallets['entropy:01JKAF3DSGM3AB87EM9N0K41AJ'];
+    const filteredWallet = result['entropy:01JKAF3DSGM3AB87EM9N0K41AJ'];
+
+    expect(filteredWallet.id).toBe(originalWallet.id);
+    expect(filteredWallet.type).toBe(originalWallet.type);
+    expect(filteredWallet.metadata).toEqual(originalWallet.metadata);
+  });
+});

--- a/ui/pages/multichain-accounts/account-list/utils.test.ts
+++ b/ui/pages/multichain-accounts/account-list/utils.test.ts
@@ -6,7 +6,7 @@ describe('filterWalletsByGroupName', () => {
   const mockWallets: AccountTreeWallets = mockState.metamask.accountTree
     .wallets as unknown as AccountTreeWallets;
 
-  it('should return original wallets when search pattern is empty', () => {
+  it('returns original wallets when search pattern is empty', () => {
     const result = filterWalletsByGroupName(mockWallets, '');
     expect(result).toBe(mockWallets);
 
@@ -14,7 +14,7 @@ describe('filterWalletsByGroupName', () => {
     expect(resultWithSpaces).toBe(mockWallets);
   });
 
-  it('should filter wallets to only include groups with matching names', () => {
+  it('filters wallets to only include groups with matching names', () => {
     const result = filterWalletsByGroupName(mockWallets, 'Account 2');
 
     expect(Object.keys(result)).toHaveLength(1);
@@ -25,13 +25,13 @@ describe('filterWalletsByGroupName', () => {
     expect(wallet.groups['entropy:01JKAF3PJ247KAM6C03G5Q0NP8/0']).toBeDefined();
   });
 
-  it('should filter wallets to only include groups with partially matching names', () => {
+  it('filters wallets to only include groups with partially matching names', () => {
     const result = filterWalletsByGroupName(mockWallets, 'Account');
 
     expect(Object.keys(result)).toHaveLength(5);
   });
 
-  it('should handle case-insensitive search', () => {
+  it('handles case-insensitive search', () => {
     const result1 = filterWalletsByGroupName(mockWallets, 'ACCOUNT 2');
     const result2 = filterWalletsByGroupName(mockWallets, 'account 2');
 
@@ -40,20 +40,20 @@ describe('filterWalletsByGroupName', () => {
     expect(Object.keys(result1)).toHaveLength(1);
   });
 
-  it('should trim search pattern before matching', () => {
+  it('trims search pattern before matching', () => {
     const result = filterWalletsByGroupName(mockWallets, '  Account 2  ');
 
     expect(Object.keys(result)).toHaveLength(1);
     expect(result['entropy:01JKAF3PJ247KAM6C03G5Q0NP8']).toBeDefined();
   });
 
-  it('should return empty object when no matches are found', () => {
+  it('returns empty object when no matches are found', () => {
     const result = filterWalletsByGroupName(mockWallets, 'nonexistent');
 
     expect(Object.keys(result)).toHaveLength(0);
   });
 
-  it('should preserve wallet properties in filtered results', () => {
+  it('preserves wallet properties in filtered results', () => {
     const result = filterWalletsByGroupName(mockWallets, 'Account 1');
     const originalWallet = mockWallets['entropy:01JKAF3DSGM3AB87EM9N0K41AJ'];
     const filteredWallet = result['entropy:01JKAF3DSGM3AB87EM9N0K41AJ'];

--- a/ui/pages/multichain-accounts/account-list/utils.ts
+++ b/ui/pages/multichain-accounts/account-list/utils.ts
@@ -1,0 +1,46 @@
+import { AccountWalletId } from '@metamask/account-api';
+import { AccountTreeWallets } from '../../../selectors/multichain-accounts/account-tree.types';
+
+/**
+ * Filter wallets based on a search pattern, returning only wallets that have groups
+ * with account names matching the search pattern.
+ *
+ * @param wallets - The wallets collection to filter.
+ * @param searchPattern - The search pattern to match group names against.
+ * @returns Filtered wallets containing only groups that match the search pattern.
+ */
+export function filterWalletsByGroupName(
+  wallets: AccountTreeWallets,
+  searchPattern: string,
+): AccountTreeWallets {
+  if (!searchPattern.trim()) {
+    return wallets;
+  }
+
+  const normalizedSearchPattern = searchPattern.trim().toLowerCase();
+  const result: AccountTreeWallets = {};
+
+  Object.entries(wallets).forEach(([walletId, wallet]) => {
+    const hasMatchingGroup = Object.values(wallet.groups || {}).some(
+      (group) => {
+        const groupName = group.metadata?.name;
+        return groupName?.toLowerCase().includes(normalizedSearchPattern);
+      },
+    );
+
+    if (hasMatchingGroup) {
+      // Recreate a new wallet with filtered groups
+      result[walletId as AccountWalletId] = {
+        ...wallet,
+        groups: Object.fromEntries(
+          Object.entries(wallet.groups || {}).filter(([_, group]) => {
+            const groupName = group.metadata?.name;
+            return groupName?.toLowerCase().includes(normalizedSearchPattern);
+          }),
+        ),
+      };
+    }
+  });
+
+  return result;
+}

--- a/ui/pages/multichain-accounts/account-list/utils.ts
+++ b/ui/pages/multichain-accounts/account-list/utils.ts
@@ -14,11 +14,11 @@ export function filterWalletsByGroupName(
   wallets: AccountTreeWallets,
   searchPattern: string,
 ): AccountTreeWallets {
-  if (!searchPattern.trim()) {
+  const normalizedSearchPattern = searchPattern.trim().toLowerCase();
+
+  if (!normalizedSearchPattern) {
     return wallets;
   }
-
-  const normalizedSearchPattern = searchPattern.trim().toLowerCase();
 
   return Object.entries(wallets).reduce((result, [walletId, wallet]) => {
     const filteredGroups = Object.entries(wallet.groups || {}).reduce(


### PR DESCRIPTION
## **Description**
This PR adds search functionality implementation for the Multichain Account List.

Notes:
- Improvement for hiding wallet header for singular wallet is added (it was initial requirement for the list).
- Create new account button is removed in search mode, as it doesn't make much sense to create account which name will be filtered already (not visible).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35616?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added search functionality to the Multichain Account List

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-370

## **Manual testing steps**
1. Go to multichain account list page while multichain state 2 feature flag is enabled.
2. Test search by typing account names in the search bar.

## **Screenshots/Recordings**
### **Before**
Search was not available before. Nothing to show here.

### **After**
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 25 22" src="https://github.com/user-attachments/assets/ed2d682d-2a31-488d-8ab6-0a8edf703570" />
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 25 40" src="https://github.com/user-attachments/assets/1c0faaf4-51b6-473d-ace8-02a07df9e12a" />
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 26 43" src="https://github.com/user-attachments/assets/3ade76ca-304a-4b13-9962-a2745c66f50d" />
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 25 02" src="https://github.com/user-attachments/assets/70e1ab83-6a12-4293-b8d0-f5190bac9930" />
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 26 02" src="https://github.com/user-attachments/assets/3b782a0e-3722-40ae-8724-b3e251f6b8ef" />
<img width="398" height="602" alt="Screenshot 2025-09-04 at 12 26 34" src="https://github.com/user-attachments/assets/01d5dcd1-6c0a-4fc6-841e-780c817756e0" />


https://github.com/user-attachments/assets/84ad68a1-4445-4d2a-bc5e-99bacdb63741


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.