### PR TITLE
test: more helpful error message if INFURA_PROJECT_ID unset

### DIFF
--- a/test/e2e/tests/tolerate-failure/power-user.spec.ts
+++ b/test/e2e/tests/tolerate-failure/power-user.spec.ts
@@ -17,6 +17,12 @@ const withState = {
 
 describe('Power user persona', function () {
   it('loads the requested number of accounts', async function () {
+    if (!process.env.INFURA_PROJECT_ID) {
+      throw new Error(
+        'Running this E2E test requires a valid process.env.INFURA_PROJECT_ID',
+      );
+    }
+
     await withFixtures(
       {
         title: this.test?.fullTitle(),


### PR DESCRIPTION
## **Description**

Give the developer a more helpful error message if `INFURA_PROJECT_ID` is unset when running `power-user.spec.ts`

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->