### PR TITLE
fix: Sidestep rounding errors with Jazzicons

### DIFF
--- a/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch
+++ b/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch
@@ -1,0 +1,21 @@
+diff --git a/index.js b/index.js
+index 77b913b9f57b8f669e7ab6aeae92c299c57a9112..5aa31c0e3a7c787dc216eabe7d59f750e1721a6c 100644
+--- a/index.js
++++ b/index.js
+@@ -46,12 +46,14 @@ function genShape(remainingColors, diameter, i, total, svg) {
+   var tx = (Math.cos(angle) * velocity)
+   var ty = (Math.sin(angle) * velocity)
+ 
+-  var translate = 'translate(' + tx + ' ' +  ty + ')'
++  // Prevent rounding errors, which causes intermittent failures when running Jest snapshot tests
++  var translate = 'translate(' + tx.toFixed(14) + ' ' +  ty.toFixed(14) + ')'
+ 
+   // Third random is a shape rotation on top of all of that.
+   var secondRot = generator.random()
+   var rot = (firstRot * 360) + secondRot * 180
+-  var rotate = 'rotate(' + rot.toFixed(1) + ' ' + center + ' ' + center + ')'
++  // Prevent rounding errors, which causes intermittent failures when running Jest snapshot tests
++  var rotate = 'rotate(' + rot.toFixed(1) + ' ' + center.toFixed(14) + ' ' + center.toFixed(14) + ')'
+   var transform = translate + ' ' + rotate
+   shape.setAttributeNS(null, 'transform', transform)
+   var fill = genColor(remainingColors)

--- a/package.json
+++ b/package.json
@@ -242,7 +242,8 @@
     "jsonpath-plus": "^10.3.0",
     "@endo/env-options@npm:^1.1.11": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.7": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
-    "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch"
+    "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
+    "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",
@@ -300,7 +301,7 @@
     "@metamask/gas-fee-controller": "^24.0.0",
     "@metamask/gator-permissions-controller": "^0.1.0",
     "@metamask/institutional-wallet-snap": "1.3.4",
-    "@metamask/jazzicon": "^2.0.0",
+    "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
     "@metamask/json-rpc-engine": "^10.0.0",
     "@metamask/json-rpc-middleware-stream": "^8.0.4",
     "@metamask/kernel-browser-runtime": "^0.4.0",

--- a/ui/components/app/account-list-item/__snapshots__/account-list-item-component.test.js.snap
+++ b/ui/components/app/account-list-item/__snapshots__/account-list-item-component.test.js.snap
@@ -28,7 +28,7 @@ exports[`AccountListItem Component render should match snapshot 1`] = `
               <rect
                 fill="#2362E1"
                 height="18"
-                transform="translate(2.018998228945791 -3.0005497255688565) rotate(458.4 9 9)"
+                transform="translate(2.01899822894579 -3.00054972556886) rotate(458.4 9.00000000000000 9.00000000000000)"
                 width="18"
                 x="0"
                 y="0"
@@ -36,7 +36,7 @@ exports[`AccountListItem Component render should match snapshot 1`] = `
               <rect
                 fill="#F94301"
                 height="18"
-                transform="translate(-8.641945850428243 4.495697794961231) rotate(268.8 9 9)"
+                transform="translate(-8.64194585042824 4.49569779496123) rotate(268.8 9.00000000000000 9.00000000000000)"
                 width="18"
                 x="0"
                 y="0"
@@ -44,7 +44,7 @@ exports[`AccountListItem Component render should match snapshot 1`] = `
               <rect
                 fill="#FA7900"
                 height="18"
-                transform="translate(-5.10539291960705 16.582508932884398) rotate(117.3 9 9)"
+                transform="translate(-5.10539291960705 16.58250893288440) rotate(117.3 9.00000000000000 9.00000000000000)"
                 width="18"
                 x="0"
                 y="0"

--- a/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
+++ b/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
@@ -47,7 +47,7 @@ exports[`Confirm Remove Account should match snapshot 1`] = `
                     <rect
                       fill="#18CDF2"
                       height="32"
-                      transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -55,7 +55,7 @@ exports[`Confirm Remove Account should match snapshot 1`] = `
                     <rect
                       fill="#035E56"
                       height="32"
-                      transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -63,7 +63,7 @@ exports[`Confirm Remove Account should match snapshot 1`] = `
                     <rect
                       fill="#F26602"
                       height="32"
-                      transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"

--- a/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
+++ b/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
@@ -29,7 +29,7 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
             <rect
               fill="#2362E1"
               height="45"
-              transform="translate(5.047495572364477 -7.501374313922141) rotate(458.4 22.5 22.5)"
+              transform="translate(5.04749557236448 -7.50137431392214) rotate(458.4 22.50000000000000 22.50000000000000)"
               width="45"
               x="0"
               y="0"
@@ -37,7 +37,7 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
             <rect
               fill="#F94301"
               height="45"
-              transform="translate(-21.604864626070608 11.239244487403075) rotate(268.8 22.5 22.5)"
+              transform="translate(-21.60486462607061 11.23924448740308) rotate(268.8 22.50000000000000 22.50000000000000)"
               width="45"
               x="0"
               y="0"
@@ -45,7 +45,7 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
             <rect
               fill="#FA7900"
               height="45"
-              transform="translate(-12.763482299017626 41.456272332211) rotate(117.3 22.5 22.5)"
+              transform="translate(-12.76348229901763 41.45627233221100) rotate(117.3 22.50000000000000 22.50000000000000)"
               width="45"
               x="0"
               y="0"

--- a/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
+++ b/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`NameDetails renders proposed names 1`] = `
                         <rect
                           fill="#C8144D"
                           height="16"
-                          transform="translate(-0.8205726313476182 -2.375300755278998) rotate(408.5 8 8)"
+                          transform="translate(-0.82057263134762 -2.37530075527900) rotate(408.5 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -95,7 +95,7 @@ exports[`NameDetails renders proposed names 1`] = `
                         <rect
                           fill="#FB1860"
                           height="16"
-                          transform="translate(7.733089412585649 -1.3465466417019656) rotate(402.6 8 8)"
+                          transform="translate(7.73308941258565 -1.34654664170197) rotate(402.6 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -103,7 +103,7 @@ exports[`NameDetails renders proposed names 1`] = `
                         <rect
                           fill="#03505E"
                           height="16"
-                          transform="translate(1.1000464230208766 -13.147318085284851) rotate(308.0 8 8)"
+                          transform="translate(1.10004642302088 -13.14731808528485) rotate(308.0 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -343,7 +343,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                         <rect
                           fill="#FB1860"
                           height="16"
-                          transform="translate(0.19210008248770236 0.5915711789105838) rotate(143.0 8 8)"
+                          transform="translate(0.19210008248770 0.59157117891058) rotate(143.0 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -351,7 +351,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                         <rect
                           fill="#FA7500"
                           height="16"
-                          transform="translate(-2.7557679797195904 -8.4018342526145) rotate(382.5 8 8)"
+                          transform="translate(-2.75576797971959 -8.40183425261450) rotate(382.5 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -359,7 +359,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                         <rect
                           fill="#F93F01"
                           height="16"
-                          transform="translate(-7.199752352370425 -10.579665389870966) rotate(411.5 8 8)"
+                          transform="translate(-7.19975235237043 -10.57966538987097) rotate(411.5 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -562,7 +562,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                         <rect
                           fill="#C8144D"
                           height="16"
-                          transform="translate(-0.8205726313476182 -2.375300755278998) rotate(408.5 8 8)"
+                          transform="translate(-0.82057263134762 -2.37530075527900) rotate(408.5 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -570,7 +570,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                         <rect
                           fill="#FB1860"
                           height="16"
-                          transform="translate(7.733089412585649 -1.3465466417019656) rotate(402.6 8 8)"
+                          transform="translate(7.73308941258565 -1.34654664170197) rotate(402.6 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -578,7 +578,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                         <rect
                           fill="#03505E"
                           height="16"
-                          transform="translate(1.1000464230208766 -13.147318085284851) rotate(308.0 8 8)"
+                          transform="translate(1.10004642302088 -13.14731808528485) rotate(308.0 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -783,7 +783,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                         <rect
                           fill="#F5C000"
                           height="16"
