### PR TITLE
fix: multichain account tree selector

### DIFF
--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -50,10 +50,9 @@ import { getSanitizedChainId, extractWalletIdFromGroupId } from './utils';
  * @param state.metamask.accountTree - Account tree state object.
  * @returns Account tree state.
  */
-export const getAccountTree = createDeepEqualSelector(
-  (state: MultichainAccountsState) => state.metamask.accountTree,
-  (accountTree: AccountTreeState): AccountTreeState => accountTree,
-);
+export const getAccountTree = (
+  state: MultichainAccountsState,
+): AccountTreeState => state.metamask.accountTree;
 
 /**
  * Common function to create consolidated wallets with accounts.


### PR DESCRIPTION
## **Description**
This PR adds fix for `getAccountTree` selector which returns the part of the state without any transformation, which means that it does not need to use `createSelector` or `createDeepEqualSelector` functions from reselect.

This resolves warnings from reselect and improves performance.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35886?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Build the extension with multichain accounts state 2 feature flag enabled.
2. Do some regular testing of multichain accounts and features.
3. Make sure that everything is working as before.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
No UI changes.

Console warnings:
<img width="1493" height="603" alt="Screenshot 2025-09-12 at 13 06 16" src="https://github.com/user-attachments/assets/6f5c6e95-163f-47d1-a79d-f28dc2fddef9" />

### **After**
Some testing that confirms that everything is working as expected:

https://github.com/user-attachments/assets/5d3e722e-7b2c-4ad5-a9ae-d61c87829297

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.