### PR TITLE
feat: show connected network icon

### DIFF
--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import {
   AlignItems,
   BackgroundColor,
+  BorderColor,
   BorderRadius,
   Display,
   IconColor,
@@ -13,6 +14,9 @@ import {
 } from '../../../helpers/constants/design-system';
 import {
   AvatarFavicon,
+  AvatarNetwork,
+  AvatarNetworkSize,
+  BadgeWrapper,
   Box,
   Icon,
   IconName,
@@ -23,8 +27,10 @@ import {
   getPermittedAccountsByOrigin,
   getSubjectMetadata,
 } from '../../../selectors';
+import { getDappActiveNetwork } from '../../../selectors/dapp';
 import { ConnectedSitePopover } from '../connected-site-popover';
 import { STATUS_CONNECTED } from '../../../helpers/constants/connected-sites';
+import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../shared/constants/network';
 
 export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
   const [showPopover, setShowPopover] = useState(false);
@@ -34,9 +40,18 @@ export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
   const subjectMetadata = useSelector(getSubjectMetadata);
   const connectedOrigin = useSelector(getOriginOfCurrentTab);
   const permittedAccountsByOrigin = useSelector(getPermittedAccountsByOrigin);
+  const dappActiveNetwork = useSelector(getDappActiveNetwork);
   const currentTabHasNoAccounts =
     !permittedAccountsByOrigin[connectedOrigin]?.length;
   const connectedSubjectsMetadata = subjectMetadata[connectedOrigin];
+
+  // Get network image URL for the badge
+  const getNetworkImageSrc = () => {
+    if (dappActiveNetwork?.chainId) {
+      return CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[dappActiveNetwork.chainId];
+    }
+    return undefined;
+  };
 
   const iconElement = currentTabHasNoAccounts ? (
     <Icon
@@ -45,11 +60,26 @@ export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
       color={IconColor.iconDefault}
     />
   ) : (
-    <AvatarFavicon
-      name={connectedSubjectsMetadata.name}
-      size={Size.SM}
-      src={connectedSubjectsMetadata.iconUrl}
-    />
+    <BadgeWrapper
+      badge={
+        dappActiveNetwork && (
+          <AvatarNetwork
+            size={AvatarNetworkSize.Xs}
+            name={dappActiveNetwork.name || dappActiveNetwork.nickname}
+            src={getNetworkImageSrc()}
+            backgroundColor={BackgroundColor.backgroundSection}
+            borderWidth={2}
+            borderColor={BorderColor.backgroundDefault}
+          />
+        )
+      }
+    >
+      <AvatarFavicon
+        name={connectedSubjectsMetadata?.name}
+        size={Size.SM}
+        src={connectedSubjectsMetadata?.iconUrl}
+      />
+    </BadgeWrapper>
   );
   return (
     <>


### PR DESCRIPTION
This PR is to add a avatar network as the badge to the connected dapp icon


## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/5652](https://github.com/MetaMask/MetaMask-planning/issues/5652)

## **Manual testing steps**

1. Connect  MM to the Dapp
2. Check the active network icon appears as the badge on the dapp

## **Screenshots/Recordings**


### **Before**
![Screenshot 2025-09-04 at 3 44 02 PM](https://github.com/user-attachments/assets/66dcb279-c1f7-4ce8-a80a-2a8c5d73ab10)


### **After**

![Screenshot 2025-09-04 at 3 43 14 PM](https://github.com/user-attachments/assets/edafe824-58aa-4a85-bd3c-a24fa82d120b)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
