### PR TITLE
fix: Add some UI adjustments to the multichain account details page

### DIFF
--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -36,7 +36,7 @@ describe('MultichainSrpBackup', () => {
     renderComponent();
 
     expect(screen.getByText('Secret Recovery Phrase')).toBeInTheDocument();
-    expect(screen.getByText('Back up')).toBeInTheDocument();
+    expect(screen.getByText('Reveal')).toBeInTheDocument();
 
     const buttonElement = screen.getByTestId(srpBackupRowTestId);
     expect(buttonElement).toHaveClass('multichain-srp-backup');
@@ -50,11 +50,11 @@ describe('MultichainSrpBackup', () => {
     expect(buttonElement).toHaveClass('custom-class');
   });
 
-  it('displays "Back up" text when shouldShowBackupReminder is false', () => {
+  it('displays "Reveal" text when shouldShowBackupReminder is false', () => {
     renderComponent({ shouldShowBackupReminder: false });
 
-    expect(screen.getByText('Back up')).toBeInTheDocument();
-    expect(screen.queryByText('Backup')).not.toBeInTheDocument();
+    expect(screen.getByText('Reveal')).toBeInTheDocument();
+    expect(screen.queryByText('Back up')).not.toBeInTheDocument();
   });
 
   it('navigates to SRP review route when shouldShowBackupReminder is true', () => {

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.tsx
@@ -75,7 +75,9 @@ export const MultichainSrpBackup: React.FC<MultichainSrpBackupProps> = ({
             variant={TextVariant.bodyMdMedium}
             color={TextColor.textAlternative}
           >
-            {t('accountDetailsSrpBackUpMessage')}
+            {shouldShowBackupReminder
+              ? t('accountDetailsSrpBackUpMessage')
+              : t('srpListStateBackedUp')}
           </Text>
           <Icon
             name={IconName.ArrowRight}

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -92,6 +92,10 @@ export const MultichainAccountDetailsPage = () => {
     setIsAccountRenameModalOpen(true);
   };
 
+  const handleWalletAction = () => {
+    history.push(walletRoute);
+  };
+
   return (
     <Page className="multichain-account-details-page">
       <Header
@@ -139,6 +143,7 @@ export const MultichainAccountDetailsPage = () => {
           <AccountDetailsRow
             label={t('networks')}
             value={`${addressCount} ${addressCount > 1 ? t('addressesLabel') : t('addressLabel')}`}
+            onClick={handleAddressesClick}
             endAccessory={
               <ButtonIcon
                 iconName={IconName.ArrowRight}
@@ -147,7 +152,6 @@ export const MultichainAccountDetailsPage = () => {
                 ariaLabel={t('addresses')}
                 marginLeft={2}
                 data-testid="network-addresses-link"
-                onClick={handleAddressesClick}
               />
             }
           />
@@ -169,6 +173,7 @@ export const MultichainAccountDetailsPage = () => {
           <AccountDetailsRow
             label={t('smartAccountLabel')}
             value={t('setUp')}
+            onClick={handleSmartAccountClick}
             endAccessory={
               <ButtonIcon
                 iconName={IconName.ArrowRight}
@@ -177,7 +182,6 @@ export const MultichainAccountDetailsPage = () => {
                 ariaLabel={t('smartAccountLabel')}
                 marginLeft={2}
                 data-testid="smart-account-action"
-                onClick={handleSmartAccountClick}
               />
             }
           />
@@ -186,6 +190,7 @@ export const MultichainAccountDetailsPage = () => {
           <AccountDetailsRow
             label={t('wallet')}
             value={wallet.metadata.name}
+            onClick={handleWalletAction}
             endAccessory={
               <ButtonIcon
                 iconName={IconName.ArrowRight}
@@ -196,9 +201,6 @@ export const MultichainAccountDetailsPage = () => {
                 data-testid="wallet-details-link"
               />
             }
-            onClick={() => {
-              history.push(walletRoute);
-            }}
           />
           {isEntropyWallet ? (
             <MultichainSrpBackup


### PR DESCRIPTION
## **Description**
This PR adds some requested changes to the multichain account details page.

Notes:
- All info rows are made clickable anywhere.
- SRP backup text is changed from "Back up" to "Reveal" when SRP is already backed up.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35818?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added minor UI and functionality adjustments to the multichain account details

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-783

Also fixes: https://consensyssoftware.atlassian.net/browse/MUL-786

## **Manual testing steps**
1. Build and use extension with multichain accounts state 2 feature flag enabled.
2. Open extension, create fresh new wallet and do not do SRP backup, go to the account list, pick some of the accounts to view its details.
3. On the account details page check that all rows are clickable anywhere and their actions are executed properly (rename, SRP backup triggered, link to another page, etc.)
4. Make sure that SRP backup text says "Back up" for the new wallet which is not backed up.
5. Backup wallet SRP by going through the process.
6. Make sure that text for the SRP on the account details page (and wallet details as well) is now "Reveal" instead of "Back up".

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/a6d3228f-bc8c-4c74-81a3-455dd4d97485


### **After**

- When SRP is backed up

https://github.com/user-attachments/assets/8146662d-f96e-4392-99a2-bf5e17681e5e

- When SRP is **not** backed up

https://github.com/user-attachments/assets/44a243a0-a153-40b3-8b25-0f486826be5c


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.