### PR TITLE
chore: Remove unused `PreferencesController` metadata property

### DIFF
--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -356,20 +356,6 @@ const controllerMetadata = {
   preferences: {
     persist: true,
     anonymous: true,
-    properties: {
-      smartTransactionsOptInStatus: {
-        persist: true,
-        anonymous: true,
-      },
-      smartTransactionsMigrationApplied: {
-        persist: true,
-        anonymous: true,
-      },
-      avatarType: {
-        persist: true,
-        anonymous: true,
-      },
-    },
   },
   ipfsGateway: {
     persist: true,


### PR DESCRIPTION
## **Description**

This property is not used, and it violates the type for controller metadata. It must have been added by mistake.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35891?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This vaguely relates to https://github.com/MetaMask/core/issues/6516. I'm doing this cleanup to simplify the changes needed for that issue.

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
