### PR TITLE
fix: cp-13.4.0 code to check if send redesign is enabled

### DIFF
--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.test.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.test.ts
@@ -1,4 +1,3 @@
-import { ENVIRONMENT } from '../../../../development/build/constants';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
@@ -30,24 +29,7 @@ describe('useRedesignedSendFlow', () => {
     return result.current;
   };
 
-  it('returns enabled true when development environment override is active', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'true';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: false },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: true });
-  });
-
-  it('returns enabled false when development environment override is not active', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'false';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
-
+  it('returns enabled false when not enabled in remote flag', () => {
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: { enabled: false },
     });
@@ -58,24 +40,7 @@ describe('useRedesignedSendFlow', () => {
     expect(result).toEqual({ enabled: false });
   });
 
-  it('returns enabled false when not in development environment', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'true';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: false },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('returns enabled true when feature flag is enabled and multichain accounts are enabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
+  it('returns enabled true when feature flag is enabled', () => {
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: { enabled: true },
     });
@@ -84,74 +49,5 @@ describe('useRedesignedSendFlow', () => {
     const result = renderHook();
 
     expect(result).toEqual({ enabled: true });
-  });
-
-  it('returns enabled false when feature flag is enabled but multichain accounts are disabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: true },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('returns enabled false when feature flag is disabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: false },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(true);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('returns enabled false when feature flag is undefined', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({});
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(true);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('returns enabled false when remote feature flags is null', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: null,
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(true);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('prioritizes development environment override over feature flags', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'true';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: true },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: true });
-    expect(mockGetIsMultichainAccountsState2Enabled).toHaveBeenCalled();
   });
 });

--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
@@ -15,6 +15,6 @@ export const useRedesignedSendFlow = () => {
     {}) as SendRedesignFeatureFlag;
 
   return {
-    enabled: isSendRedesignEnabled,
+    enabled: isSendRedesignEnabled === true,
   };
 };

--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux';
+
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
-import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
-import { ENVIRONMENT } from '../../../../development/build/constants';
 
 type SendRedesignFeatureFlag = {
   enabled: boolean;
@@ -11,31 +10,11 @@ export const useRedesignedSendFlow = () => {
   const { sendRedesign: sendRedesignFeatureFlag } = useSelector(
     getRemoteFeatureFlags,
   );
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
+
   const { enabled: isSendRedesignEnabled } = (sendRedesignFeatureFlag ??
     {}) as SendRedesignFeatureFlag;
 
-  // This environment variable is only used for local development to override the remote feature flag
-  if (
-    process.env.SEND_REDESIGN_ENABLED === 'true' &&
-    process.env.METAMASK_ENVIRONMENT === ENVIRONMENT.DEVELOPMENT
-  ) {
-    return {
-      enabled: true,
-    };
-  }
-
-  if (isSendRedesignEnabled) {
-    if (isMultichainAccountsState2Enabled) {
-      return {
-        enabled: true,
-      };
-    }
-  }
-
   return {
-    enabled: false,
+    enabled: isSendRedesignEnabled,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix code to check if send redesign is enabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36047

## **Manual testing steps**

1. Run extension locally
2. Check that new send is enabled
3.

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
