### PR TITLE
test: fix flaky test `MetaMask onboarding should not prevent network requests to basic functionality...`

### DIFF
--- a/test/e2e/page-objects/flows/network.flow.ts
+++ b/test/e2e/page-objects/flows/network.flow.ts
@@ -40,6 +40,7 @@ export const searchAndSwitchToNetworkFromGlobalMenuFlow = async (
 export const switchToNetworkFromSendFlow = async (
   driver: Driver,
   networkName: string,
+  tokenSymbol = 'ETH',
 ) => {
   console.log(`Switch to network ${networkName} in header bar`);
   const headerNavbar = new HeaderNavbar(driver);
@@ -59,7 +60,7 @@ export const switchToNetworkFromSendFlow = async (
 
   await selectNetworkDialog.selectNetworkName(networkName);
 
-  await sendToPage.clickFirstTokenListButton();
+  await sendToPage.chooseTokenToSend(tokenSymbol);
   await sendToPage.clickSendFlowBackButton();
 
   await headerNavbar.checkPageIsLoaded();

--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -127,11 +127,6 @@ class SendTokenPage {
     await this.driver.delay(2000); // Delay to ensure that the send page has cleared up
   }
 
-  async clickFirstTokenListButton() {
-    const elements = await this.driver.findElements(this.tokenListButton);
-    await elements[0].click();
-  }
-
   async clickAccountPickerButton() {
     console.log('Clicking on account picker button on send token screen');
     await this.driver.clickElement(this.accountPickerButton);

--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -132,11 +132,6 @@ class SendTokenPage {
     await this.driver.clickElement(this.accountPickerButton);
   }
 
-  async clickSecondTokenListButton() {
-    const elements = await this.driver.findElements(this.tokenListButton);
-    await elements[1].click();
-  }
-
   async clickOnAssetPicker(
     driver: Driver,
     location: 'src' | 'dest' = 'src',

--- a/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-token-send-redesign.spec.ts
@@ -139,7 +139,7 @@ async function createWalletInitiatedTransactionAndAssertDetails(
   await sendToPage.fillAmount('1');
 
   await sendToPage.clickAssetPickerButton();
-  await sendToPage.clickSecondTokenListButton();
+  await sendToPage.chooseTokenToSend('TST');
   await sendToPage.goToNextScreen();
 
   const tokenTransferTransactionConfirmation =

--- a/test/e2e/tests/send/send-network-change.spec.ts
+++ b/test/e2e/tests/send/send-network-change.spec.ts
@@ -90,7 +90,7 @@ describe('Send Flow - Network Change', function (this: Suite) {
         const initialTokenCount = initialTokens.length;
 
         // Close asset picker modal by selecting first token
-        await sendTokenPage.clickFirstTokenListButton();
+        await sendTokenPage.chooseTokenToSend('ETH');
 
         // Go back to home to change network
         await sendTokenPage.clickSendFlowBackButton();
@@ -115,7 +115,7 @@ describe('Send Flow - Network Change', function (this: Suite) {
         );
 
         // Close asset picker
-        await sendTokenPage.clickFirstTokenListButton();
+        await sendTokenPage.chooseTokenToSend('ETH');
 
         console.log('Token list updated correctly for new network');
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There's an antipattern where we click the token element that refreshes, becoming stale.

In general, we should avoid finding and element and then using the click() method. Instead we should use our driver clickElement custom function, to avoid this type of errors, as we have retrial mechanisms for that.


```
2025-09-17T00:54:39.084Z [driver] Called 'findElements' with arguments ["[data-testid=\"multichain-token-list-button\"]"]
Failure on testcase: 'MetaMask onboarding should not prevent network requests to basic functionality endpoints when the basic functionality toggle is on', for more information see the artifacts tab in CI

StaleElementReferenceError: The element with the reference e65d45c9-3144-49d3-a1f1-13f19c30b869 is stale; either its node document is not the active document, or it is no longer connected to the DOM
```

Side note: we are using **switchToNetworkFromSendFlow** in many places (this was added with the GNS). That's unnecessary, as this starts a send flow, adds a recipient, then select the asset, then from there switches network and then cancel the flow. If our goal is to switch networks, we should just use the network picker from home, avoiding all the unnecessary step. I leave this out of scope of this PR, but created an issue here: 
https://consensyssoftware.atlassian.net/browse/MMQA-994

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/d0f60c95-e455-4cc7-92aa-a7f8f320cd58" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36023?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
