### PR TITLE
test(ci): support tests that set manifestFlags.testing.infuraProjectId, such as power-user.spec.ts

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -1,4 +1,4 @@
-# This workflow is meant to better structure the main.yaml one for redability reasons.
+# This workflow is meant to better structure the main.yaml one for readability reasons.
 # It is not meant to be a reusable workflow.
 
 name: E2E Chrome
@@ -8,10 +8,14 @@ on:
     secrets:
       PR_COMMENT_TOKEN:
         required: true
+      INFURA_PROJECT_ID:
+        required: false
 
 jobs:
   test-e2e-chrome-browserify:
     uses: ./.github/workflows/run-e2e.yml
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
@@ -28,6 +32,8 @@ jobs:
   test-e2e-chrome-webpack:
     uses: ./.github/workflows/run-e2e.yml
     if: ${{ github.event_name != 'merge_group' }}
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -1,14 +1,19 @@
-# This workflow is meant to better structure the main.yaml one for redability reasons.
+# This workflow is meant to better structure the main.yaml one for readability reasons.
 # It is not meant to be a reusable workflow.
 
 name: E2E Firefox
 
 on:
   workflow_call:
+    secrets:
+      INFURA_PROJECT_ID:
+        required: false
 
 jobs:
   test-e2e-firefox-browserify:
     uses: ./.github/workflows/run-e2e.yml
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,6 +268,7 @@ jobs:
     uses: ./.github/workflows/e2e-chrome.yml
     secrets:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
   e2e-firefox:
     needs:
@@ -276,6 +277,8 @@ jobs:
       - build-test-flask-mv2-browserify
     if: ${{ needs.needs-e2e.outputs.needs-e2e == 'true' }}
     uses: ./.github/workflows/e2e-firefox.yml
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
   build-storybook:
     name: Build storybook

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -37,6 +37,9 @@ on:
           ./test-artifacts
           ./test/test-results/e2e
         description: The path to the test artifacts
+    secrets:
+      INFURA_PROJECT_ID:
+        required: false
 
 jobs:
   run-e2e:
@@ -49,6 +52,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # This is to support tests that set manifestFlags.testing.infuraProjectId, such as power-user.spec.ts
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## **Description**

@seaona noticed that `power-user.spec.ts` was failing, and it was because `secrets.INFURA_PROJECT_ID` was not being correctly passed through the workflows.  This fixes it.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->