### PR TITLE
chore: simplify Skeleton component API

### DIFF
--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -36,8 +36,9 @@ const AccountGroupBalanceChangeComponent: React.FC<
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange)}
+      isLoading={
+        !(anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange))
+      }
     >
       <Box display={Display.Flex} gap={1}>
         <SensitiveText

--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -36,9 +36,7 @@ const AccountGroupBalanceChangeComponent: React.FC<
 
   return (
     <Skeleton
-      isLoading={
-        !anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)
-      }
+      isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
     >
       <Box display={Display.Flex} gap={1}>
         <SensitiveText

--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -37,7 +37,7 @@ const AccountGroupBalanceChangeComponent: React.FC<
   return (
     <Skeleton
       isLoading={
-        !(anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange))
+        !anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)
       }
     >
       <Box display={Display.Flex} gap={1}>

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -56,10 +56,11 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={
-        anyEnabledNetworksAreAvailable ||
-        (!isZeroAmount(total) && currency !== undefined)
+      isLoading={
+        !(
+          anyEnabledNetworksAreAvailable ||
+          (!isZeroAmount(total) && currency !== undefined)
+        )
       }
     >
       <Box

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -57,10 +57,8 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
   return (
     <Skeleton
       isLoading={
-        !(
-          anyEnabledNetworksAreAvailable ||
-          (!isZeroAmount(total) && currency !== undefined)
-        )
+        !anyEnabledNetworksAreAvailable &&
+        (isZeroAmount(total) || currency === undefined)
       }
     >
       <Box

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Token Cell should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-skeleton mm-skeleton--hide-children mm-box--background-color-icon-alternative mm-box--rounded-sm"
+            class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
           >
             <p
               class="mm-box mm-text mm-text--body-sm mm-text--font-weight-normal mm-text--text-align-end mm-box--color-text-default"

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -27,9 +27,8 @@ export const TokenCellPrimaryDisplay = React.memo(
 
     return (
       <Skeleton
-        hideChildren
-        showUntil={
-          anyEnabledNetworksAreAvailable || !isZeroAmount(token.primary)
+        isLoading={
+          !(anyEnabledNetworksAreAvailable || !isZeroAmount(token.primary))
         }
       >
         <SensitiveText

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -28,7 +28,7 @@ export const TokenCellPrimaryDisplay = React.memo(
     return (
       <Skeleton
         isLoading={
-          !(anyEnabledNetworksAreAvailable || !isZeroAmount(token.primary))
+          !anyEnabledNetworksAreAvailable && isZeroAmount(token.primary)
         }
       >
         <SensitiveText

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -89,10 +89,7 @@ export const TokenCellSecondaryDisplay = React.memo(
     return (
       <Skeleton
         isLoading={
-          !(
-            anyEnabledNetworksAreAvailable ||
-            !isZeroAmount(secondaryDisplayText)
-          )
+          !anyEnabledNetworksAreAvailable && isZeroAmount(secondaryDisplayText)
         }
       >
         <SensitiveText

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -89,7 +89,10 @@ export const TokenCellSecondaryDisplay = React.memo(
     return (
       <Skeleton
         isLoading={
-          !(anyEnabledNetworksAreAvailable || !isZeroAmount(secondaryDisplayText))
+          !(
+            anyEnabledNetworksAreAvailable ||
+            !isZeroAmount(secondaryDisplayText)
+          )
         }
       >
         <SensitiveText

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -88,9 +88,8 @@ export const TokenCellSecondaryDisplay = React.memo(
     // secondary display text
     return (
       <Skeleton
-        hideChildren
-        showUntil={
-          anyEnabledNetworksAreAvailable || !isZeroAmount(secondaryDisplayText)
+        isLoading={
+          !(anyEnabledNetworksAreAvailable || !isZeroAmount(secondaryDisplayText))
         }
       >
         <SensitiveText

--- a/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
+++ b/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with po
 exports[`AggregatedMultichainPercentageOverview render renders correctly with zero values 1`] = `
 <div>
   <div
-    class="mm-box mm-skeleton mm-skeleton--hide-children mm-box--background-color-icon-alternative mm-box--rounded-sm"
+    class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
   >
     <div
       class="mm-box mm-box--display-flex"
@@ -88,7 +88,7 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with ze
 exports[`AggregatedPercentageOverview render renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-skeleton mm-skeleton--hide-children mm-box--background-color-icon-alternative mm-box--rounded-sm"
+    class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
   >
     <div
       class="mm-box gap-1 mm-box--display-flex"

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -160,10 +160,8 @@ export const AggregatedPercentageOverviewCrossChains = ({
   return (
     <Skeleton
       isLoading={
-        !(
-          anyEnabledNetworksAreAvailable ||
-          !isZeroAmount(formattedAmountChangeCrossChains)
-        )
+        !anyEnabledNetworksAreAvailable &&
+        isZeroAmount(formattedAmountChangeCrossChains)
       }
     >
       <Box display={Display.Flex} className="gap-1">

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -159,10 +159,9 @@ export const AggregatedPercentageOverviewCrossChains = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={
-        anyEnabledNetworksAreAvailable ||
-        !isZeroAmount(formattedAmountChangeCrossChains)
+      isLoading={
+        !(anyEnabledNetworksAreAvailable ||
+        !isZeroAmount(formattedAmountChangeCrossChains))
       }
     >
       <Box display={Display.Flex} className="gap-1">

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -160,8 +160,10 @@ export const AggregatedPercentageOverviewCrossChains = ({
   return (
     <Skeleton
       isLoading={
-        !(anyEnabledNetworksAreAvailable ||
-        !isZeroAmount(formattedAmountChangeCrossChains))
+        !(
+          anyEnabledNetworksAreAvailable ||
+          !isZeroAmount(formattedAmountChangeCrossChains)
+        )
       }
     >
       <Box display={Display.Flex} className="gap-1">

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -212,9 +212,7 @@ export const AggregatedMultichainPercentageOverview = ({
   return (
     <Skeleton
       isLoading={
-        !(
-          anyEnabledNetworksAreAvailable || !isZeroAmount(singleDayAmountChange)
-        )
+        !anyEnabledNetworksAreAvailable && isZeroAmount(singleDayAmountChange)
       }
     >
       <Box display={Display.Flex}>

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -123,8 +123,9 @@ export const AggregatedPercentageOverview = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange)}
+      isLoading={
+        !(anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange))
+      }
     >
       <Box display={Display.Flex} className="gap-1">
         <SensitiveText
@@ -212,9 +213,8 @@ export const AggregatedMultichainPercentageOverview = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={
-        anyEnabledNetworksAreAvailable || !isZeroAmount(singleDayAmountChange)
+      isLoading={
+        !(anyEnabledNetworksAreAvailable || !isZeroAmount(singleDayAmountChange))
       }
     >
       <Box display={Display.Flex}>

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -123,9 +123,7 @@ export const AggregatedPercentageOverview = ({
 
   return (
     <Skeleton
-      isLoading={
-        !(anyEnabledNetworksAreAvailable || !isZeroAmount(amountChange))
-      }
+      isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
     >
       <Box display={Display.Flex} className="gap-1">
         <SensitiveText

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -214,7 +214,9 @@ export const AggregatedMultichainPercentageOverview = ({
   return (
     <Skeleton
       isLoading={
-        !(anyEnabledNetworksAreAvailable || !isZeroAmount(singleDayAmountChange))
+        !(
+          anyEnabledNetworksAreAvailable || !isZeroAmount(singleDayAmountChange)
+        )
       }
     >
       <Box display={Display.Flex}>

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -284,7 +284,7 @@ export const CoinOverview = ({
           ?.pricePercentChange1d;
       return (
         <Skeleton
-          isLoading={!(anyEnabledNetworksAreAvailable || !isZeroAmount(value))}
+          isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(value)}
         >
           <Box className="wallet-overview__currency-wrapper">
             <PercentageAndAmountChange value={value} />

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -162,9 +162,8 @@ export const LegacyAggregatedBalance = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={
-        anyEnabledNetworksAreAvailable || !isZeroAmount(balanceToDisplay)
+      isLoading={
+        !(anyEnabledNetworksAreAvailable || !isZeroAmount(balanceToDisplay))
       }
     >
       <UserPreferencedCurrencyDisplay
@@ -285,8 +284,9 @@ export const CoinOverview = ({
           ?.pricePercentChange1d;
       return (
         <Skeleton
-          hideChildren
-          showUntil={anyEnabledNetworksAreAvailable || !isZeroAmount(value)}
+          isLoading={
+            !(anyEnabledNetworksAreAvailable || !isZeroAmount(value))
+          }
         >
           <Box className="wallet-overview__currency-wrapper">
             <PercentageAndAmountChange value={value} />

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -163,7 +163,7 @@ export const LegacyAggregatedBalance = ({
   return (
     <Skeleton
       isLoading={
-        !(anyEnabledNetworksAreAvailable || !isZeroAmount(balanceToDisplay))
+        !anyEnabledNetworksAreAvailable && isZeroAmount(balanceToDisplay)
       }
     >
       <UserPreferencedCurrencyDisplay

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -284,9 +284,7 @@ export const CoinOverview = ({
           ?.pricePercentChange1d;
       return (
         <Skeleton
-          isLoading={
-            !(anyEnabledNetworksAreAvailable || !isZeroAmount(value))
-          }
+          isLoading={!(anyEnabledNetworksAreAvailable || !isZeroAmount(value))}
         >
           <Box className="wallet-overview__currency-wrapper">
             <PercentageAndAmountChange value={value} />

--- a/ui/components/component-library/skeleton/README.mdx
+++ b/ui/components/component-library/skeleton/README.mdx
@@ -26,53 +26,18 @@ import { Skeleton } from '../../component-library';
 <Skeleton height={16} width={250} />
 ```
 
-### Children
+### Is Loading
 
-Use the `children` prop to pass the `Skeleton` children.
+Use the `isLoading` prop to control whether to show the skeleton loading state or the actual content. When `true`, shows skeleton with hidden children. When `false`, shows just the children content.
 
-This is useful to create a `Skeleton` component that has a similar layout to the content that will be loaded.
-
-<Canvas of={SkeletonStories.Children} />
-
-```jsx
-import {
-  Display,
-  FlexDirection,
-  BackgroundColor,
-  BorderRadius,
-} from '../../../helpers/constants/design-system';
-import { Skeleton } from '../../component-library';
-
-<Skeleton
-  display={Display.Flex}
-  flexDirection={FlexDirection.Column}
-  gap={4}
-  backgroundColor={BackgroundColor.backgroundAlternative}
-  borderRadius={BorderRadius.LG}
-  padding={4}
->
-  <Skeleton height={32} width="100%" />
-  <Skeleton height={16} width="95%" />
-  <Skeleton height={16} width="95%" />
-</Skeleton>;
-```
-
-### Hide Children
-
-Use the `hideChildren` prop to hide the `children` of the `Skeleton` component. This is useful to make sure the `Skeleton` component is the same size as the content that will be loaded.
-
-<Canvas of={SkeletonStories.HideChildren} />
+<Canvas of={SkeletonStories.IsLoading} />
 
 ```jsx
 import { Skeleton, Text, TextVariant } from '../../component-library';
 
-isLoaded ? (
-  <Text variant={TextVariant.headingMd}>Content to load</Text>
-) : (
-  <Skeleton width="max-content" hideChildren={true}>
-    <Text variant={TextVariant.headingMd}>Hidden placeholder text</Text>
-  </Skeleton>
-);
+<Skeleton width="max-content" isLoading={!isLoaded}>
+  <Text variant={TextVariant.headingMd}>Content that loads</Text>
+</Skeleton>;
 ```
 
 ### Border Radius

--- a/ui/components/component-library/skeleton/skeleton.scss
+++ b/ui/components/component-library/skeleton/skeleton.scss
@@ -16,7 +16,7 @@
   pointer-events: none;
   user-select: none;
 
-  &--hide-children * {
+  * {
     visibility: hidden;
   }
 }

--- a/ui/components/component-library/skeleton/skeleton.stories.tsx
+++ b/ui/components/component-library/skeleton/skeleton.stories.tsx
@@ -56,48 +56,24 @@ export const WidthHeight: Story = {
   ),
 };
 
-export const Children: Story = {
-  render: () => (
-    <Skeleton
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      gap={4}
-      backgroundColor={BackgroundColor.backgroundAlternative}
-      borderRadius={BorderRadius.LG}
-      padding={4}
-    >
-      <Skeleton height={32} width="100%" />
-      <Skeleton height={16} width="95%" />
-      <Skeleton height={16} width="95%" />
-    </Skeleton>
-  ),
-};
-
-export const HideChildren: Story = {
+export const IsLoading: Story = {
   args: {
     width: 'max-content',
-    hideChildren: true,
   },
-  render: (args) => {
-    const [isLoaded, setIsLoaded] = React.useState(false);
+  render: function IsLoadingStory(args) {
+    const [isLoading, setIsLoading] = React.useState(true);
     return (
       <Box>
         <Button
-          onClick={() => setIsLoaded(!isLoaded)}
+          onClick={() => setIsLoading(!isLoading)}
           variant={ButtonVariant.Secondary}
           marginBottom={4}
         >
           Toggle isLoading
         </Button>
-        {isLoaded ? (
-          <div>
-            <Text variant={TextVariant.headingMd}>Content to load</Text>
-          </div>
-        ) : (
-          <Skeleton {...args}>
-            <Text variant={TextVariant.headingMd}>Hidden placeholder text</Text>
-          </Skeleton>
-        )}
+        <Skeleton {...args} isLoading={isLoading}>
+          <Text variant={TextVariant.headingMd}>Content that loads</Text>
+        </Skeleton>
       </Box>
     );
   },
@@ -139,14 +115,30 @@ BorderRadiusStory.storyName = 'BorderRadius';
 export const TokenListSkeleton: Story = {
   render: () => (
     <Box display={Display.Flex} flexDirection={FlexDirection.Row} gap={4}>
-      <Skeleton width={32} height={32} borderRadius={BorderRadius.full} style={{
-        minWidth: 32, // add classname with this style attached
-      }} />
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={1} width={BlockSize.Full} paddingRight={12}>
+      <Skeleton
+        width={32}
+        height={32}
+        borderRadius={BorderRadius.full}
+        style={{
+          minWidth: 32, // add classname with this style attached
+        }}
+      />
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
+        gap={1}
+        width={BlockSize.Full}
+        paddingRight={12}
+      >
         <Skeleton width="100%" height={16} />
         <Skeleton width="70%" height={16} />
       </Box>
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={1} width={BlockSize.OneThird}>
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
+        gap={1}
+        width={BlockSize.OneThird}
+      >
         <Skeleton width="100%" height={16} />
         <Skeleton width="100%" height={16} />
       </Box>

--- a/ui/components/component-library/skeleton/skeleton.test.tsx
+++ b/ui/components/component-library/skeleton/skeleton.test.tsx
@@ -19,4 +19,12 @@ describe('Skeleton', () => {
     );
     expect(getByTestId('skeleton')).toHaveClass('test-class');
   });
+  it('should render the children and not the skeleton when isLoading is false', () => {
+    const { getByTestId } = render(
+      <Skeleton isLoading={false}>
+        <div data-testid="content">Content</div>
+      </Skeleton>,
+    );
+    expect(getByTestId('content')).toBeInTheDocument();
+  });
 });

--- a/ui/components/component-library/skeleton/skeleton.tsx
+++ b/ui/components/component-library/skeleton/skeleton.tsx
@@ -19,25 +19,17 @@ export const Skeleton: SkeletonComponent = React.forwardRef(
       height,
       width,
       children,
-      hideChildren = false,
-      showUntil = false,
+      isLoading = true,
       ...props
     }: SkeletonProps<C>,
     ref?: PolymorphicRef<C>,
   ) => {
-    if (showUntil === true) {
+    if (!isLoading) {
       return <>{children}</>;
     }
-
     return (
       <Box
-        className={classnames(
-          'mm-skeleton',
-          {
-            'mm-skeleton--hide-children': hideChildren,
-          },
-          className,
-        )}
+        className={classnames('mm-skeleton', className)}
         backgroundColor={BackgroundColor.iconAlternative}
         borderRadius={BorderRadius.SM}
         ref={ref}

--- a/ui/components/component-library/skeleton/skeleton.types.ts
+++ b/ui/components/component-library/skeleton/skeleton.types.ts
@@ -26,18 +26,11 @@ export type SkeletonStyleUtilityProps = Omit<
    */
   children?: React.ReactNode;
   /**
-   * Whether to make children invisible or not. This enables an alternative form
-   * of this component, where you use it as a wrapper around existing content
-   * rather than using it on its own. This allows that content to dictate the
-   * size of the skeleton rather than requiring that you supply explicit
-   * dimensions.
+   * Whether to show the skeleton loading state or the actual content.
+   * When true, shows skeleton.
+   * When false, shows just the children content.
    */
-  hideChildren?: boolean;
-  /**
-   * Intended to be used in conjunction with hideChildren; allows for showing a
-   * skeleton until a certain condition is met.
-   */
-  showUntil?: boolean;
+  isLoading?: boolean;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -107,12 +107,11 @@ export const AggregatedBalance = ({
 
   return (
     <Skeleton
-      hideChildren
-      showUntil={
-        balances &&
+      isLoading={
+        !(balances &&
         assets[selectedAccount.id]?.length > 0 &&
         (anyEnabledNetworksAreAvailable ||
-          !isZeroAmount(multichainNativeTokenBalance.amount.toString()))
+          !isZeroAmount(multichainNativeTokenBalance.amount.toString())))
       }
     >
       <Box

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -108,10 +108,12 @@ export const AggregatedBalance = ({
   return (
     <Skeleton
       isLoading={
-        !(balances &&
-        assets[selectedAccount.id]?.length > 0 &&
-        (anyEnabledNetworksAreAvailable ||
-          !isZeroAmount(multichainNativeTokenBalance.amount.toString())))
+        !(
+          balances &&
+          assets[selectedAccount.id]?.length > 0 &&
+          (anyEnabledNetworksAreAvailable ||
+            !isZeroAmount(multichainNativeTokenBalance.amount.toString()))
+        )
       }
     >
       <Box

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -108,12 +108,11 @@ export const AggregatedBalance = ({
   return (
     <Skeleton
       isLoading={
-        !(
-          balances &&
-          assets[selectedAccount.id]?.length > 0 &&
-          (anyEnabledNetworksAreAvailable ||
-            !isZeroAmount(multichainNativeTokenBalance.amount.toString()))
-        )
+        !balances ||
+        assets[selectedAccount.id] === undefined ||
+        assets[selectedAccount.id].length === 0 ||
+        (!anyEnabledNetworksAreAvailable && 
+          isZeroAmount(multichainNativeTokenBalance.amount.toString()))
       }
     >
       <Box

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -111,7 +111,7 @@ export const AggregatedBalance = ({
         !balances ||
         assets[selectedAccount.id] === undefined ||
         assets[selectedAccount.id].length === 0 ||
-        (!anyEnabledNetworksAreAvailable && 
+        (!anyEnabledNetworksAreAvailable &&
           isZeroAmount(multichainNativeTokenBalance.amount.toString()))
       }
     >


### PR DESCRIPTION
This PR adds updates to https://github.com/MetaMask/metamask-extension/pull/36045 to simplify the `Skeleton` component API by removing the `hideChildren` and updating `showUntil` to `isLoading` prop.

## Changes

### API Simplification
- **Before**: Required both `hideChildren={true}` and `showUntil={condition}` props
- **After**: Single `isLoading={!condition}` prop (defaults to `true`), removed nested skeletons functionality as there was no use case for them

### Updated Component
- Removed `hideChildren` prop entirely  
- Simplified logic: `isLoading={true}` shows skeleton, `isLoading={false}` shows content
- Always hides children when showing skeleton (no nested skeleton functionality)

### Updated Usage Across Codebase
Updated 9+ files to use the new API:
- `ui/components/ui/aggregated-balance/`
- `ui/components/app/wallet-overview/`
- `ui/components/app/assets/token-cell/`
- `ui/components/app/assets/account-group-balance/`

### Examples

**Old API:**
```jsx
<Skeleton hideChildren={true} showUntil={isLoaded}>
  <Text>Content</Text>
</Skeleton>
```

**New API:**
```jsx
<Skeleton isLoading={!isLoaded}>
  <Text>Content</Text>
</Skeleton>
```

## Benefits
- Cleaner, more intuitive API
- Eliminates confusion between CSS hiding vs conditional rendering  
- Consistent with common loading state patterns
- Reduced prop surface area

🤖 Generated with [Claude Code](https://claude.ai/code)