### PR TITLE
test: fix flaky test `Settings Redirects to ENS domains when user inputs ENS into address bar`

### DIFF
--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -2,6 +2,7 @@ import { MockttpServer } from 'mockttp';
 import { tinyDelayMs, withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import LoginPage from '../../page-objects/pages/login-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
@@ -38,6 +39,8 @@ describe('Settings', function () {
       },
       async ({ driver }) => {
         await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
 
         // The setting defaults to "on" so we can simply enter an ENS address
         // into the address bar and listen for address change

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -31,6 +31,7 @@ describe('Settings', function () {
     // on the ".eth" hostname. The proxy does too much interference with 8000.
     await withFixtures(
       {
+        fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,
         driverOptions: {

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -31,7 +31,7 @@ describe('Settings', function () {
     // on the ".eth" hostname. The proxy does too much interference with 8000.
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilder().withNetworkControllerOnMainnet().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,
         driverOptions: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Sometimes the domain resolution doesn't happen, making the spec fail:

<img width="1660" height="300" alt="Screenshot from 2025-09-05 09-38-44" src="https://github.com/user-attachments/assets/2fc43e8b-7a9a-4c53-a2b3-f9565a9793f3" />

With this PR I add a check to wait for the login page to be fully loaded before proceeding with the ENS resolution.
For the ENS resolution to work, we should either be on Mainnet or have All network selected.
With the addition of withFixtures and waiting for the login page to be loaded, we ensure that the wallet is in the correct state for the feature to work at the time we open a new tab.

https://github.com/MetaMask/metamask-extension/actions/runs/17465712128/job/49601791066


This also shows that there's a bug in the wallet, as  before we've even created a wallet, the ENS resolution is activated -- so the user hasn't had yet the chance to even accept terms and conditions --> I've opened a separate bug ticket for that


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35660?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
We didn't use fixtures, so when we did driver.navigate, we landed in the onboarding page -- we don't want ens resolution to work here, though it did.

<img width="1755" height="1373" alt="Screenshot from 2025-09-05 09-42-18" src="https://github.com/user-attachments/assets/f2d9e10f-567a-440e-b427-0cc0453c4d45" />


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
