### PR TITLE
feat: downgrade alert severity on account selected from warning to info

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.test.ts
@@ -17,7 +17,7 @@ const expectedAlert = [
     message:
       'This request is for a different account than the one selected in your wallet. To use another account, connect it to the site.',
     reason: 'Different account selected',
-    severity: 'warning',
+    severity: 'info',
     field: 'signingInWith',
   },
 ];

--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
@@ -33,7 +33,7 @@ export const useSelectedAccountAlerts = (): Alert[] => {
         key: 'selectedAccountWarning',
         reason: t('selectedAccountMismatch'),
         field: RowAlertKey.SigningInWith,
-        severity: Severity.Warning,
+        severity: Severity.Info,
         message: t('alertSelectedAccountWarning'),
       },
     ];


### PR DESCRIPTION
## **Description**
Fixes https://github.com/MetaMask/MetaMask-planning/issues/5726 - brings greater consistency to the alert system and prevents warning fatigue. The intention is to match the `different account selected` alert with 2 other similar alerts, which are both `info` level alerts:
- `website has changed`
- `network has changed`

### Before
<img width="512" height="732" alt="Image" src="https://github.com/user-attachments/assets/d13dd4af-ddd3-4aae-a5df-a7ee308a32b7" />

### After

<img width="512" height="732" alt="Image" src="https://github.com/user-attachments/assets/f5cf1f9c-d71e-4d1c-abc6-c622a856229d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
