### PR TITLE
chore: update notification address icon cp-13.4.0

### DIFF
--- a/ui/components/multichain/notification-detail-address/notification-detail-address.test.tsx
+++ b/ui/components/multichain/notification-detail-address/notification-detail-address.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
 import { NotificationDetailAddress } from './notification-detail-address';
+
+const store = configureStore(mockState);
 
 describe('NotificationDetailAddress', () => {
   it('renders without crashing', () => {
-    render(
+    renderWithProvider(
       <NotificationDetailAddress
         side="From"
         address="0x7830c87C02e56AFf27FA8Ab1241711331FA86F43"
       />,
+      store,
     );
     expect(screen.getByText('From')).toBeInTheDocument();
   });

--- a/ui/components/multichain/notification-detail-address/notification-detail-address.tsx
+++ b/ui/components/multichain/notification-detail-address/notification-detail-address.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import type { FC } from 'react';
 import { NotificationDetail } from '../notification-detail';
 import { NotificationDetailCopyButton } from '../notification-detail-copy-button';
-import { AvatarAccount, Text } from '../../component-library';
+import { Text } from '../../component-library';
 import {
   FontWeight,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { shortenAddress } from '../../../helpers/utils/util';
+import { PreferredAvatar } from '../../app/preferred-avatar';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 
 export type NotificationDetailAddressProps = {
@@ -38,7 +39,7 @@ export const NotificationDetailAddress: FC<NotificationDetailAddressProps> = ({
 
   return (
     <NotificationDetail
-      icon={<AvatarAccount address={address} />}
+      icon={<PreferredAvatar address={address} />}
       primaryTextLeft={<SideText side={side} />}
       secondaryTextLeft={
         <NotificationDetailCopyButton


### PR DESCRIPTION
## **Description**

Updated notification address icon to use user's preferred identicon

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Pre-condition: Have a notification on a sent/received transction

1. Click Notification
2. Notification's account icon should match preferred setting

## **Screenshots/Recordings**


### **Before**

<img width="102" height="154" alt="image" src="https://github.com/user-attachments/assets/8ee4b403-b5af-4e1a-b9b3-c92e7a824bd7" />


### **After**
<img width="99" height="146" alt="image" src="https://github.com/user-attachments/assets/b2064e04-f037-4195-a902-aaf2939e51ca" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
