### PR TITLE
chore: update modal header prop types to accept partial props

### DIFF
--- a/ui/components/component-library/modal-header/modal-header.types.ts
+++ b/ui/components/component-library/modal-header/modal-header.types.ts
@@ -2,16 +2,6 @@ import React from 'react';
 import type { ButtonIconProps } from '../button-icon/button-icon.types';
 import type { HeaderBaseStyleUtilityProps } from '../header-base';
 
-/**
- * Makes all props optional so that if a prop object is used not ALL required props need to be passed
- * TODO: Move to appropriate place in app as this will be highly reusable
- */
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
-type MakePropsOptional<T> = {
-  [K in keyof T]?: T[K];
-};
-
 // TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalHeaderProps extends HeaderBaseStyleUtilityProps {
@@ -31,7 +21,7 @@ export interface ModalHeaderProps extends HeaderBaseStyleUtilityProps {
   /**
    * The props to pass to the back `ButtonIcon`
    */
-  backButtonProps?: ButtonIconProps<'button'>;
+  backButtonProps?: Partial<ButtonIconProps<'button'>>;
   /**
    * The start (left) content area of ModalHeader
    * Default to have the back `ButtonIcon` when `onBack` is passed, but passing a  `startAccessory` will override this
@@ -45,7 +35,7 @@ export interface ModalHeaderProps extends HeaderBaseStyleUtilityProps {
   /**
    * The props to pass to the close `ButtonIcon`
    */
-  closeButtonProps?: MakePropsOptional<ButtonIconProps<'button'>>;
+  closeButtonProps?: Partial<ButtonIconProps<'button'>>;
   /**
    * The end (right) content area of ModalHeader
    * Default to have the close `ButtonIcon` when `onClose` is passed, but passing a  `endAccessory` will override this


### PR DESCRIPTION
## **Description**

Updated the ModalHeader component prop types to use `Partial<ButtonIconProps<'button'>>` for `backButtonProps` and `closeButtonProps` instead of a custom `MakePropsOptional<T>` utility type. This change allows passing partial button props (like data-testid attributes) for improved testing without requiring all button icon properties to be specified.

**Changes made:**
- Removed the custom `MakePropsOptional<T>` utility type
- Updated `backButtonProps` to use `Partial<ButtonIconProps<'button'>>`  
- Updated `closeButtonProps` to use `Partial<ButtonIconProps<'button'>>`

This improves the developer experience when adding test identifiers and other optional props to modal header buttons.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - General improvement for testing capabilities

## **Manual testing steps**

1. Import ModalHeader component in a test or story
2. Pass partial props to `backButtonProps` or `closeButtonProps` (e.g., `{ 'data-testid': 'back-button' }`)
3. Verify TypeScript compilation succeeds without requiring all ButtonIcon props
4. Confirm the component renders and functions correctly

## **Screenshots/Recordings**

N/A - This is a TypeScript interface change with no visual impact

### **Before**

Required using custom `MakePropsOptional<T>` type and full ButtonIcon props

### **After**

Can use standard `Partial<T>` utility type for cleaner, more maintainable code

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.