### PR TITLE
refactor: Migrate currency formatter

### DIFF
--- a/ui/helpers/formatters.test.ts
+++ b/ui/helpers/formatters.test.ts
@@ -59,6 +59,34 @@ describe('formatCurrencyWithMinThreshold', () => {
   });
 });
 
+describe('formatCurrencyTokenPrice', () => {
+  const testCases = [
+    { value: 0.000000001, expected: '<$0.00000001' },
+    { value: 0.0000123, expected: '$0.0000123' },
+    { value: 0.001, expected: '$0.00100' },
+    { value: 0.999, expected: '$0.999' },
+    { value: 0, expected: '$0.00' },
+    { value: 1, expected: '$1.00' },
+    { value: 1_000_000, expected: '$1.00M' },
+  ];
+
+  it('formats values correctly', () => {
+    const { formatCurrencyTokenPrice } = createFormatters({ locale });
+    testCases.forEach(({ value, expected }) => {
+      expect(formatCurrencyTokenPrice(value, 'USD')).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    const { formatCurrencyTokenPrice } = createFormatters({ locale });
+    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach(
+      (input) => {
+        expect(formatCurrencyTokenPrice(input, 'USD')).toBe('');
+      },
+    );
+  });
+});
+
 describe('locale variations', () => {
   describe('en-GB GBP', () => {
     it('formats standard value', () => {

--- a/ui/helpers/formatters.ts
+++ b/ui/helpers/formatters.ts
@@ -17,6 +17,11 @@ const compactTwoDecimals: Intl.NumberFormatOptions = {
   maximumFractionDigits: 2,
 };
 
+const threeSignificantDigits = {
+  minimumSignificantDigits: 3,
+  maximumSignificantDigits: 3,
+};
+
 const numberFormatCache: Record<string, Intl.NumberFormat> = {};
 
 function getCachedNumberFormat(
@@ -79,12 +84,12 @@ function formatCurrencyWithMinThreshold(
   value: number | bigint | `${number}`,
   currency: Intl.NumberFormatOptions['currency'],
 ) {
-  if (!Number.isFinite(Number(value))) {
+  const minThreshold = 0.01;
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
     return '';
   }
-
-  const number = Number(value);
-  const minThreshold = 0.01;
 
   if (number === 0) {
     return formatCurrency(config, 0, currency);
@@ -96,6 +101,33 @@ function formatCurrencyWithMinThreshold(
   }
 
   return formatCurrency(config, number, currency);
+}
+
+function formatCurrencyTokenPrice(
+  config: { locale: string },
+  value: number | bigint | `${number}`,
+  currency: Intl.NumberFormatOptions['currency'],
+) {
+  const minThreshold = 0.00000001;
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number < minThreshold) {
+    return `<${formatCurrency(config, minThreshold, currency)}`;
+  }
+
+  if (number < 1) {
+    return formatCurrency(config, number, currency, threeSignificantDigits);
+  }
+
+  if (number < 1_000_000) {
+    return formatCurrency(config, number, currency);
+  }
+
+  return formatCurrencyCompact(config, number, currency);
 }
 
 export function createFormatters({ locale = FALLBACK_LOCALE }) {
@@ -124,6 +156,13 @@ export function createFormatters({ locale = FALLBACK_LOCALE }) {
     formatCurrencyWithMinThreshold: formatCurrencyWithMinThreshold.bind(null, {
       locale,
     }),
+    /**
+     * Format token price with varying precision based on value.
+     *
+     * @param value - Numeric value to format.
+     * @param currency - ISO 4217 currency code.
+     */
+    formatCurrencyTokenPrice: formatCurrencyTokenPrice.bind(null, { locale }),
   };
 }
 

--- a/ui/helpers/formatters.ts
+++ b/ui/helpers/formatters.ts
@@ -17,6 +17,11 @@ const compactTwoDecimals: Intl.NumberFormatOptions = {
   maximumFractionDigits: 2,
 };
 
+const oneSignificantDigit = {
+  minimumSignificantDigits: 1,
+  maximumSignificantDigits: 1,
+};
+
 const threeSignificantDigits = {
   minimumSignificantDigits: 3,
   maximumSignificantDigits: 3,
@@ -115,8 +120,12 @@ function formatCurrencyTokenPrice(
     return '';
   }
 
+  if (number === 0) {
+    return formatCurrency(config, 0, currency);
+  }
+
   if (number < minThreshold) {
-    return `<${formatCurrency(config, minThreshold, currency)}`;
+    return `<${formatCurrency(config, minThreshold, currency, oneSignificantDigit)}`;
   }
 
   if (number < 1) {

--- a/ui/pages/asset/components/chart/asset-chart-price.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-price.tsx
@@ -9,10 +9,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { Box, Text } from '../../../../components/component-library';
 import { loadingOpacity, getShortDateFormatter } from '../../util';
-import {
-  threeSignificantDigits,
-  useFormatters,
-} from '../../../../helpers/formatters';
+import { useFormatters } from '../../../../helpers/formatters';
 import { Skeleton } from '../../../../components/component-library/skeleton';
 import { TokenCellPercentChange } from '../../../../components/app/assets/token-cell/cells';
 import { TokenFiatDisplayInfo } from '../../../../components/app/assets/types';

--- a/ui/pages/asset/components/chart/asset-chart-price.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-price.tsx
@@ -8,12 +8,11 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { Box, Text } from '../../../../components/component-library';
-import { formatCurrency } from '../../../../helpers/utils/confirm-tx.util';
+import { loadingOpacity, getShortDateFormatter } from '../../util';
 import {
-  getPricePrecision,
-  loadingOpacity,
-  getShortDateFormatter,
-} from '../../util';
+  threeSignificantDigits,
+  useFormatters,
+} from '../../../../helpers/formatters';
 import { Skeleton } from '../../../../components/component-library/skeleton';
 import { TokenCellPercentChange } from '../../../../components/app/assets/token-cell/cells';
 import { TokenFiatDisplayInfo } from '../../../../components/app/assets/types';
@@ -81,7 +80,7 @@ const AssetChartPrice = forwardRef(
       date: props.date,
     });
     useImperativeHandle(ref, () => ({ setPrice }));
-
+    const { formatCurrencyTokenPrice } = useFormatters();
     const { loading, currency, comparePrice } = props;
     const priceDelta =
       price !== undefined && comparePrice !== undefined
@@ -115,7 +114,7 @@ const AssetChartPrice = forwardRef(
             marginBottom={1}
             style={{ opacity: shouldShowMainPriceMuted ? loadingOpacity : 1 }}
           >
-            {formatCurrency(`${price}`, currency, getPricePrecision(price))}
+            {formatCurrencyTokenPrice(price, currency)}
           </Text>
         )}
         {shouldShowDeltaLoading && <AssetChartDeltaLoading />}

--- a/ui/pages/asset/components/chart/chart-tooltip.tsx
+++ b/ui/pages/asset/components/chart/chart-tooltip.tsx
@@ -6,13 +6,15 @@ import {
   Text,
   TextDirection,
 } from '../../../../components/component-library';
-import { formatCurrency } from '../../../../helpers/utils/confirm-tx.util';
+import {
+  threeSignificantDigits,
+  useFormatters,
+} from '../../../../helpers/formatters';
 import {
   TextAlign,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { getPricePrecision } from '../../util';
 
 // A label indicating the minimum or maximum price on the chart
 const ChartTooltip = ({
@@ -26,6 +28,7 @@ const ChartTooltip = ({
   xMax?: number;
   currency: string;
 }) => {
+  const { formatCurrencyTokenPrice } = useFormatters();
   const xAxisPercent =
     point && xMin && xMax ? (point.x - xMin) / (xMax - xMin) : 0;
 
@@ -52,11 +55,7 @@ const ChartTooltip = ({
       >
         {point?.y === undefined
           ? '\u00A0'
-          : formatCurrency(
-              `${point?.y}`,
-              currency,
-              getPricePrecision(point?.y),
-            )}
+          : formatCurrencyTokenPrice(point?.y, currency)}
       </Text>
     </Box>
   );

--- a/ui/pages/asset/components/chart/chart-tooltip.tsx
+++ b/ui/pages/asset/components/chart/chart-tooltip.tsx
@@ -6,10 +6,7 @@ import {
   Text,
   TextDirection,
 } from '../../../../components/component-library';
-import {
-  threeSignificantDigits,
-  useFormatters,
-} from '../../../../helpers/formatters';
+import { useFormatters } from '../../../../helpers/formatters';
 import {
   TextAlign,
   TextColor,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrates the fiat currency formatting in the asset chart page to use the newer utilities based on `Intl.NumberFormat`

This reduces usages of the deprecated `currency-formatter` npm package.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35717?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Tokens
2. Click on a token
3. Chart current, high and low price

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="194" height="72" alt="image" src="https://github.com/user-attachments/assets/ad219678-079f-4c20-bade-e634164e9362" />

<br />

<img width="210" height="232" alt="image" src="https://github.com/user-attachments/assets/920ff71d-6db1-4c17-8227-9a43bc6c213a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
