### PR TITLE
release: 13.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.2.2]
+### Fixed
+- fix: fixes issue related to `Routes` component that was leading the app to occasionally crash and force reinstall for some users (#35587)
+
 ## [13.2.1]
 ### Fixed
 - fix: update the Solana snap to latest version (#35642)
@@ -488,7 +492,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This changelog was split off with 12.22.0
 - All older changes can be found in [docs/CHANGELOG_older.md](https://github.com/MetaMask/metamask-extension/blob/main/docs/CHANGELOG_older.md)
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.2.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.2.2...HEAD
+[13.2.2]: https://github.com/MetaMask/metamask-extension/compare/v13.2.1...v13.2.2
 [13.2.1]: https://github.com/MetaMask/metamask-extension/compare/v13.2.0...v13.2.1
 [13.2.0]: https://github.com/MetaMask/metamask-extension/compare/v13.1.2...v13.2.0
 [13.1.2]: https://github.com/MetaMask/metamask-extension/compare/v13.1.1...v13.1.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.2.1",
+  "version": "13.2.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -441,13 +441,8 @@ export default function Routes() {
 
   useEffect(() => {
     const windowType = getEnvironmentType();
-    const { openExtensionInBrowser } = globalThis.platform ?? {};
-    if (
-      showExtensionInFullSizeView &&
-      windowType === ENVIRONMENT_TYPE_POPUP &&
-      openExtensionInBrowser
-    ) {
-      openExtensionInBrowser();
+    if (showExtensionInFullSizeView && windowType === ENVIRONMENT_TYPE_POPUP) {
+      global.platform?.openExtensionInBrowser?.();
     }
   }, [showExtensionInFullSizeView]);
 


### PR DESCRIPTION
This is the release candidate for version 13.2.2. The changelog will be found in another PR chore/13.2.2-Changelog.

  # Team sign-off checklist
  - [ ] team-accounts
  - [ ] team-assets
  - [ ] team-confirmations
  - [ ] team-design-system
  - [ ] team-notifications
  - [ ] team-platform
  - [ ] team-security
  - [ ] team-snaps-platform
  - [ ] team-sdk
  - [ ] team-stake
  - [ ] team-tiger
  - [ ] team-wallet-framework