### PR TITLE
test: fix flaky test

### DIFF
--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -244,6 +244,19 @@ class SendTokenPage {
     await this.driver.pasteIntoField(this.inputRecipient, recipientAddress);
   }
 
+  /**
+   * ENS-only: types the ENS name without clearing or using paste shortcuts,
+   * to mitigate a race condition where name is empty by avoiding extra resolution requests.
+   *
+   * @param ensName - The ENS name to type into the recipient field.
+   */
+  async fillEnsRecipient(ensName: string): Promise<void> {
+    console.log(`Fill recipient ENS-only with ${ensName}`);
+    const inputField = await this.driver.findElement(this.inputRecipient);
+    await inputField.click();
+    await inputField.sendKeys(ensName);
+  }
+
   async fillHexInput(hex: string): Promise<void> {
     console.log(`Filling hex input with: ${hex}`);
     await this.driver.pasteIntoField(this.hexInput, hex);

--- a/test/e2e/snaps/test-snap-namelookup.spec.ts
+++ b/test/e2e/snaps/test-snap-namelookup.spec.ts
@@ -8,7 +8,7 @@ import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install
 import { mockLookupSnap } from '../mock-response-data/snaps/snap-binary-mocks';
 import { switchToNetworkFromSendFlow } from '../page-objects/flows/network.flow';
 
-describe('Name lookup', function () {
+describe('Name lookup TEST', function () {
   it('validate the recipient address appears in the send flow', async function () {
     await withFixtures(
       {
@@ -34,7 +34,7 @@ describe('Name lookup', function () {
         await switchToNetworkFromSendFlow(driver, 'Ethereum');
         await homePage.startSendFlow();
         await sendTokenPage.checkPageIsLoaded();
-        await sendTokenPage.fillRecipient('metamask.domain');
+        await sendTokenPage.fillEnsRecipient('metamask.domain');
         await sendTokenPage.checkEnsAddressResolution(
           'metamask.domain',
           '0xc0ffe...54979',

--- a/test/e2e/snaps/test-snap-namelookup.spec.ts
+++ b/test/e2e/snaps/test-snap-namelookup.spec.ts
@@ -8,7 +8,7 @@ import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install
 import { mockLookupSnap } from '../mock-response-data/snaps/snap-binary-mocks';
 import { switchToNetworkFromSendFlow } from '../page-objects/flows/network.flow';
 
-describe('Name lookup TEST', function () {
+describe('Name lookup', function () {
   it('validate the recipient address appears in the send flow', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/transaction/ens.spec.ts
+++ b/test/e2e/tests/transaction/ens.spec.ts
@@ -9,7 +9,7 @@ import SendTokenPage from '../../page-objects/pages/send/send-token-page';
 import { mockServerJsonRpc } from '../ppom/mocks/mock-server-json-rpc';
 import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-balance-polling';
 
-describe('ENS', function (this: Suite) {
+describe('ENS TEST', function (this: Suite) {
   const sampleAddress: string = '1111111111111111111111111111111111111111';
 
   const shortSampleAddress = '0x11111...11111';
@@ -102,7 +102,7 @@ describe('ENS', function (this: Suite) {
         // fill ens address as recipient when user lands on send token screen
         const sendToPage = new SendTokenPage(driver);
         await sendToPage.checkPageIsLoaded();
-        await sendToPage.fillRecipient(sampleEnsDomain);
+        await sendToPage.fillEnsRecipient(sampleEnsDomain);
 
         // verify that ens domain resolves to the correct address
         await sendToPage.checkEnsAddressResolution(

--- a/test/e2e/tests/transaction/ens.spec.ts
+++ b/test/e2e/tests/transaction/ens.spec.ts
@@ -9,7 +9,7 @@ import SendTokenPage from '../../page-objects/pages/send/send-token-page';
 import { mockServerJsonRpc } from '../ppom/mocks/mock-server-json-rpc';
 import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-balance-polling';
 
-describe('ENS TEST', function (this: Suite) {
+describe('ENS', function (this: Suite) {
   const sampleAddress: string = '1111111111111111111111111111111111111111';
 
   const shortSampleAddress = '0x11111...11111';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Race condition where the ENS domain doesn't display the domain name, only the address.
See in the pic, where we can see 0x111.... but in that same component, we also expect to see the 'test-eth' domain.

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/9909fd39-4a75-4332-a26f-d34fe28481d0" />

It's a bit hard to reproduce but tweaking a bit the app code, we could reach to the same state, and then see that the div component is empty:

https://github.com/user-attachments/assets/2349273c-0bd3-4268-aa31-396a6f6002ee

In our paste driver function, we perform some actions to make sure the input is cleared:

```
 await element.sendKeys(
      Key.chord(driver.Key.MODIFIER, 'a', driver.Key.BACK_SPACE),
    );

    // Wait for DOM to update before checking if clearing worked
    await new Promise((resolve) => setTimeout(resolve, 200));

    // If previous methods fail, use Selenium's actions to select all text and replace it with the expected value
    if ((await element.getProperty('value')) !== '') {
      await driver.driver
        .actions()
        .click(element)
        .keyDown(driver.Key.MODIFIER)
        .sendKeys('a')
        .keyUp(driver.Key.MODIFIER)
        .perform();

      // Wait for second clearing method to complete
      await new Promise((resolve) => setTimeout(resolve, 200));
    }
    await element.sendKeys(input);
````

This cause the trigger of resolution, and can lead to this situation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36021?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