-                          transform="translate(1.6695934255664566 -1.8063309104606964) rotate(439.0 8 8)"
+                          transform="translate(1.66959342556646 -1.80633091046070) rotate(439.0 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -791,7 +791,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                         <rect
                           fill="#2369E1"
                           height="16"
-                          transform="translate(2.5174423326839017 8.347530486970694) rotate(166.1 8 8)"
+                          transform="translate(2.51744233268390 8.34753048697069) rotate(166.1 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -799,7 +799,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                         <rect
                           fill="#FB1864"
                           height="16"
-                          transform="translate(-12.211473117536537 6.428761618147152) rotate(254.1 8 8)"
+                          transform="translate(-12.21147311753654 6.42876161814715) rotate(254.1 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -1004,7 +1004,7 @@ exports[`NameDetails renders with saved name 1`] = `
                         <rect
                           fill="#C8144D"
                           height="16"
-                          transform="translate(-0.8205726313476182 -2.375300755278998) rotate(408.5 8 8)"
+                          transform="translate(-0.82057263134762 -2.37530075527900) rotate(408.5 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -1012,7 +1012,7 @@ exports[`NameDetails renders with saved name 1`] = `
                         <rect
                           fill="#FB1860"
                           height="16"
-                          transform="translate(7.733089412585649 -1.3465466417019656) rotate(402.6 8 8)"
+                          transform="translate(7.73308941258565 -1.34654664170197) rotate(402.6 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"
@@ -1020,7 +1020,7 @@ exports[`NameDetails renders with saved name 1`] = `
                         <rect
                           fill="#03505E"
                           height="16"
-                          transform="translate(1.1000464230208766 -13.147318085284851) rotate(308.0 8 8)"
+                          transform="translate(1.10004642302088 -13.14731808528485) rotate(308.0 8.00000000000000 8.00000000000000)"
                           width="16"
                           x="0"
                           y="0"

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
           <rect
             fill="#03475E"
             height="32"
-            transform="translate(2.9305136451897345 1.2261469525972557) rotate(127.9 16 16)"
+            transform="translate(2.93051364518973 1.22614695259726) rotate(127.9 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -29,7 +29,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
           <rect
             fill="#F95801"
             height="32"
-            transform="translate(7.1718321011849575 11.079805523008025) rotate(153.0 16 16)"
+            transform="translate(7.17183210118496 11.07980552300802) rotate(153.0 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -37,7 +37,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
           <rect
             fill="#017B8E"
             height="32"
-            transform="translate(8.451434427080768 22.468601749359266) rotate(146.6 16 16)"
+            transform="translate(8.45143442708077 22.46860174935927) rotate(146.6 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -99,7 +99,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
           <rect
             fill="#2339E1"
             height="32"
-            transform="translate(-10.577095368503558 1.2778853266411496) rotate(258.6 16 16)"
+            transform="translate(-10.57709536850356 1.27788532664115) rotate(258.6 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -107,7 +107,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
           <rect
             fill="#FB182B"
             height="32"
-            transform="translate(5.677337270662435 9.943687420321362) rotate(189.4 16 16)"
+            transform="translate(5.67733727066244 9.94368742032136) rotate(189.4 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -115,7 +115,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
           <rect
             fill="#EDF500"
             height="32"
-            transform="translate(-25.62998642818306 -17.790405786491355) rotate(296.0 16 16)"
+            transform="translate(-25.62998642818306 -17.79040578649136) rotate(296.0 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -177,7 +177,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
           <rect
             fill="#F29602"
             height="32"
-            transform="translate(-2.81750896228304 4.951916544006229) rotate(230.4 16 16)"
+            transform="translate(-2.81750896228304 4.95191654400623) rotate(230.4 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -185,7 +185,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
           <rect
             fill="#236CE1"
             height="32"
-            transform="translate(-13.498650292632812 -9.441918676693094) rotate(245.3 16 16)"
+            transform="translate(-13.49865029263281 -9.44191867669309) rotate(245.3 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -193,7 +193,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
           <rect
             fill="#018E8E"
             height="32"
-            transform="translate(18.42469405222943 23.248777206278085) rotate(173.9 16 16)"
+            transform="translate(18.42469405222943 23.24877720627808) rotate(173.9 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -255,7 +255,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
           <rect
             fill="#C81441"
             height="32"
-            transform="translate(7.8929303986963575 3.81505315001625) rotate(81.4 16 16)"
+            transform="translate(7.89293039869636 3.81505315001625) rotate(81.4 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -263,7 +263,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
           <rect
             fill="#F95001"
             height="32"
-            transform="translate(-15.115532254104156 5.65823114066517) rotate(249.8 16 16)"
+            transform="translate(-15.11553225410416 5.65823114066517) rotate(249.8 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -271,7 +271,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
           <rect
             fill="#034A5E"
             height="32"
-            transform="translate(18.782116410097146 -20.966441380827995) rotate(321.3 16 16)"
+            transform="translate(18.78211641009715 -20.96644138082799) rotate(321.3 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -333,7 +333,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
           <rect
             fill="#238CE1"
             height="32"
-            transform="translate(-0.9326359780580042 -0.7760979217397975) rotate(228.7 16 16)"
+            transform="translate(-0.93263597805800 -0.77609792173980) rotate(228.7 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -341,7 +341,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
           <rect
             fill="#018E77"
             height="32"
-            transform="translate(14.633859127624504 0.17102681763595054) rotate(175.0 16 16)"
+            transform="translate(14.63385912762450 0.17102681763595) rotate(175.0 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -349,7 +349,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
           <rect
             fill="#F26E02"
             height="32"
-            transform="translate(22.334011165851894 0.6446527074820322) rotate(17.6 16 16)"
+            transform="translate(22.33401116585189 0.64465270748203) rotate(17.6 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -411,7 +411,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
           <rect
             fill="#2388E1"
             height="32"
-            transform="translate(1.8289963783692056 -3.4661888536397423) rotate(409.8 16 16)"
+            transform="translate(1.82899637836921 -3.46618885363974) rotate(409.8 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -419,7 +419,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
           <rect
             fill="#F59700"
             height="32"
-            transform="translate(-16.75527888625542 -8.229921036962272) rotate(352.3 16 16)"
+            transform="translate(-16.75527888625542 -8.22992103696227) rotate(352.3 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -427,7 +427,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
           <rect
             fill="#18C2F2"
             height="32"
-            transform="translate(-23.454898584180004 2.8519196153955564) rotate(217.2 16 16)"
+            transform="translate(-23.45489858418000 2.85191961539556) rotate(217.2 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -489,7 +489,7 @@ exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
           <rect
             fill="#F29602"
             height="32"
-            transform="translate(-2.81750896228304 4.951916544006229) rotate(230.4 16 16)"
+            transform="translate(-2.81750896228304 4.95191654400623) rotate(230.4 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -497,7 +497,7 @@ exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
           <rect
             fill="#236CE1"
             height="32"
-            transform="translate(-13.498650292632812 -9.441918676693094) rotate(245.3 16 16)"
+            transform="translate(-13.49865029263281 -9.44191867669309) rotate(245.3 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -505,7 +505,7 @@ exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
           <rect
             fill="#018E8E"
             height="32"
-            transform="translate(18.42469405222943 23.248777206278085) rotate(173.9 16 16)"
+            transform="translate(18.42469405222943 23.24877720627808) rotate(173.9 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -59,7 +59,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                 <rect
                                   fill="#18CDF2"
                                   height="32"
-                                  transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -67,7 +67,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                 <rect
                                   fill="#035E56"
                                   height="32"
-                                  transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -75,7 +75,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                 <rect
                                   fill="#F26602"
                                   height="32"
-                                  transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -111,7 +111,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                             <rect
                               fill="#18CDF2"
                               height="32"
-                              transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                              transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"
@@ -119,7 +119,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                             <rect
                               fill="#035E56"
                               height="32"
-                              transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                              transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"
@@ -127,7 +127,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                             <rect
                               fill="#F26602"
                               height="32"
-                              transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                              transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"
@@ -370,7 +370,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                 <rect
                                   fill="#18CDF2"
                                   height="32"
-                                  transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -378,7 +378,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                 <rect
                                   fill="#035E56"
                                   height="32"
-                                  transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -386,7 +386,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                 <rect
                                   fill="#F26602"
                                   height="32"
-                                  transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -422,7 +422,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                             <rect
                               fill="#18CDF2"
                               height="32"
-                              transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                              transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"
@@ -430,7 +430,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                             <rect
                               fill="#035E56"
                               height="32"
-                              transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                              transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"
@@ -438,7 +438,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                             <rect
                               fill="#F26602"
                               height="32"
-                              transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                              transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                               width="32"
                               x="0"
                               y="0"

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
@@ -34,7 +34,7 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
                   <rect
                     fill="#18CDF2"
                     height="24"
-                    transform="translate(-0.786295127845455 -2.478213052095374) rotate(328.9 12 12)"
+                    transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -42,7 +42,7 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
                   <rect
                     fill="#035E56"
                     height="24"
-                    transform="translate(-13.723846281624033 7.94434640381145) rotate(176.2 12 12)"
+                    transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -50,7 +50,7 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
                   <rect
                     fill="#F26602"
                     height="24"
-                    transform="translate(12.500881513667943 -10.653854792247811) rotate(468.9 12 12)"
+                    transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -250,7 +250,7 @@ exports[`SnapUIAddressInput will render a matched address name 1`] = `
                   <rect
                     fill="#18CDF2"
                     height="24"
