### PR TITLE
fix: multichain QR modal block explorer link

### DIFF
--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.test.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/jest';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
+import { openBlockExplorer } from '../../multichain/menu-items/view-explorer-menu-item';
 import { AddressQRCodeModal } from './address-qr-code-modal';
 
 // Mock copy to clipboard hook
@@ -9,9 +10,18 @@ jest.mock('../../../hooks/useCopyToClipboard', () => ({
   useCopyToClipboard: jest.fn(),
 }));
 
+// Mock the openBlockExplorer function
+jest.mock(
+  '../../../components/multichain/menu-items/view-explorer-menu-item',
+  () => ({
+    openBlockExplorer: jest.fn(),
+  }),
+);
+
 const mockUseCopyToClipboard = useCopyToClipboard as jest.MockedFunction<
   typeof useCopyToClipboard
 >;
+const mockOpenBlockExplorer = openBlockExplorer as jest.Mock;
 
 describe('AddressQRCodeModal', () => {
   beforeEach(() => {
@@ -140,28 +150,30 @@ describe('AddressQRCodeModal', () => {
     expect(mockUseCopyToClipboard).toHaveBeenCalled();
   });
 
-  it('should render explorer link with correct href for Ethereum', () => {
+  it('should navigate to the correct URL for Ethereum explorer when button is clicked', () => {
+    const address = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
     renderWithProvider(
       <AddressQRCodeModal
         isOpen={true}
         onClose={jest.fn()}
-        address="0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc"
+        address={address}
         accountName="Test Account"
         networkName="Ethereum Mainnet"
         networkImageSrc="./images/eth_logo.svg"
       />,
     );
 
-    const explorerLink = screen.getByRole('link', {
+    const explorerButton = screen.getByRole('button', {
       name: 'View on Etherscan',
     });
 
-    expect(explorerLink).toHaveAttribute(
-      'href',
-      `https://etherscan.io/address/0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc`,
+    fireEvent.click(explorerButton);
+
+    expect(mockOpenBlockExplorer).toHaveBeenCalledTimes(1);
+    expect(mockOpenBlockExplorer.mock.calls[0][0]).toBe(
+      `https://etherscan.io/address/${address}`,
     );
-    expect(explorerLink).toHaveAttribute('target', '_blank');
-    expect(explorerLink).toHaveAttribute('rel', 'noreferrer');
   });
 
   it('should call onClose when close button is clicked', () => {
@@ -183,7 +195,7 @@ describe('AddressQRCodeModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('should handle different network types', () => {
+  it('should handle different network types and navigate to Solana explorer correctly', () => {
     // Test Solana
     const solanaAddress = 'Dh9ZYBBCdD5FjjgKpAi9w9GQvK4f8k3b8a8HHKhz7kLa';
     renderWithProvider(
@@ -202,16 +214,20 @@ describe('AddressQRCodeModal', () => {
     expect(screen.getByText('Dh9ZYB')).toBeInTheDocument(); // First 6 chars
     expect(screen.getByText('z7kLa')).toBeInTheDocument(); // Last 5 chars
 
-    const explorerLink = screen.getByRole('link', {
+    const explorerButton = screen.getByRole('button', {
       name: 'View on Solscan',
     });
-    expect(explorerLink).toHaveAttribute(
-      'href',
+    expect(explorerButton).toBeInTheDocument();
+
+    fireEvent.click(explorerButton);
+
+    expect(mockOpenBlockExplorer).toHaveBeenCalledTimes(1);
+    expect(mockOpenBlockExplorer.mock.calls[0][0]).toBe(
       `https://solscan.io/address/${solanaAddress}`,
     );
   });
 
-  it('should handle Bitcoin network', () => {
+  it('should handle Bitcoin network and navigate to Bitcoin explorer correctly', () => {
     const bitcoinAddress = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
     renderWithProvider(
       <AddressQRCodeModal
@@ -227,11 +243,15 @@ describe('AddressQRCodeModal', () => {
     expect(screen.getByText('Bitcoin Account / Bitcoin')).toBeInTheDocument();
     expect(screen.getByText('Bitcoin Address')).toBeInTheDocument();
 
-    const explorerLink = screen.getByRole('link', {
+    const explorerButton = screen.getByRole('button', {
       name: 'View on Blockstream',
     });
-    expect(explorerLink).toHaveAttribute(
-      'href',
+    expect(explorerButton).toBeInTheDocument();
+
+    fireEvent.click(explorerButton);
+
+    expect(mockOpenBlockExplorer).toHaveBeenCalledTimes(1);
+    expect(mockOpenBlockExplorer.mock.calls[0][0]).toBe(
       `https://blockstream.info/address/${bitcoinAddress}`,
     );
   });
@@ -251,9 +271,11 @@ describe('AddressQRCodeModal', () => {
       screen.getByText('Test Account / Unknown Network'),
     ).toBeInTheDocument();
     expect(screen.getByText('Unknown Network Address')).toBeInTheDocument();
-    // Explorer link should not be rendered for unknown networks
+    // Explorer button should not be rendered for unknown networks
     expect(
-      screen.queryByRole('link', { name: /view.*explorer/iu }),
+      screen.queryByRole('button', { name: /view.*explorer/iu }),
     ).not.toBeInTheDocument();
+    // Make sure openBlockExplorer was not called
+    expect(mockOpenBlockExplorer).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -233,15 +233,8 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
                 size={ButtonSize.Lg}
                 isFullWidth
                 onClick={handleExplorerNavigation}
-                asChild
               >
-                <a
-                  href={`${explorerInfo.url}/address/${address}`}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {explorerInfo.buttonText}
-                </a>
+                {explorerInfo.buttonText}
               </Button>
             )}
           </Box>


### PR DESCRIPTION
## **Description**
This PR adds fix for block explorer link inside multichain accounts QR code modal. The issue was that when clicked, user was sent to two block explorer websites instead of one.

#### Notes:
- There was `<a>` tag with `href` to the block explorer URL, plus the `onClick` handler registered that links to the same thing. That was the cause of the issue.
- `<a>` tag is removed.
- Button is not `asChild` anymore.
- Only onClick handler is used to open the block explorer now, which happens only once.
- Unit tests are updated to match the testing of the new (fixed) approach implemented.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35822?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug with opening multiple block explorer URLs from multichain QR code modal

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-784

## **Manual testing steps**
1. Build and use extension with multichain accounts state 2 feature flag enabled.
2. Go to the account list.
3. Pick some of the accounts and go to its account details page.
4. Click on the networks and open network list page for the given account.
5. Click on the QR code icon for some of the networks that supports block explorer (e.g. ethereum).
6. QR code modal will open.
7. Click on the button for block explorer and verify where, how and how many times it opens the explorer URLs.
8. It should open block explorer URL only once.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/963d2f04-fa1b-4237-8592-8d031d9537fe


### **After**

https://github.com/user-attachments/assets/6695f86f-6393-4be2-9159-5d035b3546a0


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.