### PR TITLE
feat: Use gasUsed from simulation for user facing network fee estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
     "@metamask/solana-wallet-snap": "^2.3.4",
     "@metamask/solana-wallet-standard": "^0.5.1",
     "@metamask/streams": "^0.4.0",
-    "@metamask/transaction-controller": "^60.1.0",
+    "@metamask/transaction-controller": "^60.2.0",
     "@metamask/user-operation-controller": "^38.0.0",
     "@metamask/utils": "^11.4.2",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -1,5 +1,6 @@
-import { merge } from 'lodash';
+import { toHex } from '@metamask/controller-utils';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { merge } from 'lodash';
 import {
   CONTRACT_INTERACTION_SENDER_ADDRESS,
   genUnapprovedContractInteractionConfirmation,
@@ -118,36 +119,68 @@ describe('useFeeCalculations', () => {
     `);
   });
 
-  it('picks up gasLimitNoBuffer for minimum network fee on estimations', () => {
+  it('picks up gasLimitNoBuffer for estimations', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
     }) as TransactionMeta;
 
-    // txParams.gas is 0xab77
-    transactionMeta.gasLimitNoBuffer = '0x9b77';
+    // txParams.gas is 0xab77 or 43895 in decimals
+    transactionMeta.gasLimitNoBuffer = toHex(39799);
 
     const { result } = renderHookWithProvider(
       () => useFeeCalculations(transactionMeta),
       mockState,
     );
 
-    expect(result.current).toMatchInlineSnapshot(`
-      {
-        "estimatedFeeFiat": "$0.03",
-        "estimatedFeeFiatWith18SignificantDigits": null,
-        "estimatedFeeNative": "0.0001",
-        "estimatedFeeNativeHex": "0x364ba3e2d900",
-        "l1FeeFiat": "",
-        "l1FeeFiatWith18SignificantDigits": "",
-        "l1FeeNative": "",
-        "l2FeeFiat": "",
-        "l2FeeFiatWith18SignificantDigits": "",
-        "l2FeeNative": "",
-        "maxFeeFiat": "$0.07",
-        "maxFeeFiatWith18SignificantDigits": null,
-        "maxFeeNative": "0.0001",
-      }
-    `);
+    // The following assertions are meant as a snapshot test. These are
+    // currently unavailable after the prettier upgrade to v3, so I'm asserting
+    // each property individually instead.
+    expect(result.current.estimatedFeeFiat).toBe('$0.03');
+    expect(result.current.estimatedFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.estimatedFeeNative).toBe('0.0001');
+    expect(result.current.estimatedFeeNativeHex).toBe('0x364ba3e2d900');
+    expect(result.current.l1FeeFiat).toBe('');
+    expect(result.current.l1FeeFiatWith18SignificantDigits).toBe('');
+    expect(result.current.l1FeeNative).toBe('');
+    expect(result.current.l2FeeFiat).toBe('');
+    expect(result.current.l2FeeFiatWith18SignificantDigits).toBe('');
+    expect(result.current.l2FeeNative).toBe('');
+    expect(result.current.maxFeeFiat).toBe('$0.06');
+    expect(result.current.maxFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.maxFeeNative).toBe('0.0001');
+  });
+
+  it('picks up gasUsed for network fee on estimations', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+    }) as TransactionMeta;
+
+    // txParams.gas is 0xab77 or 43895 in decimals
+    // gas used is lower than the gasLimitNoBuffer in the test above
+    // so the estimates should be lower
+    transactionMeta.gasUsed = toHex(37000);
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculations(transactionMeta),
+      mockState,
+    );
+
+    // The following assertions are meant as a snapshot test. These are
+    // currently unavailable after the prettier upgrade to v3, so I'm asserting
+    // each property individually instead.
+    expect(result.current.estimatedFeeFiat).toBe('$0.03');
+    expect(result.current.estimatedFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.estimatedFeeNative).toBe('0.0001');
+    expect(result.current.estimatedFeeNativeHex).toBe('0x327a19c8f800');
+    expect(result.current.l1FeeFiat).toBe('');
+    expect(result.current.l1FeeFiatWith18SignificantDigits).toBe('');
+    expect(result.current.l1FeeNative).toBe('');
+    expect(result.current.l2FeeFiat).toBe('');
+    expect(result.current.l2FeeFiatWith18SignificantDigits).toBe('');
+    expect(result.current.l2FeeNative).toBe('');
+    expect(result.current.maxFeeFiat).toBe('$0.06');
+    expect(result.current.maxFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.maxFeeNative).toBe('0.0001');
   });
 
   it('returns the correct estimate for a transaction with layer1GasFee', () => {
@@ -162,22 +195,21 @@ describe('useFeeCalculations', () => {
       mockState,
     );
 
-    expect(result.current).toMatchInlineSnapshot(`
-      {
-        "estimatedFeeFiat": "$2.54",
-        "estimatedFeeFiatWith18SignificantDigits": null,
-        "estimatedFeeNative": "0.0046",
-        "estimatedFeeNativeHex": "0x103be226d2d900",
-        "l1FeeFiat": "$2.50",
-        "l1FeeFiatWith18SignificantDigits": null,
-        "l1FeeNative": "0.0045",
-        "l2FeeFiat": "$0.04",
-        "l2FeeFiatWith18SignificantDigits": null,
-        "l2FeeNative": "0.0001",
-        "maxFeeFiat": "$0.07",
-        "maxFeeFiatWith18SignificantDigits": null,
-        "maxFeeNative": "0.0001",
-      }
-    `);
+    // The following assertions are meant as a snapshot test. These are
+    // currently unavailable after the prettier upgrade to v3, so I'm asserting
+    // each property individually instead.
+    expect(result.current.estimatedFeeFiat).toBe('$2.54');
+    expect(result.current.estimatedFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.estimatedFeeNative).toBe('0.0046');
+    expect(result.current.estimatedFeeNativeHex).toBe('0x103be226d2d900');
+    expect(result.current.l1FeeFiat).toBe('$2.50');
+    expect(result.current.l1FeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.l1FeeNative).toBe('0.0045');
+    expect(result.current.l2FeeFiat).toBe('$0.04');
+    expect(result.current.l2FeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.l2FeeNative).toBe('0.0001');
+    expect(result.current.maxFeeFiat).toBe('$2.57');
+    expect(result.current.maxFeeFiatWith18SignificantDigits).toBe(null);
+    expect(result.current.maxFeeNative).toBe('0.0046');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7497,9 +7497,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.1.0":
-  version: 60.1.0
-  resolution: "@metamask/transaction-controller@npm:60.1.0"
+"@metamask/transaction-controller@npm:^60.2.0":
+  version: 60.2.0
+  resolution: "@metamask/transaction-controller@npm:60.2.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -7529,7 +7529,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^24.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/a4d3f8b6c4e834b076f1a3700e836c7738a320c165f049038fb5fca509cd22c441ea6c24547ce9fc63ff2ab42bb22d23091470781e4c24439196b6a671f95979
+  checksum: 10/e60cfeb3893951bee5947e3aaeae4542f79a623a59f10b10270dea2ec051a28db8b24be7dc9d2f00284c97ddbf4664432f8b61cc8e5601d1a08c7e7dd2d5f519
   languageName: node
   linkType: hard
 
@@ -31762,7 +31762,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
-    "@metamask/transaction-controller": "npm:^60.1.0"
+    "@metamask/transaction-controller": "npm:^60.2.0"
     "@metamask/user-operation-controller": "npm:^38.0.0"
     "@metamask/utils": "npm:^11.4.2"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`layer1GasFees` is also now summed to the maxFee if it exists (in transactions in OP stack networks).
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35625?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
