### PR TITLE
fix(snaps): Ensure only numbers are allowed in Inputs type `number`

### DIFF
--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -1,5 +1,6 @@
 import React, {
   ChangeEvent,
+  FormEvent,
   FunctionComponent,
   useEffect,
   useRef,
@@ -9,6 +10,8 @@ import classnames from 'classnames';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 import { FormTextField, FormTextFieldProps } from '../../../component-library';
 
+const DECIMAL_INPUT_REGEX = /^\d*(\.|,)?\d*$/u;
+
 export type SnapUIInputProps = {
   name: string;
   form?: string;
@@ -17,7 +20,7 @@ export type SnapUIInputProps = {
 
 export const SnapUIInput: FunctionComponent<
   SnapUIInputProps & FormTextFieldProps<'div'>
-> = ({ name, form, label, disabled, ...props }) => {
+> = ({ name, form, label, disabled, type, textFieldProps, ...props }) => {
   const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
     useSnapInterfaceContext();
 
@@ -43,9 +46,50 @@ export const SnapUIInput: FunctionComponent<
     }
   }, [inputRef]);
 
+  /**
+   * Get the input value, replacing commas with dots for number inputs.
+   *
+   * @param text - The current text input value.
+   * @returns The processed input value.
+   */
+  const getInputValue = (text: string) => {
+    if (type === 'number') {
+      // Mimic browser behaviour where commas are replaced.
+      return text.replace(/,/gu, '.');
+    }
+
+    return text;
+  };
+
+  /**
+   * Handle input change event.
+   * The value is processed to replace commas with dots for number inputs.
+   *
+   * @param event - The change event object.
+   */
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value);
-    handleInputChange(name, event.target.value ?? null, form);
+    const textValue = getInputValue(event.target.value);
+
+    setValue(textValue);
+    handleInputChange(name, textValue ?? null, form);
+  };
+
+  /**
+   * Handle before input event to restrict invalid characters for number inputs.
+   * This is necessary because Firefox does not support type="number".
+   *
+   * @param event - The form event object.
+   */
+  const handleBeforeInput = (event: FormEvent<HTMLInputElement>) => {
+    const inputValue = (event.nativeEvent as InputEvent).data;
+
+    if (
+      type === 'number' &&
+      inputValue &&
+      !DECIMAL_INPUT_REGEX.test(inputValue)
+    ) {
+      event.preventDefault();
+    }
   };
 
   const handleFocus = () => setCurrentFocusedInput(name);
@@ -61,6 +105,13 @@ export const SnapUIInput: FunctionComponent<
       })}
       id={name}
       value={value}
+      textFieldProps={{
+        ...textFieldProps,
+        inputProps: {
+          onBeforeInput: handleBeforeInput,
+          ...textFieldProps?.inputProps,
+        },
+      }}
       onChange={handleChange}
       label={label}
       disabled={disabled}

--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -6,6 +6,7 @@ import { UIComponentFactory } from './types';
 export const constructInputProps = (props: InputElement['props']) => {
   if (!hasProperty(props, 'type')) {
     return {
+      type: 'text',
       textFieldProps: {
         type: 'text',
       },
@@ -17,6 +18,7 @@ export const constructInputProps = (props: InputElement['props']) => {
       const { step, min, max, type } = props as NumberInputProps;
 
       return {
+        type,
         textFieldProps: {
           type,
           inputProps: {
@@ -29,6 +31,7 @@ export const constructInputProps = (props: InputElement['props']) => {
     }
     default:
       return {
+        type: props.type,
         textFieldProps: {
           type: props.type,
         },


### PR DESCRIPTION
## **Description**

This PR adds a `onBeforeInput` handler to `SnapUIInput` of type `number` that validates the content typed in to ensure only numbers are allowed.

On top of that, this PR also adds a formatting step to the input content to ensure that `,` are replaced with `.`.

This is necessary as Firefox doesn't handle inputs of type `number` as Chrome does, there is no content validation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36074?quickstart=1)

## **Changelog**

CHANGELOG entry: fix issue with Snaps UI inputs of type number on Firefox

## **Related issues**

Fixes: #35941

## **Manual testing steps**

1. Open the extension on Firefox
2. Go to the Solana send flow
3. Ensure that only numbers can be used in the amount input and that `,` are replaced with `.`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
