### PR TITLE
fix(snaps): Align label margin on Snap UI form elements

### DIFF
--- a/ui/components/app/snaps/snap-ui-address-input/snap-ui-address-input.tsx
+++ b/ui/components/app/snaps/snap-ui-address-input/snap-ui-address-input.tsx
@@ -255,6 +255,7 @@ export const SnapUIAddressInput: FunctionComponent<
       value={value}
       onChange={handleChange}
       label={label}
+      labelProps={{ marginBottom: 0 }}
       disabled={disabled}
       error={Boolean(error)}
       size={FormTextFieldSize.Lg}

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -114,6 +114,7 @@ export const SnapUIInput: FunctionComponent<
       }}
       onChange={handleChange}
       label={label}
+      labelProps={{ marginBottom: 0 }}
       disabled={disabled}
       {...props}
     />

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
@@ -70,7 +70,7 @@ exports[`SnapUIForm will render with fields 1`] = `
             class="mm-box mm-form-text-field snap-ui-renderer__input snap-ui-renderer__field mm-box--display-flex mm-box--flex-direction-column"
           >
             <label
-              class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
+              class="mm-box mm-text mm-label mm-label--html-for mm-form-text-field__label mm-text--body-md mm-text--font-weight-medium mm-box--margin-bottom-0 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
               for="input"
             >
               My Input


### PR DESCRIPTION
## **Description**

This PR fixes the margin being different on some form elements (`Input` and `AddressInput`) due to the use of `FormTextField`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35794?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:Align label margin on Snap UI form elements

## **Related issues**

Fixes:#35788

## **Manual testing steps**

1. Go to test-snaps
2. Use the send-flow example snap
3. Ensure that all elements have the same label bottom margin

## **Screenshots/Recordings**

### **Before**

<img width="400" height="620" alt="image" src="https://github.com/user-attachments/assets/6d678848-ac7d-486c-ba57-f31225392fc6" />

### **After**

<img width="400" height="620" alt="image" src="https://github.com/user-attachments/assets/ee20dafb-dccc-485c-b1f8-8e05c845139a" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
