### PR TITLE
fix: using new asset selectors for re-designed send flow

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -335,7 +335,7 @@ export function NftDetailsComponent({
       }),
     );
     // We only allow sending one NFT at a time
-    navigateToSendRoute(history, { address: nft.address });
+    navigateToSendRoute(history, { address: nft.address, chainId: nftChainId });
   };
 
   const getDateCreatedTimestamp = (dateString: string) => {

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
@@ -128,7 +128,10 @@ export function AssetPickerModalNftTab({
         skipComputeEstimatedGasLimit: false,
       }),
     );
-    navigateToSendRoute(history, { address: nft.address });
+    navigateToSendRoute(history, {
+      address: nft.address,
+      chainId: nft.chainId,
+    });
     onClose && onClose();
   };
 

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -191,7 +191,10 @@ const TokenButtons = ({
           details: token,
         }),
       );
-      navigateToSendRoute(history, { address: token.address });
+      navigateToSendRoute(history, {
+        address: token.address,
+        chainId: token.chainId,
+      });
 
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
@@ -43,6 +43,7 @@ export const AmountRecipient = () => {
             flexDirection={FlexDirection.Column}
             justifyContent={JustifyContent.spaceBetween}
             className="send__body"
+            padding={4}
           >
             <Box>
               <Recipient setTo={setTo} />

--- a/ui/pages/confirmations/context/send/index.tsx
+++ b/ui/pages/confirmations/context/send/index.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { isAddress as isEvmAddress } from 'ethers/lib/utils';
+import { isHexString } from 'ethereumjs-util';
 import { isSolanaChainId } from '@metamask/bridge-controller';
 import { toHex } from '@metamask/controller-utils';
 import { useSelector } from 'react-redux';
@@ -67,7 +68,8 @@ export const SendContextProvider: React.FC<{
     asset?.address &&
     isEvmAddress(asset?.address) &&
     asset.chainId &&
-    !isSolanaChainId(asset.chainId?.toString())
+    !isSolanaChainId(asset.chainId?.toString()) &&
+    !isHexString(asset.chainId.toString())
       ? toHex(asset.chainId)
       : asset?.chainId?.toString();
 

--- a/ui/pages/confirmations/hooks/send/useSendActions.ts
+++ b/ui/pages/confirmations/hooks/send/useSendActions.ts
@@ -49,7 +49,7 @@ export const useSendActions = () => {
           {
             fromAccountId: fromAccount?.id as string,
             toAddress: toAddress as string,
-            assetId: asset.address as CaipAssetType,
+            assetId: asset.assetId as CaipAssetType,
             amount: value as string,
           },
         );

--- a/ui/pages/confirmations/hooks/send/useSendQueryParams.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendQueryParams.test.ts
@@ -11,11 +11,11 @@ import {
   SOLANA_ASSET,
 } from '../../../../../test/data/send/assets';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers';
+import { Asset } from '../../types/send';
 import { SendPages } from '../../constants/send';
 import * as SendContext from '../../context/send';
 import { useSendQueryParams } from './useSendQueryParams';
 import { useSendAssets } from './useSendAssets';
-import { Asset } from '../../types/send';
 
 jest.mock('react-router-dom-v5-compat', () => ({
   ...jest.requireActual('react-router-dom-v5-compat'),

--- a/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
+++ b/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
@@ -1,4 +1,4 @@
-import { Hex } from '@metamask/utils';
+import { Hex, isHexString } from '@metamask/utils';
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import { isAddress as isEvmAddress } from 'ethers/lib/utils';
 import { useEffect, useMemo } from 'react';
@@ -6,12 +6,14 @@ import { useHistory } from 'react-router-dom';
 import { useLocation, useSearchParams } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 
+import { toHex } from '../../../../../shared/lib/delegation/utils';
 import useMultiChainAssets from '../../../../components/app/assets/hooks/useMultichainAssets';
 import { SEND_ROUTE } from '../../../../helpers/constants/routes';
 import { getAllTokens } from '../../../../selectors';
 import { Asset } from '../../types/send';
 import { SendPages } from '../../constants/send';
 import { useSendContext } from '../../context/send';
+import { useSendAssets } from './useSendAssets';
 
 export const getAssetFromList = (
   evmTokens: Record<Hex, Record<Hex, Asset[]>>,
@@ -50,6 +52,7 @@ export const useSendQueryParams = () => {
   const evmTokens: Record<Hex, Record<Hex, Asset[]>> = useSelector(
     getAllTokens,
   );
+  const { tokens, nfts } = useSendAssets();
 
   const subPath = useMemo(() => {
     const path = pathname.split('/').filter(Boolean)[1];
@@ -126,8 +129,38 @@ export const useSendQueryParams = () => {
     if (asset) {
       return;
     }
+    let nativeAsset;
+    if (paramChainId && !paramAsset) {
+      nativeAsset = {
+        ...getNativeAssetForChainId(paramChainId),
+        chainId: paramChainId,
+      };
+    }
     let newAsset;
-    if (paramAsset) {
+    const add = paramAsset ?? nativeAsset?.address ?? nativeAsset?.assetId;
+    if (add) {
+      const cid = paramChainId ?? nativeAsset?.chainId;
+      const chainId =
+        isEvmAddress(add) && cid && !isHexString(cid) ? toHex(cid) : cid;
+
+      if (chainId) {
+        newAsset = tokens?.find(
+          ({ assetId, chainId: tokenChainId }) =>
+            chainId === tokenChainId &&
+            assetId?.toLowerCase() === add.toLowerCase(),
+        );
+      }
+
+      if (!newAsset) {
+        newAsset = nfts?.find(
+          ({ assetId, chainId: tokenChainId }) =>
+            chainId === tokenChainId &&
+            assetId?.toLowerCase() === add.toLowerCase(),
+        );
+      }
+    }
+
+    if (!newAsset && paramAsset) {
       if (isEvmAddress(paramAsset)) {
         newAsset = getAssetFromList(evmTokens, paramAsset as Hex);
       } else {
@@ -136,22 +169,19 @@ export const useSendQueryParams = () => {
         );
       }
     }
-    if (!newAsset && paramChainId) {
-      newAsset = {
-        ...getNativeAssetForChainId(paramChainId),
-        chainId: paramChainId,
-      };
-    }
+
     if (newAsset) {
       updateAsset(newAsset);
     }
   }, [
     asset,
+    evmTokens,
     paramAsset,
     paramChainId,
     // using only multiChainAssets as dependency causes infinite loading
     multiChainAssets?.length,
-    evmTokens,
+    nfts,
+    tokens,
     updateAsset,
   ]);
 };

--- a/ui/pages/confirmations/hooks/send/useSendType.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendType.test.ts
@@ -25,9 +25,24 @@ describe('useSendType', () => {
     jest.clearAllMocks();
   });
 
-  it('return correct type for evm aset send', () => {
+  it('return correct type for evm asset send', () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: EVM_ASSET,
+      chainId: '0x5',
+    } as unknown as SendContext.SendContextType);
+    const result = renderHook();
+    expect(result).toEqual({
+      isEvmNativeSendType: false,
+      isEvmSendType: true,
+      isNonEvmNativeSendType: false,
+      isNonEvmSendType: false,
+      isSolanaSendType: false,
+    });
+  });
+
+  it('use assetId is address is undefined', () => {
+    jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+      asset: { ...EVM_ASSET, assetId: EVM_ASSET.address, address: undefined },
       chainId: '0x5',
     } as unknown as SendContext.SendContextType);
     const result = renderHook();

--- a/ui/pages/confirmations/hooks/send/useSendType.ts
+++ b/ui/pages/confirmations/hooks/send/useSendType.ts
@@ -6,20 +6,21 @@ import { useSendContext } from '../../context/send';
 
 export const useSendType = () => {
   const { asset, chainId } = useSendContext();
+  const address = asset?.address || asset?.assetId;
 
   // isSolanaChainId is added here for evmCheck as native sol token has valid evm address in extension
   const isEvmSendType = useMemo(
     () =>
-      asset?.address && asset?.chainId
-        ? isEvmAddress(asset.address) && !isSolanaChainId(asset?.chainId)
+      address && asset?.chainId
+        ? isEvmAddress(address) && !isSolanaChainId(asset?.chainId)
         : undefined,
-    [asset?.address, asset?.chainId],
+    [address, asset?.chainId],
   );
   const isSolanaSendType = useMemo(
     () => (chainId ? isSolanaChainId(chainId) : undefined),
     [chainId],
   );
-  const assetIsNative = asset ? isNativeAddress(asset.address) : undefined;
+  const assetIsNative = asset ? isNativeAddress(address) : undefined;
 
   return useMemo(
     () => ({

--- a/ui/pages/confirmations/send/send-inner.test.tsx
+++ b/ui/pages/confirmations/send/send-inner.test.tsx
@@ -13,6 +13,12 @@ jest.mock('react-router-dom-v5-compat', () => ({
   useSearchParams: () => [{ get: () => null }],
 }));
 
+jest.mock('../hooks/send/useSendAssets', () => {
+  return {
+    useSendAssets: jest.fn().mockReturnValue({ tokens: [], nfts: [] }),
+  };
+});
+
 jest.mock('../components/send/asset', () => ({
   Asset: () => <div data-testid="asset-page">Asset page</div>,
 }));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Using new asset selectors on send page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5752

## **Manual testing steps**

1. Enable new send
2. Check various send flow
3. Ensure they work as expected

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
