### PR TITLE
feat: added ui for error states

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5631,6 +5631,9 @@
     "message": "Membership is paused due to insufficient token balance. $1 to resume coverage.",
     "description": "The $1 is the action text 'Update payment'"
   },
+  "shieldTxMembershipErrorInsufficientTokenTooltip": {
+    "message": "Insufficient token balance in your wallet. Top up or select an alternative payment method to resume coverage."
+  },
   "shieldTxMembershipErrorMembershipEnding": {
     "message": "Your membership is ending on $1. $2 to maintain uninterrupted access",
     "description": "The $1 is date and $2 is the action text 'Renew now'"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5612,6 +5612,35 @@
   "shieldTxMembershipCancel": {
     "message": "Cancel membership"
   },
+  "shieldTxMembershipErrorDeclinedCard": {
+    "message": "Membership is paused due to declined card. $1 to resume coverage.",
+    "description": "The $1 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorInsufficientFunds": {
+    "message": "Insufficient funds for your $1 renewal. $2 to keep your access.",
+    "description": "The $1 is date and $2 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorInsufficientToken": {
+    "message": "Insufficient $1",
+    "description": "The $1 is the token symbol"
+  },
+  "shieldTxMembershipErrorInsufficientTokenBalance": {
+    "message": "Membership is paused due to insufficient token balance. $1 to resume coverage.",
+    "description": "The $1 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorMembershipEnding": {
+    "message": "Your membership is ending on $1. $2 to maintain uninterrupted access",
+    "description": "The $1 is date and $2 is the action text 'Renew now'"
+  },
+  "shieldTxMembershipErrorRenewNow": {
+    "message": "Renew now"
+  },
+  "shieldTxMembershipErrorUpdateCardDetails": {
+    "message": "Update card details"
+  },
+  "shieldTxMembershipErrorUpdatePayment": {
+    "message": "Update payment"
+  },
   "shieldTxMembershipFreeTrial": {
     "message": "Free trial"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5616,6 +5616,9 @@
     "message": "Membership is paused due to declined card. $1 to resume coverage.",
     "description": "The $1 is the action text 'Update payment'"
   },
+  "shieldTxMembershipErrorDeclinedCardTooltip": {
+    "message": "Your payment was declined. Please update your payment method to continue your coverage."
+  },
   "shieldTxMembershipErrorInsufficientFunds": {
     "message": "Insufficient funds for your $1 renewal. $2 to keep your access.",
     "description": "The $1 is date and $2 is the action text 'Update payment'"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5631,6 +5631,9 @@
     "message": "Membership is paused due to insufficient token balance. $1 to resume coverage.",
     "description": "The $1 is the action text 'Update payment'"
   },
+  "shieldTxMembershipErrorInsufficientTokenTooltip": {
+    "message": "Insufficient token balance in your wallet. Top up or select an alternative payment method to resume coverage."
+  },
   "shieldTxMembershipErrorMembershipEnding": {
     "message": "Your membership is ending on $1. $2 to maintain uninterrupted access",
     "description": "The $1 is date and $2 is the action text 'Renew now'"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5612,6 +5612,35 @@
   "shieldTxMembershipCancel": {
     "message": "Cancel membership"
   },
+  "shieldTxMembershipErrorDeclinedCard": {
+    "message": "Membership is paused due to declined card. $1 to resume coverage.",
+    "description": "The $1 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorInsufficientFunds": {
+    "message": "Insufficient funds for your $1 renewal. $2 to keep your access.",
+    "description": "The $1 is date and $2 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorInsufficientToken": {
+    "message": "Insufficient $1",
+    "description": "The $1 is the token symbol"
+  },
+  "shieldTxMembershipErrorInsufficientTokenBalance": {
+    "message": "Membership is paused due to insufficient token balance. $1 to resume coverage.",
+    "description": "The $1 is the action text 'Update payment'"
+  },
+  "shieldTxMembershipErrorMembershipEnding": {
+    "message": "Your membership is ending on $1. $2 to maintain uninterrupted access",
+    "description": "The $1 is date and $2 is the action text 'Renew now'"
+  },
+  "shieldTxMembershipErrorRenewNow": {
+    "message": "Renew now"
+  },
+  "shieldTxMembershipErrorUpdateCardDetails": {
+    "message": "Update card details"
+  },
+  "shieldTxMembershipErrorUpdatePayment": {
+    "message": "Update payment"
+  },
   "shieldTxMembershipFreeTrial": {
     "message": "Free trial"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5616,6 +5616,9 @@
     "message": "Membership is paused due to declined card. $1 to resume coverage.",
     "description": "The $1 is the action text 'Update payment'"
   },
+  "shieldTxMembershipErrorDeclinedCardTooltip": {
+    "message": "Your payment was declined. Please update your payment method to continue your coverage."
+  },
   "shieldTxMembershipErrorInsufficientFunds": {
     "message": "Insufficient funds for your $1 renewal. $2 to keep your access.",
     "description": "The $1 is date and $2 is the action text 'Update payment'"

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -194,7 +194,7 @@ const TransactionShield = () => {
       return (
         <Tooltip
           position="top"
-          title={t('shieldTxMembershipErrorInsufficientTokenBalanceTooltip')}
+          title={t('shieldTxMembershipErrorInsufficientTokenTooltip')}
         >
           <ButtonLink
             startIconName={IconName.Danger}

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { Skeleton } from '../../../components/component-library/skeleton';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import Tooltip from '../../../components/ui/tooltip';
 import CancelMembershipModal from './cancel-membership-modal';
 
 const MEMBERSHIP_ERROR_STATES = {
@@ -48,7 +49,7 @@ const TransactionShield = () => {
     useState(false);
   const [isActiveMembership, setIsActiveMembership] = useState(true);
   const [membershipErrorState] = useState<MembershipErrorState | null>(
-    MEMBERSHIP_ERROR_STATES.MEMBERSHIP_ENDING,
+    MEMBERSHIP_ERROR_STATES.INSUFFICIENT_TOKEN_BALANCE,
   );
 
   const shieldDetails = [
@@ -191,30 +192,40 @@ const TransactionShield = () => {
       MEMBERSHIP_ERROR_STATES.INSUFFICIENT_TOKEN_BALANCE
     ) {
       return (
-        <ButtonLink
-          startIconName={IconName.Danger}
-          danger
-          onClick={() => {
-            console.log('Insufficient USDT');
-          }}
+        <Tooltip
+          position="top"
+          title={t('shieldTxMembershipErrorInsufficientTokenBalanceTooltip')}
         >
-          {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
-        </ButtonLink>
+          <ButtonLink
+            startIconName={IconName.Danger}
+            danger
+            onClick={() => {
+              console.log('Insufficient USDT');
+            }}
+          >
+            {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
+          </ButtonLink>
+        </Tooltip>
       );
     }
     if (
       membershipErrorState === MEMBERSHIP_ERROR_STATES.DECLINED_CARD_PAYMENT
     ) {
       return (
-        <ButtonLink
-          startIconName={IconName.Danger}
-          danger
-          onClick={() => {
-            console.log('Update card details');
-          }}
+        <Tooltip
+          position="top"
+          title={t('shieldTxMembershipErrorDeclinedCardTooltip')}
         >
-          {t('shieldTxMembershipErrorUpdateCardDetails')}
-        </ButtonLink>
+          <ButtonLink
+            startIconName={IconName.Danger}
+            danger
+            onClick={() => {
+              console.log('Update card details');
+            }}
+          >
+            {t('shieldTxMembershipErrorUpdateCardDetails')}
+          </ButtonLink>
+        </Tooltip>
       );
     }
     if (membershipErrorState === MEMBERSHIP_ERROR_STATES.INSUFFICIENT_FUNDS) {

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -196,15 +196,20 @@ const TransactionShield = () => {
           position="top"
           title={t('shieldTxMembershipErrorInsufficientTokenTooltip')}
         >
-          <ButtonLink
-            startIconName={IconName.Danger}
-            danger
-            onClick={() => {
-              console.log('Insufficient USDT');
-            }}
-          >
-            {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
-          </ButtonLink>
+          <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+            <Icon
+              name={IconName.Danger}
+              color={IconColor.errorDefault}
+              size={IconSize.Md}
+            />
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.errorDefault}
+              className="underline"
+            >
+              {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
+            </Text>
+          </Box>
         </Tooltip>
       );
     }
@@ -216,48 +221,56 @@ const TransactionShield = () => {
           position="top"
           title={t('shieldTxMembershipErrorDeclinedCardTooltip')}
         >
-          <ButtonLink
-            startIconName={IconName.Danger}
-            danger
-            onClick={() => {
-              console.log('Update card details');
-            }}
-          >
-            {t('shieldTxMembershipErrorUpdateCardDetails')}
-          </ButtonLink>
+          <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+            <Icon
+              name={IconName.Danger}
+              color={IconColor.errorDefault}
+              size={IconSize.Md}
+            />
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.errorDefault}
+              className="underline"
+            >
+              {t('shieldTxMembershipErrorUpdateCardDetails')}
+            </Text>
+          </Box>
         </Tooltip>
       );
     }
     if (membershipErrorState === MEMBERSHIP_ERROR_STATES.INSUFFICIENT_FUNDS) {
       return (
-        <ButtonLink
-          startIconName={IconName.Danger}
-          startIconProps={{
-            color: IconColor.warningDefault,
-          }}
-          color={TextColor.warningDefault}
-          onClick={() => {
-            console.log('Insufficient funds');
-          }}
-        >
-          USDT
-        </ButtonLink>
+        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+          <Icon
+            name={IconName.Danger}
+            color={IconColor.warningDefault}
+            size={IconSize.Md}
+          />
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.warningDefault}
+          >
+            USDT
+          </Text>
+        </Box>
       );
     }
     if (membershipErrorState === MEMBERSHIP_ERROR_STATES.MEMBERSHIP_ENDING) {
       return (
-        <ButtonLink
-          startIconName={IconName.Danger}
-          startIconProps={{
-            color: IconColor.warningDefault,
-          }}
-          color={TextColor.warningDefault}
-          onClick={() => {
-            console.log('Membership ending');
-          }}
-        >
-          {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
-        </ButtonLink>
+        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+          <Icon
+            name={IconName.Danger}
+            color={IconColor.warningDefault}
+            size={IconSize.Md}
+          />
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.warningDefault}
+            className="underline"
+          >
+            {t('shieldTxMembershipErrorInsufficientToken', ['USDT'])}
+          </Text>
+        </Box>
       );
     }
     return 'USDT';

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -48,9 +48,7 @@ const TransactionShield = () => {
   const [isCancelMembershipModalOpen, setIsCancelMembershipModalOpen] =
     useState(false);
   const [isActiveMembership, setIsActiveMembership] = useState(true);
-  const [membershipErrorState] = useState<MembershipErrorState | null>(
-    MEMBERSHIP_ERROR_STATES.INSUFFICIENT_TOKEN_BALANCE,
-  );
+  const [membershipErrorState] = useState<MembershipErrorState | null>(null);
 
   const shieldDetails = [
     {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added UI to display different error states on metamask shield membership status


Figma: https://www.figma.com/design/HTAO1SrmixV4ppv7qIvLoa/Metamask-Shield?node-id=10109-23294&t=DB7F42ij5tBF4dzz-4
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35874?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added UI for showing subscription error states

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="623" height="821" alt="Screenshot 2025-09-16 at 11 24 06 AM" src="https://github.com/user-attachments/assets/32fabde0-9d1b-4ed5-9d43-4df1ea79a912" />

<img width="456" height="188" alt="Screenshot 2025-09-16 at 11 24 12 AM" src="https://github.com/user-attachments/assets/53a31e2c-4dc9-4a37-9fa7-14432a589a8f" />

<img width="623" height="835" alt="Screenshot 2025-09-16 at 11 25 44 AM" src="https://github.com/user-attachments/assets/7874a87d-d7e0-4d83-99c7-f34f24b77bf1" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
