### PR TITLE
chore: Collect metrics for unavailable/degraded custom RPC

### DIFF
--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -12,16 +12,26 @@ describe('onRpcEndpointUnavailable', () => {
     >,
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
+  let isPublicEndpointUrlMock: jest.SpyInstance<
+    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+  >;
 
   beforeEach(() => {
     shouldCreateRpcServiceEventsMock = jest.spyOn(
       networkControllerUtilsModule,
       'shouldCreateRpcServiceEvents',
     );
+
+    isPublicEndpointUrlMock = jest.spyOn(
+      networkControllerUtilsModule,
+      'isPublicEndpointUrl',
+    );
   });
 
   it('calls shouldCreateRpcServiceEvents with the correct parameters', () => {
     shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+    isPublicEndpointUrlMock.mockReturnValue(true);
     const trackEvent = jest.fn();
 
     onRpcEndpointUnavailable({
@@ -35,9 +45,7 @@ describe('onRpcEndpointUnavailable', () => {
     });
 
     expect(shouldCreateRpcServiceEventsMock).toHaveBeenCalledWith({
-      endpointUrl: 'https://example.com',
       error: new HttpError(420),
-      infuraProjectId: 'the-infura-project-id',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -46,6 +54,7 @@ describe('onRpcEndpointUnavailable', () => {
   describe('if the Segment event should be created', () => {
     it('calls trackEvent with the correct parameters', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointUnavailable({
@@ -73,6 +82,7 @@ describe('onRpcEndpointUnavailable', () => {
 
     it('captures the HTTP status in the error if present', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointUnavailable({
@@ -94,6 +104,34 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+        },
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    it('anonymizes the endpoint URL if it is a custom endpoint', () => {
+      shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(false);
+      const trackEvent = jest.fn();
+
+      onRpcEndpointUnavailable({
+        chainId: '0xaa36a7',
+        endpointUrl: 'https://custom-endpoint.com',
+        error: undefined,
+        infuraProjectId: 'the-infura-project-id',
+        trackEvent,
+        metaMetricsId:
+          '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
+      });
+
+      // The names of Segment properties have a particular case.
+      /* eslint-disable @typescript-eslint/naming-convention */
+      expect(trackEvent).toHaveBeenCalledWith({
+        category: 'Network',
+        event: 'RPC Service Unavailable',
+        properties: {
+          chain_id_caip: 'eip155:11155111',
+          rpc_endpoint_url: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -127,16 +165,26 @@ describe('onRpcEndpointDegraded', () => {
     >,
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
+  let isPublicEndpointUrlMock: jest.SpyInstance<
+    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+  >;
 
   beforeEach(() => {
     shouldCreateRpcServiceEventsMock = jest.spyOn(
       networkControllerUtilsModule,
       'shouldCreateRpcServiceEvents',
     );
+
+    isPublicEndpointUrlMock = jest.spyOn(
+      networkControllerUtilsModule,
+      'isPublicEndpointUrl',
+    );
   });
 
   it('calls shouldCreateRpcServiceEvents with the correct parameters', () => {
     shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+    isPublicEndpointUrlMock.mockReturnValue(true);
     const trackEvent = jest.fn();
 
     onRpcEndpointDegraded({
@@ -150,9 +198,7 @@ describe('onRpcEndpointDegraded', () => {
     });
 
     expect(shouldCreateRpcServiceEventsMock).toHaveBeenCalledWith({
-      endpointUrl: 'https://example.com',
       error: new HttpError(420),
-      infuraProjectId: 'the-infura-project-id',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -161,6 +207,7 @@ describe('onRpcEndpointDegraded', () => {
   describe('if the Segment event should be created', () => {
     it('calls trackEvent with the correct parameters', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointDegraded({
@@ -188,6 +235,7 @@ describe('onRpcEndpointDegraded', () => {
 
     it('captures the HTTP status in the error if present', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointDegraded({
@@ -209,6 +257,34 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+        },
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    it('anonymizes the endpoint URL if it is a custom endpoint', () => {
+      shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(false);
+      const trackEvent = jest.fn();
+
+      onRpcEndpointDegraded({
+        chainId: '0xaa36a7',
+        endpointUrl: 'https://custom-endpoint.com',
+        error: undefined,
+        infuraProjectId: 'the-infura-project-id',
+        trackEvent,
+        metaMetricsId:
+          '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
+      });
+
+      // The names of Segment properties have a particular case.
+      /* eslint-disable @typescript-eslint/naming-convention */
+      expect(trackEvent).toHaveBeenCalledWith({
+        category: 'Network',
+        event: 'RPC Service Degraded',
+        properties: {
+          chain_id_caip: 'eip155:11155111',
+          rpc_endpoint_url: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -4,8 +4,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import MetaMetricsController from '../../controllers/metametrics-controller';
 import { onlyKeepHost } from '../../../../shared/lib/only-keep-host';
+import MetaMetricsController from '../../controllers/metametrics-controller';
 import { isPublicEndpointUrl, shouldCreateRpcServiceEvents } from './utils';
 
 /**

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -4,9 +4,9 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { onlyKeepHost } from '../../../../shared/lib/only-keep-host';
 import MetaMetricsController from '../../controllers/metametrics-controller';
-import { shouldCreateRpcServiceEvents } from './utils';
+import { onlyKeepHost } from '../../../../shared/lib/only-keep-host';
+import { isPublicEndpointUrl, shouldCreateRpcServiceEvents } from './utils';
 
 /**
  * Called when an endpoint is determined to be "unavailable". Creates a Segment
@@ -129,9 +129,7 @@ export function trackRpcEndpointEvent(
 ): void {
   if (
     !shouldCreateRpcServiceEvents({
-      endpointUrl,
       error,
-      infuraProjectId,
       metaMetricsId,
     })
   ) {
@@ -142,7 +140,9 @@ export function trackRpcEndpointEvent(
   /* eslint-disable @typescript-eslint/naming-convention */
   const properties = {
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
-    rpc_endpoint_url: onlyKeepHost(endpointUrl),
+    rpc_endpoint_url: isPublicEndpointUrl(endpointUrl, infuraProjectId)
+      ? onlyKeepHost(endpointUrl)
+      : 'custom',
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/app/scripts/lib/network-controller/utils.test.ts
+++ b/app/scripts/lib/network-controller/utils.test.ts
@@ -2,7 +2,6 @@ import { generateDeterministicRandomNumber } from '@metamask/remote-feature-flag
 
 import { QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME } from '../../../../shared/constants/network';
 import {
-  KNOWN_CUSTOM_ENDPOINTS,
   PRODUCTION_LIKE_ENVIRONMENTS,
   getIsQuicknodeEndpointUrl,
   getIsMetaMaskInfuraEndpointUrl,
@@ -32,8 +31,6 @@ jest.mock('../../../../shared/constants/network', () => {
 const generateDeterministicRandomNumberMock = jest.mocked(
   generateDeterministicRandomNumber,
 );
-
-const MOCK_METAMASK_INFURA_PROJECT_ID = 'metamask-infura-project-id';
 
 const MOCK_METAMETRICS_ID =
   '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420';
@@ -102,23 +99,6 @@ describe('getIsQuicknodeEndpointUrl', () => {
   });
 });
 
-const ENDPOINTS_TO_TEST = [
-  [
-    'an Infura endpoint using the MetaMask API key',
-    () => `https://mainnet.infura.io/v3/${MOCK_METAMASK_INFURA_PROJECT_ID}`,
-  ],
-  ...Object.entries(QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME).map(
-    ([infuraNetworkName, getUrl]) => [
-      `the Quicknode endpoint URL for ${infuraNetworkName}`,
-      getUrl,
-    ],
-  ),
-  ...KNOWN_CUSTOM_ENDPOINTS.map(({ name, url }) => [
-    `the known custom network ${name} (${url})`,
-    () => url,
-  ]),
-];
-
 describe('shouldCreateRpcServiceEvents', () => {
   describe('if not given an error', () => {
     const error = undefined;
@@ -131,28 +111,22 @@ describe('shouldCreateRpcServiceEvents', () => {
           describe('if the user is in the MetaMetrics sample', () => {
             const sampleUserRanking = 0.009999;
 
-            // @ts-expect-error The Mocha types are incorrect.
-            describe.each(ENDPOINTS_TO_TEST)(
-              'if the endpoint URL is %s',
-              (_description: string) => {
-                it('returns true', async () => {
-                  await withChangesToEnvironmentVariables(() => {
-                    process.env.METAMASK_ENVIRONMENT = environment;
-                    setQuicknodeEnvironmentVariables();
-                    generateDeterministicRandomNumberMock.mockReturnValue(
-                      sampleUserRanking,
-                    );
+            it('returns true', async () => {
+              await withChangesToEnvironmentVariables(() => {
+                process.env.METAMASK_ENVIRONMENT = environment;
+                setQuicknodeEnvironmentVariables();
+                generateDeterministicRandomNumberMock.mockReturnValue(
+                  sampleUserRanking,
+                );
 
-                    expect(
-                      shouldCreateRpcServiceEvents({
-                        error,
-                        metaMetricsId: MOCK_METAMETRICS_ID,
-                      }),
-                    ).toBe(true);
-                  });
-                });
-              },
-            );
+                expect(
+                  shouldCreateRpcServiceEvents({
+                    error,
+                    metaMetricsId: MOCK_METAMETRICS_ID,
+                  }),
+                ).toBe(true);
+              });
+            });
           });
 
           describe('if the user is not in the MetaMetrics sample', () => {

--- a/app/scripts/lib/network-controller/utils.test.ts
+++ b/app/scripts/lib/network-controller/utils.test.ts
@@ -134,7 +134,7 @@ describe('shouldCreateRpcServiceEvents', () => {
             // @ts-expect-error The Mocha types are incorrect.
             describe.each(ENDPOINTS_TO_TEST)(
               'if the endpoint URL is %s',
-              (_description: string, getEndpointUrl: () => string) => {
+              (_description: string) => {
                 it('returns true', async () => {
                   await withChangesToEnvironmentVariables(() => {
                     process.env.METAMASK_ENVIRONMENT = environment;
@@ -145,9 +145,7 @@ describe('shouldCreateRpcServiceEvents', () => {
 
                     expect(
                       shouldCreateRpcServiceEvents({
-                        endpointUrl: getEndpointUrl(),
                         error,
-                        infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
                         metaMetricsId: MOCK_METAMETRICS_ID,
                       }),
                     ).toBe(true);
@@ -169,9 +167,7 @@ describe('shouldCreateRpcServiceEvents', () => {
 
                 expect(
                   shouldCreateRpcServiceEvents({
-                    endpointUrl: 'https://example.com',
                     error,
-                    infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
                     metaMetricsId: MOCK_METAMETRICS_ID,
                   }),
                 ).toBe(false);
@@ -184,27 +180,19 @@ describe('shouldCreateRpcServiceEvents', () => {
       describe('if the environment is non-production', () => {
         const environment = 'development';
 
-        // @ts-expect-error The Mocha types are incorrect.
-        describe.each(ENDPOINTS_TO_TEST)(
-          'if the endpoint URL is %s',
-          (_description: string, getEndpointUrl: () => string) => {
-            it('returns true', async () => {
-              await withChangesToEnvironmentVariables(() => {
-                process.env.METAMASK_ENVIRONMENT = environment;
-                setQuicknodeEnvironmentVariables();
+        it('returns true', async () => {
+          await withChangesToEnvironmentVariables(() => {
+            process.env.METAMASK_ENVIRONMENT = environment;
+            setQuicknodeEnvironmentVariables();
 
-                expect(
-                  shouldCreateRpcServiceEvents({
-                    endpointUrl: getEndpointUrl(),
-                    error,
-                    infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
-                    metaMetricsId: MOCK_METAMETRICS_ID,
-                  }),
-                ).toBe(true);
-              });
-            });
-          },
-        );
+            expect(
+              shouldCreateRpcServiceEvents({
+                error,
+                metaMetricsId: MOCK_METAMETRICS_ID,
+              }),
+            ).toBe(true);
+          });
+        });
       });
 
       describe('if the environment is not set', () => {
@@ -214,9 +202,7 @@ describe('shouldCreateRpcServiceEvents', () => {
 
             expect(
               shouldCreateRpcServiceEvents({
-                endpointUrl: 'https://example.com',
                 error,
-                infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
                 metaMetricsId: MOCK_METAMETRICS_ID,
               }),
             ).toBe(false);
@@ -231,9 +217,7 @@ describe('shouldCreateRpcServiceEvents', () => {
       it('returns false', async () => {
         expect(
           shouldCreateRpcServiceEvents({
-            endpointUrl: 'https://example.com',
             error: undefined,
-            infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
             metaMetricsId,
           }),
         ).toBe(false);
@@ -246,9 +230,7 @@ describe('shouldCreateRpcServiceEvents', () => {
       it('returns false', async () => {
         expect(
           shouldCreateRpcServiceEvents({
-            endpointUrl: 'https://example.com',
             error: undefined,
-            infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
             metaMetricsId,
           }),
         ).toBe(false);
@@ -267,30 +249,22 @@ describe('shouldCreateRpcServiceEvents', () => {
           describe('if the user is in the MetaMetrics sample', () => {
             const sampleUserRanking = 0.009999;
 
-            // @ts-expect-error The Mocha types are incorrect.
-            describe.each(ENDPOINTS_TO_TEST)(
-              'if the endpoint URL is %s',
-              (_description: string, getEndpointUrl: () => string) => {
-                it('returns true', async () => {
-                  await withChangesToEnvironmentVariables(() => {
-                    process.env.METAMASK_ENVIRONMENT = environment;
-                    setQuicknodeEnvironmentVariables();
-                    generateDeterministicRandomNumberMock.mockReturnValue(
-                      sampleUserRanking,
-                    );
+            it('returns true', async () => {
+              await withChangesToEnvironmentVariables(() => {
+                process.env.METAMASK_ENVIRONMENT = environment;
+                setQuicknodeEnvironmentVariables();
+                generateDeterministicRandomNumberMock.mockReturnValue(
+                  sampleUserRanking,
+                );
 
-                    expect(
-                      shouldCreateRpcServiceEvents({
-                        endpointUrl: getEndpointUrl(),
-                        error,
-                        infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
-                        metaMetricsId: MOCK_METAMETRICS_ID,
-                      }),
-                    ).toBe(true);
-                  });
-                });
-              },
-            );
+                expect(
+                  shouldCreateRpcServiceEvents({
+                    error,
+                    metaMetricsId: MOCK_METAMETRICS_ID,
+                  }),
+                ).toBe(true);
+              });
+            });
           });
 
           describe('if the user is not in the MetaMetrics sample', () => {
@@ -305,9 +279,7 @@ describe('shouldCreateRpcServiceEvents', () => {
 
                 expect(
                   shouldCreateRpcServiceEvents({
-                    endpointUrl: 'https://example.com',
                     error,
-                    infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
                     metaMetricsId: MOCK_METAMETRICS_ID,
                   }),
                 ).toBe(false);
@@ -320,27 +292,19 @@ describe('shouldCreateRpcServiceEvents', () => {
       describe('if the environment is non-production', () => {
         const environment = 'development';
 
-        // @ts-expect-error The Mocha types are incorrect.
-        describe.each(ENDPOINTS_TO_TEST)(
-          'if the endpoint URL is %s',
-          (_description: string, getEndpointUrl: () => string) => {
-            it('returns true', async () => {
-              await withChangesToEnvironmentVariables(() => {
-                process.env.METAMASK_ENVIRONMENT = environment;
-                setQuicknodeEnvironmentVariables();
+        it('returns true', async () => {
+          await withChangesToEnvironmentVariables(() => {
+            process.env.METAMASK_ENVIRONMENT = environment;
+            setQuicknodeEnvironmentVariables();
 
-                expect(
-                  shouldCreateRpcServiceEvents({
-                    endpointUrl: getEndpointUrl(),
-                    error,
-                    infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
-                    metaMetricsId: MOCK_METAMETRICS_ID,
-                  }),
-                ).toBe(true);
-              });
-            });
-          },
-        );
+            expect(
+              shouldCreateRpcServiceEvents({
+                error,
+                metaMetricsId: MOCK_METAMETRICS_ID,
+              }),
+            ).toBe(true);
+          });
+        });
       });
 
       describe('if the environment is not set', () => {
@@ -350,9 +314,7 @@ describe('shouldCreateRpcServiceEvents', () => {
 
             expect(
               shouldCreateRpcServiceEvents({
-                endpointUrl: 'https://example.com',
                 error,
-                infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
                 metaMetricsId: MOCK_METAMETRICS_ID,
               }),
             ).toBe(false);
@@ -367,9 +329,7 @@ describe('shouldCreateRpcServiceEvents', () => {
       it('returns false', async () => {
         expect(
           shouldCreateRpcServiceEvents({
-            endpointUrl: 'https://example.com',
             error: undefined,
-            infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
             metaMetricsId,
           }),
         ).toBe(false);
@@ -382,9 +342,7 @@ describe('shouldCreateRpcServiceEvents', () => {
       it('returns false', async () => {
         expect(
           shouldCreateRpcServiceEvents({
-            endpointUrl: 'https://example.com',
             error: undefined,
-            infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
             metaMetricsId,
           }),
         ).toBe(false);
@@ -398,9 +356,7 @@ describe('shouldCreateRpcServiceEvents', () => {
     it('returns false', async () => {
       expect(
         shouldCreateRpcServiceEvents({
-          endpointUrl: 'https://example.com',
           error,
-          infuraProjectId: MOCK_METAMASK_INFURA_PROJECT_ID,
           metaMetricsId: MOCK_METAMETRICS_ID,
         }),
       ).toBe(false);

--- a/app/scripts/lib/network-controller/utils.ts
+++ b/app/scripts/lib/network-controller/utils.ts
@@ -89,33 +89,25 @@ export function getIsQuicknodeEndpointUrl(endpointUrl: string): boolean {
  * - The RPC endpoint is slow
  * - The user does not have local connectivity issues
  * - The user is in the MetaMetrics sample
- * - Capturing the endpoint URL in Segment would not violate the user's privacy
  *
  * @param args - The arguments.
- * @param args.endpointUrl - The URL of the endpoint.
  * @param args.error - The connection or response error encountered after making
  * a request to the RPC endpoint.
- * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
  * @returns True if Segment events should be created, false otherwise.
  */
 export function shouldCreateRpcServiceEvents({
-  endpointUrl,
   error,
-  infuraProjectId,
   metaMetricsId,
 }: {
-  endpointUrl: string;
   error?: unknown;
-  infuraProjectId: string;
   metaMetricsId: string | null | undefined;
 }) {
   return (
     (!error || !isConnectionError(error)) &&
     metaMetricsId !== undefined &&
     metaMetricsId !== null &&
-    isSamplingMetaMetricsUser(metaMetricsId) &&
-    isPublicEndpointUrl(endpointUrl, infuraProjectId)
+    isSamplingMetaMetricsUser(metaMetricsId)
   );
 }
 
@@ -151,7 +143,10 @@ function isSamplingMetaMetricsUser(metaMetricsId: string) {
  * @returns True if the endpoint URL is safe to share with external data
  * collection services, false otherwise.
  */
-function isPublicEndpointUrl(endpointUrl: string, infuraProjectId: string) {
+export function isPublicEndpointUrl(
+  endpointUrl: string,
+  infuraProjectId: string,
+) {
   const isMetaMaskInfuraEndpointUrl = getIsMetaMaskInfuraEndpointUrl(
     endpointUrl,
     infuraProjectId,


### PR DESCRIPTION
## **Description**

This allows for the unavailable/degraded metrics to trigger for custom RPCs without sending any private RPC urls by setting the RPC URL to `custom` if it is.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36081?quickstart=1)

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
