### PR TITLE
refactor: use Link to simplify routing

### DIFF
--- a/ui/components/multichain/app-header/app-header.test.js
+++ b/ui/components/multichain/app-header/app-header.test.js
@@ -24,6 +24,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('react-router-dom-v5-compat', () => ({
+  // eslint-disable-next-line react/prop-types
   Link: ({ children, ...props }) => <a {...props}>{children}</a>,
 }));
 

--- a/ui/components/multichain/app-header/app-header.test.js
+++ b/ui/components/multichain/app-header/app-header.test.js
@@ -23,6 +23,10 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
 const render = ({
   stateChanges = {},
   location = {},

--- a/ui/components/multichain/global-menu/global-menu.test.tsx
+++ b/ui/components/multichain/global-menu/global-menu.test.tsx
@@ -21,6 +21,15 @@ const render = (metamaskStateChanges = {}) => {
   );
 };
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  Link: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >) => <a {...props}>{children}</a>,
+}));
+
 const mockLockMetaMask = jest.fn();
 const mockSetAccountDetailsAddress = jest.fn();
 jest.mock('../../../store/actions', () => ({
@@ -42,7 +51,7 @@ describe('Global Menu', () => {
   it('disables the settings item when there is an active transaction', async () => {
     const { getByTestId } = render();
     await waitFor(() => {
-      expect(getByTestId('global-menu-settings')).toBeDisabled();
+      expect(getByTestId('global-menu-settings')).not.toHaveAttribute('href');
     });
   });
 
@@ -56,7 +65,9 @@ describe('Global Menu', () => {
   it('disables the connected sites item when there is an active transaction', async () => {
     const { getByTestId } = render();
     await waitFor(() => {
-      expect(getByTestId('global-menu-connected-sites')).toBeDisabled();
+      expect(getByTestId('global-menu-connected-sites')).not.toHaveAttribute(
+        'href',
+      );
     });
   });
 

--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -258,9 +258,9 @@ export const GlobalMenu = ({
         style={{ height: '1px', borderBottomWidth: 0 }}
       ></Box>
       <MenuItem
+        to={PERMISSIONS}
         iconName={IconName.SecurityTick}
         onClick={() => {
-          history.push(PERMISSIONS);
           trackEvent({
             event: MetaMetricsEventName.NavPermissionsOpened,
             category: MetaMetricsEventCategory.Navigation,
@@ -306,11 +306,9 @@ export const GlobalMenu = ({
         {t('networks')}
       </MenuItem>
       <MenuItem
+        to={SNAPS_ROUTE}
         iconName={IconName.Snaps}
-        onClick={() => {
-          history.push(SNAPS_ROUTE);
-          closeMenu();
-        }}
+        onClick={closeMenu}
         showInfoDot={snapsUpdatesAvailable}
       >
         {t('snaps')}
@@ -341,10 +339,10 @@ export const GlobalMenu = ({
         {supportText}
       </MenuItem>
       <MenuItem
+        to={SETTINGS_ROUTE}
         iconName={IconName.Setting}
         disabled={hasUnapprovedTransactions}
         onClick={() => {
-          history.push(SETTINGS_ROUTE);
           trackEvent({
             category: MetaMetricsEventCategory.Navigation,
             event: MetaMetricsEventName.NavSettingsOpened,
@@ -359,11 +357,11 @@ export const GlobalMenu = ({
         {t('settings')}
       </MenuItem>
       <MenuItem
+        to={DEFAULT_ROUTE}
         ref={lastItemRef} // ref for last item in GlobalMenu
         iconName={IconName.Lock}
         onClick={() => {
           dispatch(lockMetamask(t('lockMetaMaskLoadingMessage')));
-          history.push(DEFAULT_ROUTE);
           trackEvent({
             category: MetaMetricsEventCategory.Navigation,
             event: MetaMetricsEventName.AppLocked,

--- a/ui/components/ui/menu/menu-item.tsx
+++ b/ui/components/ui/menu/menu-item.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import classnames from 'classnames';
+import { Link } from 'react-router-dom-v5-compat';
 
 import {
   BadgeWrapper,
@@ -23,6 +24,7 @@ type MenuItemProps = {
   'data-testid'?: string;
   iconName: IconName;
   iconColor?: IconColor;
+  to?: string;
   onClick?: () => void;
   subtitle?: string;
   disabled?: boolean;
@@ -30,7 +32,10 @@ type MenuItemProps = {
   textVariant?: TextVariant;
 };
 
-const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(
+const MenuItem = React.forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  MenuItemProps
+>(
   (
     {
       children,
@@ -43,54 +48,76 @@ const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(
       disabled,
       showInfoDot,
       textVariant,
+      to,
     }: MenuItemProps,
     ref,
-  ) => (
-    <button
-      className={classnames('menu-item', className)}
-      data-testid={dataTestId}
-      onClick={onClick}
-      ref={ref}
-      disabled={disabled}
-    >
-      {iconName && showInfoDot && (
-        <BadgeWrapper
-          anchorElementShape={BadgeWrapperAnchorElementShape.circular}
-          display={Display.Block}
-          position={BadgeWrapperPosition.topRight}
-          positionObj={{ top: -6, right: 4 }}
-          badge={
-            <Icon
-              name={IconName.FullCircle}
-              size={IconSize.Xs}
-              color={IconColor.primaryDefault}
-              style={{ '--size': '10px' } as React.CSSProperties}
-            />
-          }
-        >
-          <Icon name={iconName} size={IconSize.Sm} marginRight={2} />
-        </BadgeWrapper>
-      )}
-      {iconName && !showInfoDot && (
-        <Icon
-          name={iconName}
-          size={IconSize.Sm}
-          marginRight={3}
-          color={iconColor}
-        />
-      )}
-      <div>
-        <Text variant={textVariant} as="div">
-          {children}
-        </Text>
-        {subtitle ? (
-          <Text variant={TextVariant.bodyXs} color={TextColor.textAlternative}>
-            {subtitle}
+  ) => {
+    const content = (
+      <>
+        {iconName && showInfoDot && (
+          <BadgeWrapper
+            anchorElementShape={BadgeWrapperAnchorElementShape.circular}
+            display={Display.Block}
+            position={BadgeWrapperPosition.topRight}
+            positionObj={{ top: -6, right: 4 }}
+            badge={
+              <Icon
+                name={IconName.FullCircle}
+                size={IconSize.Xs}
+                color={IconColor.primaryDefault}
+                style={{ '--size': '10px' } as React.CSSProperties}
+              />
+            }
+          >
+            <Icon name={iconName} size={IconSize.Sm} marginRight={2} />
+          </BadgeWrapper>
+        )}
+        {iconName && !showInfoDot && (
+          <Icon
+            name={iconName}
+            size={IconSize.Sm}
+            marginRight={3}
+            color={iconColor}
+          />
+        )}
+        <div>
+          <Text variant={textVariant} as="div">
+            {children}
           </Text>
-        ) : null}
-      </div>
-    </button>
-  ),
+          {subtitle ? (
+            <Text
+              variant={TextVariant.bodyXs}
+              color={TextColor.textAlternative}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </div>
+      </>
+    );
+
+    return to ? (
+      <Link
+        to={to}
+        className={classnames('menu-item', className)}
+        data-testid={dataTestId}
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        onClick={onClick}
+      >
+        {content}
+      </Link>
+    ) : (
+      <button
+        className={classnames('menu-item', className)}
+        data-testid={dataTestId}
+        disabled={disabled}
+        ref={ref as React.Ref<HTMLButtonElement>}
+        onClick={onClick}
+      >
+        {content}
+      </button>
+    );
+  },
 );
 
 MenuItem.displayName = 'MenuItem';

--- a/ui/components/ui/menu/menu-item.tsx
+++ b/ui/components/ui/menu/menu-item.tsx
@@ -96,17 +96,29 @@ const MenuItem = React.forwardRef<
       </>
     );
 
-    return to ? (
-      <Link
-        to={to}
-        className={classnames('menu-item', className)}
-        data-testid={dataTestId}
-        ref={ref as React.Ref<HTMLAnchorElement>}
-        onClick={onClick}
-      >
-        {content}
-      </Link>
-    ) : (
+    if (to) {
+      return disabled ? (
+        <span
+          className={classnames('menu-item', className)}
+          data-testid={dataTestId}
+          ref={ref as React.Ref<HTMLSpanElement>}
+        >
+          {content}
+        </span>
+      ) : (
+        <Link
+          to={to}
+          className={classnames('menu-item', className)}
+          data-testid={dataTestId}
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          onClick={onClick}
+        >
+          {content}
+        </Link>
+      );
+    }
+
+    return (
       <button
         className={classnames('menu-item', className)}
         data-testid={dataTestId}

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -79,7 +79,7 @@ const mapStateToProps = (state, ownProps) => {
   const snapsMetadata = getSnapsMetadata(state);
   const conversionDate = currencyRates[ticker]?.conversionDate;
 
-  const pathNameTail = pathname.match(/[^/]+$/u)[0];
+  const pathNameTail = pathname.match(/[^/]+$/u)?.[0] || '';
   const isAddressEntryPage = pathNameTail.includes('0x');
   const isAddContactPage = Boolean(pathname.match(CONTACT_ADD_ROUTE));
   const isEditContactPage = Boolean(pathname.match(CONTACT_EDIT_ROUTE));


### PR DESCRIPTION
## **Description**

Improve route handling by using react-router's `Link` component for simple navigation. Instead of manually creating event handlers, useCallback, calling history.push, and applying custom styling cursor: pointer

See Before v After

- Text components shouldn't normally have onClick, otherwise need to include Aria attributes for accessibility
- Separation of concerns between routing and analytics
- Less changes once migrating react-router since useHistory has been replaced

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35925?quickstart=1)

Later on, we can apply this pattern to other screens

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click the main menu
2. Navigate to either Settings, Permissions or Snaps
3. Click back

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

```jsx

import { useCallback } from 'react'
import { useHistory } from 'react-router'

const history = useHistory();

const handleClickLink = useCallback(() => {
  history.push(destination);
  ...
}, [dep1, dep2, ...])

<Text onClick={handleClickLink} style={ { cursor: 'pointer' }} />

```

<!-- [screenshots/recordings] -->

### **After**

```jsx

<Link to={destination} /><Text ... /></Link>

```

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
