### PR TITLE
fix: Add TTL for address security alert response cache cp-13.4.0

### DIFF
--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -1148,10 +1148,19 @@ export class AppStateController extends BaseController<
       return undefined;
     }
 
+    // Handle legacy cache entries without timestamp
+    if (!cached.timestamp) {
+      this.update((state) => {
+        delete state.addressSecurityAlertResponses[address.toLowerCase()];
+      });
+      return undefined;
+    }
+
     // Check if the cached response has expired (15 minute TTL)
     const now = Date.now();
     const ADDRESS_SECURITY_ALERT_TTL = 15 * MINUTE;
     if (now - cached.timestamp > ADDRESS_SECURITY_ALERT_TTL) {
+      // Remove expired entry
       this.update((state) => {
         delete state.addressSecurityAlertResponses[address.toLowerCase()];
       });

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -1148,7 +1148,6 @@ export class AppStateController extends BaseController<
       return undefined;
     }
 
-    // Handle legacy cache entries without timestamp
     if (!cached.timestamp) {
       this.update((state) => {
         delete state.addressSecurityAlertResponses[address.toLowerCase()];

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -1150,7 +1150,7 @@ export class AppStateController extends BaseController<
 
     // Check if the cached response has expired (15 minute TTL)
     const now = Date.now();
-    const ADDRESS_SECURITY_ALERT_TTL = 15 * MINUTE;
+    const ADDRESS_SECURITY_ALERT_TTL = Number(MINUTE);
     if (now - cached.timestamp > ADDRESS_SECURITY_ALERT_TTL) {
       // Remove expired entry
       this.update((state) => {

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -1148,13 +1148,6 @@ export class AppStateController extends BaseController<
       return undefined;
     }
 
-    if (!cached.timestamp) {
-      this.update((state) => {
-        delete state.addressSecurityAlertResponses[address.toLowerCase()];
-      });
-      return undefined;
-    }
-
     // Check if the cached response has expired (15 minute TTL)
     const now = Date.now();
     const ADDRESS_SECURITY_ALERT_TTL = 15 * MINUTE;

--- a/app/scripts/lib/trust-signals/types.ts
+++ b/app/scripts/lib/trust-signals/types.ts
@@ -57,6 +57,10 @@ export type ScanAddressResponse = {
   label: string;
 };
 
+export type CachedScanAddressResponse = ScanAddressResponse & {
+  timestamp: number;
+};
+
 export type GetAddressSecurityAlertResponse = (
   address: string,
 ) => ScanAddressResponse | undefined;

--- a/app/scripts/migrations/179.test.ts
+++ b/app/scripts/migrations/179.test.ts
@@ -50,11 +50,13 @@ describe(`migration #${version}`, () => {
       AppStateController: {
         addressSecurityAlertResponses: {
           '0x123abc': {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             result_type: 'Benign',
             label: 'Some label',
             // Note: no timestamp field (legacy format)
           },
           '0x456def': {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             result_type: 'Warning',
             label: 'Another label',
             // Note: no timestamp field (legacy format)
@@ -106,11 +108,13 @@ describe(`migration #${version}`, () => {
       AppStateController: {
         addressSecurityAlertResponses: {
           '0x123abc': {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             result_type: 'Benign',
             label: 'Some label',
             timestamp: 1642678800000, // Already has timestamp
           },
           '0x456def': {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             result_type: 'Warning',
             label: 'Another label',
             // Mixed: this one doesn't have timestamp

--- a/app/scripts/migrations/179.test.ts
+++ b/app/scripts/migrations/179.test.ts
@@ -1,0 +1,135 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './179';
+
+const oldVersion = 178;
+
+describe(`migration #${version}`, () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('Does nothing if AppStateController is not in state', async () => {
+    const oldState = {
+      SomeOtherController: {
+        someProperty: 'value',
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: cloneDeep(oldState),
+    });
+
+    expect(transformedState.data).toStrictEqual(oldState);
+  });
+
+  it('Does nothing if addressSecurityAlertResponses is not in AppStateController', async () => {
+    const oldState = {
+      AppStateController: {
+        someOtherProperty: 'value',
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: cloneDeep(oldState),
+    });
+
+    expect(transformedState.data).toStrictEqual(oldState);
+  });
+
+  it('Clears existing addressSecurityAlertResponses cache entries', async () => {
+    const oldState = {
+      AppStateController: {
+        addressSecurityAlertResponses: {
+          '0x123abc': {
+            result_type: 'Benign',
+            label: 'Some label',
+            // Note: no timestamp field (legacy format)
+          },
+          '0x456def': {
+            result_type: 'Warning',
+            label: 'Another label',
+            // Note: no timestamp field (legacy format)
+          },
+        },
+        otherProperty: 'should remain unchanged',
+      },
+      OtherController: {
+        someData: 'should remain unchanged',
+      },
+    };
+
+    const expectedState = {
+      AppStateController: {
+        addressSecurityAlertResponses: {}, // Cleared
+        otherProperty: 'should remain unchanged',
+      },
+      OtherController: {
+        someData: 'should remain unchanged',
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: cloneDeep(oldState),
+    });
+
+    expect(transformedState.data).toStrictEqual(expectedState);
+  });
+
+  it('Handles non-object addressSecurityAlertResponses gracefully', async () => {
+    const oldState = {
+      AppStateController: {
+        addressSecurityAlertResponses: null,
+        otherProperty: 'value',
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: cloneDeep(oldState),
+    });
+
+    expect(transformedState.data).toStrictEqual(oldState);
+  });
+
+  it('Clears addressSecurityAlertResponses even if it already has entries with timestamps', async () => {
+    const oldState = {
+      AppStateController: {
+        addressSecurityAlertResponses: {
+          '0x123abc': {
+            result_type: 'Benign',
+            label: 'Some label',
+            timestamp: 1642678800000, // Already has timestamp
+          },
+          '0x456def': {
+            result_type: 'Warning',
+            label: 'Another label',
+            // Mixed: this one doesn't have timestamp
+          },
+        },
+      },
+    };
+
+    const expectedState = {
+      AppStateController: {
+        addressSecurityAlertResponses: {}, // Still cleared for consistency
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: cloneDeep(oldState),
+    });
+
+    expect(transformedState.data).toStrictEqual(expectedState);
+  });
+});

--- a/app/scripts/migrations/179.ts
+++ b/app/scripts/migrations/179.ts
@@ -1,0 +1,49 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { captureException } from '../../../shared/lib/sentry';
+
+export const version = 179;
+
+/**
+ * This migration clears the legacy addressSecurityAlertResponses cache entries
+ * that don't have timestamp fields, preparing for the new TTL-based caching system.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  try {
+    const appStateControllerState = state.AppStateController;
+    if (
+      hasProperty(state, 'AppStateController') &&
+      isObject(appStateControllerState) &&
+      hasProperty(appStateControllerState, 'addressSecurityAlertResponses') &&
+      isObject(appStateControllerState.addressSecurityAlertResponses)
+    ) {
+      // Clear all existing cache entries to force fresh fetches with timestamps
+      // This ensures all cached entries will have the new timestamp field for TTL tracking
+      appStateControllerState.addressSecurityAlertResponses = {};
+    }
+    return state;
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${version}: Failed to clear addressSecurityAlertResponses cache. Error: ${(error as Error).message}`,
+      ),
+    );
+    return state;
+  }
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -212,6 +212,7 @@ const migrations = [
   require('./176'),
   require('./177'),
   require('./178'),
+  require('./179'),
 ];
 
 export default migrations;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR improves the caching mechanism for **address security alert responses**.  
Previously, address scan responses were cached indefinitely, which could result in outdated or stale alerts being displayed to users.  

The fix introduces a **15-minute TTL** for cached responses. When an address security alert response is requested, the cache is checked first. If the cached response is older than 15 minutes, it is removed and a new scan will be required.  

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36169?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a 15-minute TTL for address security alert responses.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start a transaction and see that we make a call to the security alerts API
2. Make another transaction and you should not see another network call until 15 minutes
3. After the 15 minutes you should see another call for that transaction!

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
