### PR TITLE
feat: Add controller metadata to encryption controllers

### DIFF
--- a/app/scripts/controllers/decrypt-message.test.ts
+++ b/app/scripts/controllers/decrypt-message.test.ts
@@ -1,3 +1,4 @@
+import { deriveStateFromMetadata } from '@metamask/base-controller';
 import {
   DecryptMessageManager,
   DecryptMessageParams,
@@ -302,6 +303,58 @@ describe('DecryptMessageController', () => {
       properties: {
         action: 'Decrypt Message Request',
       },
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      expect(
+        deriveStateFromMetadata(
+          decryptMessageController.state,
+          decryptMessageController.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`{}`);
+    });
+
+    it('includes expected state in state logs', () => {
+      expect(
+        deriveStateFromMetadata(
+          decryptMessageController.state,
+          decryptMessageController.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "unapprovedDecryptMsgCount": 0,
+          "unapprovedDecryptMsgs": {},
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      expect(
+        deriveStateFromMetadata(
+          decryptMessageController.state,
+          decryptMessageController.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`{}`);
+    });
+
+    it('exposes expected state to UI', () => {
+      expect(
+        deriveStateFromMetadata(
+          decryptMessageController.state,
+          decryptMessageController.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "unapprovedDecryptMsgCount": 0,
+          "unapprovedDecryptMsgs": {},
+        }
+      `);
     });
   });
 });

--- a/app/scripts/controllers/decrypt-message.ts
+++ b/app/scripts/controllers/decrypt-message.ts
@@ -30,8 +30,18 @@ import { stripHexPrefix } from '../../../shared/modules/hexstring-utils';
 const controllerName = 'DecryptMessageController';
 
 const stateMetadata = {
-  unapprovedDecryptMsgs: { persist: false, anonymous: false },
-  unapprovedDecryptMsgCount: { persist: false, anonymous: false },
+  unapprovedDecryptMsgs: {
+    includeInStateLogs: true,
+    persist: false,
+    anonymous: false,
+    usedInUi: true,
+  },
+  unapprovedDecryptMsgCount: {
+    includeInStateLogs: true,
+    persist: false,
+    anonymous: false,
+    usedInUi: true,
+  },
 };
 
 export const managerName = 'DecryptMessageManager';

--- a/app/scripts/controllers/encryption-public-key.test.ts
+++ b/app/scripts/controllers/encryption-public-key.test.ts
@@ -1,3 +1,4 @@
+import { deriveStateFromMetadata } from '@metamask/base-controller';
 import {
   EncryptionPublicKeyManager,
   AbstractMessage,
@@ -355,6 +356,58 @@ describe('EncryptionPublicKeyController', () => {
           messageIdMock,
         ),
       ).toEqual(stateMock);
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      expect(
+        deriveStateFromMetadata(
+          encryptionPublicKeyController.state,
+          encryptionPublicKeyController.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`{}`);
+    });
+
+    it('includes expected state in state logs', () => {
+      expect(
+        deriveStateFromMetadata(
+          encryptionPublicKeyController.state,
+          encryptionPublicKeyController.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "unapprovedEncryptionPublicKeyMsgCount": 0,
+          "unapprovedEncryptionPublicKeyMsgs": {},
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      expect(
+        deriveStateFromMetadata(
+          encryptionPublicKeyController.state,
+          encryptionPublicKeyController.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`{}`);
+    });
+
+    it('exposes expected state to UI', () => {
+      expect(
+        deriveStateFromMetadata(
+          encryptionPublicKeyController.state,
+          encryptionPublicKeyController.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "unapprovedEncryptionPublicKeyMsgCount": 0,
+          "unapprovedEncryptionPublicKeyMsgs": {},
+        }
+      `);
     });
   });
 });

--- a/app/scripts/controllers/encryption-public-key.ts
+++ b/app/scripts/controllers/encryption-public-key.ts
@@ -29,8 +29,18 @@ const managerName = 'EncryptionPublicKeyManager';
 const methodNameGetEncryptionPublicKey = 'eth_getEncryptionPublicKey';
 
 const stateMetadata = {
-  unapprovedEncryptionPublicKeyMsgs: { persist: false, anonymous: false },
-  unapprovedEncryptionPublicKeyMsgCount: { persist: false, anonymous: false },
+  unapprovedEncryptionPublicKeyMsgs: {
+    includeInStateLogs: true,
+    persist: false,
+    anonymous: false,
+    usedInUi: true,
+  },
+  unapprovedEncryptionPublicKeyMsgCount: {
+    includeInStateLogs: true,
+    persist: false,
+    anonymous: false,
+    usedInUi: true,
+  },
 };
 
 const getDefaultState = () => ({


### PR DESCRIPTION
## **Description**

The new metadata properties `includeInStateLogs` and `usedInUi` have been added to all extension controllers maintained by the confirmations team.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35705?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This is related to this recent ADR: https://github.com/MetaMask/decisions/blob/main/decisions/core/0014-Expand-Controller-Metadata.md

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
