### PR TITLE
feat: Use the extensionReturnTxHashAsap param from remoteFeatureFlags for Smart Transactions

### DIFF
--- a/shared/modules/selectors/feature-flags.test.ts
+++ b/shared/modules/selectors/feature-flags.test.ts
@@ -1,50 +1,58 @@
 import { RpcEndpointType } from '@metamask/network-controller';
+import { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '../../constants/network';
 // Import the module to spy on
 import * as featureFlags from '../feature-flags';
 import {
   getFeatureFlagsByChainId,
   type SwapsFeatureFlags,
+  type SmartTransactionsNetworks,
+  type FeatureFlagsMetaMaskState,
 } from './feature-flags';
 import { ProviderConfigState } from './networks';
 
-type MockState = ProviderConfigState & {
-  metamask: {
-    networkConfigurationsByChainId: Record<
-      string,
-      {
-        chainId: string;
-        rpcEndpoints: {
-          networkClientId: string;
-          type: RpcEndpointType;
-          url: string;
-        }[];
-        blockExplorerUrls: string[];
-        defaultBlockExplorerUrlIndex: number;
-        name: string;
-        nativeCurrency: string;
-        defaultRpcEndpointIndex: number;
-      }
-    >;
-    selectedNetworkClientId: string;
-    networksMetadata: {
-      [clientId: string]: { status: string };
-    };
-    swapsState: {
-      swapsFeatureFlags: SwapsFeatureFlags;
+type MockState = ProviderConfigState &
+  FeatureFlagsMetaMaskState & {
+    metamask: {
+      networkConfigurationsByChainId: Record<
+        string,
+        {
+          chainId: string;
+          rpcEndpoints: {
+            networkClientId: string;
+            type: RpcEndpointType;
+            url: string;
+          }[];
+          blockExplorerUrls: string[];
+          defaultBlockExplorerUrlIndex: number;
+          name: string;
+          nativeCurrency: string;
+          defaultRpcEndpointIndex: number;
+        }
+      >;
+      selectedNetworkClientId: string;
+      networksMetadata: {
+        [clientId: string]: { status: string };
+      };
+      swapsState: {
+        swapsFeatureFlags: SwapsFeatureFlags;
+      };
+      remoteFeatureFlags?: {
+        smartTransactionsNetworks?: SmartTransactionsNetworks;
+      };
     };
   };
-};
 
 describe('Feature Flags Selectors', () => {
-  const createMockState = (chainId = CHAIN_IDS.MAINNET): MockState => {
-    // Use a simpler approach - explicit type cast for test purposes
-    return {
+  const createMockState = (
+    chainId: Hex = CHAIN_IDS.MAINNET,
+    includeRemoteFlags = false,
+  ): MockState => {
+    const state: MockState = {
       metamask: {
-        // Network state for provider config
         networkConfigurationsByChainId: {
           [chainId]: {
-            chainId,
+            chainId: chainId as Hex,
             rpcEndpoints: [
               {
                 networkClientId: 'test-client-id',
@@ -63,7 +71,6 @@ describe('Feature Flags Selectors', () => {
         networksMetadata: {
           'test-client-id': { status: 'available' },
         },
-        // Swaps feature flags
         swapsState: {
           swapsFeatureFlags: {
             ethereum: {
@@ -72,7 +79,6 @@ describe('Feature Flags Selectors', () => {
               smartTransactions: {
                 expectedDeadline: 45,
                 maxDeadline: 150,
-                extensionReturnTxHashAsap: false,
               },
             },
             bsc: {
@@ -81,7 +87,6 @@ describe('Feature Flags Selectors', () => {
               smartTransactions: {
                 expectedDeadline: 60,
                 maxDeadline: 180,
-                extensionReturnTxHashAsap: true,
               },
             },
             smartTransactions: {
@@ -91,8 +96,20 @@ describe('Feature Flags Selectors', () => {
             },
           } as SwapsFeatureFlags,
         },
+        remoteFeatureFlags: includeRemoteFlags
+          ? {
+              smartTransactionsNetworks: {
+                default: {
+                  batchStatusPollingInterval: 1000,
+                  extensionActive: true,
+                  extensionReturnTxHashAsap: true,
+                },
+              },
+            }
+          : undefined,
       },
     };
+    return state;
   };
 
   describe('getFeatureFlagsByChainId', () => {
@@ -157,7 +174,7 @@ describe('Feature Flags Selectors', () => {
           mobileActive: true,
           expectedDeadline: 60,
           maxDeadline: 180,
-          extensionReturnTxHashAsap: true,
+          extensionReturnTxHashAsap: false,
         },
       });
     });
@@ -174,6 +191,53 @@ describe('Feature Flags Selectors', () => {
           maxDeadline: 150,
           extensionReturnTxHashAsap: false,
         },
+      });
+    });
+
+    describe('remote feature flags', () => {
+      it('uses extensionReturnTxHashAsap from remote flags when available', () => {
+        const state = createMockState(CHAIN_IDS.MAINNET, true);
+        const result = getFeatureFlagsByChainId(state);
+
+        expect(result).toStrictEqual({
+          smartTransactions: {
+            mobileActive: true,
+            extensionActive: true,
+            expectedDeadline: 45,
+            maxDeadline: 150,
+            extensionReturnTxHashAsap: true,
+          },
+        });
+      });
+
+      it('defaults to false when remote flags are not available', () => {
+        const state = createMockState(CHAIN_IDS.MAINNET, false);
+        const result = getFeatureFlagsByChainId(state);
+
+        expect(result).toStrictEqual({
+          smartTransactions: {
+            mobileActive: true,
+            extensionActive: true,
+            expectedDeadline: 45,
+            maxDeadline: 150,
+            extensionReturnTxHashAsap: false,
+          },
+        });
+      });
+
+      it('uses default remote flag value for all networks', () => {
+        const state = createMockState(CHAIN_IDS.BSC, true);
+        const result = getFeatureFlagsByChainId(state);
+
+        expect(result).toStrictEqual({
+          smartTransactions: {
+            extensionActive: true,
+            mobileActive: true,
+            expectedDeadline: 60,
+            maxDeadline: 180,
+            extensionReturnTxHashAsap: true,
+          },
+        });
       });
     });
   });

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -1,3 +1,4 @@
+import { Hex } from '@metamask/utils';
 import { getNetworkNameByChainId } from '../feature-flags';
 import { ProviderConfigState, getCurrentChainId } from './networks';
 
@@ -24,15 +25,15 @@ export type SwapsFeatureFlags = {
   smartTransactions: SmartTransactionsFeatureFlag;
 };
 
-type SmartTransactionNetwork = {
+export type SmartTransactionNetwork = {
   extensionActive?: boolean;
   sentinelUrl?: string;
   extensionReturnTxHashAsap?: boolean;
+  batchStatusPollingInterval?: number;
 };
 
-type SmartTransactionsNetworks = {
-  [chainId: string]: SmartTransactionNetwork | undefined;
-} & {
+export type SmartTransactionsNetworks = {
+  [chainId: Hex]: SmartTransactionNetwork | undefined;
   default?: SmartTransactionNetwork;
 };
 

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -24,10 +24,25 @@ export type SwapsFeatureFlags = {
   smartTransactions: SmartTransactionsFeatureFlag;
 };
 
+type SmartTransactionNetwork = {
+  extensionActive?: boolean;
+  sentinelUrl?: string;
+  extensionReturnTxHashAsap?: boolean;
+};
+
+type SmartTransactionsNetworks = {
+  [chainId: string]: SmartTransactionNetwork | undefined;
+} & {
+  default?: SmartTransactionNetwork;
+};
+
 export type FeatureFlagsMetaMaskState = {
   metamask: {
     swapsState: {
       swapsFeatureFlags: SwapsFeatureFlags;
+    };
+    remoteFeatureFlags?: {
+      smartTransactionsNetworks?: SmartTransactionsNetworks;
     };
   };
 };
@@ -44,10 +59,17 @@ export function getFeatureFlagsByChainId(
   if (!featureFlags?.[networkName]) {
     return null;
   }
+  const smartTransactionsNetworks =
+    state.metamask.remoteFeatureFlags?.smartTransactionsNetworks;
+  const defaultConfig = smartTransactionsNetworks?.default;
+  const extensionReturnTxHashAsap =
+    defaultConfig?.extensionReturnTxHashAsap ?? false;
+
   return {
     smartTransactions: {
       ...featureFlags.smartTransactions,
       ...featureFlags[networkName].smartTransactions,
+      extensionReturnTxHashAsap,
     },
   };
 }


### PR DESCRIPTION
## **Description**
Use the `extensionReturnTxHashAsap` param from remoteFeatureFlags for Smart Transactions.

Currently we only use this one STX flag from remote feature flags, but in the future we can read the rest of the feature flags for Smart Transactions from there as well, which will allow us to stop using STX feature flags coming from swaps-api.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36240?quickstart=1)

## **Changelog**

CHANGELOG entry: Used the extensionReturnTxHashAsap param from remoteFeatureFlags for Smart Transactions

## **Related issues**

Fixes:

## **Manual testing steps**

1. Have STX on in Advanced Settings
2. Do a simple Send transaction e.g. on Ethereum mainnet or BNB chain
3. A txHash will be returned immediately after a transaction submission

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
