### PR TITLE
fix: guard setBasicFunctionality calls with state 2 feature flag

### DIFF
--- a/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -18,11 +18,11 @@ import {
   NetworkControllerFindNetworkClientIdByChainIdAction,
   NetworkControllerGetNetworkClientByIdAction,
 } from '@metamask/network-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../../controllers/preferences-controller';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 
 type Actions =
   | AccountsControllerListMultichainAccountsAction
@@ -77,7 +77,9 @@ export function getMultichainAccountServiceMessenger(
   });
 }
 
-type AllowedInitializationActions = PreferencesControllerGetStateAction | RemoteFeatureFlagControllerGetStateAction;
+type AllowedInitializationActions =
+  | PreferencesControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
 
 type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
 
@@ -100,7 +102,10 @@ export function getMultichainAccountServiceInitMessenger(
 ) {
   return messenger.getRestricted({
     name: 'MultichainAccountServiceInit',
-    allowedActions: ['PreferencesController:getState', 'RemoteFeatureFlagController:getState'],
+    allowedActions: [
+      'PreferencesController:getState',
+      'RemoteFeatureFlagController:getState',
+    ],
     allowedEvents: ['PreferencesController:stateChange'],
   });
 }

--- a/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/controller-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -22,6 +22,7 @@ import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../../controllers/preferences-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 
 type Actions =
   | AccountsControllerListMultichainAccountsAction
@@ -76,7 +77,7 @@ export function getMultichainAccountServiceMessenger(
   });
 }
 
-type AllowedInitializationActions = PreferencesControllerGetStateAction;
+type AllowedInitializationActions = PreferencesControllerGetStateAction | RemoteFeatureFlagControllerGetStateAction;
 
 type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
 
@@ -99,7 +100,7 @@ export function getMultichainAccountServiceInitMessenger(
 ) {
   return messenger.getRestricted({
     name: 'MultichainAccountServiceInit',
-    allowedActions: ['PreferencesController:getState'],
+    allowedActions: ['PreferencesController:getState', 'RemoteFeatureFlagController:getState'],
     allowedEvents: ['PreferencesController:stateChange'],
   });
 }

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -9,7 +9,7 @@ import {
   MultichainAccountServiceMessenger,
 } from '../messengers/accounts';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
