### PR TITLE
chore(CODEOWNERS): replace wallet-ux team references with core-extension-ux

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,20 +99,20 @@ app/scripts/constants/snaps.ts       @MetaMask/core-platform
 # Co-owned by Confirmations and Snaps
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/core-platform
 
-# Wallet UX
-ui/components/app/whats-new-popup     @MetaMask/wallet-ux
-ui/css                                @MetaMask/wallet-ux
-ui/pages/home                         @MetaMask/wallet-ux
-ui/components/multichain/             @MetaMask/wallet-ux
+# Core Extension UX
+ui/components/app/whats-new-popup     @MetaMask/core-extension-ux
+ui/css                                @MetaMask/core-extension-ux
+ui/pages/home                         @MetaMask/core-extension-ux
+ui/components/multichain/             @MetaMask/core-extension-ux
 
-# Co-owned by accounts and wallet-ux
-ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-picker/         @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-details/        @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-overview/       @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-list-item/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-list-menu/      @MetaMask/accounts-engineers @MetaMask/wallet-ux
-ui/components/multichain/account-list-item-menu/ @MetaMask/accounts-engineers @MetaMask/wallet-ux
+# Co-owned by accounts and core-extension-ux
+ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-picker/         @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-details/        @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-overview/       @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-list-item/      @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-list-menu/      @MetaMask/accounts-engineers @MetaMask/core-extension-ux
+ui/components/multichain/account-list-item-menu/ @MetaMask/accounts-engineers @MetaMask/core-extension-ux
 
 # Web3Auth / Onboarding
 ui/pages/onboarding-flow              @MetaMask/web3auth


### PR DESCRIPTION
## **Description**

- Updated all @MetaMask/wallet-ux references to @MetaMask/core-extension-ux
- Updated section header from 'Wallet UX' to 'Core Extension UX'
- Updated comment from 'Co-owned by accounts and wallet-ux' to 'Co-owned by accounts and core-extension-ux'
- Affects 11 code ownership assignments across UI components

## **Changelog**

CHANGELOG entry: null

## **Screenshots/Recordings**
N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
