### PR TITLE
fix: error in solana assets when toggling fiat mode

### DIFF
--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -74,7 +74,7 @@ export const Amount = () => {
 
   const toggleFiatMode = useCallback(() => {
     const newFiatMode = !fiatMode;
-    if (amount) {
+    if (amount !== undefined) {
       setAmount(newFiatMode ? getFiatValue(amount) : getNativeValue(amount));
     }
     setFiatMode(newFiatMode);

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -74,7 +74,7 @@ export const Amount = () => {
 
   const toggleFiatMode = useCallback(() => {
     const newFiatMode = !fiatMode;
-    if (amount !== undefined) {
+    if (amount) {
       setAmount(newFiatMode ? getFiatValue(amount) : getNativeValue(amount));
     }
     setFiatMode(newFiatMode);

--- a/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
+++ b/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
@@ -55,7 +55,7 @@ const getNativeValueFn = ({
   return (
     convertedCurrency(
       amount,
-      conversionRate !== 0 ? 1 / conversionRate : 0,
+      conversionRate === 0 ? 0 : 1 / conversionRate,
       asset?.decimals,
     ) ?? '0'
   );
@@ -100,7 +100,7 @@ export const useCurrencyConversions = () => {
   const multichainAssetsRates = useSelector(getAssetsRates);
 
   const conversionRate = useMemo(() => {
-    const assetAddress = asset?.assetId ?? asset?.address;
+    const assetAddress = asset?.address ?? asset?.assetId;
     if (
       !asset ||
       !assetAddress ||

--- a/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
+++ b/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
@@ -127,12 +127,7 @@ export const useCurrencyConversions = () => {
     return parseFloat(
       multichainAssetsRates[assetAddress as CaipAssetType]?.rate ?? 0,
     );
-  }, [
-    asset?.address,
-    contractExchangeRates,
-    conversionRateEvm,
-    multichainAssetsRates,
-  ]);
+  }, [asset, contractExchangeRates, conversionRateEvm, multichainAssetsRates]);
 
   const getFiatValue = useCallback(
     (amount: string) =>

--- a/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
+++ b/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
@@ -27,7 +27,7 @@ type ConversionArgs = {
 };
 
 const getFiatValueFn = ({ amount, conversionRate }: ConversionArgs) => {
-  if (!amount) {
+  if (!amount?.length) {
     return '0.00';
   }
   return convertedCurrency(amount, conversionRate, 2) ?? '0.00';
@@ -49,7 +49,7 @@ const getNativeValueFn = ({
   amount,
   conversionRate,
 }: ConversionArgs) => {
-  if (!amount) {
+  if (!amount?.length) {
     return '0';
   }
   return convertedCurrency(amount, 1 / conversionRate, asset?.decimals) ?? '0';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

amount page crashes when toggling fiat mode on empty string

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19579

## **Manual testing steps**

1. Enable new send locally
2. Toggle fiat mode on amount with while input is empty
3. It should not throw error

## **Screenshots/Recordings**
todo

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
