### PR TITLE
fix: Participate Metric Toggle cp-13.4.0

### DIFF
--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -164,6 +164,9 @@ describe('Segment User Traits', function () {
 
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.checkPageIsLoaded();
+        // Toggle participate in meta metrics first, then toggle data collection for marketing
+        // Data Collection toggle is disabled if participate in meta metrics is off
+        await privacySettings.toggleParticipateInMetaMetrics();
         await privacySettings.toggleDataCollectionForMarketing();
         events = await getEventPayloads(driver, mockedEndpoints);
         assert.equal(events.length, 1);

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -332,9 +332,11 @@ export default function OnboardingWelcome() {
   const handleLogin = useCallback(
     async (loginType, loginOption) => {
       try {
-        // reset the participate in meta metrics in case it was set to true from previous login attempts
-        // to prevent the queued events from being sent
-        dispatch(setParticipateInMetaMetrics(null));
+        if (!isFireFox) {
+          // reset the participate in meta metrics in case it was set to true from previous login attempts
+          // to prevent the queued events from being sent
+          dispatch(setParticipateInMetaMetrics(null));
+        }
 
         if (loginType === LOGIN_TYPE.SRP) {
           if (loginOption === LOGIN_OPTION.NEW) {

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -332,6 +332,10 @@ export default function OnboardingWelcome() {
   const handleLogin = useCallback(
     async (loginType, loginOption) => {
       try {
+        // reset the participate in meta metrics in case it was set to true from previous login attempts
+        // to prevent the queued events from being sent
+        dispatch(setParticipateInMetaMetrics(null));
+
         if (loginType === LOGIN_TYPE.SRP) {
           if (loginOption === LOGIN_OPTION.NEW) {
             await onCreateClick();
@@ -353,7 +357,7 @@ export default function OnboardingWelcome() {
         }
 
         if (!isFireFox) {
-          // sent queued events
+          // automatically set participate in meta metrics to true for social login users in chrome
           dispatch(setParticipateInMetaMetrics(true));
         }
       } catch (error) {

--- a/ui/pages/onboarding-flow/welcome/welcome.test.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.js
@@ -246,7 +246,7 @@ describe('Welcome Page', () => {
       expect(getBrowserNameSpy).toHaveBeenCalled();
 
       // should not set Metametrics optin status for social login in Firefox
-      expect(enabledMetricsSpy).not.toHaveBeenCalled();
+      expect(enabledMetricsSpy).not.toHaveBeenCalledWith(true);
     });
   });
 
@@ -279,7 +279,7 @@ describe('Welcome Page', () => {
       });
 
       // should not set Metametrics optin status for SPR user
-      expect(enabledMetricsSpy).not.toHaveBeenCalled();
+      expect(enabledMetricsSpy).not.toHaveBeenCalledWith(true);
 
       // should navigate to create password page
       expect(mockUseNavigate).toHaveBeenCalledWith(

--- a/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.test.tsx
+++ b/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.test.tsx
@@ -57,7 +57,7 @@ const arrangeMocks = (stateOverrides: StateOverrides = {}) => {
       <MetametricsToggle
         dataCollectionForMarketing={false}
         // eslint-disable-next-line no-empty-function
-        setDataCollectionForMarketing={() => {}}
+        setDataCollectionForMarketing={() => Promise.resolve()}
       />
     </Provider>,
   );

--- a/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
+++ b/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
@@ -30,7 +30,7 @@ const MetametricsToggle = ({
   setDataCollectionForMarketing,
 }: {
   dataCollectionForMarketing: boolean;
-  setDataCollectionForMarketing: (value: boolean) => void;
+  setDataCollectionForMarketing: (value: boolean) => Promise<void>;
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
@@ -47,8 +47,23 @@ const MetametricsToggle = ({
   const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
   const useExternalServices = useSelector(getUseExternalServices);
 
-  const handleUseParticipateInMetaMetrics = async () => {
-    if (participateInMetaMetrics) {
+  const handleUseParticipateInMetaMetrics = async (isParticipated: boolean) => {
+    if (isParticipated) {
+      await enableMetametrics();
+      trackEvent({
+        category: MetaMetricsEventCategory.Settings,
+        event: MetaMetricsEventName.TurnOnMetaMetrics,
+        properties: {
+          isProfileSyncingEnabled: isBackupAndSyncEnabled,
+          participateInMetaMetrics,
+        },
+      });
+    } else {
+      // disable data collection for marketing if participate in meta metrics is set to false
+      if (dataCollectionForMarketing) {
+        await setDataCollectionForMarketing(false);
+      }
+
       await disableMetametrics();
       trackEvent({
         category: MetaMetricsEventCategory.Settings,
@@ -72,20 +87,6 @@ const MetametricsToggle = ({
           location: 'Settings',
         },
       });
-    } else {
-      await enableMetametrics();
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.TurnOnMetaMetrics,
-        properties: {
-          isProfileSyncingEnabled: isBackupAndSyncEnabled,
-          participateInMetaMetrics,
-        },
-      });
-    }
-
-    if (dataCollectionForMarketing) {
-      setDataCollectionForMarketing(false);
     }
   };
 
@@ -113,7 +114,7 @@ const MetametricsToggle = ({
           <ToggleButton
             value={participateInMetaMetrics}
             disabled={!useExternalServices}
-            onToggle={handleUseParticipateInMetaMetrics}
+            onToggle={(value) => handleUseParticipateInMetaMetrics(!value)}
             offLabel={t('off')}
             onLabel={t('on')}
           />

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -163,8 +163,10 @@ export default class SecurityTab extends PureComponent {
     }
 
     if (this.props.socialLoginEnabled) {
-      const res = await this.props.getMarketingConsent();
-      this.props.setDataCollectionForMarketing(res);
+      // Fetch marketing consent from remote server for social login users
+      const marketingConsentFromRemote = await this.props.getMarketingConsent();
+      // Update marketing consent in the store
+      this.props.setDataCollectionForMarketing(marketingConsentFromRemote);
     }
   }
 

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -116,6 +116,7 @@ export default class SecurityTab extends PureComponent {
     socialLoginEnabled: PropTypes.bool,
     socialLoginType: PropTypes.string,
     setMarketingConsent: PropTypes.func,
+    getMarketingConsent: PropTypes.func,
   };
 
   state = {
@@ -159,6 +160,11 @@ export default class SecurityTab extends PureComponent {
     handleSettingsRefs(t, t('securityAndPrivacy'), this.settingsRefs);
     if (this.props.metaMetricsDataDeletionId) {
       await updateDataDeletionTaskStatus();
+    }
+
+    if (this.props.socialLoginEnabled) {
+      const res = await this.props.getMarketingConsent();
+      this.props.setDataCollectionForMarketing(res);
     }
   }
 
@@ -472,6 +478,7 @@ export default class SecurityTab extends PureComponent {
       dataCollectionForMarketing,
       useExternalServices,
       socialLoginEnabled,
+      participateInMetaMetrics,
     } = this.props;
 
     const handleToggle = this.toggleDataCollectionForMarketing.bind(this);
@@ -503,7 +510,7 @@ export default class SecurityTab extends PureComponent {
           >
             <ToggleButton
               value={dataCollectionForMarketing}
-              disabled={!useExternalServices}
+              disabled={!useExternalServices || !participateInMetaMetrics}
               onToggle={(prev) => handleToggle(!prev)}
               offLabel={t('off')}
               onLabel={t('on')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- In the Social Login Flow, the metrics toggle is enabled by default. However, users were unable to disable it from the settings page. In this PR, we’ve fixed the toggle issue, and now users can successfully disable it from the Security Settings UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36063?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Disabled `Data Collection For Marketing Toggle` if user does not participate in Metametrics

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/36063

## **Manual testing steps**

1. Open the extension.  
2. Create a wallet using the new Social Login (e.g., Google or Apple).  
3. Navigate to **Settings Page > Security and Privacy**.  
4. At the end of the section, you should be able to toggle the `Participate in MetaMetrics` value.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/8d98885a-c535-4947-9696-57f1c317e7ea



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
