### PR TITLE
fix: Move network selector above banner in activity tab empty state

### DIFF
--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -734,11 +734,11 @@ export default function TransactionList({
 
   return (
     <>
-      {showRampsCard ? (
-        <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
-      ) : null}
       <Box className="transaction-list" {...boxProps}>
         {renderFilterButton()}
+        {showRampsCard ? (
+          <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
+        ) : null}
         {pendingTransactions.length === 0 &&
         completedTransactions.length === 0 ? (
           <NoTransactions />

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -727,11 +727,12 @@ export default function UnifiedTransactionList({
             networkConfig={multichainNetworkConfig}
           />
         ))}
-      {showRampsCard ? (
-        <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
-      ) : null}
+
       <Box className="transaction-list" {...boxProps}>
         {renderFilterButton()}
+        {showRampsCard ? (
+          <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
+        ) : null}
         {processedUnifiedActivityItems.length === 0 ? (
           <NoTransactions />
         ) : (

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -405,41 +405,41 @@ exports[`AssetPage should render a native asset 1`] = `
             Your activity
           </h4>
           <div
-            class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
-          >
-            <div
-              class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
-            >
-              <h4
-                class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
-              >
-                Tips for using a wallet
-              </h4>
-              <button
-                aria-label="Close"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
-                data-testid="ramp-card-close-btn"
-              >
-                <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/close.svg');"
-                />
-              </button>
-            </div>
-            <p
-              class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
-            >
-              Adding tokens unlocks more ways to use web3.
-            </p>
-            <button
-              class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
-            >
-              Token marketplace
-            </button>
-          </div>
-          <div
             class="mm-box transaction-list"
           >
+            <div
+              class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
+            >
+              <div
+                class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+              >
+                <h4
+                  class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
+                >
+                  Tips for using a wallet
+                </h4>
+                <button
+                  aria-label="Close"
+                  class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
+                  data-testid="ramp-card-close-btn"
+                >
+                  <span
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    style="mask-image: url('./images/icons/close.svg');"
+                  />
+                </button>
+              </div>
+              <p
+                class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
+              >
+                Adding tokens unlocks more ways to use web3.
+              </p>
+              <button
+                class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
+              >
+                Token marketplace
+              </button>
+            </div>
             <div
               class="mm-box nfts-tab__link mm-box--margin-top-12 mm-box--margin-bottom-12 mm-box--padding-top-6 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
             >
@@ -888,41 +888,41 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
             Your activity
           </h4>
           <div
-            class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
-          >
-            <div
-              class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
-            >
-              <h4
-                class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
-              >
-                Tips for using a wallet
-              </h4>
-              <button
-                aria-label="Close"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
-                data-testid="ramp-card-close-btn"
-              >
-                <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/close.svg');"
-                />
-              </button>
-            </div>
-            <p
-              class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
-            >
-              Adding tokens unlocks more ways to use web3.
-            </p>
-            <button
-              class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
-            >
-              Token marketplace
-            </button>
-          </div>
-          <div
             class="mm-box transaction-list"
           >
+            <div
+              class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
+            >
+              <div
+                class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+              >
+                <h4
+                  class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
+                >
+                  Tips for using a wallet
+                </h4>
+                <button
+                  aria-label="Close"
+                  class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
+                  data-testid="ramp-card-close-btn"
+                >
+                  <span
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    style="mask-image: url('./images/icons/close.svg');"
+                  />
+                </button>
+              </div>
+              <p
+                class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
+              >
+                Adding tokens unlocks more ways to use web3.
+              </p>
+              <button
+                class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
+              >
+                Token marketplace
+              </button>
+            </div>
             <div
               class="mm-box nfts-tab__link mm-box--margin-top-12 mm-box--margin-bottom-12 mm-box--padding-top-6 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
             >
@@ -1400,41 +1400,41 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
             Your activity
           </h4>
           <div
-            class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
-          >
-            <div
-              class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
-            >
-              <h4
-                class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
-              >
-                Tips for using a wallet
-              </h4>
-              <button
-                aria-label="Close"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
-                data-testid="ramp-card-close-btn"
-              >
-                <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/close.svg');"
-                />
-              </button>
-            </div>
-            <p
-              class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
-            >
-              Adding tokens unlocks more ways to use web3.
-            </p>
-            <button
-              class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
-            >
-              Token marketplace
-            </button>
-          </div>
-          <div
             class="mm-box transaction-list"
           >
+            <div
+              class="mm-box ramps-card ramps-card-activity mm-box--margin-2 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--rounded-lg"
+            >
+              <div
+                class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+              >
+                <h4
+                  class="mm-box mm-text ramps-card__title mm-text--heading-sm mm-box--color-text-default"
+                >
+                  Tips for using a wallet
+                </h4>
+                <button
+                  aria-label="Close"
+                  class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-info-inverse mm-box--background-color-transparent mm-box--rounded-lg"
+                  data-testid="ramp-card-close-btn"
+                >
+                  <span
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    style="mask-image: url('./images/icons/close.svg');"
+                  />
+                </button>
+              </div>
+              <p
+                class="mm-box mm-text ramps-card__body mm-text--body-md mm-box--color-text-default"
+              >
+                Adding tokens unlocks more ways to use web3.
+              </p>
+              <button
+                class="mm-box mm-text mm-button-base mm-button-base--size-md ramps-card__cta-button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-xl"
+              >
+                Token marketplace
+              </button>
+            </div>
             <div
               class="mm-box nfts-tab__link mm-box--margin-top-12 mm-box--margin-bottom-12 mm-box--padding-top-6 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
             >


### PR DESCRIPTION
## **Description**

This PR fixes the layout issue in the activity tab where the network selector was appearing below the banner in empty state. The fix moves the RampsCard (banner) inside the transaction-list container, positioning it after the filter button (network selector) to ensure proper visual hierarchy.

**What is the reason for the change?**
The current layout had the banner appearing above the network selector, which created a poor user experience and violated the intended design hierarchy.

**What is the improvement/solution?**
Repositioned the RampsCard within the transaction-list Box component, placing it after the renderFilterButton() call in both transaction list components, ensuring the network selector appears above the banner as intended.

## **Changelog**

CHANGELOG entry: Fixed activity tab layout to show network selector above banner in empty state

## **Related issues**

Fixes: N/A
Related: https://consensyssoftware.atlassian.net/browse/DSYS-164

## **Manual testing steps**

1. Go to the activity tab when there are no transactions
2. Verify the network selector/filter button appears above the banner
3. Test on both unified and legacy transaction list views
4. Confirm the layout is consistent across different screen sizes

## **Screenshots/Recordings**

### **Before**
Banner appeared above the network selector, disrupting the visual hierarchy.

<img width="405" height="603" alt="Screenshot 2025-09-19 at 11 56 59 AM" src="https://github.com/user-attachments/assets/c533ee9b-cc41-4fd1-a189-97003bdce649" />

### **After**
Network selector now correctly appears above the banner in empty state.

<img width="403" height="607" alt="Screenshot 2025-09-19 at 11 56 13 AM" src="https://github.com/user-attachments/assets/02f5442b-484c-4730-8281-5b1116ca82cb" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.