### PR TITLE
fix: migrate identicons cp-13.4.0

### DIFF
--- a/ui/components/app/confirm/info/row/address.tsx
+++ b/ui/components/app/confirm/info/row/address.tsx
@@ -1,5 +1,6 @@
 import { NameType } from '@metamask/name-controller';
 import React, { memo, useState } from 'react';
+import { AvatarAccountSize } from '@metamask/design-system-react';
 import {
   AlignItems,
   Display,
@@ -10,7 +11,7 @@ import { Box, Text } from '../../../../component-library';
 import NicknamePopovers from '../../../modals/nickname-popovers';
 import Name from '../../../name/name';
 import { shortenAddress } from '../../../../../helpers/utils/util';
-import Identicon from '../../../../ui/identicon';
+import { PreferredAvatar } from '../../../preferred-avatar';
 import { useFallbackDisplayName } from './hook';
 
 export type ConfirmInfoRowAddressProps = {
@@ -44,7 +45,10 @@ export const ConfirmInfoRowAddress = memo(
                 alignItems={AlignItems.center}
                 onClick={isSnapUsingThis ? () => null : handleDisplayNameClick}
               >
-                <Identicon address={address} diameter={16} />
+                <PreferredAvatar
+                  address={address}
+                  size={AvatarAccountSize.Xs}
+                />
                 <Text
                   marginLeft={2}
                   color={TextColor.inherit}

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -16,6 +16,9 @@ const getImage = async (image, ipfsGateway) => {
   return await getAssetImageURL(image, ipfsGateway);
 };
 
+/**
+ * @deprecated Use PreferredAvatar instead
+ */
 export default class Identicon extends Component {
   static propTypes = {
     /**

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -134,11 +134,10 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
           class="request-encryption-public-key__request-icon"
         >
           <div
-            class=""
+            class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-[10px] h-10 w-10"
           >
             <div
-              class="identicon"
-              style="height: 40px; width: 40px; border-radius: 20px;"
+              class="flex [&>div]:!rounded-none"
             >
               <div
                 style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 40px; height: 40px; display: inline-block; background: rgb(245, 228, 0);"

--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import log from 'loglevel';
-
+import { AvatarAccountSize } from '@metamask/design-system-react';
 import AccountListItem from '../../components/app/account-list-item';
-import Identicon from '../../components/ui/identicon';
+import { PreferredAvatar } from '../../components/app/preferred-avatar';
 import { PageContainerFooter } from '../../components/ui/page-container';
 
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
@@ -107,7 +107,10 @@ export default class ConfirmEncryptionPublicKey extends Component {
 
     return (
       <div className="request-encryption-public-key__request-icon">
-        <Identicon diameter={40} address={requesterAddress} />
+        <PreferredAvatar
+          size={AvatarAccountSize.Lg}
+          address={requesterAddress}
+        />
       </div>
     );
   };

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -13,11 +13,10 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
         class="mm-box mm-box--margin-top-2 mm-box--display-flex"
       >
         <div
-          class=""
+          class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
           <div
-            class="identicon"
-            style="height: 32px; width: 32px; border-radius: 16px;"
+            class="flex [&>div]:!rounded-none"
           >
             <div
               style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
@@ -221,11 +220,10 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
         class="mm-box mm-box--margin-top-2 mm-box--display-flex"
       >
         <div
-          class=""
+          class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
           <div
-            class="identicon"
-            style="height: 32px; width: 32px; border-radius: 16px;"
+            class="flex [&>div]:!rounded-none"
           >
             <div
               style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 100, 242);"

--- a/ui/pages/confirmations/components/confirm/header/header-info.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header-info.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
+import { AvatarAccountSize } from '@metamask/design-system-react';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventLocation,
@@ -39,7 +40,7 @@ import useConfirmationRecipientInfo from '../../../hooks/useConfirmationRecipien
 import { SignatureRequestType } from '../../../types/confirm';
 import { isSignatureTransactionType } from '../../../utils/confirm';
 import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
-import Identicon from '../../../../../components/ui/identicon';
+import { PreferredAvatar } from '../../../../../components/app/preferred-avatar';
 import { getHDEntropyIndex } from '../../../../../selectors/selectors';
 import { AdvancedDetailsButton } from './advanced-details-button';
 
@@ -144,7 +145,10 @@ const HeaderInfo = () => {
                 flexDirection={FlexDirection.Column}
                 alignItems={AlignItems.center}
               >
-                <Identicon address={fromAddress} diameter={40} />
+                <PreferredAvatar
+                  address={fromAddress}
+                  size={AvatarAccountSize.Lg}
+                />
                 <Text
                   fontWeight={FontWeight.Bold}
                   variant={TextVariant.bodyMd}

--- a/ui/pages/confirmations/components/confirm/header/header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header.tsx
@@ -10,7 +10,7 @@ import {
   Box,
   Text,
 } from '../../../../../components/component-library';
-import Identicon from '../../../../../components/ui/identicon';
+import { PreferredAvatar } from '../../../../../components/app/preferred-avatar';
 import {
   AlignItems,
   Display,
@@ -51,7 +51,7 @@ const Header = () => {
     >
       <Box alignItems={AlignItems.flexStart} display={Display.Flex} padding={4}>
         <Box display={Display.Flex} marginTop={2}>
-          <Identicon address={fromAddress} diameter={32} />
+          <PreferredAvatar address={fromAddress} />
           <AvatarNetwork
             src={networkImageUrl}
             name={networkDisplayName}

--- a/ui/pages/confirmations/components/contract-token-values/contract-token-values.js
+++ b/ui/pages/confirmations/components/contract-token-values/contract-token-values.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getAccountLink } from '@metamask/etherscan-link';
+import { AvatarAccountSize } from '@metamask/design-system-react';
 import Box from '../../../../components/ui/box/box';
 import Tooltip from '../../../../components/ui/tooltip/tooltip';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import Identicon from '../../../../components/ui/identicon';
+import { PreferredAvatar } from '../../../../components/app/preferred-avatar';
 import {
   Text,
   ButtonIcon,
@@ -38,7 +39,7 @@ export default function ContractTokenValues({
       justifyContent={JustifyContent.center}
       gap={2}
     >
-      <Identicon address={address} diameter={24} />
+      <PreferredAvatar address={address} size={AvatarAccountSize.Sm} />
       <Text
         variant={TextVariant.headingLg}
         fontWeight={FontWeight.Bold}

--- a/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.js
+++ b/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.js
@@ -11,7 +11,7 @@ import {
   JustifyContent,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import Identicon from '../../../../components/ui/identicon';
+import { PreferredAvatar } from '../../../../components/app/preferred-avatar';
 import { shortenAddress } from '../../../../helpers/utils/util';
 import {
   Icon,
@@ -81,7 +81,7 @@ const SetApproveForAllWarning = ({
         className="set-approval-for-all-warning__content__account"
       >
         <Box display={DISPLAY.FLEX}>
-          <Identicon address={senderAddress} diameter={32} />
+          <PreferredAvatar address={senderAddress} />
           <Text
             variant={TextVariant.bodyMd}
             as="h5"

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -20,11 +20,10 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               >
                 <div
                   style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
@@ -281,11 +280,10 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               />
             </div>
             <div
@@ -770,11 +768,10 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               />
             </div>
             <div
@@ -1206,11 +1203,10 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               >
                 <div
                   style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
@@ -1985,11 +1981,10 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               >
                 <div
                   style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 59);"
@@ -2460,11 +2455,10 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               >
                 <div
                   style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 59);"
@@ -3155,9 +3149,12 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class="identicon__image-border"
-              style="height: 32px; width: 32px; border-radius: 16px;"
-            />
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+            >
+              <div
+                class="flex [&>div]:!rounded-none"
+              />
+            </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
             >
@@ -3266,11 +3263,10 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             class="mm-box mm-box--margin-top-2 mm-box--display-flex"
           >
             <div
-              class=""
+              class="inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
               <div
-                class="identicon"
-                style="height: 32px; width: 32px; border-radius: 16px;"
+                class="flex [&>div]:!rounded-none"
               />
             </div>
             <div


### PR DESCRIPTION
## **Description**

Migrate Identicons to use the new account avatar

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #35872 

## **Manual testing steps**

1. Connect to the test dapp
2. Trigger a Signature
3. See account icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="394" height="195" alt="image" src="https://github.com/user-attachments/assets/cca54999-69d9-45bd-b5bf-53cf365654fd" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
