### PR TITLE
test: fix flakly test ` Request Queuing for Multiple Dapps and Txs on different networks should put txs from different dapps on different networks adds extra tx after in same queue. `

### DIFF
--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
@@ -86,6 +86,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
         await driver.executeScript(
           `window.ethereum.request(${switchEthereumChainRequest})`,
         );
+        await secondTestDapp.checkNetworkIsConnected('0x53a');
 
         // Dapp 1 send 2 tx
         await driver.switchToWindowWithUrl(DAPP_URL);
@@ -94,12 +95,18 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
         await firstTestDapp.clickSimpleSendButton();
 
         await driver.waitUntilXWindowHandles(4);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.checkPageIsLoaded();
+        await transactionConfirmation.checkPageNumbers(1, 2);
 
         // Dapp 2 send 2 tx
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
         await secondTestDapp.checkNetworkIsConnected('0x53a');
         await secondTestDapp.clickSimpleSendButton();
         await secondTestDapp.clickSimpleSendButton();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await transactionConfirmation.checkPageNumbers(1, 4);
 
         // Dapp 1 send 1 tx
         await driver.switchToWindowWithUrl(DAPP_URL);
@@ -107,8 +114,6 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
         await firstTestDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        const transactionConfirmation = new TransactionConfirmation(driver);
-        await transactionConfirmation.checkPageIsLoaded();
 
         // Verify we're on the first confirmation of 5
         await transactionConfirmation.checkPageNumbers(1, 5);
@@ -118,7 +123,9 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
 
         // Navigate to next confirmation
         await transactionConfirmation.clickNextPage();
+        await transactionConfirmation.checkPageNumbers(2, 5);
         await transactionConfirmation.clickNextPage();
+        await transactionConfirmation.checkPageNumbers(3, 5);
 
         // Verify we're now on Localhost 8546 network
         await transactionConfirmation.checkNetworkIsDisplayed('Localhost 8546');

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
@@ -106,6 +106,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
         await secondTestDapp.clickSimpleSendButton();
         await secondTestDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await transactionConfirmation.checkPageIsLoaded();
         await transactionConfirmation.checkPageNumbers(1, 4);
 
         // Dapp 1 send 1 tx
@@ -113,7 +114,6 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
         await firstTestDapp.checkNetworkIsConnected('0x539');
         await firstTestDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-
 
         // Verify we're on the first confirmation of 5
         await transactionConfirmation.checkPageNumbers(1, 5);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There's a race condition with the order of the transactions. In this spec, we trigger 5 transactions in total, from 2 different dapps, connected to 2 different networks. If we trigger a transaction from dapp1 (net1) and subsequently a transaction from dapp2 (net2) if this happens very fast the order is reversed.
Then when we try to locate the correct network in the dialog the spec fails.

With this fix, we ensure that each tx is loaded, before triggering a new one, preventing this type of race condition.

```javascript
TimeoutError: Waiting for element to be located By(xpath, .//*[./@data-testid = 'confirmation__token-details-section'][(contains(string(.), 'Localhost 8546') or contains(string(.), 'Localhost8546'))])
Wait timed out after 10006ms
```

<img width="400" height="619" alt="image" src="https://github.com/user-attachments/assets/95af84d0-16ee-4316-ad52-09b6d928f69d" />



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/35944?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
