### PR TITLE
fix: simplify transaction value calculation in useInsufficientBalanceAlerts hook

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -74,7 +74,8 @@ export const useMaxValueRefresher = () => {
   useEffect(() => {
     if (
       !isMaxValueMode ||
-      transactionMeta.type !== TransactionType.simpleSend
+      (transactionMeta.type !== TransactionType.simpleSend &&
+        transactionMeta.type !== TransactionType.tokenMethodTransfer)
     ) {
       return;
     }

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -74,8 +74,7 @@ export const useMaxValueRefresher = () => {
   useEffect(() => {
     if (
       !isMaxValueMode ||
-      (transactionMeta.type !== TransactionType.simpleSend &&
-        transactionMeta.type !== TransactionType.tokenMethodTransfer)
+      transactionMeta.type !== TransactionType.simpleSend
     ) {
       return;
     }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -10,7 +10,6 @@ import {
   getUseTransactionSimulations,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
-  selectTransactionValue,
 } from '../../../../../selectors';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -33,6 +32,7 @@ export function useInsufficientBalanceAlerts({
     chainId,
     selectedGasFeeToken,
     gasFeeTokens,
+    txParams: { value } = {},
   } = currentConfirmation ?? {};
 
   const batchTransactionValues =
@@ -46,11 +46,7 @@ export function useInsufficientBalanceAlerts({
     selectTransactionAvailableBalance(state, transactionId, chainId),
   );
 
-  const value = useSelector((state) =>
-    selectTransactionValue(state, transactionId),
-  );
-
-  const totalValue = sumHexes(value, ...batchTransactionValues);
+  const totalValue = sumHexes(value ?? '0x0', ...batchTransactionValues);
 
   const { hexMaximumTransactionFee } = useSelector((state) =>
     selectTransactionFeeById(state, transactionId),

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -32,7 +32,7 @@ export function useInsufficientBalanceAlerts({
     chainId,
     selectedGasFeeToken,
     gasFeeTokens,
-    txParams: { value } = {},
+    txParams: { value = '0x0' } = {},
   } = currentConfirmation ?? {};
 
   const batchTransactionValues =

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -46,7 +46,7 @@ export function useInsufficientBalanceAlerts({
     selectTransactionAvailableBalance(state, transactionId, chainId),
   );
 
-  const totalValue = sumHexes(value ?? '0x0', ...batchTransactionValues);
+  const totalValue = sumHexes(value, ...batchTransactionValues);
 
   const { hexMaximumTransactionFee } = useSelector((state) =>
     selectTransactionFeeById(state, transactionId),

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.ts
@@ -43,7 +43,7 @@ export const getEstimatedTotalGas = (
 type GetMaxAmountArgs = {
   asset?: Asset;
   layer1GasFees: Hex;
-  isEvmSendType?: boolean;
+  isEvmNativeSendType?: boolean;
   gasFeeEstimates?: GasFeeEstimatesType;
   rawBalanceNumeric: Numeric;
 };
@@ -52,7 +52,7 @@ const getMaxAmountFn = ({
   asset,
   layer1GasFees,
   gasFeeEstimates,
-  isEvmSendType,
+  isEvmNativeSendType,
   rawBalanceNumeric,
 }: GetMaxAmountArgs) => {
   if (!asset) {
@@ -60,16 +60,9 @@ const getMaxAmountFn = ({
   }
 
   let estimatedTotalGas = new Numeric('0', 10);
-  if (isEvmSendType) {
-    const nativeTokenAddressForChainId = getNativeTokenAddress(
-      asset.chainId as Hex,
-    );
-    if (
-      nativeTokenAddressForChainId.toLowerCase() ===
-      asset.address?.toLowerCase()
-    ) {
-      estimatedTotalGas = getEstimatedTotalGas(layer1GasFees, gasFeeEstimates);
-    }
+
+  if (isEvmNativeSendType) {
+    estimatedTotalGas = getEstimatedTotalGas(layer1GasFees, gasFeeEstimates);
   }
 
   const balance = rawBalanceNumeric.minus(estimatedTotalGas);
@@ -112,11 +105,17 @@ export const useMaxAmount = () => {
     return getMaxAmountFn({
       asset,
       gasFeeEstimates,
-      isEvmSendType,
+      isEvmNativeSendType,
       layer1GasFees: layer1GasFees ?? '0x0',
       rawBalanceNumeric,
     });
-  }, [asset, gasFeeEstimates, isEvmSendType, layer1GasFees, rawBalanceNumeric]);
+  }, [
+    asset,
+    gasFeeEstimates,
+    isEvmNativeSendType,
+    layer1GasFees,
+    rawBalanceNumeric,
+  ]);
 
   return {
     getMaxAmount,

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.ts
@@ -1,6 +1,5 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { useCallback } from 'react';
 import { DefaultRootState, useSelector } from 'react-redux';
 

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -274,15 +274,6 @@ export function selectIsMaxValueEnabled(state, transactionId) {
   return state.confirmTransaction.maxValueMode?.[transactionId] ?? false;
 }
 
-export const selectMaxValue = createSelector(
-  selectTransactionFeeById,
-  selectTransactionAvailableBalance,
-  (transactionFee, balance) =>
-    balance && transactionFee.hexMaximumTransactionFee
-      ? subtractHexes(balance, transactionFee.hexMaximumTransactionFee)
-      : undefined,
-);
-
 const maxValueModeSelector = (state) => state.confirmTransaction.maxValueMode;
 
 export function selectMaxValueModeForTransaction(state, transactionId) {

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -22,7 +22,6 @@ import {
 import {
   decGWEIToHexWEI,
   getValueFromWeiHex,
-  subtractHexes,
   sumHexes,
 } from '../../shared/modules/conversion.utils';
 import { getProviderConfig } from '../../shared/modules/selectors/networks';

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -283,15 +283,6 @@ export const selectMaxValue = createSelector(
       : undefined,
 );
 
-/** @type {state: any, transactionId: string => string} */
-export const selectTransactionValue = createSelector(
-  selectIsMaxValueEnabled,
-  selectMaxValue,
-  selectTransactionMetadata,
-  (isMaxValueEnabled, maxValue, transactionMetadata) =>
-    isMaxValueEnabled ? maxValue : transactionMetadata?.txParams?.value,
-);
-
 const maxValueModeSelector = (state) => state.confirmTransaction.maxValueMode;
 
 export function selectMaxValueModeForTransaction(state, transactionId) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix getting transaction value in `useInsufficientBalanceAlerts` hook, value from txParams can be used as it is already updated to MaxValue if max value mode is enabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5782

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
