### PR TITLE
chore: reduce over-mocking

### DIFF
--- a/ui/components/app/srp-quiz-modal/SRPQuiz/SRPQuiz.test.js
+++ b/ui/components/app/srp-quiz-modal/SRPQuiz/SRPQuiz.test.js
@@ -15,16 +15,6 @@ const store = configureStore({
 
 let openTabSpy;
 
-jest.mock('react-router-dom', () => {
-  const original = jest.requireActual('react-router-dom');
-  return {
-    ...original,
-    useHistory: () => ({
-      push: jest.fn(),
-    }),
-  };
-});
-
 async function waitForStage(stage) {
   return await waitFor(() => {
     expect(screen.getByTestId(`srp_stage_${stage}`)).toBeInTheDocument();

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.unified-swap-bridge.test.tsx
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.unified-swap-bridge.test.tsx
@@ -2,19 +2,13 @@ import { TransactionStatus } from '@metamask/transaction-controller';
 import { fireEvent } from '@testing-library/react';
 import { StatusTypes } from '@metamask/bridge-controller';
 import React from 'react';
-import * as reactRouterDom from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import mockUnifiedSwapTxGroup from '../../../../test/data/swap/mock-unified-swap-transaction-group.json';
 import mockBridgeTxData from '../../../../test/data/bridge/mock-bridge-transaction-details.json';
-import { renderWithProvider } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import { createBridgeMockStore } from '../../../../test/data/bridge/mock-bridge-store';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import TransactionListItem from '.';
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: jest.fn(),
-}));
 
 jest.mock('../../../store/background-connection', () => ({
   ...jest.requireActual('../../../store/background-connection'),
@@ -135,14 +129,8 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
   });
 
   it('should render completed bridge tx summary', () => {
-    const mockPush = jest
-      .fn()
-      .mockImplementation((...args) => jest.fn(...args));
-    jest.spyOn(reactRouterDom, 'useHistory').mockReturnValue({
-      push: mockPush,
-    });
     const { bridgeHistoryItem, srcTxMetaId } = mockBridgeTxData;
-    const { queryByTestId, getByTestId } = renderWithProvider(
+    const { queryByTestId, getByTestId, history } = renderWithProvider(
       <TransactionListItem
         transactionGroup={mockBridgeTxData.transactionGroup}
       />,
@@ -156,6 +144,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
         }),
       ),
     );
+    const mockPush = jest.spyOn(history, 'push');
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
       '?Bridged to OP MainnetConfirmed-2 USDC',
@@ -172,12 +161,6 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
   });
 
   it('should render failed bridge tx summary', () => {
-    const mockPush = jest
-      .fn()
-      .mockImplementation((...args) => jest.fn(...args));
-    jest.spyOn(reactRouterDom, 'useHistory').mockReturnValue({
-      push: mockPush,
-    });
     const { bridgeHistoryItem, srcTxMetaId } = mockBridgeTxData;
     const failedTransactionGroup = {
       ...mockBridgeTxData.transactionGroup,
@@ -186,18 +169,20 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
         status: TransactionStatus.failed,
       },
     };
-    const { queryByTestId, getByTestId, getByText } = renderWithProvider(
-      <TransactionListItem transactionGroup={failedTransactionGroup} />,
-      configureStore()(
-        createBridgeMockStore({
-          bridgeStatusStateOverrides: {
-            txHistory: {
-              [srcTxMetaId]: bridgeHistoryItem,
+    const { queryByTestId, getByTestId, getByText, history } =
+      renderWithProvider(
+        <TransactionListItem transactionGroup={failedTransactionGroup} />,
+        configureStore()(
+          createBridgeMockStore({
+            bridgeStatusStateOverrides: {
+              txHistory: {
+                [srcTxMetaId]: bridgeHistoryItem,
+              },
             },
-          },
-        }),
-      ),
-    );
+          }),
+        ),
+      );
+    const mockPush = jest.spyOn(history, 'push');
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
       '?Bridged to OP MainnetFailed-2 USDC',

--- a/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
+++ b/ui/components/multichain-accounts/account-show-srp-row/account-show-srp-row.test.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithProvider } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import { MOCK_ACCOUNT_EOA } from '../../../../test/data/mock-accounts';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
 import { AccountShowSrpRow } from './account-show-srp-row';
 
 const middleware = [thunk];
 const mockStore = configureMockStore(middleware);
-
-const mockPush = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockPush,
-  }),
-}));
 
 jest.mock('../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string) => key,
@@ -56,19 +47,13 @@ const createMockState = (
 });
 
 describe('AccountShowSrpRow', () => {
-  beforeEach(() => {
-    mockPush.mockClear();
-  });
-
   describe('Component Rendering', () => {
     it('should render with basic props', () => {
       const state = createMockState();
       const store = mockStore(state);
 
       renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
-        </MemoryRouter>,
+        <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />,
         store,
       );
 
@@ -94,12 +79,7 @@ describe('AccountShowSrpRow', () => {
         },
       };
 
-      renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={account} />
-        </MemoryRouter>,
-        store,
-      );
+      renderWithProvider(<AccountShowSrpRow account={account} />, store);
 
       expect(screen.getByText('secretRecoveryPhrase')).toBeInTheDocument();
       expect(screen.getByText('backup')).toBeInTheDocument();
@@ -111,9 +91,7 @@ describe('AccountShowSrpRow', () => {
       const store = mockStore(state);
 
       renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
-        </MemoryRouter>,
+        <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />,
         store,
       );
 
@@ -142,9 +120,7 @@ describe('AccountShowSrpRow', () => {
       };
 
       renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={accountWithSecondKeyring} />
-        </MemoryRouter>,
+        <AccountShowSrpRow account={accountWithSecondKeyring} />,
         store,
       );
 
@@ -173,12 +149,11 @@ describe('AccountShowSrpRow', () => {
         },
       };
 
-      renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={account} />
-        </MemoryRouter>,
+      const { history } = renderWithProvider(
+        <AccountShowSrpRow account={account} />,
         store,
       );
+      const mockPush = jest.spyOn(history, 'push');
 
       const row = screen.getByText('secretRecoveryPhrase').closest('div');
       if (row) {
@@ -194,12 +169,11 @@ describe('AccountShowSrpRow', () => {
       const state = createMockState(true);
       const store = mockStore(state);
 
-      renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
-        </MemoryRouter>,
+      const { history } = renderWithProvider(
+        <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />,
         store,
       );
+      const mockPush = jest.spyOn(history, 'push');
 
       const row = screen.getByText('secretRecoveryPhrase').closest('div');
       if (row) {
@@ -217,9 +191,7 @@ describe('AccountShowSrpRow', () => {
       const store = mockStore(state);
 
       renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />
-        </MemoryRouter>,
+        <AccountShowSrpRow account={MOCK_ACCOUNT_EOA} />,
         store,
       );
 
@@ -247,9 +219,7 @@ describe('AccountShowSrpRow', () => {
       };
 
       renderWithProvider(
-        <MemoryRouter>
-          <AccountShowSrpRow account={accountWithSnapKeyring} />
-        </MemoryRouter>,
+        <AccountShowSrpRow account={accountWithSnapKeyring} />,
         store,
       );
 

--- a/ui/components/multichain-accounts/multichain-account-list-menu/multichain-account-list-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list-menu/multichain-account-list-menu.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
-import reactRouterDom from 'react-router-dom';
 import {
   BtcAccountType,
   EthAccountType,
@@ -43,11 +42,6 @@ jest.mock('../../../store/actions', () => {
     detectNfts: () => mockDetectNfts,
   };
 });
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: jest.fn(() => []),
-}));
 
 type TestState = {
   metamask: AccountsControllerState &
@@ -144,15 +138,6 @@ const render = (
 };
 
 describe('MultichainAccountListMenu', () => {
-  const historyPushMock = jest.fn();
-
-  beforeEach(() => {
-    jest
-      .spyOn(reactRouterDom, 'useHistory')
-      .mockImplementation()
-      .mockReturnValue({ push: historyPushMock });
-  });
-
   afterEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -16,18 +16,6 @@ import {
   MultichainAccountListProps,
 } from './multichain-account-list';
 
-const mockHistoryPush = jest.fn();
-
-jest.mock('react-router-dom', () => {
-  const original = jest.requireActual('react-router-dom');
-  return {
-    ...original,
-    useHistory: () => ({
-      push: mockHistoryPush,
-    }),
-  };
-});
-
 jest.mock('../../../store/actions', () => {
   const actualActions = jest.requireActual('../../../store/actions');
   return {
@@ -179,7 +167,8 @@ describe('MultichainAccountList', () => {
   });
 
   it('marks only the selected account with a check icon and dispatches action on click', () => {
-    renderComponent();
+    const { history } = renderComponent();
+    const mockHistoryPush = jest.spyOn(history, 'push');
 
     // With default props, checkboxes should not be shown (showAccountCheckbox defaults to false)
     // Check that no checkboxes are present
@@ -509,10 +498,11 @@ describe('MultichainAccountList', () => {
     });
 
     it('handles checkbox click to select unselected account', () => {
-      renderComponent({
+      const { history } = renderComponent({
         selectedAccountGroups: [walletOneGroupId],
         showAccountCheckbox: true,
       });
+      const mockHistoryPush = jest.spyOn(history, 'push');
 
       const checkboxes = screen.getAllByRole('checkbox');
 
@@ -527,10 +517,11 @@ describe('MultichainAccountList', () => {
     });
 
     it('handles checkbox click to deselect selected account', () => {
-      renderComponent({
+      const { history } = renderComponent({
         selectedAccountGroups: [walletOneGroupId],
         showAccountCheckbox: true,
       });
+      const mockHistoryPush = jest.spyOn(history, 'push');
 
       const checkboxes = screen.getAllByRole('checkbox');
 

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -10,20 +10,7 @@ const menuIconSelector = '.multichain-account-cell-popover-menu-button-icon';
 const menuItemSelector = '.multichain-account-cell-menu-item';
 const errorColorSelector = '.mm-box--color-error-default';
 
-const mockHistoryPush = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-}));
-
 describe('MultichainAccountMenu', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   const renderComponent = (
     props: MultichainAccountMenuProps = {
       accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
@@ -104,7 +91,8 @@ describe('MultichainAccountMenu', () => {
   });
 
   it('navigates to account details page when clicking the account details option', async () => {
-    renderComponent();
+    const { history } = renderComponent();
+    const mockHistoryPush = jest.spyOn(history, 'push');
 
     const menuButton = document.querySelector(menuButtonSelector);
 

--- a/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
+++ b/ui/components/multichain-accounts/multichain-srp-backup/multichain-srp-backup.test.tsx
@@ -6,14 +6,6 @@ import configureStore from '../../../store/store';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
 import { MultichainSrpBackup } from './multichain-srp-backup';
 
-const mockHistoryPush = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-}));
-
 const srpBackupRowTestId = 'multichain-srp-backup';
 const srpQuizHeaderTestId = 'srp-quiz-header';
 
@@ -58,7 +50,8 @@ describe('MultichainSrpBackup', () => {
   });
 
   it('navigates to SRP review route when shouldShowBackupReminder is true', () => {
-    renderComponent({ shouldShowBackupReminder: true });
+    const { history } = renderComponent({ shouldShowBackupReminder: true });
+    const mockHistoryPush = jest.spyOn(history, 'push');
 
     fireEvent.click(screen.getByTestId(srpBackupRowTestId));
 
@@ -68,10 +61,11 @@ describe('MultichainSrpBackup', () => {
   });
 
   it('opens SRP quiz modal when shouldShowBackupReminder is false', async () => {
-    renderComponent({
+    const { history } = renderComponent({
       shouldShowBackupReminder: false,
       keyringId: 'test-keyring-id',
     });
+    const mockHistoryPush = jest.spyOn(history, 'push');
 
     fireEvent.click(screen.getByTestId(srpBackupRowTestId));
 

--- a/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
+++ b/ui/components/multichain/account-list-menu/account-list-menu.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
-import reactRouterDom from 'react-router-dom';
 import {
   BtcAccountType,
   EthAccountType,
@@ -33,11 +32,6 @@ jest.mock('../../../store/actions', () => {
     detectNfts: () => mockDetectNfts,
   };
 });
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: jest.fn(() => []),
-}));
 
 const render = (
   state = {},
@@ -111,15 +105,6 @@ const render = (
 };
 
 describe('AccountListMenu', () => {
-  const historyPushMock = jest.fn();
-
-  beforeEach(() => {
-    jest
-      .spyOn(reactRouterDom, 'useHistory')
-      .mockImplementation()
-      .mockReturnValue({ push: historyPushMock });
-  });
-
   afterEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();

--- a/ui/components/multichain/app-header/app-header.test.js
+++ b/ui/components/multichain/app-header/app-header.test.js
@@ -15,14 +15,6 @@ jest.mock('../../../../app/scripts/lib/util', () => ({
   getEnvironmentType: jest.fn(),
 }));
 
-const mockUseHistory = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockUseHistory,
-  }),
-}));
-
 jest.mock('react-router-dom-v5-compat', () => ({
   // eslint-disable-next-line react/prop-types
   Link: ({ children, ...props }) => <a {...props}>{children}</a>,

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.test.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import {
@@ -19,16 +19,6 @@ const VALID_ADDRESS = '0x312BE6a98441F9F6e3F6246B13CA19701e0AC3B9';
 const INVALID_ADDRESS = 'aoinsafasdfa';
 const VALID_TOKENID = '1201';
 const INVALID_TOKENID = 'abcde';
-
-// Create a spy for the history push function
-const mockPush = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockPush,
-  }),
-}));
 
 jest.mock('../../../store/actions.ts', () => ({
   addNftVerifyOwnership: jest
@@ -50,8 +40,6 @@ describe('ImportNftsModal', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    // Reset the push spy before each test
-    mockPush.mockClear();
   });
 
   it('should enable the "Import" button when valid entries are input into both Address and TokenId fields', () => {
@@ -271,10 +259,11 @@ describe('ImportNftsModal', () => {
 
   it('should route to default route when cancel button is clicked', () => {
     const onClose = jest.fn();
-    const { getByText } = renderWithProvider(
+    const { getByText, history } = renderWithProvider(
       <ImportNftsModal onClose={onClose} />,
       store,
     );
+    const mockPush = jest.spyOn(history, 'push');
 
     const cancelButton = getByText('Cancel');
     fireEvent.click(cancelButton);
@@ -286,7 +275,11 @@ describe('ImportNftsModal', () => {
 
   it('should route to default route when close button is clicked', () => {
     const onClose = jest.fn();
-    renderWithProvider(<ImportNftsModal onClose={onClose} />, store);
+    const { history } = renderWithProvider(
+      <ImportNftsModal onClose={onClose} />,
+      store,
+    );
+    const mockPush = jest.spyOn(history, 'push');
 
     fireEvent.click(document.querySelector('button[aria-label="Close"]'));
 

--- a/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.test.tsx
+++ b/ui/components/multichain/notification-detail-block-explorer-button/notification-detail-block-explorer-button.test.tsx
@@ -64,16 +64,6 @@ const mockNotification = {
   type: 'ERC20_RECEIVED',
 };
 
-jest.mock('react-router-dom', () => {
-  const original = jest.requireActual('react-router-dom');
-  return {
-    ...original,
-    useHistory: () => ({
-      push: jest.fn(),
-    }),
-  };
-});
-
 describe('NotificationDetailBlockExplorerButton', () => {
   it('renders correctly with a valid block explorer URL', () => {
     render(

--- a/ui/hooks/bridge/useBridging.test.ts
+++ b/ui/hooks/bridge/useBridging.test.ts
@@ -6,14 +6,6 @@ import { mockNetworkState } from '../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import useBridging from './useBridging';
 
-const mockHistoryPush = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-}));
-
 const mockDispatch = jest.fn().mockReturnValue(() => jest.fn());
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -84,7 +76,7 @@ describe('useBridging', () => {
         isSwap: boolean,
       ) => {
         const openTabSpy = jest.spyOn(global.platform, 'openTab');
-        const { result } = renderUseBridging({
+        const { result, history } = renderUseBridging({
           metamask: {
             useExternalServices: true,
             ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
@@ -108,6 +100,7 @@ describe('useBridging', () => {
             },
           },
         });
+        const mockHistoryPush = jest.spyOn(history, 'push');
 
         result.current.openBridgeExperience(location, token, isSwap);
 

--- a/ui/pages/confirmations/components/confirm/nav/nav.test.tsx
+++ b/ui/pages/confirmations/components/confirm/nav/nav.test.tsx
@@ -16,14 +16,6 @@ jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn(),
 }));
 
-const mockHistoryReplace = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    replace: mockHistoryReplace,
-  }),
-}));
-
 const render = () => {
   const store = configureStore(
     getMockConfirmState({
@@ -106,7 +98,8 @@ describe('ConfirmNav', () => {
   });
 
   it('invoke history replace method when next button is clicked', () => {
-    const { getByLabelText } = render();
+    const { getByLabelText, history } = render();
+    const mockHistoryReplace = jest.spyOn(history, 'replace');
     const nextButton = getByLabelText('Next Confirmation');
     fireEvent.click(nextButton);
     expect(mockHistoryReplace).toHaveBeenCalledTimes(1);

--- a/ui/pages/confirmations/components/confirm/smart-account-update/smart-account-update.test.tsx
+++ b/ui/pages/confirmations/components/confirm/smart-account-update/smart-account-update.test.tsx
@@ -21,14 +21,6 @@ jest.mock('../../../../../store/actions', () => ({
   setSmartAccountOptIn: jest.fn(),
 }));
 
-const mockReplace = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    replace: mockReplace,
-  }),
-}));
-
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
   const actual = jest.requireActual('react-redux');
@@ -84,10 +76,11 @@ describe('SmartAccountUpdate', () => {
         upgradeAccountConfirmation as Confirmation,
       ),
     );
-    const { getByTestId } = renderWithConfirmContextProvider(
+    const { getByTestId, history } = renderWithConfirmContextProvider(
       <SmartAccountUpdate />,
       mockStore,
     );
+    const mockReplace = jest.spyOn(history, 'replace');
 
     fireEvent.click(getByTestId('smart-account-update-close'));
     expect(mockReplace).toHaveBeenCalled();

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
@@ -13,16 +13,6 @@ import { AmountRecipient } from './amount-recipient';
 
 const MOCK_ADDRESS = '0xdB055877e6c13b6A6B25aBcAA29B393777dD0a73';
 
-const mockHistory = {
-  goBack: jest.fn(),
-  push: jest.fn(),
-};
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => mockHistory,
-}));
-
 jest.mock('react-router-dom-v5-compat', () => ({
   ...jest.requireActual('react-router-dom-v5-compat'),
   useLocation: () => ({ pathname: '/send/asset' }),


### PR DESCRIPTION
## **Description**

- Reduce over-mocking of react-router
- Unnecessary mocking makes it difficult to use react-router features when needed

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36051?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

yarn test:unit

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

```jsx
const mockHistoryPush = jest.fn();

jest.mock('react-router-dom', () => {
  const original = jest.requireActual('react-router-dom');
  return {
    ...original,
    useHistory: () => ({
      push: mockHistoryPush,
    }),
  };
});
```
<!-- [screenshots/recordings] -->

### **After**

```jsx
// history from renderWithProvider

const mockHistoryPush = jest.spyOn(history, 'push');

```

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
