### PR TITLE
Reject invalid GATOR_PERMISSIONS_PROVIDER_SNAP_ID configuration

### DIFF
--- a/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
+++ b/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
@@ -27,16 +27,28 @@ function buildInitRequestMock(): jest.Mocked<
 }
 
 describe('GatorPermissionsControllerInit', () => {
-  const MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID = 'local:http://localhost:8082';
+  const MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
+    'npm:@metamask/permissions-kernel-snap';
   const GatorPermissionsControllerClassMock = jest.mocked(
     GatorPermissionsController,
   );
+  const originalGatorPermissionProviderSnapId =
+    process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
     process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
       MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
+  });
+
+  afterEach(() => {
+    if (originalGatorPermissionProviderSnapId) {
+      process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
+        originalGatorPermissionProviderSnapId;
+    } else {
+      delete process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
+    }
   });
 
   it('returns controller instance', () => {
@@ -101,68 +113,49 @@ describe('GatorPermissionsControllerInit', () => {
     });
   });
 
-  describe('GATOR_PERMISSIONS_PROVIDER_SNAP_ID being set to invalid format', () => {
-    it('handles empty string GATOR_PERMISSIONS_PROVIDER_SNAP_ID', () => {
-      const requestMock = buildInitRequestMock();
-      process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID = '';
-      jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
+  it('resolves the default when GATOR_PERMISSIONS_PROVIDER_SNAP_ID is not specified', () => {
+    const requestMock = buildInitRequestMock();
 
-      GatorPermissionsControllerInit(requestMock);
+    delete process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
-      expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
-        messenger: requestMock.controllerMessenger,
-        state: {
-          isGatorPermissionsEnabled: true,
-          ...requestMock.persistedState.GatorPermissionsController,
-        },
-      });
+    GatorPermissionsControllerInit(requestMock);
+
+    expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
+      messenger: requestMock.controllerMessenger,
+      state: {
+        isGatorPermissionsEnabled: true,
+      },
     });
 
-    it('handles undefined GATOR_PERMISSIONS_PROVIDER_SNAP_ID', () => {
-      const requestMock = buildInitRequestMock();
-      delete process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
-      jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
+    const calledWithState =
+      GatorPermissionsControllerClassMock.mock.calls[0][0].state;
 
-      GatorPermissionsControllerInit(requestMock);
-
-      expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
-        messenger: requestMock.controllerMessenger,
-        state: {
-          isGatorPermissionsEnabled: true,
-          ...requestMock.persistedState.GatorPermissionsController,
-        },
-      });
+    expect(calledWithState).toEqual({
+      isGatorPermissionsEnabled: true,
     });
 
-    it('handles invalid GATOR_PERMISSIONS_PROVIDER_SNAP_ID format', () => {
-      const requestMock = buildInitRequestMock();
-      process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID = 'invalid-snap-id';
-      jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
+    // GatorPermissionsController requires that the key does not exist if the snap id is not specified
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        calledWithState,
+        'gatorPermissionsProviderSnapId',
+      ),
+    ).toBe(false);
+  });
 