-import { RemoteFeatureFlagControllerGetStateAction } from '../../controllers/remote-feature-flag-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { MultichainAccountServiceInit } from './multichain-account-service-init';
 
 jest.mock('@metamask/multichain-account-service');

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -1,5 +1,6 @@
 import { MultichainAccountService } from '@metamask/multichain-account-service';
 import { ActionConstraint, Messenger } from '@metamask/base-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ControllerInitRequest } from '../types';
 import {
@@ -9,7 +10,6 @@ import {
   MultichainAccountServiceMessenger,
 } from '../messengers/accounts';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { MultichainAccountServiceInit } from './multichain-account-service-init';
 
 jest.mock('@metamask/multichain-account-service');
@@ -21,7 +21,9 @@ function buildInitRequestMock(): jest.Mocked<
   >
 > {
   const baseControllerMessenger = new Messenger<
-    PreferencesControllerGetStateAction | RemoteFeatureFlagControllerGetStateAction | ActionConstraint,
+    | PreferencesControllerGetStateAction
+    | RemoteFeatureFlagControllerGetStateAction
+    | ActionConstraint,
     never
   >();
 

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -9,6 +9,7 @@ import {
   MultichainAccountServiceMessenger,
 } from '../messengers/accounts';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '../../controllers/remote-feature-flag-controller';
 import { MultichainAccountServiceInit } from './multichain-account-service-init';
 
 jest.mock('@metamask/multichain-account-service');
@@ -20,13 +21,26 @@ function buildInitRequestMock(): jest.Mocked<
   >
 > {
   const baseControllerMessenger = new Messenger<
-    PreferencesControllerGetStateAction | ActionConstraint,
+    PreferencesControllerGetStateAction | RemoteFeatureFlagControllerGetStateAction | ActionConstraint,
     never
   >();
 
   baseControllerMessenger.registerActionHandler(
     'PreferencesController:getState',
     jest.fn().mockReturnValue({}),
+  );
+
+  baseControllerMessenger.registerActionHandler(
+    'RemoteFeatureFlagController:getState',
+    jest.fn().mockReturnValue({
+      remoteFeatureFlags: {
+        enableMultichainAccounts: {
+          enabled: false,
+          featureVersion: null,
+          minimumVersion: null,
+        },
+      },
+    }),
   );
 
   return {

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -8,6 +8,7 @@ import { previousValueComparator } from '../../lib/util';
 import {
   FEATURE_VERSION_2,
   isMultichainAccountsFeatureEnabled,
+  MultichainAccountsFeatureFlag,
 } from '../../../../shared/lib/multichain-accounts/remote-feature-flag';
 
 /**
@@ -41,7 +42,9 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
           'RemoteFeatureFlagController:getState',
         );
         const multichainAccountsFeatureFlag =
-          remoteFeatureFlags?.enableMultichainAccounts;
+          remoteFeatureFlags?.enableMultichainAccounts as
+            | MultichainAccountsFeatureFlag
+            | undefined;
 
         if (
           isMultichainAccountsFeatureEnabled(

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -37,9 +37,9 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
       if (prevUseExternalServices !== currUseExternalServices) {
         // Only call MultichainAccountService if State 2 (BIP-44 multichain accounts) is enabled
         // to prevent unwanted account alignment from running
-        const remoteFeatureFlags = initMessenger.call(
+        const { remoteFeatureFlags } = initMessenger.call(
           'RemoteFeatureFlagController:getState',
-        ).remoteFeatureFlags;
+        );
         const multichainAccountsFeatureFlag =
           remoteFeatureFlags?.enableMultichainAccounts;
 

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -42,7 +42,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
         ).remoteFeatureFlags;
         const multichainAccountsFeatureFlag =
           remoteFeatureFlags?.enableMultichainAccounts;
-        
+
         if (
           isMultichainAccountsFeatureEnabled(
             multichainAccountsFeatureFlag,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevents unwanted multichain account alignment from running when State 2 (BIP-44 multichain accounts) is disabled. This fixes a release blocker where Solana accounts were being created automatically during preferences changes even when the feature is not enabled.

**Root Cause Analysis:**
The issue was caused by unguarded `setBasicFunctionality` calls in the MultichainAccountService initialization that triggered `MultichainAccountService.alignWallets()` regardless of the State 2 feature flag status. This alignment process created Solana accounts to match existing EVM accounts when users toggled external services preferences.

**Technical Details:**
1. `PreferencesController:stateChange` events called `setBasicFunctionality` without feature flag guard
2. This triggered `MultichainAccountService.alignWallets()` even when State 2 was disabled  
3. Alignment created unwanted Solana accounts to match existing EVM accounts
4. Users saw phantom Solana Snap accounts in their account list

**Changes:**
- Add `isMultichainAccountsFeatureEnabled` guard in `multichain-account-service-init.ts`
- Only call `setBasicFunctionality` when State 2 (FEATURE_VERSION_2) is enabled
- Update messenger types to include `RemoteFeatureFlagController:getState` action
- Update test mocks to handle new feature flag dependency

This is the equivalent fix to [MetaMask Mobile PR #19939](https://github.com/MetaMask/metamask-mobile/pull/19939), ensuring consistent behavior across both platforms.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36234?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed unwanted Solana Snap accounts appearing when BIP-44 multichain accounts feature is disabled

## **Related issues**

Fixes: Release blocker - unwanted Solana Snap accounts appearing when State 2 is disabled
Related: MetaMask Mobile PR #19939

## **Manual testing steps**

```gherkin
Feature: Prevent unwanted Solana account creation

  Scenario: User changes external services preference with State 2 disabled
    Given State 2 (BIP-44 multichain accounts) feature flag is disabled
    And user has existing EVM accounts
    
    When user toggles "Use external services" in Settings > Security & Privacy
    Then MultichainAccountService.setBasicFunctionality should not be called
    And no unwanted Solana Snap accounts should be created
    And only existing EVM accounts should remain visible
    
  Scenario: User changes external services preference with State 2 enabled
    Given State 2 feature flag is enabled
    And user has existing EVM accounts
    
    When user toggles "Use external services" in Settings > Security & Privacy  
    Then MultichainAccountService.setBasicFunctionality should be called
    And account alignment should proceed normally
```

## **Screenshots/Recordings**

### **Before**
- Unwanted Solana Snap accounts appeared when toggling external services
- Issue occurred even when State 2 (BIP-44 multichain accounts) was disabled
- Alignment ran unconditionally on preferences changes

### **After**
- No unwanted Solana accounts created when State 2 is disabled
- `setBasicFunctionality` calls are properly guarded by feature flag
- Alignment only runs when State 2 is actually enabled

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.