### PR TITLE
fix: flaky ledger e2e tests

### DIFF
--- a/test/e2e/page-objects/pages/swap/swap-page.ts
+++ b/test/e2e/page-objects/pages/swap/swap-page.ts
@@ -170,13 +170,10 @@ class SwapPage {
   }
 
   async swapProcessingMessageCheck(message: string): Promise<void> {
-    await this.driver.wait(async () => {
-      const confirmedTxs = await this.driver.findElements({
-        css: this.transactionHeader,
-        text: message,
-      });
-      return confirmedTxs.length === 1;
-    }, 10000);
+    await this.driver.waitForSelector({
+      css: this.transactionHeader,
+      text: message,
+    });
   }
 
   async checkSwapButtonIsEnabled(): Promise<void> {

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
@@ -17,7 +17,7 @@ const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
 describe('Ledger Swap', function () {
   // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('swaps ETH to DAI', async function () {
+  it('swaps ETH to DAI', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().withLedgerAccount().build(),
@@ -79,7 +79,6 @@ describe('Ledger Swap', function () {
 
         await swapPage.checkSwapButtonIsEnabled();
         await swapPage.submitSwap();
-
         await swapPage.waitForTransactionToComplete();
 
         await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
@@ -81,10 +81,6 @@ describe('Ledger Swap', function () {
         await swapPage.submitSwap();
         await swapPage.waitForTransactionToComplete();
 
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
-
         await homePage.checkPageIsLoaded();
         // check activity list
         await homePage.goToActivityList();

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
@@ -2,14 +2,9 @@ import { Browser } from 'selenium-webdriver';
 import FixtureBuilder from '../../../fixture-builder';
 import { WINDOW_TITLES, withFixtures } from '../../../helpers';
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
-import HeaderNavbar from '../../../page-objects/pages/header-navbar';
-import SettingsPage from '../../../page-objects/pages/settings/settings-page';
 import { checkActivityTransaction } from '../../swaps/shared';
-
 import HomePage from '../../../page-objects/pages/home/homepage';
-import AdvancedSettings from '../../../page-objects/pages/settings/advanced-settings';
 import SwapPage from '../../../page-objects/pages/swap/swap-page';
-
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../../../stub/keyring-bridge';
 import { mockLedgerTransactionRequests } from './mocks';
 
@@ -20,9 +15,15 @@ describe('Ledger Swap', function () {
   it('swaps ETH to DAI', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().withLedgerAccount().build(),
+        fixtures: new FixtureBuilder()
+          .withPreferencesControllerSmartTransactionsOptedOut()
+          .withLedgerAccount()
+          .build(),
         localNodeOptions: {
           loadState: './test/e2e/seeder/network-states/with50Dai.json',
+        },
+        manifestFlags: {
+          testing: { disableSmartTransactionsOverride: true },
         },
         title: this.test?.fullTitle(),
         testSpecificMock: mockLedgerTransactionRequests,
@@ -36,20 +37,6 @@ describe('Ledger Swap', function () {
         await loginWithBalanceValidation(driver, undefined, undefined, '20');
 
         const homePage = new HomePage(driver);
-
-        // disable smart transactions
-        const headerNavbar = new HeaderNavbar(driver);
-        await headerNavbar.checkPageIsLoaded();
-        await headerNavbar.openSettingsPage();
-        const settingsPage = new SettingsPage(driver);
-
-        await settingsPage.checkPageIsLoaded();
-        await settingsPage.clickAdvancedTab();
-        const advancedSettingsPage = new AdvancedSettings(driver);
-        await advancedSettingsPage.checkPageIsLoaded();
-        await advancedSettingsPage.toggleSmartTransactions();
-        await settingsPage.closeSettingsPage();
-
         await homePage.checkIfSwapButtonIsClickable();
 
         await homePage.startSwapFlow();
@@ -75,9 +62,11 @@ describe('Ledger Swap', function () {
 
         await swapPage.enterSwapAmount('2');
         await swapPage.selectDestinationToken('DAI');
-        await swapPage.dismissManualTokenWarning();
 
+        await swapPage.dismissManualTokenWarning();
         await swapPage.checkSwapButtonIsEnabled();
+        // To mitigate flakiness where the Swap page is re-rendered after submitting the swap (#36501)
+        await driver.delay(5000);
         await swapPage.submitSwap();
         await swapPage.waitForTransactionToComplete();
 

--- a/test/e2e/tests/hardware-wallets/ledger/mocks.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/mocks.ts
@@ -182,7 +182,7 @@ export async function mockLedgerTransactionRequests(mockServer: MockttpServer) {
 // Mock network information for swap API
 async function mockSwapNetworkInfo(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1')
+    .forGet('https://bridge.api.cx.metamask.io/networks/1')
     .thenCallback(() => ({
       statusCode: 200,
       json: {
@@ -312,7 +312,7 @@ async function mockLedgerIframeBridge(mockServer: MockttpServer) {
 // Mock swap feature flags API
 async function mockSwapFeatureFlags(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/featureFlags')
+    .forGet('https://bridge.api.cx.metamask.io/featureFlags')
     .thenCallback(() => ({
       statusCode: 200,
       json: {
@@ -337,7 +337,7 @@ async function mockSwapFeatureFlags(mockServer: MockttpServer) {
 // Mock swap tokens API
 async function mockSwapTokens(mockServer: MockttpServer) {
   return await mockServer
-    .forGet('https://swap.api.cx.metamask.io/networks/1/tokens')
+    .forGet('https://bridge.api.cx.metamask.io/networks/1/tokens')
     .thenCallback(() => ({
       statusCode: 200,
       json: [


### PR DESCRIPTION
## **Description**

Fix flaky e2e tests on Ledger flows

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35888?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Local testing

- run `yarn && yarn start:test` in one terminal tab and wait for build end
- run `yarn test:e2e:single test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts` on another terminal tab

Otherwise check this PR CI.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unskips and stabilizes the Ledger ETH→DAI swap e2e by disabling Smart Transactions, adding a brief delay, updating wait logic, and switching swap API mocks to bridge endpoints.
> 
> - **E2E Tests (Ledger swap)**:
>   - Unskips `swaps ETH to DAI` in `test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts`.
>   - Disables Smart Transactions via fixtures (`withPreferencesControllerSmartTransactionsOptedOut`) and manifest flag (`testing.disableSmartTransactionsOverride`); removes UI steps to toggle it.
>   - Adds a 5s delay before submitting swap to mitigate re-render flakiness; minor tab-switch simplification.
> - **Page Object**:
>   - `test/e2e/page-objects/pages/swap/swap-page.ts`: replace polling loop in `swapProcessingMessageCheck` with `waitForSelector` on `awaiting-swap-header`.
> - **Mocks**:
>   - `test/e2e/tests/hardware-wallets/ledger/mocks.ts`: point network info, feature flags, and tokens endpoints from `swap.api` to `bridge.api`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bba0fb00177e47ca15eea8b6d5a042ba22710cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->