### PR TITLE
fix: only show connected and active badge

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -191,6 +191,9 @@ const AccountListItem = ({
     currentTabOrigin && currentTabIsConnectedToSelectedAddress;
   const isSingleAccount = accountsCount === 1;
 
+  // Only show connected status badge if account is actually connected
+  const shouldShowConnectedStatusBadge = showConnectedStatus && isConnected;
+
   const getIsAggregatedFiatOverviewBalanceProp = () => {
     const isAggregatedFiatOverviewBalance =
       (!isTestnet && process.env.PORTFOLIO_VIEW && shouldShowFiat) ||
@@ -241,7 +244,7 @@ const AccountListItem = ({
           <ConnectedStatus
             address={account.address}
             isActive={isActive}
-            showConnectedStatus={showConnectedStatus}
+            showConnectedStatus={shouldShowConnectedStatusBadge}
           />
         </Box>
         <Box display={[Display.None, Display.Flex]}>


### PR DESCRIPTION
This PR ensures that in account list badge is shown only for accounts connected and active. It removes the not connected badge and tooltip


CHANGELOG entry:

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/5712](https://github.com/MetaMask/MetaMask-planning/issues/5712)

## **Manual testing steps**

1. Connect MM to Dapp
2. Open account list menu
3. check it renders badge for connected and active accounts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/14ff1414-4f6a-451f-a529-707717e7ffe4



### **After**




https://github.com/user-attachments/assets/1bc2d280-7df0-457a-a82e-f5d392bae16d

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
