### PR TITLE
test: fix flaky test `Phishing Detection should display the MetaMask Phishing Detection page and take the user to the blocked page if they continue`

### DIFF
--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -9,7 +9,7 @@ const {
   unlockWallet,
   WINDOW_TITLES,
   createWebSocketConnection,
-  largeDelayMs,
+  veryLargeDelayMs,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const {
@@ -58,7 +58,7 @@ describe('Phishing Detection', function () {
         await unlockWallet(driver);
         await openDapp(driver);
         // To mitigate a race condition where 2 requests are made to the localhost:8080 which triggers a page refresh
-        await driver.delay(largeDelayMs);
+        await driver.delay(veryLargeDelayMs);
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
 
         // we need to wait for this selector to mitigate a race condition on the phishing page site

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -9,6 +9,7 @@ const {
   unlockWallet,
   WINDOW_TITLES,
   createWebSocketConnection,
+  largeDelayMs,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 const {
@@ -56,6 +57,8 @@ describe('Phishing Detection', function () {
       async ({ driver }) => {
         await unlockWallet(driver);
         await openDapp(driver);
+        // To mitigate a race condition where 2 requests are made to the localhost:8080 which triggers a page refresh
+        await driver.delay(largeDelayMs);
         await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
 
         // we need to wait for this selector to mitigate a race condition on the phishing page site


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This test is flaky because sometimes, 2 requests to the test dapp (localhost:8080) are triggered instead of 1.
This causes that the phishing detection redirects the first request to the phishing page, and whenever we click on the Continue button to go to the site, it redirects the second request to the phishing page again, causing the test to fail because it cannot locate the test dapp elements.

After checking both in the test side (navigate) and in the app side, it seems that the only place where this request could be triggered twice is at the webdriver internal logic level. 

Browser starts navigating but something goes wrong (ie there's a very quick redirect) WebDriver automatically retries the navigation ~ 650ms later. It's common when page load is interrupted, which could be this case (as we quickly redirect the user to the phishing page).

Given we cannot wait for any condition, a delay is added to account for the refresh if 2 requests happen.


See logs added while debugging, when a page refresh happened:

<img width="1122" height="120" alt="Screenshot from 2025-09-03 16-26-57" src="https://github.com/user-attachments/assets/607a5139-e97f-4a0f-aaf6-f8671a494935" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35622?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci or run manually

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

You can see the quick refresh:


https://github.com/user-attachments/assets/17950f80-4df8-4aed-94eb-ed9164df6105



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
