### PR TITLE
fix: multichain UI for search, details and wallet

### DIFF
--- a/ui/pages/multichain-accounts/account-list/account-list.tsx
+++ b/ui/pages/multichain-accounts/account-list/account-list.tsx
@@ -99,6 +99,7 @@ export const AccountList = () => {
       <Content className="account-list-page__content">
         <Box
           flexDirection={FlexDirection.Column}
+          paddingTop={1}
           paddingLeft={4}
           paddingRight={4}
           paddingBottom={2}

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -101,7 +101,7 @@ export const MultichainAccountDetailsPage = () => {
           />
         }
       >
-        {t('accountDetails')}
+        {multichainAccount.metadata.name}
       </Header>
       <Content
         className="multichain-account-details-page__content"

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.test.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.test.tsx
@@ -46,11 +46,12 @@ describe('WalletDetailsPage', () => {
   it('renders the page with correct components and wallet information', () => {
     renderComponent();
 
-    expect(screen.getByText('Wallet details')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Wallet 1' }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('Back')).toBeInTheDocument();
-
     expect(screen.getByText('Wallet name')).toBeInTheDocument();
-    expect(screen.getByText('Wallet 1')).toBeInTheDocument();
+    expect(screen.getAllByText('Wallet 1')[1]).toBeInTheDocument();
     expect(screen.getByText('Balance')).toBeInTheDocument();
     expect(screen.getByText('Secret Recovery Phrase')).toBeInTheDocument();
     expect(screen.getByText('Account 1')).toBeInTheDocument();

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
@@ -104,7 +104,7 @@ export const WalletDetailsPage = () => {
           />
         }
       >
-        {t('walletDetails')}
+        {wallet?.metadata.name}
       </Header>
       <Content>
         <Box


### PR DESCRIPTION
## **Description**
This PR adds small adjustments to the UI/UX for search bar on the account list, wallet details and accounts details.

Updates:
- Search bar now has padding at the top which makes its outline border properly visible when focused.
- Account details page title is now the account name.
- Wallet details page title is now the wallet name.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35793?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed multichain accounts UI for search bar, account details page and wallet details page

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-697

Also fixes: https://consensyssoftware.atlassian.net/browse/MUL-782

## **Manual testing steps**
1. Build extension with multichain accounts state 2 feature flag enabled.
2. Go to the account list, click into the search bar input. Check outline border visibility.
3. Go to the account details for some account. Check that the page title matches the account name.
4. Go to wallet details for some of the wallets and check that the page title is matching the wallet name.

## **Screenshots/Recordings**
### **Before**


https://github.com/user-attachments/assets/9023f97b-b182-459b-ba78-ff19c10cd9a2


### **After**

https://github.com/user-attachments/assets/5c9fcd64-cd19-4bda-963e-d6f402dcc24e


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.