### PR TITLE
test: Restore support for Jest inline snapshots

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,9 @@ module.exports = {
   coverageDirectory: './coverage/unit',
   coveragePathIgnorePatterns: ['.stories.*', '.snap$'],
   coverageReporters: ['html', 'json'],
+  // The path to the Prettier executable used to format snapshots
+  // Jest doesn't support Prettier 3 yet, so we use Prettier 2
+  prettierPath: require.resolve('prettier-2'),
   reporters: [
     'default',
     [

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -6,6 +6,9 @@ module.exports = {
   coverageDirectory: './coverage/integration',
   coveragePathIgnorePatterns: ['.stories.*', '.snap', '.test.(js|ts|tsx)'],
   coverageReporters: ['html', 'json'],
+  // The path to the Prettier executable used to format snapshots
+  // Jest doesn't support Prettier 3 yet, so we use Prettier 2
+  prettierPath: require.resolve('prettier-2'),
   reporters: [
     'default',
     [

--- a/package.json
+++ b/package.json
@@ -659,6 +659,7 @@
     "postcss-loader": "^8.1.1",
     "postcss-rtlcss": "^4.0.9",
     "prettier": "^3.6.2",
+    "prettier-2": "npm:prettier@^2.8.8",
     "prettier-eslint": "^16.4.2",
     "prettier-plugin-sort-json": "^4.1.1",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32023,6 +32023,7 @@ __metadata:
     postcss-loader: "npm:^8.1.1"
     postcss-rtlcss: "npm:^4.0.9"
     prettier: "npm:^3.6.2"
+    prettier-2: "npm:prettier@^2.8.8"
     prettier-eslint: "npm:^16.4.2"
     prettier-plugin-sort-json: "npm:^4.1.1"
     process: "npm:^0.11.10"
@@ -35454,6 +35455,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-2@npm:prettier@^2.8.8, prettier@npm:^2.8.0":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+  languageName: node
+  linkType: hard
+
 "prettier-eslint@npm:^16.4.2":
   version: 16.4.2
   resolution: "prettier-eslint@npm:16.4.2"
@@ -35497,15 +35507,6 @@ __metadata:
   peerDependencies:
     prettier: ^3.0.0
   checksum: 10/ac39fcf1ed5aedb93d92609c07832c2fb787431dc29ff5d9d1b4ff59cd00bbeabc753867500ce38f2d45200be0c411623ebca95f983e938b20da00e2717c5336
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.8.0":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Restore support for Jest inline snapshots, which were broken in #28638 due to an incompatibility between Jest and Prettier v3. Support was restored by following Jest's recommendation of using Prettier v2 as Jest's formatter.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35692?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes #35691

This is how we fixed this problem in core as well, see https://github.com/MetaMask/core/pull/5330

## **Manual testing steps**

1. Make a change to an inline snapshot, then run `yarn jest -u [test path]` to ensure the changes get reversed.
   * I tested with `app/scripts/lib/transaction/decode/four-byte.test.ts`

## **Screenshots/Recordings**

### **Before**

```
 FAIL  app/scripts/lib/transaction/decode/four-byte.test.ts
  ● Test suite failed to run

    Jest: Inline Snapshots are not supported when using Prettier 3.0.0 or above.
    See https://jestjs.io/docs/configuration/#prettierpath-string for alternatives.

      at saveInlineSnapshots (node_modules/jest-snapshot/build/InlineSnapshots.js:101:15)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.28 s, estimated 2 s
Ran all test suites matching /.\/app\/scripts\/lib\/transaction\/decode\/four-byte.test.ts/i.
```

### **After**

```
 PASS  app/scripts/lib/transaction/decode/four-byte.test.ts
  Four Byte
    decodeTransactionDataWithFourByte
      ✓ returns expected data (22 ms)
      ✓ returns expected data with tuples and arrays (4 ms)

 › 1 snapshot updated.
Snapshot Summary
 › 1 snapshot updated from 1 test suite.

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   1 updated, 1 passed, 2 total
Time:        1.251 s, estimated 2 s
Ran all test suites matching /.\/app\/scripts\/lib\/transaction\/decode\/four-byte.test.ts/i.

```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