-                    transform="translate(-0.786295127845455 -2.478213052095374) rotate(328.9 12 12)"
+                    transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -258,7 +258,7 @@ exports[`SnapUIAddressInput will render a matched address name 1`] = `
                   <rect
                     fill="#035E56"
                     height="24"
-                    transform="translate(-13.723846281624033 7.94434640381145) rotate(176.2 12 12)"
+                    transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -266,7 +266,7 @@ exports[`SnapUIAddressInput will render a matched address name 1`] = `
                   <rect
                     fill="#F26602"
                     height="24"
-                    transform="translate(12.500881513667943 -10.653854792247811) rotate(468.9 12 12)"
+                    transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -343,7 +343,7 @@ exports[`SnapUIAddressInput will render avatar when displayAvatar is true 1`] = 
                   <rect
                     fill="#03405E"
                     height="24"
-                    transform="translate(-5.1032274517898335 -4.005457853807921) rotate(369.5 12 12)"
+                    transform="translate(-5.10322745178983 -4.00545785380792) rotate(369.5 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -351,7 +351,7 @@ exports[`SnapUIAddressInput will render avatar when displayAvatar is true 1`] = 
                   <rect
                     fill="#FAA200"
                     height="24"
-                    transform="translate(4.654017159434154 -10.422671895325516) rotate(387.5 12 12)"
+                    transform="translate(4.65401715943415 -10.42267189532552) rotate(387.5 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"
@@ -359,7 +359,7 @@ exports[`SnapUIAddressInput will render avatar when displayAvatar is true 1`] = 
                   <rect
                     fill="#016F8E"
                     height="24"
-                    transform="translate(-16.380316861028035 -8.91841489898652) rotate(241.5 12 12)"
+                    transform="translate(-16.38031686102804 -8.91841489898652) rotate(241.5 12.00000000000000 12.00000000000000)"
                     width="24"
                     x="0"
                     y="0"

--- a/ui/components/component-library/avatar-account/__snapshots__/avatar-account.test.tsx.snap
+++ b/ui/components/component-library/avatar-account/__snapshots__/avatar-account.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`AvatarAccount should render correctly 1`] = `
           <rect
             fill="#F2CA02"
             height="32"
-            transform="translate(1.431306801437213 -0.09488555961102602) rotate(529.4 16 16)"
+            transform="translate(1.43130680143721 -0.09488555961103) rotate(529.4 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -29,7 +29,7 @@ exports[`AvatarAccount should render correctly 1`] = `
           <rect
             fill="#FAA200"
             height="32"
-            transform="translate(10.974858326048588 -13.039888710538095) rotate(336.9 16 16)"
+            transform="translate(10.97485832604859 -13.03988871053810) rotate(336.9 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"
@@ -37,7 +37,7 @@ exports[`AvatarAccount should render correctly 1`] = `
           <rect
             fill="#C8142C"
             height="32"
-            transform="translate(-22.963750275720685 -20.223166935456838) rotate(276.6 16 16)"
+            transform="translate(-22.96375027572068 -20.22316693545684) rotate(276.6 16.00000000000000 16.00000000000000)"
             width="32"
             x="0"
             y="0"

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -47,7 +47,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#F2C602"
                           height="32"
-                          transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
+                          transform="translate(5.02062044750432 0.81039489042363) rotate(161.5 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -55,7 +55,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#F5ED00"
                           height="32"
-                          transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
+                          transform="translate(-9.40812135399240 -10.30504258407245) rotate(246.0 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -63,7 +63,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#FB183A"
                           height="32"
-                          transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
+                          transform="translate(9.19255526987956 26.91416082088715) rotate(215.5 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -106,7 +106,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#F2C602"
                   height="32"
-                  transform="translate(5.020620447504322 0.8103948904236289) rotate(161.5 16 16)"
+                  transform="translate(5.02062044750432 0.81039489042363) rotate(161.5 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -114,7 +114,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#F5ED00"
                   height="32"
-                  transform="translate(-9.408121353992403 -10.305042584072448) rotate(246.0 16 16)"
+                  transform="translate(-9.40812135399240 -10.30504258407245) rotate(246.0 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -122,7 +122,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#FB183A"
                   height="32"
-                  transform="translate(9.192555269879563 26.914160820887155) rotate(215.5 16 16)"
+                  transform="translate(9.19255526987956 26.91416082088715) rotate(215.5 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -280,7 +280,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#18CDF2"
                           height="32"
-                          transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                          transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -288,7 +288,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#035E56"
                           height="32"
-                          transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                          transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -296,7 +296,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <rect
                           fill="#F26602"
                           height="32"
-                          transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                          transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -339,7 +339,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#18CDF2"
                   height="32"
-                  transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -347,7 +347,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#035E56"
                   height="32"
-                  transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -355,7 +355,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <rect
                   fill="#F26602"
                   height="32"
-                  transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"

--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -34,7 +34,7 @@ exports[`AccountPicker renders properly 1`] = `
                   <rect
                     fill="#18CDF2"
                     height="16"
-                    transform="translate(-0.52419675189697 -1.6521420347302493) rotate(328.9 8 8)"
+                    transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -42,7 +42,7 @@ exports[`AccountPicker renders properly 1`] = `
                   <rect
                     fill="#035E56"
                     height="16"
-                    transform="translate(-9.149230854416022 5.2962309358743) rotate(176.2 8 8)"
+                    transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -50,7 +50,7 @@ exports[`AccountPicker renders properly 1`] = `
                   <rect
                     fill="#F26602"
                     height="16"
-                    transform="translate(8.333921009111961 -7.102569861498541) rotate(468.9 8 8)"
+                    transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"

--- a/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
+++ b/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`AddressListItem displays duplicate contact warning icon 1`] = `
                 <rect
                   fill="#F5D800"
                   height="32"
-                  transform="translate(-2.259751642128839 9.986727856309313) rotate(238.2 16 16)"
+                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -37,7 +37,7 @@ exports[`AddressListItem displays duplicate contact warning icon 1`] = `
                 <rect
                   fill="#1888F2"
                   height="32"
-                  transform="translate(3.5983407434334205 13.963394795558013) rotate(211.2 16 16)"
+                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -45,7 +45,7 @@ exports[`AddressListItem displays duplicate contact warning icon 1`] = `
                 <rect
                   fill="#017E8E"
                   height="32"
-                  transform="translate(5.504819407037733 -22.91863393981918) rotate(404.9 16 16)"
+                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -150,7 +150,7 @@ exports[`AddressListItem renders the address and label without duplicate contact
                 <rect
                   fill="#F5D800"
                   height="32"
