### PR TITLE
fix: use transaction `chainId` instead of global network for `advancedGasFee`

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -1,6 +1,7 @@
 import {
   type PublishBatchHookRequest,
   type PublishBatchHookTransaction,
+  SavedGasFees,
   TransactionController,
   TransactionControllerMessenger,
   TransactionMeta,
@@ -47,7 +48,6 @@ export const TransactionControllerInit: ControllerInitFunction<
     controllerMessenger,
     initMessenger,
     getFlatState,
-    getGlobalChainId,
     getPermittedAccounts,
     getTransactionMetricsRequest,
     updateAccountBalanceForTransactionNetwork,
@@ -78,10 +78,10 @@ export const TransactionControllerInit: ControllerInitFunction<
     getNetworkState: () => networkController().state,
     // @ts-expect-error Controller type does not support undefined return value
     getPermittedAccounts,
-    // @ts-expect-error Preferences controller uses Record rather than specific type
-    getSavedGasFees: () => {
-      const globalChainId = getGlobalChainId();
-      return preferencesController().state.advancedGasFee[globalChainId];
+    getSavedGasFees: (chainId) => {
+      return preferencesController().state.advancedGasFee[
+        chainId
+      ] as unknown as SavedGasFees | undefined;
     },
     getSimulationConfig: async (url) => {
       const getToken = () =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the reliance on the global network state when retrieving `advancedGasFee`.
Instead, it now uses the `chainId` from the transaction itself, ensuring that gas fee retrieval is accurate and consistent across different networks.

core: https://github.com/MetaMask/core/blob/c7a58f768874a7ba33ed8ed4577dbef9a53927f9/packages/transaction-controller/src/utils/gas-fees.ts#L68

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36110?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed retrieve `advancedGasFee` using the transaction’s `chainId` instead of the global network

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35189

## **Manual testing steps**

1. Select Mainnet as the only network in the network selector (just as example)
2. Create a send transaction and edit the gas fee in the 'advanced' settings (Max/ priority fee, gas limit).
3. Check the box: "Save these values as my default for the Linea mainnet network."
4. Keep the network the same in your wallet, but go to a dapp that initiates a transaction on another network. (Example: https://linea.build/hub/rewards. Initiates a transaction on Linea, though my wallet only has Mainnet selected)
5. When the dapp initiates a transaction, the gas settings that you saved on Mainnet will be set by default, even though the transaction is for Linea. Where otherwise the dapp would select the 'site' gas settings.

## **Screenshots/Recordings**

[advance-gas.webm](https://github.com/user-attachments/assets/5b28f17f-2710-4113-be80-d918f650fd5e)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
