### PR TITLE
feat: disable temporarily flaky ledger tests

### DIFF
--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
@@ -12,7 +12,8 @@ import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
 
 describe('Ledger Hardware', function (this: Suite) {
-  it('can create an ERC20 token', async function () {
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('can create an ERC20 token', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder()

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
@@ -16,7 +16,8 @@ import { mockLedgerTransactionRequests } from './mocks';
 const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
 describe('Ledger Swap', function () {
-  it('swaps ETH to DAI', async function () {
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('swaps ETH to DAI', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().withLedgerAccount().build(),


### PR DESCRIPTION
## **Description**

As some ledger tests have been flagged as flaky (see logs [here](https://github.com/MetaMask/metamask-extension/actions/runs/17572388816/job/49911360531) and [here](https://github.com/MetaMask/metamask-extension/actions/runs/17584255730/job/49950752019) ), we decided to disable them until we understand what's the issue.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35791?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