-                  transform="translate(-2.259751642128839 9.986727856309313) rotate(238.2 16 16)"
+                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -158,7 +158,7 @@ exports[`AddressListItem renders the address and label without duplicate contact
                 <rect
                   fill="#1888F2"
                   height="32"
-                  transform="translate(3.5983407434334205 13.963394795558013) rotate(211.2 16 16)"
+                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -166,7 +166,7 @@ exports[`AddressListItem renders the address and label without duplicate contact
                 <rect
                   fill="#017E8E"
                   height="32"
-                  transform="translate(5.504819407037733 -22.91863393981918) rotate(404.9 16 16)"
+                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -252,7 +252,7 @@ exports[`AddressListItem uses a confusable when it should 1`] = `
                 <rect
                   fill="#F5D800"
                   height="32"
-                  transform="translate(-2.259751642128839 9.986727856309313) rotate(238.2 16 16)"
+                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -260,7 +260,7 @@ exports[`AddressListItem uses a confusable when it should 1`] = `
                 <rect
                   fill="#1888F2"
                   height="32"
-                  transform="translate(3.5983407434334205 13.963394795558013) rotate(211.2 16 16)"
+                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -268,7 +268,7 @@ exports[`AddressListItem uses a confusable when it should 1`] = `
                 <rect
                   fill="#017E8E"
                   height="32"
-                  transform="translate(5.504819407037733 -22.91863393981918) rotate(404.9 16 16)"
+                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -120,7 +120,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                   <rect
                     fill="#18CDF2"
                     height="32"
-                    transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -128,7 +128,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                   <rect
                     fill="#035E56"
                     height="32"
-                    transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -136,7 +136,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                   <rect
                     fill="#F26602"
                     height="32"
-                    transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"

--- a/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
+++ b/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
@@ -27,7 +27,7 @@ exports[`Badge Status should not render the badge if showConnectedStatus is fals
               <rect
                 fill="#18CDF2"
                 height="32"
-                transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                 width="32"
                 x="0"
                 y="0"
@@ -35,7 +35,7 @@ exports[`Badge Status should not render the badge if showConnectedStatus is fals
               <rect
                 fill="#035E56"
                 height="32"
-                transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                 width="32"
                 x="0"
                 y="0"
@@ -43,7 +43,7 @@ exports[`Badge Status should not render the badge if showConnectedStatus is fals
               <rect
                 fill="#F26602"
                 height="32"
-                transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                 width="32"
                 x="0"
                 y="0"
@@ -96,7 +96,7 @@ exports[`Badge Status should render correctly 1`] = `
                   <rect
                     fill="#18CDF2"
                     height="32"
-                    transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -104,7 +104,7 @@ exports[`Badge Status should render correctly 1`] = `
                   <rect
                     fill="#035E56"
                     height="32"
-                    transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -112,7 +112,7 @@ exports[`Badge Status should render correctly 1`] = `
                   <rect
                     fill="#F26602"
                     height="32"
-                    transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"

--- a/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
+++ b/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                                   <rect
                                     fill="#FA4300"
                                     height="32"
-                                    transform="translate(-1.712066926084717 -0.6920409130150889) rotate(264.3 16 16)"
+                                    transform="translate(-1.71206692608472 -0.69204091301509) rotate(264.3 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -171,7 +171,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                                   <rect
                                     fill="#018E77"
                                     height="32"
-                                    transform="translate(-11.340391831620598 -14.992292625888258) rotate(296.3 16 16)"
+                                    transform="translate(-11.34039183162060 -14.99229262588826) rotate(296.3 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -179,7 +179,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                                   <rect
                                     fill="#F26E02"
                                     height="32"
-                                    transform="translate(18.207719499376854 -18.300980401883564) rotate(444.6 16 16)"
+                                    transform="translate(18.20771949937685 -18.30098040188356) rotate(444.6 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -222,7 +222,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                           <rect
                             fill="#FA4300"
                             height="32"
-                            transform="translate(-1.712066926084717 -0.6920409130150889) rotate(264.3 16 16)"
+                            transform="translate(-1.71206692608472 -0.69204091301509) rotate(264.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -230,7 +230,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                           <rect
                             fill="#018E77"
                             height="32"
-                            transform="translate(-11.340391831620598 -14.992292625888258) rotate(296.3 16 16)"
+                            transform="translate(-11.34039183162060 -14.99229262588826) rotate(296.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -238,7 +238,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                           <rect
                             fill="#F26E02"
                             height="32"
-                            transform="translate(18.207719499376854 -18.300980401883564) rotate(444.6 16 16)"
+                            transform="translate(18.20771949937685 -18.30098040188356) rotate(444.6 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`Connections Content should render correctly 1`] = `
                                 <rect
                                   fill="#18CDF2"
                                   height="32"
-                                  transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -113,7 +113,7 @@ exports[`Connections Content should render correctly 1`] = `
                                 <rect
                                   fill="#035E56"
                                   height="32"
-                                  transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -121,7 +121,7 @@ exports[`Connections Content should render correctly 1`] = `
                                 <rect
                                   fill="#F26602"
                                   height="32"
-                                  transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -164,7 +164,7 @@ exports[`Connections Content should render correctly 1`] = `
                         <rect
                           fill="#18CDF2"
                           height="32"
-                          transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                          transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -172,7 +172,7 @@ exports[`Connections Content should render correctly 1`] = `
                         <rect
                           fill="#035E56"
                           height="32"
-                          transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                          transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -180,7 +180,7 @@ exports[`Connections Content should render correctly 1`] = `
                         <rect
                           fill="#F26602"
                           height="32"
-                          transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                          transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/__snapshots__/site-cell-tooltip.test.js.snap
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/__snapshots__/site-cell-tooltip.test.js.snap
@@ -38,7 +38,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#018E7E"
                     height="16"
-                    transform="translate(1.2744369446245154 -0.7053655586725533) rotate(363.1 8 8)"
+                    transform="translate(1.27443694462452 -0.70536555867255) rotate(363.1 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -46,7 +46,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#F91A01"
                     height="16"
-                    transform="translate(4.77517448786361 4.320459175535714) rotate(54.5 8 8)"
+                    transform="translate(4.77517448786361 4.32045917553571) rotate(54.5 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -54,7 +54,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#FB1882"
                     height="16"
-                    transform="translate(-12.741493192782233 -7.733296510164053) rotate(360.4 8 8)"
+                    transform="translate(-12.74149319278223 -7.73329651016405) rotate(360.4 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -86,7 +86,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#C81459"
                     height="16"
-                    transform="translate(0.10864265332766807 3.0706102866109184) rotate(138.0 8 8)"
+                    transform="translate(0.10864265332767 3.07061028661092) rotate(138.0 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -94,7 +94,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#018E89"
                     height="16"
-                    transform="translate(6.382605835258964 0.38215457860863067) rotate(152.6 8 8)"
+                    transform="translate(6.38260583525896 0.38215457860863) rotate(152.6 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -102,7 +102,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#2372E1"
                     height="16"
-                    transform="translate(-12.49164843832654 -7.756211576864221) rotate(374.4 8 8)"
+                    transform="translate(-12.49164843832654 -7.75621157686422) rotate(374.4 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -134,7 +134,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#1885F2"
                     height="16"
-                    transform="translate(0.05978858756790129 -0.031134724604508498) rotate(387.3 8 8)"
+                    transform="translate(0.05978858756790 -0.03113472460451) rotate(387.3 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -142,7 +142,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#FB1849"
                     height="16"
-                    transform="translate(-9.720573090114765 2.147084032854713) rotate(199.5 8 8)"
+                    transform="translate(-9.72057309011477 2.14708403285471) rotate(199.5 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"
@@ -150,7 +150,7 @@ exports[`SiteCellTooltip should render correctly 1`] = `
                   <rect
                     fill="#C8143B"
                     height="16"
-                    transform="translate(-13.051635417362899 8.223931749994133) rotate(284.9 8 8)"
+                    transform="translate(-13.05163541736290 8.22393174999413) rotate(284.9 8.00000000000000 8.00000000000000)"
                     width="16"
                     x="0"
                     y="0"

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -84,7 +84,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                           <rect
                             fill="#2362E1"
                             height="32"
-                            transform="translate(3.589330184792517 -5.334310623233522) rotate(458.4 16 16)"
+                            transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -92,7 +92,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                           <rect
                             fill="#F94301"
                             height="32"
-                            transform="translate(-15.363459289650208 7.992351635486631) rotate(268.8 16 16)"
+                            transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -100,7 +100,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                           <rect
                             fill="#FA7900"
                             height="32"
-                            transform="translate(-9.076254079301423 29.480015880683375) rotate(117.3 16 16)"
+                            transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -254,7 +254,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                         <rect
                                           fill="#2362E1"
                                           height="32"
-                                          transform="translate(3.589330184792517 -5.334310623233522) rotate(458.4 16 16)"
+                                          transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
                                           width="32"
                                           x="0"
                                           y="0"
@@ -262,7 +262,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                         <rect
                                           fill="#F94301"
                                           height="32"
-                                          transform="translate(-15.363459289650208 7.992351635486631) rotate(268.8 16 16)"
+                                          transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
                                           width="32"
                                           x="0"
                                           y="0"
@@ -270,7 +270,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                         <rect
                                           fill="#FA7900"
                                           height="32"
-                                          transform="translate(-9.076254079301423 29.480015880683375) rotate(117.3 16 16)"
+                                          transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
                                           width="32"
                                           x="0"
                                           y="0"
@@ -313,7 +313,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                 <rect
                                   fill="#2362E1"
                                   height="32"
-                                  transform="translate(3.589330184792517 -5.334310623233522) rotate(458.4 16 16)"
+                                  transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -321,7 +321,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                 <rect
                                   fill="#F94301"
                                   height="32"
-                                  transform="translate(-15.363459289650208 7.992351635486631) rotate(268.8 16 16)"
+                                  transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"
@@ -329,7 +329,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                                 <rect
                                   fill="#FA7900"
                                   height="32"
-                                  transform="translate(-9.076254079301423 29.480015880683375) rotate(117.3 16 16)"
+                                  transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
                                   width="32"
                                   x="0"
                                   y="0"

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
                     <rect
                       fill="#18CDF2"
                       height="32"
-                      transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -54,7 +54,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
                     <rect
                       fill="#035E56"
                       height="32"
-                      transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -62,7 +62,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
                     <rect
                       fill="#F26602"
                       height="32"
-                      transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#18CDF2"
                             height="32"
-                            transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                            transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -62,7 +62,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#035E56"
                             height="32"
-                            transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                            transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -70,7 +70,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#F26602"
                             height="32"
-                            transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                            transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -113,7 +113,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#18CDF2"
                     height="32"
-                    transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -121,7 +121,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#035E56"
                     height="32"
-                    transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -129,7 +129,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#F26602"
                     height="32"
-                    transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -335,7 +335,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#018E74"
                             height="32"
-                            transform="translate(6.3132478822336004 -5.428280652507946) rotate(358.4 16 16)"
+                            transform="translate(6.31324788223360 -5.42828065250795) rotate(358.4 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -343,7 +343,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#18CAF2"
                             height="32"
-                            transform="translate(7.685615565022901 -12.13837331367715) rotate(414.8 16 16)"
+                            transform="translate(7.68561556502290 -12.13837331367715) rotate(414.8 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -351,7 +351,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#C81474"
                             height="32"
-                            transform="translate(-5.608908748503153 -25.081111298235626) rotate(322.3 16 16)"
+                            transform="translate(-5.60890874850315 -25.08111129823563) rotate(322.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -394,7 +394,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#018E74"
                     height="32"
-                    transform="translate(6.3132478822336004 -5.428280652507946) rotate(358.4 16 16)"
+                    transform="translate(6.31324788223360 -5.42828065250795) rotate(358.4 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -402,7 +402,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#18CAF2"
                     height="32"
-                    transform="translate(7.685615565022901 -12.13837331367715) rotate(414.8 16 16)"
+                    transform="translate(7.68561556502290 -12.13837331367715) rotate(414.8 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -410,7 +410,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#C81474"
                     height="32"
-                    transform="translate(-5.608908748503153 -25.081111298235626) rotate(322.3 16 16)"
+                    transform="translate(-5.60890874850315 -25.08111129823563) rotate(322.3 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -616,7 +616,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#C81432"
                             height="32"
-                            transform="translate(-0.583645999400264 -3.1039565032560605) rotate(331.7 16 16)"
+                            transform="translate(-0.58364599940026 -3.10395650325606) rotate(331.7 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -624,7 +624,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#187AF2"
                             height="32"
-                            transform="translate(-12.717635568312648 6.331674609038503) rotate(160.5 16 16)"
+                            transform="translate(-12.71763556831265 6.33167460903850) rotate(160.5 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -632,7 +632,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#FB183E"
                             height="32"
-                            transform="translate(28.6680862233552 -2.984235702254764) rotate(517.6 16 16)"
+                            transform="translate(28.66808622335520 -2.98423570225476) rotate(517.6 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -675,7 +675,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#C81432"
                     height="32"
-                    transform="translate(-0.583645999400264 -3.1039565032560605) rotate(331.7 16 16)"
+                    transform="translate(-0.58364599940026 -3.10395650325606) rotate(331.7 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -683,7 +683,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#187AF2"
                     height="32"
-                    transform="translate(-12.717635568312648 6.331674609038503) rotate(160.5 16 16)"
+                    transform="translate(-12.71763556831265 6.33167460903850) rotate(160.5 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -691,7 +691,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#FB183E"
                     height="32"
-                    transform="translate(28.6680862233552 -2.984235702254764) rotate(517.6 16 16)"
+                    transform="translate(28.66808622335520 -2.98423570225476) rotate(517.6 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -911,7 +911,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#2340E1"
                             height="32"
-                            transform="translate(-1.9490904468166024 -1.0214651118866318) rotate(257.0 16 16)"
+                            transform="translate(-1.94909044681660 -1.02146511188663) rotate(257.0 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -919,7 +919,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#016D8E"
                             height="32"
-                            transform="translate(12.81547793667531 3.042947044480663) rotate(77.0 16 16)"
+                            transform="translate(12.81547793667531 3.04294704448066) rotate(77.0 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -927,7 +927,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#F5F500"
                             height="32"
-                            transform="translate(13.127605578158805 -22.247335466025433) rotate(465.0 16 16)"
+                            transform="translate(13.12760557815881 -22.24733546602543) rotate(465.0 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -970,7 +970,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#2340E1"
                     height="32"
-                    transform="translate(-1.9490904468166024 -1.0214651118866318) rotate(257.0 16 16)"
+                    transform="translate(-1.94909044681660 -1.02146511188663) rotate(257.0 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -978,7 +978,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#016D8E"
                     height="32"
-                    transform="translate(12.81547793667531 3.042947044480663) rotate(77.0 16 16)"
+                    transform="translate(12.81547793667531 3.04294704448066) rotate(77.0 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -986,7 +986,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#F5F500"
                     height="32"
-                    transform="translate(13.127605578158805 -22.247335466025433) rotate(465.0 16 16)"
+                    transform="translate(13.12760557815881 -22.24733546602543) rotate(465.0 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1192,7 +1192,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#C81435"
                             height="32"
-                            transform="translate(-2.119319732745029 -1.8856543404847388) rotate(249.5 16 16)"
+                            transform="translate(-2.11931973274503 -1.88565434048474) rotate(249.5 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1200,7 +1200,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#F5E400"
                             height="32"
-                            transform="translate(-1.5132951940983728 12.006291365578917) rotate(269.5 16 16)"
+                            transform="translate(-1.51329519409837 12.00629136557892) rotate(269.5 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1208,7 +1208,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#F96001"
                             height="32"
-                            transform="translate(7.578094081568198 24.82791748135462) rotate(216.3 16 16)"
+                            transform="translate(7.57809408156820 24.82791748135462) rotate(216.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1251,7 +1251,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#C81435"
                     height="32"
-                    transform="translate(-2.119319732745029 -1.8856543404847388) rotate(249.5 16 16)"
+                    transform="translate(-2.11931973274503 -1.88565434048474) rotate(249.5 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1259,7 +1259,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#F5E400"
                     height="32"
-                    transform="translate(-1.5132951940983728 12.006291365578917) rotate(269.5 16 16)"
+                    transform="translate(-1.51329519409837 12.00629136557892) rotate(269.5 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1267,7 +1267,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#F96001"
                     height="32"
-                    transform="translate(7.578094081568198 24.82791748135462) rotate(216.3 16 16)"
+                    transform="translate(7.57809408156820 24.82791748135462) rotate(216.3 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1491,7 +1491,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#238FE1"
                             height="32"
-                            transform="translate(-4.225116043000625 4.953154575894918) rotate(161.9 16 16)"
+                            transform="translate(-4.22511604300063 4.95315457589492) rotate(161.9 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1499,7 +1499,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#FB1891"
                             height="32"
-                            transform="translate(-4.425829304725563 12.962271707551116) rotate(224.3 16 16)"
+                            transform="translate(-4.42582930472556 12.96227170755112) rotate(224.3 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1507,7 +1507,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                           <rect
                             fill="#F90901"
                             height="32"
-                            transform="translate(-26.833286698037487 -15.298402889891959) rotate(344.7 16 16)"
+                            transform="translate(-26.83328669803749 -15.29840288989196) rotate(344.7 16.00000000000000 16.00000000000000)"
                             width="32"
                             x="0"
                             y="0"
@@ -1550,7 +1550,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#238FE1"
                     height="32"
-                    transform="translate(-4.225116043000625 4.953154575894918) rotate(161.9 16 16)"
+                    transform="translate(-4.22511604300063 4.95315457589492) rotate(161.9 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1558,7 +1558,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#FB1891"
                     height="32"
-                    transform="translate(-4.425829304725563 12.962271707551116) rotate(224.3 16 16)"
+                    transform="translate(-4.42582930472556 12.96227170755112) rotate(224.3 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"
@@ -1566,7 +1566,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <rect
                     fill="#F90901"
                     height="32"
-                    transform="translate(-26.833286698037487 -15.298402889891959) rotate(344.7 16 16)"
+                    transform="translate(-26.83328669803749 -15.29840288989196) rotate(344.7 16.00000000000000 16.00000000000000)"
                     width="32"
                     x="0"
                     y="0"

--- a/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
+++ b/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Toast should render Toast component 1`] = `
                 <rect
                   fill="#018E8C"
                   height="32"
-                  transform="translate(6.427263444332595 -1.7203295797723996) rotate(470.8 16 16)"
+                  transform="translate(6.42726344433259 -1.72032957977240) rotate(470.8 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -38,7 +38,7 @@ exports[`Toast should render Toast component 1`] = `
                 <rect
                   fill="#F93301"
                   height="32"
-                  transform="translate(1.1564119766476293 16.128853746500315) rotate(198.5 16 16)"
+                  transform="translate(1.15641197664763 16.12885374650032) rotate(198.5 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -46,7 +46,7 @@ exports[`Toast should render Toast component 1`] = `
                 <rect
                   fill="#FA6800"
                   height="32"
-                  transform="translate(22.348080171264016 5.115369684577057) rotate(148.9 16 16)"
+                  transform="translate(22.34808017126402 5.11536968457706) rotate(148.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"

--- a/ui/components/ui/identicon/__snapshots__/identicon.component.test.js.snap
+++ b/ui/components/ui/identicon/__snapshots__/identicon.component.test.js.snap
@@ -21,7 +21,7 @@ exports[`Identicon should match snapshot with address prop div 1`] = `
           <rect
             fill="#2362E1"
             height="46"
-            transform="translate(5.159662140639244 -7.668071520898189) rotate(458.4 23 23)"
+            transform="translate(5.15966214063924 -7.66807152089819) rotate(458.4 23.00000000000000 23.00000000000000)"
             width="46"
             x="0"
             y="0"
@@ -29,7 +29,7 @@ exports[`Identicon should match snapshot with address prop div 1`] = `
           <rect
             fill="#F94301"
             height="46"
-            transform="translate(-22.084972728872177 11.489005476012034) rotate(268.8 23 23)"
+            transform="translate(-22.08497272887218 11.48900547601203) rotate(268.8 23.00000000000000 23.00000000000000)"
             width="46"
             x="0"
             y="0"
@@ -37,7 +37,7 @@ exports[`Identicon should match snapshot with address prop div 1`] = `
           <rect
             fill="#FA7900"
             height="46"
-            transform="translate(-13.047115238995795 42.377522828482356) rotate(117.3 23 23)"
+            transform="translate(-13.04711523899580 42.37752282848236) rotate(117.3 23.00000000000000 23.00000000000000)"
             width="46"
             x="0"
             y="0"

--- a/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -114,7 +114,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -122,7 +122,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -215,7 +215,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#FA6C00"
                         height="32"
-                        transform="translate(0.012499013728094784 -0.006385319322122122) rotate(489.0 16 16)"
+                        transform="translate(0.01249901372809 -0.00638531932212) rotate(489.0 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -223,7 +223,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#FB1868"
                         height="32"
-                        transform="translate(-14.408597140338982 -8.780736166288932) rotate(387.1 16 16)"
+                        transform="translate(-14.40859714033898 -8.78073616628893) rotate(387.1 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -231,7 +231,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#F5BC00"
                         height="32"
-                        transform="translate(-12.05422484490241 -22.091892032818553) rotate(345.4 16 16)"
+                        transform="translate(-12.05422484490241 -22.09189203281855) rotate(345.4 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -313,7 +313,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#F28A02"
                         height="32"
-                        transform="translate(5.856796012320635 8.737636484049885) rotate(159.5 16 16)"
+                        transform="translate(5.85679601232064 8.73763648404988) rotate(159.5 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -321,7 +321,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#18ADF2"
                         height="32"
-                        transform="translate(-10.732044487284895 -4.4515520487224745) rotate(339.9 16 16)"
+                        transform="translate(-10.73204448728490 -4.45155204872247) rotate(339.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -329,7 +329,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#FB1873"
                         height="32"
-                        transform="translate(16.743885100341735 -17.079268707848318) rotate(454.3 16 16)"
+                        transform="translate(16.74388510034174 -17.07926870784832) rotate(454.3 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -411,7 +411,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -419,7 +419,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -427,7 +427,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -520,7 +520,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#C81456"
                         height="32"
-                        transform="translate(6.080278063321545 4.084834576158491) rotate(206.2 16 16)"
+                        transform="translate(6.08027806332155 4.08483457615849) rotate(206.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -528,7 +528,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#018E8C"
                         height="32"
-                        transform="translate(-15.505408615168813 -13.011985761210282) rotate(356.3 16 16)"
+                        transform="translate(-15.50540861516881 -13.01198576121028) rotate(356.3 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -536,7 +536,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#03555E"
                         height="32"
-                        transform="translate(27.992111032774744 3.078238146270286) rotate(92.1 16 16)"
+                        transform="translate(27.99211103277474 3.07823814627029) rotate(92.1 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -618,7 +618,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -626,7 +626,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -634,7 +634,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -819,7 +819,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -827,7 +827,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -835,7 +835,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -917,7 +917,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#FA6C00"
                         height="32"
-                        transform="translate(0.012499013728094784 -0.006385319322122122) rotate(489.0 16 16)"
+                        transform="translate(0.01249901372809 -0.00638531932212) rotate(489.0 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -925,7 +925,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#FB1868"
                         height="32"
-                        transform="translate(-14.408597140338982 -8.780736166288932) rotate(387.1 16 16)"
+                        transform="translate(-14.40859714033898 -8.78073616628893) rotate(387.1 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -933,7 +933,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#F5BC00"
                         height="32"
-                        transform="translate(-12.05422484490241 -22.091892032818553) rotate(345.4 16 16)"
+                        transform="translate(-12.05422484490241 -22.09189203281855) rotate(345.4 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1015,7 +1015,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#F28A02"
                         height="32"
-                        transform="translate(5.856796012320635 8.737636484049885) rotate(159.5 16 16)"
+                        transform="translate(5.85679601232064 8.73763648404988) rotate(159.5 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1023,7 +1023,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#18ADF2"
                         height="32"
-                        transform="translate(-10.732044487284895 -4.4515520487224745) rotate(339.9 16 16)"
+                        transform="translate(-10.73204448728490 -4.45155204872247) rotate(339.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1031,7 +1031,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#FB1873"
                         height="32"
-                        transform="translate(16.743885100341735 -17.079268707848318) rotate(454.3 16 16)"
+                        transform="translate(16.74388510034174 -17.07926870784832) rotate(454.3 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1113,7 +1113,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1121,7 +1121,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1129,7 +1129,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1211,7 +1211,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#C81456"
                         height="32"
-                        transform="translate(6.080278063321545 4.084834576158491) rotate(206.2 16 16)"
+                        transform="translate(6.08027806332155 4.08483457615849) rotate(206.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1219,7 +1219,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#018E8C"
                         height="32"
-                        transform="translate(-15.505408615168813 -13.011985761210282) rotate(356.3 16 16)"
+                        transform="translate(-15.50540861516881 -13.01198576121028) rotate(356.3 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1227,7 +1227,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#03555E"
                         height="32"
-                        transform="translate(27.992111032774744 3.078238146270286) rotate(92.1 16 16)"
+                        transform="translate(27.99211103277474 3.07823814627029) rotate(92.1 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1309,7 +1309,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1317,7 +1317,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -1325,7 +1325,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -42,7 +42,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                         <rect
                           fill="#18CDF2"
                           height="32"
-                          transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                          transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -50,7 +50,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                         <rect
                           fill="#035E56"
                           height="32"
-                          transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                          transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -58,7 +58,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                         <rect
                           fill="#F26602"
                           height="32"
-                          transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                          transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                           width="32"
                           x="0"
                           y="0"
@@ -257,7 +257,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                       <rect
                         fill="#18CDF2"
                         height="32"
-                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -265,7 +265,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                       <rect
                         fill="#035E56"
                         height="32"
-                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"
@@ -273,7 +273,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                       <rect
                         fill="#F26602"
                         height="32"
-                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                         width="32"
                         x="0"
                         y="0"

--- a/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
+++ b/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
@@ -67,7 +67,7 @@ exports[`ConfirmDecryptMessage Component matches snapshot 1`] = `
                         <rect
                           fill="#18CDF2"
                           height="18"
-                          transform="translate(-0.5897213458840913 -1.8586597890715306) rotate(328.9 9 9)"
+                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -75,7 +75,7 @@ exports[`ConfirmDecryptMessage Component matches snapshot 1`] = `
                         <rect
                           fill="#035E56"
                           height="18"
-                          transform="translate(-10.292884711218024 5.9582598028585885) rotate(176.2 9 9)"
+                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -83,7 +83,7 @@ exports[`ConfirmDecryptMessage Component matches snapshot 1`] = `
                         <rect
                           fill="#F26602"
                           height="18"
-                          transform="translate(9.375661135250958 -7.990391094185859) rotate(468.9 9 9)"
+                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -259,7 +259,7 @@ exports[`ConfirmDecryptMessage Component shows error on decrypt inline error 1`]
                         <rect
                           fill="#18CDF2"
                           height="18"
-                          transform="translate(-0.5897213458840913 -1.8586597890715306) rotate(328.9 9 9)"
+                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -267,7 +267,7 @@ exports[`ConfirmDecryptMessage Component shows error on decrypt inline error 1`]
                         <rect
                           fill="#035E56"
                           height="18"
-                          transform="translate(-10.292884711218024 5.9582598028585885) rotate(176.2 9 9)"
+                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -275,7 +275,7 @@ exports[`ConfirmDecryptMessage Component shows error on decrypt inline error 1`]
                         <rect
                           fill="#F26602"
                           height="18"
-                          transform="translate(9.375661135250958 -7.990391094185859) rotate(468.9 9 9)"
+                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -449,7 +449,7 @@ exports[`ConfirmDecryptMessage Component shows the correct message data 1`] = `
                         <rect
                           fill="#18CDF2"
                           height="18"
-                          transform="translate(-0.5897213458840913 -1.8586597890715306) rotate(328.9 9 9)"
+                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -457,7 +457,7 @@ exports[`ConfirmDecryptMessage Component shows the correct message data 1`] = `
                         <rect
                           fill="#035E56"
                           height="18"
-                          transform="translate(-10.292884711218024 5.9582598028585885) rotate(176.2 9 9)"
+                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -465,7 +465,7 @@ exports[`ConfirmDecryptMessage Component shows the correct message data 1`] = `
                         <rect
                           fill="#F26602"
                           height="18"
-                          transform="translate(9.375661135250958 -7.990391094185859) rotate(468.9 9 9)"
+                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -67,7 +67,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                         <rect
                           fill="#F2BE02"
                           height="18"
-                          transform="translate(3.0840328880287724 -2.9223901886104127) rotate(387.1 9 9)"
+                          transform="translate(3.08403288802877 -2.92239018861041) rotate(387.1 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -75,7 +75,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                         <rect
                           fill="#01778E"
                           height="18"
-                          transform="translate(-1.465568967274283 9.396341018731759) rotate(227.4 9 9)"
+                          transform="translate(-1.46556896727428 9.39634101873176) rotate(227.4 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -83,7 +83,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                         <rect
                           fill="#C81435"
                           height="18"
-                          transform="translate(10.107951098008673 -7.083365091692127) rotate(422.3 9 9)"
+                          transform="translate(10.10795109800867 -7.08336509169213) rotate(422.3 9.00000000000000 9.00000000000000)"
                           width="18"
                           x="0"
                           y="0"
@@ -151,7 +151,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                   <rect
                     fill="#F2BE02"
                     height="40"
-                    transform="translate(6.853406417841717 -6.49420041913425) rotate(387.1 20 20)"
+                    transform="translate(6.85340641784172 -6.49420041913425) rotate(387.1 20.00000000000000 20.00000000000000)"
                     width="40"
                     x="0"
                     y="0"
@@ -159,7 +159,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                   <rect
                     fill="#01778E"
                     height="40"
-                    transform="translate(-3.2568199272761853 20.88075781940391) rotate(227.4 20 20)"
+                    transform="translate(-3.25681992727619 20.88075781940391) rotate(227.4 20.00000000000000 20.00000000000000)"
                     width="40"
                     x="0"
                     y="0"
@@ -167,7 +167,7 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
                   <rect
                     fill="#C81435"
                     height="40"
-                    transform="translate(22.462113551130386 -15.740811314871396) rotate(422.3 20 20)"
+                    transform="translate(22.46211355113039 -15.74081131487140) rotate(422.3 20.00000000000000 20.00000000000000)"
                     width="40"
                     x="0"
                     y="0"

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
                 <rect
                   fill="#18CDF2"
                   height="32"
-                  transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -38,7 +38,7 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
                 <rect
                   fill="#035E56"
                   height="32"
-                  transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -46,7 +46,7 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
                 <rect
                   fill="#F26602"
                   height="32"
-                  transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -237,7 +237,7 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
                 <rect
                   fill="#C81420"
                   height="32"
-                  transform="translate(-5.505236904904678 -5.265123363737541) rotate(385.9 16 16)"
+                  transform="translate(-5.50523690490468 -5.26512336373754) rotate(385.9 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -245,7 +245,7 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
                 <rect
                   fill="#E9F500"
                   height="32"
-                  transform="translate(10.674469406726399 12.429928159193388) rotate(184.5 16 16)"
+                  transform="translate(10.67446940672640 12.42992815919339) rotate(184.5 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
@@ -253,7 +253,7 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
                 <rect
                   fill="#FAB300"
                   height="32"
-                  transform="translate(1.815455199236231 -26.03028190637629) rotate(431.3 16 16)"
+                  transform="translate(1.81545519923623 -26.03028190637629) rotate(431.3 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                     <rect
                       fill="#18CDF2"
                       height="32"
-                      transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -45,7 +45,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                     <rect
                       fill="#035E56"
                       height="32"
-                      transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -53,7 +53,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                     <rect
                       fill="#F26602"
                       height="32"
-                      transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -1220,7 +1220,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                     <rect
                       fill="#18CDF2"
                       height="32"
-                      transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -1228,7 +1228,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                     <rect
                       fill="#035E56"
                       height="32"
-                      transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -1236,7 +1236,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                     <rect
                       fill="#F26602"
                       height="32"
-                      transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -1998,7 +1998,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                     <rect
                       fill="#017B8E"
                       height="32"
-                      transform="translate(0.7994460693567097 -0.8216011156969824) rotate(317.9 16 16)"
+                      transform="translate(0.79944606935671 -0.82160111569698) rotate(317.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -2006,7 +2006,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                     <rect
                       fill="#F2B602"
                       height="32"
-                      transform="translate(-7.493396036912253 11.409935428284795) rotate(134.1 16 16)"
+                      transform="translate(-7.49339603691225 11.40993542828480) rotate(134.1 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -2014,7 +2014,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                     <rect
                       fill="#FA8E00"
                       height="32"
-                      transform="translate(-25.712272690754798 -11.558881043268883) rotate(364.0 16 16)"
+                      transform="translate(-25.71227269075480 -11.55888104326888) rotate(364.0 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -2472,7 +2472,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                     <rect
                       fill="#017B8E"
                       height="32"
-                      transform="translate(0.7994460693567097 -0.8216011156969824) rotate(317.9 16 16)"
+                      transform="translate(0.79944606935671 -0.82160111569698) rotate(317.9 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -2480,7 +2480,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                     <rect
                       fill="#F2B602"
                       height="32"
-                      transform="translate(-7.493396036912253 11.409935428284795) rotate(134.1 16 16)"
+                      transform="translate(-7.49339603691225 11.40993542828480) rotate(134.1 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"
@@ -2488,7 +2488,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                     <rect
                       fill="#FA8E00"
                       height="32"
-                      transform="translate(-25.712272690754798 -11.558881043268883) rotate(364.0 16 16)"
+                      transform="translate(-25.71227269075480 -11.55888104326888) rotate(364.0 16.00000000000000 16.00000000000000)"
                       width="32"
                       x="0"
                       y="0"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -140,7 +140,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                                       <rect
                                         fill="#18CDF2"
                                         height="32"
-                                        transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                         width="32"
                                         x="0"
                                         y="0"
@@ -148,7 +148,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                                       <rect
                                         fill="#035E56"
                                         height="32"
-                                        transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                         width="32"
                                         x="0"
                                         y="0"
@@ -156,7 +156,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                                       <rect
                                         fill="#F26602"
                                         height="32"
-                                        transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                         width="32"
                                         x="0"
                                         y="0"
@@ -199,7 +199,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                               <rect
                                 fill="#18CDF2"
                                 height="32"
-                                transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -207,7 +207,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                               <rect
                                 fill="#035E56"
                                 height="32"
-                                transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -215,7 +215,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                               <rect
                                 fill="#F26602"
                                 height="32"
-                                transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                               <rect
                                 fill="#FB188D"
                                 height="32"
-                                transform="translate(-1.104254133951512 -2.2862708533878) rotate(359.4 16 16)"
+                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -145,7 +145,7 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                               <rect
                                 fill="#018E77"
                                 height="32"
-                                transform="translate(-14.912843860816645 10.855110856776372) rotate(246.0 16 16)"
+                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -153,7 +153,7 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                               <rect
                                 fill="#C81471"
                                 height="32"
-                                transform="translate(-30.373404418783903 -6.946818612317597) rotate(324.3 16 16)"
+                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -375,7 +375,7 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                               <rect
                                 fill="#FB188D"
                                 height="32"
-                                transform="translate(-1.104254133951512 -2.2862708533878) rotate(359.4 16 16)"
+                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -383,7 +383,7 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                               <rect
                                 fill="#018E77"
                                 height="32"
-                                transform="translate(-14.912843860816645 10.855110856776372) rotate(246.0 16 16)"
+                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -391,7 +391,7 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                               <rect
                                 fill="#C81471"
                                 height="32"
-                                transform="translate(-30.373404418783903 -6.946818612317597) rotate(324.3 16 16)"
+                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -613,7 +613,7 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                               <rect
                                 fill="#FB188D"
                                 height="32"
-                                transform="translate(-1.104254133951512 -2.2862708533878) rotate(359.4 16 16)"
+                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -621,7 +621,7 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                               <rect
                                 fill="#018E77"
                                 height="32"
-                                transform="translate(-14.912843860816645 10.855110856776372) rotate(246.0 16 16)"
+                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -629,7 +629,7 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                               <rect
                                 fill="#C81471"
                                 height="32"
-                                transform="translate(-30.373404418783903 -6.946818612317597) rotate(324.3 16 16)"
+                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"

--- a/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
+++ b/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`ConnectPage should render correctly 1`] = `
                                   <rect
                                     fill="#18CDF2"
                                     height="32"
-                                    transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -156,7 +156,7 @@ exports[`ConnectPage should render correctly 1`] = `
                                   <rect
                                     fill="#035E56"
                                     height="32"
-                                    transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -164,7 +164,7 @@ exports[`ConnectPage should render correctly 1`] = `
                                   <rect
                                     fill="#F26602"
                                     height="32"
-                                    transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -200,7 +200,7 @@ exports[`ConnectPage should render correctly 1`] = `
                               <rect
                                 fill="#18CDF2"
                                 height="32"
-                                transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -208,7 +208,7 @@ exports[`ConnectPage should render correctly 1`] = `
                               <rect
                                 fill="#035E56"
                                 height="32"
-                                transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -216,7 +216,7 @@ exports[`ConnectPage should render correctly 1`] = `
                               <rect
                                 fill="#F26602"
                                 height="32"
-                                transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -569,7 +569,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                                   <rect
                                     fill="#18CDF2"
                                     height="32"
-                                    transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -577,7 +577,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                                   <rect
                                     fill="#035E56"
                                     height="32"
-                                    transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -585,7 +585,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                                   <rect
                                     fill="#F26602"
                                     height="32"
-                                    transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                     width="32"
                                     x="0"
                                     y="0"
@@ -621,7 +621,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                               <rect
                                 fill="#18CDF2"
                                 height="32"
-                                transform="translate(-1.04839350379394 -3.3042840694604987) rotate(328.9 16 16)"
+                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -629,7 +629,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                               <rect
                                 fill="#035E56"
                                 height="32"
-                                transform="translate(-18.298461708832043 10.5924618717486) rotate(176.2 16 16)"
+                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"
@@ -637,7 +637,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                               <rect
                                 fill="#F26602"
                                 height="32"
-                                transform="translate(16.667842018223922 -14.205139722997082) rotate(468.9 16 16)"
+                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
                                 width="32"
                                 x="0"
                                 y="0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6306,13 +6306,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/jazzicon@npm:^2.0.0":
+"@metamask/jazzicon@npm:2.0.0":
   version: 2.0.0
   resolution: "@metamask/jazzicon@npm:2.0.0"
   dependencies:
     color: "npm:^0.11.3"
     mersenne-twister: "npm:^1.1.0"
   checksum: 10/0b5add49e8d28270e4f8ca6159aa4ea0848f70cbb1cb217de2b0c13799a45fb27b8a6f0b3f72b6a76cbb55446764f79daf71e7d2a830a14b8e5e54d5e57bf7d1
+  languageName: node
+  linkType: hard
+
+"@metamask/jazzicon@patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch":
+  version: 2.0.0
+  resolution: "@metamask/jazzicon@patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch::version=2.0.0&hash=cb7501"
+  dependencies:
+    color: "npm:^0.11.3"
+    mersenne-twister: "npm:^1.1.0"
+  checksum: 10/e1286d6cfb0f2cb541c1e43a00f7e5c6b12a5483d31ed7035b6a36a69891ae8fa4327a83a2f4211e382e734fae197b7ce61c1d30f4fffdf7857160a326540560
   languageName: node
   linkType: hard
 
@@ -31830,7 +31840,7 @@ __metadata:
     "@metamask/gas-fee-controller": "npm:^24.0.0"
     "@metamask/gator-permissions-controller": "npm:^0.1.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.4"
-    "@metamask/jazzicon": "npm:^2.0.0"
+    "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
     "@metamask/json-rpc-engine": "npm:^10.0.0"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.4"
     "@metamask/kernel-browser-runtime": "npm:^0.4.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

We use the `@metamask/jazzicon` library to render account avatars. This library generates an SVG icon by generating a random number and then performing math to determine how to lay out the parts of the icon. However, the coordinates of these parts come out to numbers with a large number of decimal numbers, and due to floating point rounding errors, the number of decimals may vary each time the library is used. This impacts snapshot tests for components that make use of `jazzicon` because it means that sometimes the generated SVG fails to match the snapshot.

To address the issue and remove the intermittent failures, this commit patches `jazzicon` to limit the number of decimal numbers in the generated SVG code. We will fix `jazzicon` directly in a future update.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36172?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

This is not the first time this has come up. See older discussion in Slack: https://consensys.slack.com/archives/CTQAGKY5V/p1734371798693529

## **Manual testing steps**

(N/A)

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
