### PR TITLE
fix: padding for the account picker

### DIFF
--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -236,8 +236,8 @@ export const AppHeaderUnlockedContent = ({
                 });
               }}
               disabled={disableAccountPicker}
-              paddingLeft={2}
-              paddingRight={2}
+              paddingLeft={isMultichainAccountsState2Enabled ? 0 : 2}
+              paddingRight={isMultichainAccountsState2Enabled ? 0 : 2}
             />
             <>{!isMultichainAccountsState2Enabled && CopyButton}</>
           </Text>


### PR DESCRIPTION
## **Description**
This PR fixes padding on the account picker that is unwanted for multichain accounts state two.

Notes:
- Padding on the left side of the account picker is removed when multichain accounts state 2 feature flag is enabled.
- Padding on the right side is also removed because it doesn't make sense to exist because of the hover effect.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35807?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed account picker alignment under multichain accounts feature flag

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-733

## **Manual testing steps**
1. Build extension with feature flag enabled for multichain accounts state 2.
2. Open extension.
3. Inspect alignment of the account picker at the top (in header) represented by the account name and arrow icon.
4. Make sure that alignment is as desired.

## **Screenshots/Recordings**
### **Before**
Multichain accounts state 2:
<img width="401" height="604" alt="Screenshot 2025-09-10 at 17 29 53" src="https://github.com/user-attachments/assets/9db61cbc-dd80-4851-aa2c-2948c3e9065f" />

Without feature flag:
<img width="401" height="604" alt="Screenshot 2025-09-10 at 17 32 44" src="https://github.com/user-attachments/assets/dd588e47-0cc7-4aa5-a2fc-c2ec175adb90" />

### **After**
Multichain accounts state 2:
<img width="401" height="604" alt="Screenshot 2025-09-10 at 17 25 55" src="https://github.com/user-attachments/assets/64ef84e8-5490-466d-b81a-daf333bec0ab" />

Without feature flag:
<img width="401" height="604" alt="Screenshot 2025-09-10 at 17 35 18" src="https://github.com/user-attachments/assets/9d6c8190-bce0-4092-b824-d9af3173e791" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.