-      GatorPermissionsControllerInit(requestMock);
+  describe('GATOR_PERMISSIONS_PROVIDER_SNAP_ID incorrectly specified', () => {
+    ['', '   ', 'invalid-snap-id'].forEach((invalidSnapId) => {
+      it(`throws when provided invalid GATOR_PERMISSIONS_PROVIDER_SNAP_ID: ${invalidSnapId}`, () => {
+        const requestMock = buildInitRequestMock();
 
-      expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
-        messenger: requestMock.controllerMessenger,
-        state: {
-          isGatorPermissionsEnabled: true,
-          ...requestMock.persistedState.GatorPermissionsController,
-        },
-      });
-    });
+        process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
+          invalidSnapId as string;
 
-    it('handles whitespace-only GATOR_PERMISSIONS_PROVIDER_SNAP_ID', () => {
-      const requestMock = buildInitRequestMock();
-      process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID = '   ';
-      jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
+        expect(() => GatorPermissionsControllerInit(requestMock)).toThrow(
+          'GATOR_PERMISSIONS_PROVIDER_SNAP_ID must be set to a valid snap id',
+        );
 
-      GatorPermissionsControllerInit(requestMock);
-
-      expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
-        messenger: requestMock.controllerMessenger,
-        state: {
-          isGatorPermissionsEnabled: true,
-          ...requestMock.persistedState.GatorPermissionsController,
-        },
+        expect(GatorPermissionsControllerClassMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
+++ b/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
@@ -27,8 +27,7 @@ function buildInitRequestMock(): jest.Mocked<
 }
 
 describe('GatorPermissionsControllerInit', () => {
-  const MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
-    'npm:@metamask/permissions-kernel-snap';
+  const MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID = 'npm:mock-snap-id';
   const GatorPermissionsControllerClassMock = jest.mocked(
     GatorPermissionsController,
   );

--- a/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.ts
+++ b/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.ts
@@ -9,22 +9,34 @@ import { GatorPermissionsControllerMessenger } from '../messengers/gator-permiss
 
 const generateDefaultGatorPermissionsControllerState =
   (): Partial<GatorPermissionsControllerState> => {
-    const snapId = process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
-    const baseGatorPermissionsControllerState: Partial<GatorPermissionsControllerState> =
-      {
-        isGatorPermissionsEnabled: isGatorPermissionsFeatureEnabled(),
-      };
+    const gatorPermissionsProviderSnapId =
+      process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
-    try {
-      assertIsValidSnapId(snapId);
-    } catch (error) {
-      return baseGatorPermissionsControllerState;
+    // if GATOR_PERMISSIONS_PROVIDER_SNAP_ID is not specified, GatorPermissionsController will initialize it's default
+    if (gatorPermissionsProviderSnapId !== undefined) {
+      try {
+        assertIsValidSnapId(gatorPermissionsProviderSnapId);
+      } catch (error) {
+        throw new Error(
+          'GATOR_PERMISSIONS_PROVIDER_SNAP_ID must be set to a valid snap id',
+          {
+            cause: error,
+          },
+        );
+      }
     }
 
-    return {
-      ...baseGatorPermissionsControllerState,
-      gatorPermissionsProviderSnapId: snapId,
+    const isGatorPermissionsEnabled = isGatorPermissionsFeatureEnabled();
+
+    const state: Partial<GatorPermissionsControllerState> = {
+      isGatorPermissionsEnabled,
     };
+
+    if (gatorPermissionsProviderSnapId) {
+      state.gatorPermissionsProviderSnapId = gatorPermissionsProviderSnapId;
+    }
+
+    return state;
   };
 
 export const GatorPermissionsControllerInit: ControllerInitFunction<

--- a/builds.yml
+++ b/builds.yml
@@ -108,11 +108,6 @@ buildTypes:
       - GOOGLE_CLIENT_ID_REF: GOOGLE_FLASK_CLIENT_ID
       - APPLE_CLIENT_ID_REF: APPLE_FLASK_CLIENT_ID
 
-      # EIP-7715 Readable Permissions
-      - PERMISSIONS_KERNEL_SNAP_ID: ''
-      - GATOR_PERMISSIONS_ENABLED: false
-      - GATOR_PERMISSIONS_PROVIDER_SNAP_ID: ''
-
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
     buildNameOverride: MetaMask Flask
@@ -332,9 +327,9 @@ env:
   - METAMASK_RAMP_API_CONTENT_BASE_URL: https://on-ramp-content.api.cx.metamask.io
 
   # EIP-7715 Readable Permissions
-  - PERMISSIONS_KERNEL_SNAP_ID: ''
   - GATOR_PERMISSIONS_ENABLED: false
-  - GATOR_PERMISSIONS_PROVIDER_SNAP_ID: ''
+  - PERMISSIONS_KERNEL_SNAP_ID: 'npm:@metamask/permissions-kernel-snap'
+  - GATOR_PERMISSIONS_PROVIDER_SNAP_ID: 'npm:@metamask/gator-permissions-snap'
 
   ###
   # Meta variables


### PR DESCRIPTION
## **Description**

When instantiating the `GatorPermissionsController`, previously invalid snapIds specified by `process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID` would be ignored, falling back to the default value specified by the controller implementation.

This is undesired because the configuration that is supplied at build time is being ignored. The preferred behaviour is to fail, and require valid configuration.

This change throws an error if an invalid snapId is specified, and adds reasonable configuration values to builds.yml configuration. If no values are specified, the default from Gator Permissions Controller is used.

In order to enable the feature for any build (local, flask, production) with the production snaps, only the `GATOR_PERMISSIONS_ENABLED` variable would need to be set.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35775?quickstart=1)

## **Changelog**

This PR is not user facing, as it's targeting a feature branch. Change log details will be provided in that PR.

## **Related**

https://github.com/MetaMask/metamask-extension/pull/35627

## **Manual testing steps**

Provide explicit configuration (default):
1. Extension should start successfully

Provide no configuration:
1. Remove the `GATOR_PERMISSIONS_PROVIDER_SNAP_ID` from builds.yml
2. Extension should start successfully

Provide invalid configuration
1. Set `GATOR_PERMISSIONS_PROVIDER_SNAP_ID` to an invalid snapId (ie "invalid-snap-id")
2. Extension should fail to start
