### PR TITLE
test: fix flaky test `Test Snap getEntropy can use snap_getEntropy inside a snap`

### DIFF
--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -277,14 +277,12 @@ export class TestSnaps {
    * @param dropDownName - The name of the dropdown locator to select the entropy source from.
    * @param name - The name of the entropy source to select.
    */
-  async scrollAndSelectEntropySource(
+  async selectEntropySource(
     dropDownName: keyof typeof dropDownLocator,
     name: string,
   ) {
     const locator = dropDownLocator[dropDownName];
     console.log(`Select ${dropDownName} entropy source`);
-    const selector = await this.driver.findElement(locator);
-    await this.driver.scrollToElement(selector);
     await this.driver.clickElement(locator);
     await this.driver.clickElement({
       text: name,

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -2,11 +2,10 @@ import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { Driver } from '../webdriver/driver';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
-import { WINDOW_TITLES, withFixtures } from '../helpers';
+import { withFixtures } from '../helpers';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { mockBip32Snap } from '../mock-response-data/snaps/snap-binary-mocks';
-import SnapInstall from '../page-objects/pages/dialog/snap-install';
 
 const bip32PublicKey =
   '"0x043e98d696ae15caef75fa8dd204a7c5c08d1272b2218ba3c20feeb4c691eec366606ece56791c361a2320e7fad8bcbb130f66d51c591fc39767ab2856e93f8dfb"';
@@ -64,15 +63,9 @@ describe('Test Snap bip-32', function () {
           bip32CompressedPublicKey,
         );
 
-        const snapEntropyDialog = new SnapInstall(driver);
-
         // Enter secp256k1 signature message, click sign button, approve and validate the result
         await testSnaps.fillMessage('messageSecp256k1Input', 'foo bar');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapEntropyDialog.checkPageIsLoaded();
-        await snapEntropyDialog.clickApproveButton();
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await switchAndApproveDialogSwitchToTestSnap(driver);
         await testSnaps.checkMessageResultSpan(
           'bip32MessageResultSecp256k1Span',

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -29,6 +29,9 @@ describe('Test Snap bip-32', function () {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockBip32Snap,
         title: this.test?.fullTitle(),
+        ignoredConsoleErrors: [
+          'UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}',
+        ],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -127,6 +127,7 @@ describe('Test Snap bip-32', function () {
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
+        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -106,10 +106,8 @@ describe('Test Snap bip-32', function () {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'bip32EntropyDropDown',
-          'SRP 2',
-        );
+        await testSnaps.selectEntropySource('bip32EntropyDropDown', 'SRP 2');
+
         await testSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
         await switchAndApproveDialogSwitchToTestSnap(driver);
@@ -119,10 +117,7 @@ describe('Test Snap bip-32', function () {
         );
 
         // Select an invalid (non-existent) entropy source, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'bip32EntropyDropDown',
-          'Invalid',
-        );
+        await testSnaps.selectEntropySource('bip32EntropyDropDown', 'Invalid');
         await testSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
 

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -121,13 +121,12 @@ describe('Test Snap bip-32', function () {
         await testSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
 
-        // Check the error message and close the alert.
+        // Verify that the expected error alert appears
 
         await driver.waitForBrowserAlert({
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
-        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -1,5 +1,4 @@
 import { TestSnaps } from '../page-objects/pages/test-snaps';
-import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import { Driver } from '../webdriver/driver';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
@@ -122,9 +121,7 @@ describe('Test Snap bip-32', function () {
         await testSnaps.fillMessage('messageSecp256k1Input', 'bar baz');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
 
-        const snapInstall = new SnapInstall(driver);
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.clickApproveButton();
+        // Check the error message and close the alert.
 
         await driver.waitForBrowserAlert({
           text: 'Entropy source with ID "invalid" not found.',

--- a/test/e2e/snaps/test-snap-bip-32.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-32.spec.ts
@@ -2,10 +2,11 @@ import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { Driver } from '../webdriver/driver';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
-import { withFixtures } from '../helpers';
+import { WINDOW_TITLES, withFixtures } from '../helpers';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { mockBip32Snap } from '../mock-response-data/snaps/snap-binary-mocks';
+import SnapInstall from '../page-objects/pages/dialog/snap-install';
 
 const bip32PublicKey =
   '"0x043e98d696ae15caef75fa8dd204a7c5c08d1272b2218ba3c20feeb4c691eec366606ece56791c361a2320e7fad8bcbb130f66d51c591fc39767ab2856e93f8dfb"';
@@ -63,9 +64,15 @@ describe('Test Snap bip-32', function () {
           bip32CompressedPublicKey,
         );
 
+        const snapEntropyDialog = new SnapInstall(driver);
+
         // Enter secp256k1 signature message, click sign button, approve and validate the result
         await testSnaps.fillMessage('messageSecp256k1Input', 'foo bar');
         await testSnaps.clickButton('signBip32messageSecp256k1Button');
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await snapEntropyDialog.checkPageIsLoaded();
+        await snapEntropyDialog.clickApproveButton();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await switchAndApproveDialogSwitchToTestSnap(driver);
         await testSnaps.checkMessageResultSpan(
           'bip32MessageResultSecp256k1Span',
@@ -92,7 +99,7 @@ describe('Test Snap bip-32', function () {
         );
 
         // Select entropy source SRP 1, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip32EntropyDropDown',
           'SRP 1 (primary)',
         );
@@ -106,7 +113,7 @@ describe('Test Snap bip-32', function () {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip32EntropyDropDown',
           'SRP 2',
         );
@@ -119,7 +126,7 @@ describe('Test Snap bip-32', function () {
         );
 
         // Select an invalid (non-existent) entropy source, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip32EntropyDropDown',
           'Invalid',
         );

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -1,8 +1,9 @@
 import { TestSnaps } from '../page-objects/pages/test-snaps';
+import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import { Driver } from '../webdriver/driver';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
-import { withFixtures } from '../helpers';
+import { withFixtures, WINDOW_TITLES } from '../helpers';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { mockBip44Snap } from '../mock-response-data/snaps/snap-binary-mocks';
@@ -23,9 +24,6 @@ describe('Test Snap bip-44', function () {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockBip44Snap,
         title: this.test?.fullTitle(),
-        ignoredConsoleErrors: [
-          'UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}',
-        ],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.
@@ -89,10 +87,15 @@ describe('Test Snap bip-44', function () {
 
         await testSnaps.fillMessage('messageBip44Input', 'foo bar');
         await testSnaps.clickButton('signBip44MessageButton');
-        await driver.waitForAlert(
-          'Entropy source with ID "invalid" not found.',
-        );
-        await driver.closeAlertPopup();
+
+        const snapInstall = new SnapInstall(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await snapInstall.clickApproveButton();
+
+        await driver.waitForBrowserAlert({
+          text: 'Entropy source with ID "invalid" not found.',
+          windowTitle: WINDOW_TITLES.TestSnaps,
+        });
       },
     );
   });

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -58,7 +58,7 @@ describe('Test Snap bip-44', function () {
         );
 
         // Select entropy source SRP 1, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip44EntropyDropDown',
           'SRP 1 (primary)',
         );
@@ -71,7 +71,7 @@ describe('Test Snap bip-44', function () {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip44EntropyDropDown',
           'SRP 2',
         );
@@ -84,7 +84,7 @@ describe('Test Snap bip-44', function () {
         );
 
         // Select an invalid (non-existent) entropy source, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'bip44EntropyDropDown',
           'Invalid',
         );

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -91,7 +91,6 @@ describe('Test Snap bip-44', function () {
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
-        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -23,6 +23,9 @@ describe('Test Snap bip-44', function () {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockBip44Snap,
         title: this.test?.fullTitle(),
+        ignoredConsoleErrors: [
+          'UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}',
+        ],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -71,10 +71,8 @@ describe('Test Snap bip-44', function () {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'bip44EntropyDropDown',
-          'SRP 2',
-        );
+        await testSnaps.selectEntropySource('bip44EntropyDropDown', 'SRP 2');
+
         await testSnaps.fillMessage('messageBip44Input', 'foo bar');
         await testSnaps.clickButton('signBip44MessageButton');
         await switchAndApproveDialogSwitchToTestSnap(driver);
@@ -84,10 +82,8 @@ describe('Test Snap bip-44', function () {
         );
 
         // Select an invalid (non-existent) entropy source, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'bip44EntropyDropDown',
-          'Invalid',
-        );
+        await testSnaps.selectEntropySource('bip44EntropyDropDown', 'Invalid');
+
         await testSnaps.fillMessage('messageBip44Input', 'foo bar');
         await testSnaps.clickButton('signBip44MessageButton');
         await driver.waitForAlert(

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -1,5 +1,4 @@
 import { TestSnaps } from '../page-objects/pages/test-snaps';
-import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import { Driver } from '../webdriver/driver';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import FixtureBuilder from '../fixture-builder';
@@ -87,10 +86,6 @@ describe('Test Snap bip-44', function () {
 
         await testSnaps.fillMessage('messageBip44Input', 'foo bar');
         await testSnaps.clickButton('signBip44MessageButton');
-
-        const snapInstall = new SnapInstall(driver);
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await snapInstall.clickApproveButton();
 
         await driver.waitForBrowserAlert({
           text: 'Entropy source with ID "invalid" not found.',

--- a/test/e2e/snaps/test-snap-bip-44.spec.ts
+++ b/test/e2e/snaps/test-snap-bip-44.spec.ts
@@ -91,6 +91,7 @@ describe('Test Snap bip-44', function () {
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
+        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -81,6 +81,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
+        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -1,9 +1,10 @@
 import { Suite } from 'mocha';
 import { Driver } from '../webdriver/driver';
-import { withFixtures } from '../helpers';
+import { withFixtures, WINDOW_TITLES } from '../helpers';
 import FixtureBuilder from '../fixture-builder';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import { TestSnaps } from '../page-objects/pages/test-snaps';
+import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import { switchAndApproveDialogSwitchToTestSnap } from '../page-objects/flows/snap-permission.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { mockGetEntropySnap } from '../mock-response-data/snaps/snap-binary-mocks';
@@ -22,9 +23,6 @@ describe('Test Snap getEntropy', function (this: Suite) {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockGetEntropySnap,
         title: this.test?.fullTitle(),
-        ignoredConsoleErrors: [
-          'UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}',
-        ],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.
@@ -74,11 +72,15 @@ describe('Test Snap getEntropy', function (this: Suite) {
         await testSnaps.selectEntropySource('getEntropyDropDown', 'Invalid');
 
         await testSnaps.scrollAndClickButton('signEntropyMessageButton');
-        await switchAndApproveDialogSwitchToTestSnap(driver);
-        await driver.waitForAlert(
-          'Entropy source with ID "invalid" not found.',
-        );
-        await driver.closeAlertPopup();
+
+        const snapInstall = new SnapInstall(driver);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await snapInstall.clickApproveButton();
+
+        await driver.waitForBrowserAlert({
+          text: 'Entropy source with ID "invalid" not found.',
+          windowTitle: WINDOW_TITLES.TestSnaps,
+        });
       },
     );
   });

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -81,7 +81,6 @@ describe('Test Snap getEntropy', function (this: Suite) {
           text: 'Entropy source with ID "invalid" not found.',
           windowTitle: WINDOW_TITLES.TestSnaps,
         });
-        await driver.closeAlertPopup();
       },
     );
   });

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -22,6 +22,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockGetEntropySnap,
         title: this.test?.fullTitle(),
+        ignoredConsoleErrors: ['UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}'],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.
@@ -45,7 +46,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
         );
 
         // Select entropy source SRP 1, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'getEntropyDropDown',
           'SRP 1 (primary)',
         );
@@ -58,7 +59,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'getEntropyDropDown',
           'SRP 2',
         );
@@ -70,7 +71,7 @@ describe('Test Snap getEntropy', function (this: Suite) {
         );
 
         // Select entropy source invalid, enter a message, sign, approve and validate the result
-        await testSnaps.scrollAndSelectEntropySource(
+        await testSnaps.selectEntropySource(
           'getEntropyDropDown',
           'Invalid',
         );

--- a/test/e2e/snaps/test-snap-get-entropy.spec.ts
+++ b/test/e2e/snaps/test-snap-get-entropy.spec.ts
@@ -22,7 +22,9 @@ describe('Test Snap getEntropy', function (this: Suite) {
         fixtures: new FixtureBuilder().withKeyringControllerMultiSRP().build(),
         testSpecificMock: mockGetEntropySnap,
         title: this.test?.fullTitle(),
-        ignoredConsoleErrors: ['UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}'],
+        ignoredConsoleErrors: [
+          'UnexpectedAlertOpenError: unexpected alert open: {Alert text : Entropy source with ID "invalid" not found.}',
+        ],
       },
       async ({ driver }: { driver: Driver }) => {
         // We explicitly choose to await balances to prevent flakiness due to long login times.
@@ -59,10 +61,8 @@ describe('Test Snap getEntropy', function (this: Suite) {
         );
 
         // Select entropy source SRP 2, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'getEntropyDropDown',
-          'SRP 2',
-        );
+        await testSnaps.selectEntropySource('getEntropyDropDown', 'SRP 2');
+
         await testSnaps.scrollAndClickButton('signEntropyMessageButton');
         await switchAndApproveDialogSwitchToTestSnap(driver);
         await testSnaps.checkMessageResultSpan(
@@ -71,10 +71,8 @@ describe('Test Snap getEntropy', function (this: Suite) {
         );
 
         // Select entropy source invalid, enter a message, sign, approve and validate the result
-        await testSnaps.selectEntropySource(
-          'getEntropyDropDown',
-          'Invalid',
-        );
+        await testSnaps.selectEntropySource('getEntropyDropDown', 'Invalid');
+
         await testSnaps.scrollAndClickButton('signEntropyMessageButton');
         await switchAndApproveDialogSwitchToTestSnap(driver);
         await driver.waitForAlert(

--- a/test/e2e/tests/onboarding/seedless-onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/seedless-onboarding.spec.ts
@@ -18,7 +18,7 @@ import { shortenAddress } from '../../../../ui/helpers/utils/util';
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 describe('Metamask onboarding (with social login)', function () {
-  it.only('Creates a new wallet with Google login and completes the onboarding process TEST', async function () {
+  it('Creates a new wallet with Google login and completes the onboarding process', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ onboarding: true }).build(),

--- a/test/e2e/tests/onboarding/seedless-onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/seedless-onboarding.spec.ts
@@ -18,7 +18,7 @@ import { shortenAddress } from '../../../../ui/helpers/utils/util';
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 describe('Metamask onboarding (with social login)', function () {
-  it('Creates a new wallet with Google login and completes the onboarding process', async function () {
+  it.only('Creates a new wallet with Google login and completes the onboarding process TEST', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ onboarding: true }).build(),

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1483,7 +1483,7 @@ class Driver {
               /Alert text\s*:\s*(.+?)(?:\s*\}|$)/u,
             );
             if (alertTextMatch) {
-              const alertText = alertTextMatch[1];
+              const alertText = alertTextMatch[1].trim();
               if (alertText !== text) {
                 throw new Error(
                   `Expected alert text to be "${text}", but got "${alertText}".`,
@@ -1492,7 +1492,7 @@ class Driver {
               return true;
             }
             throw new Error(
-              'Could not extract alert text from UnexpectedAlertOpenError',
+              `Could not extract alert text from UnexpectedAlertOpenError. Full error message: "${error.message}"`,
             );
           } else {
             throw error;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky due to a limitiation of the window switch whenever there is the alert open (modal dialogs, such as alerts, confirms, prompts, are blocking by design). The normal (and working flow) is:

1. We trigger a function from the test dapp
2. MetaMask dialog opens
3. We confirm, and MetaMAsk dialog closes
4. We switch back to the test dapp
5. After some seconds, a browser alert appears

However, if the alert(5) appears *before* we have switched windows, then it's not possible to switch windows and we get into a limbo state --> the dialog is closed, and we cannot switch to the test dapp to accept/close the alert.

In this case, an error appears and the test fails. I found that no matter if we ignore the error, the test will fail after because we try to close the dialog (not possible bc we cannot switch windows), so the best solution is to modify the waitForBrowserAlert function to be more robust. This way, we'll be able to use it in all cases (both in the case we are already in the correct window where the alert will appear, and in the case where we are *not* in the window where the alert will appear).

<img width="1190" height="182" alt="image" src="https://github.com/user-attachments/assets/69c3a1e7-e076-4783-81b3-6fb730b1805c" />

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36087?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
