### PR TITLE
fix: cp-13.4.0 updated network icon in network manager button

### DIFF
--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -386,6 +386,89 @@ class AssetListPage {
     });
   }
 
+  /**
+   * Gets the network icon details from the sort-by-networks button
+   *
+   * @returns Object containing icon src, alt text, and visibility status, or null if no icon found
+   */
+  async getNetworkIcon(): Promise<{
+    src: string;
+    alt: string;
+    isVisible: boolean;
+  } | null> {
+    console.log('Getting network icon details from sort-by-networks button');
+    const iconDetails = await this.driver.executeScript(`
+      const button = document.querySelector('[data-testid="sort-by-networks"]');
+      const avatarNetwork = button?.querySelector('.mm-avatar-network img');
+      return avatarNetwork ? {
+        src: avatarNetwork.src,
+        alt: avatarNetwork.alt,
+        isVisible: avatarNetwork.offsetWidth > 0 && avatarNetwork.offsetHeight > 0
+      } : null;
+    `);
+    return iconDetails as {
+      src: string;
+      alt: string;
+      isVisible: boolean;
+    } | null;
+  }
+
+  /**
+   * Checks if the network icon is visible in the sort-by-networks button
+   *
+   * @returns true if icon is present and visible, false otherwise
+   */
+  async isNetworkIconVisible(): Promise<boolean> {
+    console.log('Checking if network icon is visible');
+    const iconElement = await this.driver.executeScript(`
+      const button = document.querySelector('[data-testid="sort-by-networks"]');
+      const avatarNetwork = button?.querySelector('.mm-avatar-network');
+      return avatarNetwork ? {
+        isPresent: true,
+        isVisible: avatarNetwork.offsetWidth > 0 && avatarNetwork.offsetHeight > 0
+      } : { isPresent: false, isVisible: false };
+    `);
+
+    const result = iconElement as { isPresent: boolean; isVisible: boolean };
+    return result.isPresent && result.isVisible;
+  }
+
+  /**
+   * Verifies that the network icon matches expected characteristics
+   *
+   * @param expectedIndicators - Array of strings that should be present in the icon URL
+   * @throws Error if icon is not found or doesn't match expected characteristics
+   */
+  async checkNetworkIconContains(expectedIndicators: string[]): Promise<void> {
+    console.log(
+      `Checking network icon contains one of: ${expectedIndicators.join(', ')}`,
+    );
+
+    const iconDetails = await this.getNetworkIcon();
+
+    if (!iconDetails) {
+      throw new Error('Network icon not found in sort-by-networks button');
+    }
+
+    if (!iconDetails.isVisible) {
+      throw new Error('Network icon is not visible');
+    }
+
+    const hasValidIcon = expectedIndicators.some((indicator) =>
+      iconDetails.src.toLowerCase().includes(indicator.toLowerCase()),
+    );
+
+    if (!hasValidIcon) {
+      throw new Error(
+        `Expected icon to contain one of ${expectedIndicators.join(', ')}, but got: ${iconDetails.src}`,
+      );
+    }
+
+    console.log(
+      `✅ Network icon verification passed - Icon src: ${iconDetails.src}`,
+    );
+  }
+
   async checkPriceChartIsShown(): Promise<void> {
     console.log(`Verify the price chart is displayed`);
     await this.driver.waitUntil(

--- a/test/e2e/tests/network/sort-by-networks-icon.spec.ts
+++ b/test/e2e/tests/network/sort-by-networks-icon.spec.ts
@@ -1,0 +1,136 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import FixtureBuilder from '../../fixture-builder';
+import { withFixtures } from '../../helpers';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import AssetListPage from '../../page-objects/pages/home/asset-list';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+
+describe('Sort By Networks Icon', function (this: Suite) {
+  it('should display the correct network icon when only Ethereum Mainnet is enabled', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+        const assetListPage = new AssetListPage(driver);
+
+        // Wait for the sort-by-networks button to be present
+        await driver.waitForSelector('[data-testid="sort-by-networks"]');
+
+        // Check that the button text shows the correct network name
+        const networkLabel = await assetListPage.getNetworksFilterLabel();
+        console.log(`Network label: ${networkLabel}`);
+
+        // For single network, it should show the network name (e.g., "Ethereum Mainnet")
+        const expectedNetworkNames = ['Ethereum Mainnet', 'Mainnet', 'Ethereum'];
+        const isCorrectNetworkName = expectedNetworkNames.some(name =>
+          networkLabel.includes(name)
+        );
+
+        if (!isCorrectNetworkName) {
+          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+        }
+
+        // Check that the network icon is displayed and has the correct source
+        const expectedIconIndicators = [
+          'ethereum', 'eth', 'ETH',
+          // Could also be a data URL or contain the token image URL path
+          'images/icons', '/images/'
+        ];
+
+        await assetListPage.checkNetworkIconContains(expectedIconIndicators);
+      },
+    );
+  });
+
+  it('should display the correct network icon when only Linea Mainnet is enabled', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnLinea()
+          .withEnabledNetworks({ eip155: { [CHAIN_IDS.LINEA_MAINNET]: true } })
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+        const assetListPage = new AssetListPage(driver);
+
+        // Wait for the sort-by-networks button to be present
+        await driver.waitForSelector('[data-testid="sort-by-networks"]');
+
+        // Check that the button text shows the correct network name
+        const networkLabel = await assetListPage.getNetworksFilterLabel();
+        console.log(`Network label: ${networkLabel}`);
+
+        // For Linea, it should show "Linea Mainnet" or similar
+        const expectedNetworkNames = ['Linea Mainnet', 'Linea'];
+        const isCorrectNetworkName = expectedNetworkNames.some(name =>
+          networkLabel.includes(name)
+        );
+
+        if (!isCorrectNetworkName) {
+          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+        }
+
+        // Check that the network icon is displayed and has the correct source
+        const expectedIconIndicators = [
+          'linea', 'LINEA', 'Linea',
+          // Could also be a data URL or contain the token image URL path
+          'images/icons', '/images/'
+        ];
+
+        await assetListPage.checkNetworkIconContains(expectedIconIndicators);
+      },
+    );
+  });
+
+  it('should display the correct network icon when only Polygon is enabled', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnPolygon()
+          .withEnabledNetworks({ eip155: { [CHAIN_IDS.POLYGON]: true } })
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+        const assetListPage = new AssetListPage(driver);
+
+        // Wait for the sort-by-networks button to be present
+        await driver.waitForSelector('[data-testid="sort-by-networks"]');
+
+        // Check that the button text shows the correct network name
+        const networkLabel = await assetListPage.getNetworksFilterLabel();
+        console.log(`Network label: ${networkLabel}`);
+
+        // For Polygon, it should show "Polygon Mainnet" or similar
+        const expectedNetworkNames = ['Polygon', 'POL'];
+        const isCorrectNetworkName = expectedNetworkNames.some(name =>
+          networkLabel.includes(name)
+        );
+
+        if (!isCorrectNetworkName) {
+          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+        }
+
+        // Check that the network icon is displayed and has the correct source
+        const expectedIconIndicators = [
+          'polygon', 'POLYGON', 'Polygon', 'pol', 'POL', 'matic', 'MATIC',
+          // Could also be a data URL or contain the token image URL path
+          'images/icons', '/images/'
+        ];
+
+        await assetListPage.checkNetworkIconContains(expectedIconIndicators);
+      },
+    );
+  });
+
+});

