### PR TITLE
fix: enable networks automatically when added to fix token detection

### DIFF
--- a/app/scripts/controller-init/messengers/assets/network-order-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/assets/network-order-controller-messenger.test.ts
@@ -4,8 +4,8 @@ import { getNetworkOrderControllerMessenger } from './network-order-controller-m
 describe('getNetworkOrderControllerMessenger', () => {
   it('returns a restricted messenger', () => {
     const messenger = new Messenger<never, never>();
-    const nftControllerMessenger =
+    const networkOrderControllerMessenger =
       getNetworkOrderControllerMessenger(messenger);
-    expect(nftControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+    expect(networkOrderControllerMessenger).toBeInstanceOf(RestrictedMessenger);
   });
 });

--- a/app/scripts/controller-init/messengers/assets/network-order-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/assets/network-order-controller-messenger.ts
@@ -2,6 +2,7 @@ import { Messenger } from '@metamask/base-controller';
 import {
   NetworkControllerGetStateAction,
   NetworkControllerNetworkRemovedEvent,
+  NetworkControllerNetworkAddedEvent,
   NetworkControllerSetActiveNetworkAction,
   NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
@@ -11,7 +12,8 @@ type Actions =
   | NetworkControllerSetActiveNetworkAction;
 type Events =
   | NetworkControllerStateChangeEvent
-  | NetworkControllerNetworkRemovedEvent;
+  | NetworkControllerNetworkRemovedEvent
+  | NetworkControllerNetworkAddedEvent;
 
 export type NetworkOrderControllerMessenger = ReturnType<
   typeof getNetworkOrderControllerMessenger
@@ -25,6 +27,7 @@ export function getNetworkOrderControllerMessenger(
     allowedEvents: [
       'NetworkController:stateChange',
       'NetworkController:networkRemoved',
+      'NetworkController:networkAdded',
     ],
     allowedActions: [
       'NetworkController:getState',

--- a/test/e2e/tests/network/switch-network.spec.ts
+++ b/test/e2e/tests/network/switch-network.spec.ts
@@ -45,18 +45,20 @@ describe('Switch network - ', function (this: Suite) {
         await loginWithBalanceValidation(driver);
         const homePage = new HomePage(driver);
 
-        // Validate the switch network functionality to Ethereum
+        // Test starts with a custom network localhost:8545
+
+        // In the send flow we use Ethereum token which changes the network to Ethereum on the home page becuase custom network was previously selected
         await switchToNetworkFromSendFlow(driver, 'Ethereum');
-        await homePage.checkLocalNodeBalanceIsDisplayed();
+        await homePage.checkExpectedBalanceIsDisplayed('25', 'ETH');
 
         // Add Arbitrum network
         await searchAndSwitchToNetworkFromGlobalMenuFlow(driver, 'Arbitrum');
-        await homePage.checkLocalNodeBalanceIsDisplayed();
+        await homePage.checkExpectedBalanceIsDisplayed('$85,000.00', 'USD');
 
-        // Validate the switch network functionality back to Ethereum
+        // Switching network in send flow should not affect the home page network filter
         await switchToNetworkFromSendFlow(driver, 'Ethereum');
         await homePage.checkPageIsLoaded();
-        await homePage.checkLocalNodeBalanceIsDisplayed();
+        await homePage.checkExpectedBalanceIsDisplayed('$85,000.00', 'USD');
       },
     );
   });

--- a/test/e2e/tests/network/switch-network.spec.ts
+++ b/test/e2e/tests/network/switch-network.spec.ts
@@ -49,11 +49,7 @@ describe('Switch network - ', function (this: Suite) {
         await switchToNetworkFromSendFlow(driver, 'Ethereum');
         await homePage.checkLocalNodeBalanceIsDisplayed();
 
-        // Validate the switch network functionality to test network
-        await switchToNetworkFromSendFlow(driver, 'Localhost 8545');
-        await homePage.checkLocalNodeBalanceIsDisplayed();
-
-        // Add Arbitrum network and perform the switch network functionality
+        // Add Arbitrum network
         await searchAndSwitchToNetworkFromGlobalMenuFlow(driver, 'Arbitrum');
         await homePage.checkLocalNodeBalanceIsDisplayed();
 


### PR DESCRIPTION
## **Description**


**What is the reason for the change?**
When a user adds a new network (e.g., Polygon) and immediately navigates to Swap → Token Picker, the token list shows infinite loading because networks are added to `networkConfigurationsByChainId` but NOT automatically enabled in `enabledNetworkMap`. This prevents token detection polling hooks from triggering.

**What is the improvement/solution?**
Implemented event-driven network enabling in `NetworkOrderController` to automatically enable newly added networks, triggering token detection and resolving the infinite loading issue.


## **Changelog**

CHANGELOG entry: Fixed token list infinite loading when adding new networks by automatically enabling networks for token detection.

## **Related issues**

Fixes: #35910,  [ASSETS-1221](https://consensyssoftware.atlassian.net/browse/ASSETS-1221) 

## **Manual testing steps**

1. Go to MetaMask extension
2. Add a new network (e.g., Polygon) via Settings → Networks → Add Network
3. Immediately navigate to Swap → Token Picker
4. Verify that tokens load properly (no infinite loading)
5. Verify that the network appears in the network list and is enabled
6. Test with both EVM networks (Polygon) and ensure functionality works

## **Screenshots/Recordings**

<!-- Screenshots will be added during manual testing -->

### **Before**

- Adding Polygon network → Navigate to Swap → Token Picker shows infinite loading
- Tokens only appear after manually switching network filter on main page

[![Reproducing Bug 35910 - Watch Video](https://cdn.loom.com/sessions/thumbnails/796361e7ba944e5aa315ff456fd90d7c-beb6cb0e4f30827d-full-play.gif)](https://www.loom.com/share/796361e7ba944e5aa315ff456fd90d7c)

### **After**

- Adding Polygon network → Navigate to Swap → Token Picker loads tokens immediately
- No manual intervention required

[![Bug Fix #35910 - Watch Video](https://cdn.loom.com/sessions/thumbnails/1312d88195534068951d0cba02461615-c965bd375d3f59b4-full-play.gif)](https://www.loom.com/share/1312d88195534068951d0cba02461615)


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[ASSETS-1221]: https://consensyssoftware.atlassian.net/browse/ASSETS-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