--- a/test/e2e/tests/network/sort-by-networks-icon.spec.ts
+++ b/test/e2e/tests/network/sort-by-networks-icon.spec.ts
@@ -28,20 +28,29 @@ describe('Sort By Networks Icon', function (this: Suite) {
         console.log(`Network label: ${networkLabel}`);
 
         // For single network, it should show the network name (e.g., "Ethereum Mainnet")
-        const expectedNetworkNames = ['Ethereum Mainnet', 'Mainnet', 'Ethereum'];
-        const isCorrectNetworkName = expectedNetworkNames.some(name =>
-          networkLabel.includes(name)
+        const expectedNetworkNames = [
+          'Ethereum Mainnet',
+          'Mainnet',
+          'Ethereum',
+        ];
+        const isCorrectNetworkName = expectedNetworkNames.some((name) =>
+          networkLabel.includes(name),
         );
 
         if (!isCorrectNetworkName) {
-          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+          throw new Error(
+            `Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`,
+          );
         }
 
         // Check that the network icon is displayed and has the correct source
         const expectedIconIndicators = [
-          'ethereum', 'eth', 'ETH',
+          'ethereum',
+          'eth',
+          'ETH',
           // Could also be a data URL or contain the token image URL path
-          'images/icons', '/images/'
+          'images/icons',
+          '/images/',
         ];
 
         await assetListPage.checkNetworkIconContains(expectedIconIndicators);
@@ -71,19 +80,24 @@ describe('Sort By Networks Icon', function (this: Suite) {
 
         // For Linea, it should show "Linea Mainnet" or similar
         const expectedNetworkNames = ['Linea Mainnet', 'Linea'];
-        const isCorrectNetworkName = expectedNetworkNames.some(name =>
-          networkLabel.includes(name)
+        const isCorrectNetworkName = expectedNetworkNames.some((name) =>
+          networkLabel.includes(name),
         );
 
         if (!isCorrectNetworkName) {
-          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+          throw new Error(
+            `Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`,
+          );
         }
 
         // Check that the network icon is displayed and has the correct source
         const expectedIconIndicators = [
-          'linea', 'LINEA', 'Linea',
+          'linea',
+          'LINEA',
+          'Linea',
           // Could also be a data URL or contain the token image URL path
-          'images/icons', '/images/'
+          'images/icons',
+          '/images/',
         ];
 
         await assetListPage.checkNetworkIconContains(expectedIconIndicators);
@@ -113,24 +127,32 @@ describe('Sort By Networks Icon', function (this: Suite) {
 
         // For Polygon, it should show "Polygon Mainnet" or similar
         const expectedNetworkNames = ['Polygon', 'POL'];
-        const isCorrectNetworkName = expectedNetworkNames.some(name =>
-          networkLabel.includes(name)
+        const isCorrectNetworkName = expectedNetworkNames.some((name) =>
+          networkLabel.includes(name),
         );
 
         if (!isCorrectNetworkName) {
-          throw new Error(`Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`);
+          throw new Error(
+            `Expected network name to include one of ${expectedNetworkNames.join(', ')}, but got: ${networkLabel}`,
+          );
         }
 
         // Check that the network icon is displayed and has the correct source
         const expectedIconIndicators = [
-          'polygon', 'POLYGON', 'Polygon', 'pol', 'POL', 'matic', 'MATIC',
+          'polygon',
+          'POLYGON',
+          'Polygon',
+          'pol',
+          'POL',
+          'matic',
+          'MATIC',
           // Could also be a data URL or contain the token image URL path
-          'images/icons', '/images/'
+          'images/icons',
+          '/images/',
         ];
 
         await assetListPage.checkNetworkIconContains(expectedIconIndicators);
       },
     );
   });
-
 });

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -50,6 +50,7 @@ import ImportControl from '../import-control';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
 import {
+  CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
   FEATURED_NETWORK_CHAIN_IDS,
   TEST_CHAINS,
 } from '../../../../../../shared/constants/network';
@@ -162,10 +163,13 @@ const AssetListControlBar = ({
     );
   }, [currentMultichainNetwork.network.chainId]);
 
-  const allOpts: Record<string, boolean> = {};
-  Object.keys(allNetworks || {}).forEach((chainId) => {
-    allOpts[chainId] = true;
-  });
+  const allOpts: Record<string, boolean> = useMemo(() => {
+    const opts: Record<string, boolean> = {};
+    Object.keys(allNetworks || {}).forEach((chainId) => {
+      opts[chainId] = true;
+    });
+    return opts;
+  }, [allNetworks]);
 
   useEffect(() => {
     if (isTestNetwork) {
@@ -189,7 +193,12 @@ const AssetListControlBar = ({
         }),
       );
     }
-  }, []);
+  }, [
+    allOpts,
+    currentMultichainNetwork.network.chainId,
+    dispatch,
+    networksToDisplay,
+  ]);
 
   const windowType = getEnvironmentType();
   const isFullScreen =
@@ -385,11 +394,9 @@ const AssetListControlBar = ({
       return undefined;
     }
 
-    return currentMultichainNetwork?.network?.rpcPrefs?.imageUrl;
-  }, [
-    currentMultichainNetwork?.network?.rpcPrefs?.imageUrl,
-    enabledNetworksByNamespace,
-  ]);
+    const singleEnabledChainId = chainIds[0];
+    return CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[singleEnabledChainId];
+  }, [enabledNetworksByNamespace]);
 
   return (
     <Box


### PR DESCRIPTION
This PR ensures that sort-by-networks button render correct name and icon when single network is enables


## **Related issues**

Fixes: #35884 

## **Manual testing steps**

1. Connect to a dapp and stay on dapp page
2. Click on dapp icon
3. Click on network name
4. Switch networks
5. Click anywhere on the page for MM to close
6. Open MetaMask
7. Check network manager icon 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b9cfd8ff-bd8e-46c3-9696-ad116f920ccd



### **After**

https://github.com/user-attachments/assets/8aa22e56-c8d7-4382-8eab-2ae508d16e4d



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
