### PR TITLE
feat: Notify users about degraded and unavailable networks

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -1710,6 +1710,9 @@ const state = {
       },
     },
     openSeaEnabled: true,
+    networkConnectionBanner: {
+      status: 'unknown',
+    },
   },
   appState: {
     isAccountMenuOpen: false,

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6521,6 +6521,10 @@
     "message": "Plug your Ledger directly into your computer, then  unlock it and open the Ethereum app.",
     "description": "$1 represents the `hardwareWalletSupportLinkConversion` localization key"
   },
+  "stillConnectingTo": {
+    "message": "Still connecting to $1...",
+    "description": "Message shown when network connection is slow. $1 is the network name."
+  },
   "stillGettingMessage": {
     "message": "Still getting this message?"
   },
@@ -7358,6 +7362,10 @@
     "message": "U2F",
     "description": "A name on an API for the browser to interact with devices that support the U2F protocol. On some browsers we use it to connect MetaMask to Ledger devices."
   },
+  "unableToConnectTo": {
+    "message": "Unable to connect to $1",
+    "description": "Message shown when network connection fails. $1 is the network name."
+  },
   "unapproved": {
     "message": "Unapproved"
   },
@@ -7441,6 +7449,10 @@
   },
   "updateRequest": {
     "message": "Update request"
+  },
+  "updateRpc": {
+    "message": "Update RPC",
+    "description": "Button text to update RPC endpoint"
   },
   "updateToTheLatestVersion": {
     "message": "Update to the latest version"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7363,7 +7363,7 @@
     "description": "A name on an API for the browser to interact with devices that support the U2F protocol. On some browsers we use it to connect MetaMask to Ledger devices."
   },
   "unableToConnectTo": {
-    "message": "Unable to connect to $1",
+    "message": "Unable to connect to $1.",
     "description": "Message shown when network connection fails. $1 is the network name."
   },
   "unapproved": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6521,6 +6521,10 @@
     "message": "Plug your Ledger directly into your computer, then  unlock it and open the Ethereum app.",
     "description": "$1 represents the `hardwareWalletSupportLinkConversion` localization key"
   },
+  "stillConnectingTo": {
+    "message": "Still connecting to $1...",
+    "description": "Message shown when network connection is slow. $1 is the network name."
+  },
   "stillGettingMessage": {
     "message": "Still getting this message?"
   },
@@ -7358,6 +7362,10 @@
     "message": "U2F",
     "description": "A name on an API for the browser to interact with devices that support the U2F protocol. On some browsers we use it to connect MetaMask to Ledger devices."
   },
+  "unableToConnectTo": {
+    "message": "Unable to connect to $1",
+    "description": "Message shown when network connection fails. $1 is the network name."
+  },
   "unapproved": {
     "message": "Unapproved"
   },
@@ -7441,6 +7449,10 @@
   },
   "updateRequest": {
     "message": "Update request"
+  },
+  "updateRpc": {
+    "message": "Update RPC",
+    "description": "Button text to update RPC endpoint"
   },
   "updateToTheLatestVersion": {
     "message": "Update to the latest version"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7363,7 +7363,7 @@
     "description": "A name on an API for the browser to interact with devices that support the U2F protocol. On some browsers we use it to connect MetaMask to Ledger devices."
   },
   "unableToConnectTo": {
-    "message": "Unable to connect to $1",
+    "message": "Unable to connect to $1.",
     "description": "Message shown when network connection fails. $1 is the network name."
   },
   "unapproved": {

--- a/app/scripts/controller-init/network-controller-init.ts
+++ b/app/scripts/controller-init/network-controller-init.ts
@@ -7,7 +7,7 @@ import {
 import { BlockExplorerUrl, ChainId } from '@metamask/controller-utils';
 import { hasProperty } from '@metamask/utils';
 import { SECOND } from '../../../shared/constants/time';
-import { getIsQuicknodeEndpointUrl } from '../lib/network-controller/utils';
+import { getIsQuicknodeEndpointUrl } from '../../../shared/lib/network-utils';
 import {
   onRpcEndpointDegraded,
   onRpcEndpointUnavailable,

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -966,6 +966,9 @@ describe('AppStateController', () => {
               },
               "lastUpdatedAt": null,
               "lastViewedUserSurvey": null,
+              "networkConnectionBanner": {
+                "status": "unknown",
+              },
               "newPrivacyPolicyToastClickedOrClosed": null,
               "newPrivacyPolicyToastShownDate": null,
               "nftsDropdownState": {},

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -36,6 +36,7 @@ import { SecurityAlertResponse } from '../lib/ppom/types';
 import {
   AccountOverviewTabKey,
   CarouselSlide,
+  NetworkConnectionBanner,
 } from '../../../shared/constants/app-state';
 import type {
   ThrottledOrigins,
@@ -78,6 +79,7 @@ export type AppStateControllerState = {
   lastInteractedConfirmationInfo?: LastInteractedConfirmationInfo;
   lastUpdatedAt: number | null;
   lastViewedUserSurvey: number | null;
+  networkConnectionBanner: NetworkConnectionBanner;
   newPrivacyPolicyToastClickedOrClosed: boolean | null;
   newPrivacyPolicyToastShownDate: number | null;
   nftsDetectionNoticeDismissed: boolean;
@@ -191,6 +193,7 @@ type AppStateControllerInitState = Partial<
     | 'signatureSecurityAlertResponses'
     | 'addressSecurityAlertResponses'
     | 'currentExtensionPopupId'
+    | 'networkConnectionBanner'
   >
 >;
 
@@ -258,6 +261,9 @@ function getInitialStateOverrides() {
     currentExtensionPopupId: 0,
     nftsDropdownState: {},
     signatureSecurityAlertResponses: {},
+    networkConnectionBanner: {
+      status: 'unknown' as const,
+    },
   };
 }
 
@@ -370,6 +376,12 @@ const controllerMetadata = {
     includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: true,
+  },
+  networkConnectionBanner: {
+    includeInStateLogs: false,
+    persist: false,
+    anonymous: false,
     usedInUi: true,
   },
   newPrivacyPolicyToastClickedOrClosed: {
@@ -1091,6 +1103,19 @@ export class AppStateController extends BaseController<
   setShowNetworkBanner(showNetworkBanner: boolean): void {
     this.update((state) => {
       state.showNetworkBanner = showNetworkBanner;
+    });
+  }
+
+  /**
+   * Updates the network connection banner state
+   *
+   * @param networkConnectionBanner - The new banner state
+   */
+  updateNetworkConnectionBanner(
+    networkConnectionBanner: AppStateControllerState['networkConnectionBanner'],
+  ): void {
+    this.update((state) => {
+      state.networkConnectionBanner = networkConnectionBanner;
     });
   }
 

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -1,4 +1,5 @@
 import { HttpError } from '@metamask/controller-utils';
+import * as networkUtilsModule from '../../../../shared/lib/network-utils';
 import {
   onRpcEndpointDegraded,
   onRpcEndpointUnavailable,
@@ -13,8 +14,8 @@ describe('onRpcEndpointUnavailable', () => {
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
   let isPublicEndpointUrlMock: jest.SpyInstance<
-    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
-    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+    ReturnType<typeof networkUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkUtilsModule.isPublicEndpointUrl>
   >;
 
   beforeEach(() => {
@@ -24,7 +25,7 @@ describe('onRpcEndpointUnavailable', () => {
     );
 
     isPublicEndpointUrlMock = jest.spyOn(
-      networkControllerUtilsModule,
+      networkUtilsModule,
       'isPublicEndpointUrl',
     );
   });
@@ -166,8 +167,8 @@ describe('onRpcEndpointDegraded', () => {
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
   let isPublicEndpointUrlMock: jest.SpyInstance<
-    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
-    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+    ReturnType<typeof networkUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkUtilsModule.isPublicEndpointUrl>
   >;
 
   beforeEach(() => {
@@ -177,7 +178,7 @@ describe('onRpcEndpointDegraded', () => {
     );
 
     isPublicEndpointUrlMock = jest.spyOn(
-      networkControllerUtilsModule,
+      networkUtilsModule,
       'isPublicEndpointUrl',
     );
   });

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -5,8 +5,9 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { onlyKeepHost } from '../../../../shared/lib/only-keep-host';
+import { isPublicEndpointUrl } from '../../../../shared/lib/network-utils';
 import MetaMetricsController from '../../controllers/metametrics-controller';
-import { isPublicEndpointUrl, shouldCreateRpcServiceEvents } from './utils';
+import { shouldCreateRpcServiceEvents } from './utils';
 
 /**
  * Called when an endpoint is determined to be "unavailable". Creates a Segment

--- a/app/scripts/lib/network-controller/utils.ts
+++ b/app/scripts/lib/network-controller/utils.ts
@@ -1,11 +1,5 @@
-import { escapeRegExp } from 'lodash';
 import { isConnectionError } from '@metamask/network-controller';
 import { generateDeterministicRandomNumber } from '@metamask/remote-feature-flag-controller';
-import { BUILT_IN_CUSTOM_NETWORKS_RPC } from '@metamask/controller-utils';
-import {
-  FEATURED_RPCS,
-  QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME,
-} from '../../../../shared/constants/network';
 import { ENVIRONMENT } from '../../../../development/build/constants';
 
 /**
@@ -21,66 +15,6 @@ export const PRODUCTION_LIKE_ENVIRONMENTS = [
   ENVIRONMENT.PRODUCTION,
   ENVIRONMENT.RELEASE_CANDIDATE,
 ];
-
-/**
- * The list of unofficial endpoints that we allow users to add easily.
- */
-const FEATURED_RPC_ENDPOINTS = FEATURED_RPCS.flatMap((networkConfiguration) =>
-  networkConfiguration.rpcEndpoints.map((rpcEndpoint) => ({
-    name: rpcEndpoint.name ?? networkConfiguration.name,
-    url: rpcEndpoint.url,
-  })),
-);
-
-/**
- * The list of unofficial endpoints that can be added as default networks.
- */
-const BUILT_IN_CUSTOM_ENDPOINTS = Object.entries(
-  BUILT_IN_CUSTOM_NETWORKS_RPC,
-).map(([name, url]) => ({ name, url }));
-
-/**
- * The list of known unofficial endpoints.
- */
-export const KNOWN_CUSTOM_ENDPOINTS = [
-  ...FEATURED_RPC_ENDPOINTS,
-  ...BUILT_IN_CUSTOM_ENDPOINTS,
-];
-
-/**
- * The list of known unofficial endpoints.
- */
-const KNOWN_CUSTOM_ENDPOINT_URLS = KNOWN_CUSTOM_ENDPOINTS.map(({ url }) => url);
-
-/**
- * Determines whether the given RPC endpoint URL matches an Infura URL that uses
- * our API key.
- *
- * @param endpointUrl - The URL of the RPC endpoint.
- * @param infuraProjectId - Our Infura project ID.
- * @returns True if the URL is an Infura URL, false otherwise.
- */
-export function getIsMetaMaskInfuraEndpointUrl(
-  endpointUrl: string,
-  infuraProjectId: string,
-): boolean {
-  return new RegExp(
-    `^https://[^.]+\\.infura\\.io/v3/${escapeRegExp(infuraProjectId)}$`,
-    'u',
-  ).test(endpointUrl);
-}
-
-/**
- * Determines whether the given RPC endpoint URL matches a known Quicknode URL.
- *
- * @param endpointUrl - The URL of the RPC endpoint.
- * @returns True if the URL is a Quicknode URL, false otherwise.
- */
-export function getIsQuicknodeEndpointUrl(endpointUrl: string): boolean {
-  return Object.values(QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME)
-    .map((getUrl) => getUrl())
-    .includes(endpointUrl);
-}
 
 /**
  * Events should only be created in Segment when an RPC endpoint is detected to
@@ -131,33 +65,4 @@ function isSamplingMetaMetricsUser(metaMetricsId: string) {
   }
 
   return true;
-}
-
-/**
- * Some URLs that users add as networks refer to private servers, and we do not
- * want to report these in Segment (or any other data collection service). This
- * function returns whether the given RPC endpoint is safe to share.
- *
- * @param endpointUrl - The URL of the endpoint.
- * @param infuraProjectId - Our Infura project ID.
- * @returns True if the endpoint URL is safe to share with external data
- * collection services, false otherwise.
- */
-export function isPublicEndpointUrl(
-  endpointUrl: string,
-  infuraProjectId: string,
-) {
-  const isMetaMaskInfuraEndpointUrl = getIsMetaMaskInfuraEndpointUrl(
-    endpointUrl,
-    infuraProjectId,
-  );
-  const isQuicknodeEndpointUrl = getIsQuicknodeEndpointUrl(endpointUrl);
-  const isKnownCustomEndpointUrl =
-    KNOWN_CUSTOM_ENDPOINT_URLS.includes(endpointUrl);
-
-  return (
-    isMetaMaskInfuraEndpointUrl ||
-    isQuicknodeEndpointUrl ||
-    isKnownCustomEndpointUrl
-  );
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2956,6 +2956,11 @@ export default class MetamaskController extends EventEmitter {
         appStateController.setHasShownMultichainAccountsIntroModal.bind(
           appStateController,
         ),
+      updateNetworkConnectionBanner:
+        appStateController.updateNetworkConnectionBanner.bind(
+          appStateController,
+        ),
+
       // EnsController
       tryReverseResolveAddress:
         ensController.reverseResolveAddress.bind(ensController),

--- a/shared/constants/app-state.ts
+++ b/shared/constants/app-state.ts
@@ -45,9 +45,9 @@ export enum PasswordChangeToastType {
 }
 
 export type NetworkConnectionBanner =
-  | { status: 'unknown' }
+  | { status: 'unknown' | 'available' }
   | {
-      status: 'degraded' | 'unavailable' | 'available';
+      status: 'degraded' | 'unavailable';
       networkName: string;
       networkClientId: NetworkClientId;
       chainId: Hex;

--- a/shared/constants/app-state.ts
+++ b/shared/constants/app-state.ts
@@ -1,3 +1,5 @@
+import { NetworkClientId } from '@metamask/network-controller';
+import { Hex } from 'viem';
 import { TraceName } from '../lib/trace';
 import { MetaMetricsEventName } from './metametrics';
 
@@ -41,3 +43,12 @@ export enum PasswordChangeToastType {
   Success = 'success',
   Errored = 'errored',
 }
+
+export type NetworkConnectionBanner =
+  | { status: 'unknown' }
+  | {
+      status: 'degraded' | 'unavailable' | 'available';
+      networkName: string;
+      networkClientId: NetworkClientId;
+      chainId: Hex;
+    };

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -739,6 +739,8 @@ export enum MetaMetricsEventName {
   NavConnectedSitesOpened = 'Connected Sites Opened',
   NavMainMenuOpened = 'Main Menu Opened',
   NavPermissionsOpened = 'Permissions Opened',
+  NetworkConnectionBannerShown = 'Network Connection Banner Shown',
+  NetworkConnectionBannerUpdateRpcClicked = 'Network Connection Banner Update RPC Clicked',
   UpdatePermissionedNetworks = 'Update Permissioned Networks',
   UpdatePermissionedAccounts = 'Update Permissioned Accounts',
   ViewPermissionedNetworks = 'View Permissioned Networks',

--- a/shared/lib/network-utils.test.ts
+++ b/shared/lib/network-utils.test.ts
@@ -1,0 +1,204 @@
+import { BUILT_IN_CUSTOM_NETWORKS_RPC } from '@metamask/controller-utils';
+
+import {
+  FEATURED_RPCS,
+  QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME,
+} from '../constants/network';
+import {
+  getIsMetaMaskInfuraEndpointUrl,
+  getIsQuicknodeEndpointUrl,
+  isPublicEndpointUrl,
+} from './network-utils';
+
+jest.mock('../constants/network', () => ({
+  FEATURED_RPCS: [
+    {
+      chainId: '0x111',
+      name: 'Featured Network 1',
+      nativeCurrency: 'ETH',
+      rpcEndpoints: [
+        {
+          name: 'Featured RPC 1',
+          url: 'https://featured.example.com/1',
+          type: 'custom',
+        },
+        {
+          name: 'Featured RPC 2',
+          url: 'https://featured.example.com/2',
+          type: 'custom',
+        },
+      ],
+    },
+    {
+      chainId: '0x222',
+      name: 'Featured Network 2',
+      nativeCurrency: 'ETH',
+      rpcEndpoints: [
+        {
+          url: 'https://featured.example.com/3',
+          type: 'custom',
+        },
+      ],
+    },
+  ],
+  QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME: {
+    'ethereum-mainnet': () => 'https://mainnet.quiknode.pro/test',
+    'ethereum-sepolia': () => 'https://sepolia.quiknode.pro/test',
+  },
+}));
+
+jest.mock('@metamask/controller-utils', () => ({
+  BUILT_IN_CUSTOM_NETWORKS_RPC: {
+    'Custom Network': 'https://custom.example.com/1',
+    'Custom Network 2': 'https://custom.example.com/2',
+  },
+}));
+
+const MOCK_METAMASK_INFURA_PROJECT_ID = 'metamask-infura-project-id';
+
+describe('getIsMetaMaskInfuraEndpointUrl', () => {
+  it('returns true given an Infura v3 URL with the MetaMask API key at the end', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v3/the-infura-project-id',
+        'the-infura-project-id',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true given an Infura v3 URL with {infuraProjectId} at the end', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v3/{infuraProjectId}',
+        'the-infura-project-id',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false given an Infura URL with a different API key at the end', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v3/some-other-project-id',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false given an Infura URL but the version is not v3', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v2/the-infura-project-id',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false if the URL does not have infura.io as the host', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-other-domain.com/v3/the-infura-project-id',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false if the URL does not use HTTPS', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'http://some-subdomain.infura.io/v3/the-infura-project-id',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false given an Infura URL with a MetaMask API key at the end, but there is a query string', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v3/the-infura-project-id?foo=bar',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false given an Infura URL with a MetaMask API key at the end, but there is a fragment', () => {
+    expect(
+      getIsMetaMaskInfuraEndpointUrl(
+        'https://some-subdomain.infura.io/v3/the-infura-project-id#fragment',
+        'the-infura-project-id',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for an empty URL', () => {
+    expect(getIsMetaMaskInfuraEndpointUrl('', 'the-infura-project-id')).toBe(
+      false,
+    );
+  });
+});
+
+describe('getIsQuicknodeEndpointUrl', () => {
+  for (const getQuicknodeEndpointUrl of Object.values(
+    QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME,
+  )) {
+    const quicknodeEndpointUrl = getQuicknodeEndpointUrl();
+    it(`returns true for known Quicknode URL "${quicknodeEndpointUrl}"`, () => {
+      // We can assume this is set.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(getIsQuicknodeEndpointUrl(quicknodeEndpointUrl!)).toBe(true);
+    });
+  }
+
+  it('returns false for unknown URLs', () => {
+    expect(getIsQuicknodeEndpointUrl('https://unknown.example.com')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for an empty URL', () => {
+    expect(getIsQuicknodeEndpointUrl('')).toBe(false);
+  });
+});
+
+describe('isPublicEndpointUrl', () => {
+  it('returns true for Infura URLs', () => {
+    expect(
+      isPublicEndpointUrl(
+        `https://mainnet.infura.io/v3/${MOCK_METAMASK_INFURA_PROJECT_ID}`,
+        MOCK_METAMASK_INFURA_PROJECT_ID,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for Quicknode URLs', () => {
+    const quicknodeUrl =
+      QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME['ethereum-mainnet']();
+    expect(
+      // We can assume this is set.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      isPublicEndpointUrl(quicknodeUrl!, MOCK_METAMASK_INFURA_PROJECT_ID),
+    ).toBe(true);
+  });
+
+  it('returns true for featured RPC endpoints', () => {
+    const featuredUrl = FEATURED_RPCS[0].rpcEndpoints[0].url;
+    expect(
+      isPublicEndpointUrl(featuredUrl, MOCK_METAMASK_INFURA_PROJECT_ID),
+    ).toBe(true);
+  });
+
+  it('returns true for built-in custom endpoints', () => {
+    const builtInUrl = Object.values(BUILT_IN_CUSTOM_NETWORKS_RPC)[0];
+    expect(
+      isPublicEndpointUrl(builtInUrl, MOCK_METAMASK_INFURA_PROJECT_ID),
+    ).toBe(true);
+  });
+
+  it('returns false for unknown URLs', () => {
+    expect(
+      isPublicEndpointUrl(
+        'https://unknown.example.com',
+        MOCK_METAMASK_INFURA_PROJECT_ID,
+      ),
+    ).toBe(false);
+  });
+});

--- a/shared/lib/network-utils.ts
+++ b/shared/lib/network-utils.ts
@@ -1,4 +1,10 @@
-import { CHAIN_SPEC_URL } from '../constants/network';
+import { escapeRegExp } from 'lodash';
+import { BUILT_IN_CUSTOM_NETWORKS_RPC } from '@metamask/controller-utils';
+import {
+  CHAIN_SPEC_URL,
+  FEATURED_RPCS,
+  QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME,
+} from '../constants/network';
 import { getStorageItem } from './storage-helpers';
 
 const cacheKey = `cachedFetch:${CHAIN_SPEC_URL}`;
@@ -9,6 +15,31 @@ type ChainInfo = {
   chainId: number;
   rpc?: string[];
 };
+
+/**
+ * The list of unofficial endpoints that we allow users to add easily.
+ */
+const FEATURED_RPC_ENDPOINTS = FEATURED_RPCS.flatMap((networkConfiguration) =>
+  networkConfiguration.rpcEndpoints.map((rpcEndpoint) => ({
+    name: rpcEndpoint.name ?? networkConfiguration.name,
+    url: rpcEndpoint.url,
+  })),
+);
+
+/**
+ * The list of unofficial endpoints that can be added as default networks.
+ */
+const BUILT_IN_CUSTOM_ENDPOINTS = Object.entries(
+  BUILT_IN_CUSTOM_NETWORKS_RPC,
+).map(([name, url]) => ({ name, url }));
+
+/**
+ * The list of known unofficial endpoint URLs.
+ */
+const KNOWN_CUSTOM_ENDPOINT_URLS = [
+  ...FEATURED_RPC_ENDPOINTS,
+  ...BUILT_IN_CUSTOM_ENDPOINTS,
+].map(({ url }) => url);
 
 /**
  * Get chains list from cache only without making network requests. This
@@ -23,4 +54,63 @@ export async function getSafeChainsListFromCacheOnly(): Promise<ChainInfo[]> {
     console.error('Error retrieving chains list from cache', error);
     return [];
   }
+}
+
+/**
+ * Determines whether the given RPC endpoint URL matches an Infura URL that uses
+ * our API key.
+ *
+ * @param endpointUrl - The URL of the RPC endpoint.
+ * @param infuraProjectId - Our Infura project ID.
+ * @returns True if the URL is an Infura URL, false otherwise.
+ */
+export function getIsMetaMaskInfuraEndpointUrl(
+  endpointUrl: string,
+  infuraProjectId: string,
+): boolean {
+  return new RegExp(
+    `^https://[^.]+\\.infura\\.io/v3/(?:\\{infuraProjectId\\}|${escapeRegExp(infuraProjectId)})$`,
+    'u',
+  ).test(endpointUrl);
+}
+
+/**
+ * Determines whether the given RPC endpoint URL matches a known Quicknode URL.
+ *
+ * @param endpointUrl - The URL of the RPC endpoint.
+ * @returns True if the URL is a Quicknode URL, false otherwise.
+ */
+export function getIsQuicknodeEndpointUrl(endpointUrl: string): boolean {
+  return Object.values(QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME)
+    .map((getUrl) => getUrl())
+    .includes(endpointUrl);
+}
+
+/**
+ * Some URLs that users add as networks refer to private servers, and we do not
+ * want to report these in Segment (or any other data collection service). This
+ * function returns whether the given RPC endpoint is safe to share.
+ *
+ * @param endpointUrl - The URL of the endpoint.
+ * @param infuraProjectId - Our Infura project ID.
+ * @returns True if the endpoint URL is safe to share with external data
+ * collection services, false otherwise.
+ */
+export function isPublicEndpointUrl(
+  endpointUrl: string,
+  infuraProjectId: string,
+) {
+  const isMetaMaskInfuraEndpointUrl = getIsMetaMaskInfuraEndpointUrl(
+    endpointUrl,
+    infuraProjectId,
+  );
+  const isQuicknodeEndpointUrl = getIsQuicknodeEndpointUrl(endpointUrl);
+  const isKnownCustomEndpointUrl =
+    KNOWN_CUSTOM_ENDPOINT_URLS.includes(endpointUrl);
+
+  return (
+    isMetaMaskInfuraEndpointUrl ||
+    isQuicknodeEndpointUrl ||
+    isKnownCustomEndpointUrl
+  );
 }

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -140,6 +140,7 @@ export type ControllerStatePropertiesEnumerated = {
   enableEnforcedSimulationsForTransactions: AppStateControllerState['enableEnforcedSimulationsForTransactions'];
   enforcedSimulationsSlippage: AppStateControllerState['enforcedSimulationsSlippage'];
   enforcedSimulationsSlippageForTransactions: AppStateControllerState['enforcedSimulationsSlippageForTransactions'];
+  networkConnectionBanner: AppStateControllerState['networkConnectionBanner'];
   quoteRequest: BridgeControllerState['quoteRequest'];
   quotes: BridgeControllerState['quotes'];
   quotesInitialLoadTime: BridgeControllerState['quotesInitialLoadTime'];

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -2343,7 +2343,10 @@
     "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
     "isGatorPermissionsEnabled": false,
     "isFetchingGatorPermissions": false,
-    "isUpdatingGatorPermissions": false
+    "isUpdatingGatorPermissions": false,
+    "networkConnectionBanner": {
+      "status": "unknown"
+    }
   },
   "ramps": {
     "buyableChains": [

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -47,6 +47,7 @@
     "trezorModel": null,
     "onboardingDate": null,
     "lastViewedUserSurvey": null,
+    "networkConnectionBanner": "object",
     "isRampCardClosed": false,
     "newPrivacyPolicyToastClickedOrClosed": "boolean",
     "newPrivacyPolicyToastShownDate": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -188,6 +188,7 @@
       }
     },
     "networkConfigurationsByChainId": "object",
+    "networkConnectionBanner": "object",
     "keyrings": "object",
     "selectedAddress": "string",
     "usePhishDetect": true,

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -739,6 +739,9 @@
       "nativeCurrency": "SepoliaETH"
     }
   },
+  "networkConnectionBanner": {
+    "status": "unknown"
+  },
   "networksMetadata": {
     "goerli-network-id": {
       "EIPS": {

--- a/ui/components/app/network-connection-banner/index.ts
+++ b/ui/components/app/network-connection-banner/index.ts
@@ -1,0 +1,1 @@
+export { NetworkConnectionBanner } from './network-connection-banner';

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -107,7 +107,7 @@ describe('NetworkConnectionBanner', () => {
           bannerType: 'degraded',
           eventName:
             MetaMetricsEventName.NetworkConnectionBannerUpdateRpcClicked,
-          networkClientId: '0x1',
+          networkClientId: 'mainnet',
         });
       });
     });
@@ -180,7 +180,7 @@ describe('NetworkConnectionBanner', () => {
           bannerType: 'unavailable',
           eventName:
             MetaMetricsEventName.NetworkConnectionBannerUpdateRpcClicked,
-          networkClientId: '0x1',
+          networkClientId: 'mainnet',
         });
       });
     });

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -205,9 +205,6 @@ describe('NetworkConnectionBanner', () => {
     it('does not render the banner', () => {
       mockUseNetworkConnectionBanner.mockReturnValue({
         status: 'available',
-        networkName: 'Ethereum Mainnet',
-        networkClientId: 'mainnet',
-        chainId: '0x1',
         trackNetworkBannerEvent: jest.fn(),
       });
       const store = configureStore({});

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -129,7 +129,7 @@ describe('NetworkConnectionBanner', () => {
       );
 
       expect(
-        getByText('Unable to connect to Ethereum Mainnet'),
+        getByText('Unable to connect to Ethereum Mainnet.'),
       ).toBeInTheDocument();
       expect(getByText('Update RPC')).toBeInTheDocument();
     });

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -51,12 +51,11 @@ describe('NetworkConnectionBanner', () => {
       });
       const store = configureStore({});
 
-      const { getByText, getByTestId } = renderWithProvider(
+      const { getByText } = renderWithProvider(
         <NetworkConnectionBanner />,
         store,
       );
 
-      expect(getByTestId('spinner')).toBeInTheDocument();
       expect(
         getByText('Still connecting to Ethereum Mainnet...'),
       ).toBeInTheDocument();
@@ -124,12 +123,11 @@ describe('NetworkConnectionBanner', () => {
       });
       const store = configureStore({});
 
-      const { getByText, getByTestId } = renderWithProvider(
+      const { getByText } = renderWithProvider(
         <NetworkConnectionBanner />,
         store,
       );
 
-      expect(getByTestId('icon')).toBeInTheDocument();
       expect(
         getByText('Unable to connect to Ethereum Mainnet'),
       ).toBeInTheDocument();

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+
+import { useNetworkConnectionBanner } from '../../../hooks/useNetworkConnectionBanner';
+import { setEditedNetwork } from '../../../store/actions';
+import configureStore from '../../../store/store';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import { NetworkConnectionBanner } from './network-connection-banner';
+
+jest.mock('../../../store/actions', () => ({
+  updateNetworkConnectionBanner: jest.fn(() => ({
+    type: 'UPDATE_NETWORK_CONNECTION_BANNER',
+  })),
+  setEditedNetwork: jest.fn(() => ({
+    type: 'SET_EDITED_NETWORK',
+  })),
+}));
+
+jest.mock('../../../hooks/useNetworkConnectionBanner', () => ({
+  useNetworkConnectionBanner: jest.fn(),
+}));
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => 'light',
+}));
+
+const mockUseNetworkConnectionBanner = jest.mocked(useNetworkConnectionBanner);
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockSetEditedNetwork = jest.mocked(setEditedNetwork);
+
+describe('NetworkConnectionBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(jest.fn());
+  });
+
+  describe('when the status of the banner is "degraded"', () => {
+    it('renders the banner with a "Still connecting" message', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'degraded',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { getByText, getByTestId } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(getByTestId('spinner')).toBeInTheDocument();
+      expect(
+        getByText('Still connecting to Ethereum Mainnet...'),
+      ).toBeInTheDocument();
+      expect(getByText('Update RPC')).toBeInTheDocument();
+    });
+
+    describe('when the "Update RPC" link is clicked', () => {
+      it('navigates to the edit form for the degraded network', () => {
+        mockUseNetworkConnectionBanner.mockReturnValue({
+          status: 'degraded',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+          trackNetworkBannerEvent: jest.fn(),
+        });
+        const store = configureStore({});
+        const navigateMock = jest.fn();
+        mockUseNavigate.mockReturnValue(navigateMock);
+
+        const { getByText } = renderWithProvider(
+          <NetworkConnectionBanner />,
+          store,
+        );
+        fireEvent.click(getByText('Update RPC'));
+
+        expect(mockSetEditedNetwork).toHaveBeenCalledWith({ chainId: '0x1' });
+        expect(navigateMock).toHaveBeenCalledWith('/settings/networks');
+      });
+
+      it('creates a metrics event', () => {
+        const trackNetworkBannerEventMock = jest.fn();
+        mockUseNetworkConnectionBanner.mockReturnValue({
+          status: 'degraded',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+          trackNetworkBannerEvent: trackNetworkBannerEventMock,
+        });
+        const store = configureStore({});
+
+        const { getByText } = renderWithProvider(
+          <NetworkConnectionBanner />,
+          store,
+        );
+        fireEvent.click(getByText('Update RPC'));
+
+        expect(trackNetworkBannerEventMock).toHaveBeenCalledWith({
+          bannerType: 'degraded',
+          eventName:
+            MetaMetricsEventName.NetworkConnectionBannerUpdateRpcClicked,
+          networkClientId: '0x1',
+        });
+      });
+    });
+  });
+
+  describe('when the status of the banner is "unavailable"', () => {
+    it('renders the banner with a "Unable to connect" message', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'unavailable',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { getByText, getByTestId } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(getByTestId('icon')).toBeInTheDocument();
+      expect(
+        getByText('Unable to connect to Ethereum Mainnet'),
+      ).toBeInTheDocument();
+      expect(getByText('Update RPC')).toBeInTheDocument();
+    });
+
+    describe('when the "Update RPC" link is clicked', () => {
+      it('navigates to the edit form for the unavailable network', () => {
+        mockUseNetworkConnectionBanner.mockReturnValue({
+          status: 'unavailable',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+          trackNetworkBannerEvent: jest.fn(),
+        });
+        const store = configureStore({});
+        const navigateMock = jest.fn();
+        mockUseNavigate.mockReturnValue(navigateMock);
+
+        const { getByText } = renderWithProvider(
+          <NetworkConnectionBanner />,
+          store,
+        );
+        fireEvent.click(getByText('Update RPC'));
+
+        expect(mockSetEditedNetwork).toHaveBeenCalledWith({ chainId: '0x1' });
+        expect(navigateMock).toHaveBeenCalledWith('/settings/networks');
+      });
+
+      it('creates a metrics event', () => {
+        const trackNetworkBannerEventMock = jest.fn();
+        mockUseNetworkConnectionBanner.mockReturnValue({
+          status: 'unavailable',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+          trackNetworkBannerEvent: trackNetworkBannerEventMock,
+        });
+        const store = configureStore({});
+
+        const { getByText } = renderWithProvider(
+          <NetworkConnectionBanner />,
+          store,
+        );
+        fireEvent.click(getByText('Update RPC'));
+
+        expect(trackNetworkBannerEventMock).toHaveBeenCalledWith({
+          bannerType: 'unavailable',
+          eventName:
+            MetaMetricsEventName.NetworkConnectionBannerUpdateRpcClicked,
+          networkClientId: '0x1',
+        });
+      });
+    });
+  });
+
+  describe('when the status of the banner is "unknown"', () => {
+    it('does not render the banner', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'unknown',
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { container } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(container.firstChild).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the status of the banner is "available"', () => {
+    it('does not render the banner', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'available',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { container } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(container.firstChild).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -1,7 +1,6 @@
 import React, { SVGProps, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useDispatch } from 'react-redux';
-import { lightTheme, darkTheme } from '@metamask/design-tokens';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   BannerBase,
@@ -16,67 +15,23 @@ import {
   IconColor,
 } from '../../../helpers/constants/design-system';
 import { useNetworkConnectionBanner } from '../../../hooks/useNetworkConnectionBanner';
-import { useTheme } from '../../../hooks/useTheme';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
 import { setEditedNetwork } from '../../../store/actions';
 import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
-import { ThemeType } from '../../../../shared/constants/preferences';
 import { NetworkConnectionBanner as NetworkConnectionBannerType } from '../../../../shared/constants/app-state';
 
-type BannerIcon =
-  | {
-      type: 'spinner';
-      color: string;
-      verticalAdjustment: string;
-    }
-  | {
-      type: 'static';
-      color: IconColor;
-      name: IconName;
-      verticalAdjustment: string;
-    };
-
-const Spinner = ({
-  color,
-  size,
-  ...rest
-}: {
-  color: string;
-  size: number;
-} & SVGProps<SVGSVGElement>) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...rest}
-  >
-    {/* Draw an arc that covers 60% of the circle */}
-    <path
-      d="M 12 2 A 10 10 0 1 1 2 12"
-      stroke={color}
-      strokeWidth="2"
-      strokeLinecap="round"
-      fill="none"
-    >
-      <animateTransform
-        attributeName="transform"
-        type="rotate"
-        values="0 12 12;360 12 12"
-        dur="1.5s"
-        repeatCount="indefinite"
-      />
-    </path>
-  </svg>
-);
+type BannerIcon = {
+  color: IconColor;
+  name: IconName;
+  verticalAdjustment: string;
+  className?: string;
+};
 
 const getBannerContent = (
   networkConnectionBanner: Exclude<
     NetworkConnectionBannerType,
     { status: 'unknown' }
   >,
-  theme: ThemeType,
   t: ReturnType<typeof useI18nContext>,
 ): {
   message: string;
@@ -87,17 +42,14 @@ const getBannerContent = (
   const verticalAdjustment = '0.2rem';
 
   if (networkConnectionBanner.status === 'degraded') {
-    const warningColor =
-      theme === 'light'
-        ? lightTheme.colors.warning.default
-        : darkTheme.colors.warning.default;
     return {
       message: t('stillConnectingTo', [networkConnectionBanner.networkName]),
       backgroundColor: BackgroundColor.warningMuted,
       icon: {
-        type: 'spinner',
-        color: warningColor,
+        color: IconColor.warningDefault,
+        name: IconName.Loading,
         verticalAdjustment,
+        className: 'animate-spin',
       },
     };
   }
@@ -106,7 +58,6 @@ const getBannerContent = (
     message: t('unableToConnectTo', [networkConnectionBanner.networkName]),
     backgroundColor: BackgroundColor.errorMuted,
     icon: {
-      type: 'static',
       color: IconColor.errorDefault,
       name: IconName.Danger,
       verticalAdjustment,
@@ -116,7 +67,6 @@ const getBannerContent = (
 
 export const NetworkConnectionBanner = () => {
   const t = useI18nContext();
-  const theme = useTheme();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const networkConnectionBanner = useNetworkConnectionBanner();
@@ -146,7 +96,6 @@ export const NetworkConnectionBanner = () => {
 
   const { message, backgroundColor, icon } = getBannerContent(
     networkConnectionBanner,
-    theme,
     t,
   );
 
@@ -156,22 +105,14 @@ export const NetworkConnectionBanner = () => {
         className="network-connection-banner"
         backgroundColor={backgroundColor}
         startAccessory={
-          icon.type === 'spinner' ? (
-            <Spinner
-              color={icon.color}
-              size={16}
-              style={{ marginTop: icon.verticalAdjustment }}
-              data-testid="spinner"
-            />
-          ) : (
-            <Icon
-              name={icon.name}
-              size={IconSize.Sm}
-              color={icon.color}
-              style={{ marginTop: icon.verticalAdjustment }}
-              data-testid="icon"
-            />
-          )
+          <Icon
+            name={icon.name}
+            size={IconSize.Sm}
+            color={icon.color}
+            className={icon.className}
+            style={{ marginTop: icon.verticalAdjustment }}
+            data-testid="icon"
+          />
         }
         actionButtonLabel={t('updateRpc')}
         actionButtonOnClick={updateRpc}

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -12,7 +12,9 @@ import {
 import {
   BackgroundColor,
   BlockSize,
+  BorderRadius,
   IconColor,
+  TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useNetworkConnectionBanner } from '../../../hooks/useNetworkConnectionBanner';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
@@ -39,7 +41,7 @@ const getBannerContent = (
   icon: BannerIcon;
 } => {
   // Align the indicator with the text
-  const verticalAdjustment = '0.2rem';
+  const verticalAdjustment = '0.25em';
 
   if (networkConnectionBanner.status === 'degraded') {
     return {
@@ -118,6 +120,15 @@ export const NetworkConnectionBanner = () => {
           }
           actionButtonLabel={t('updateRpc')}
           actionButtonOnClick={updateRpc}
+          borderRadius={BorderRadius.SM}
+          childrenWrapperProps={{
+            variant: TextVariant.inherit,
+            style: {
+              display: 'inline-block',
+              verticalAlign: 'middle',
+              paddingRight: '8px',
+            },
+          }}
         >
           {message}
         </BannerBase>

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -1,4 +1,4 @@
-import React, { SVGProps, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useDispatch } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -30,7 +30,7 @@ type BannerIcon = {
 const getBannerContent = (
   networkConnectionBanner: Exclude<
     NetworkConnectionBannerType,
-    { status: 'unknown' }
+    { status: 'unknown' | 'available' }
   >,
   t: ReturnType<typeof useI18nContext>,
 ): {
@@ -88,39 +88,44 @@ export const NetworkConnectionBanner = () => {
   }, [networkConnectionBanner, dispatch, navigate]);
 
   if (
-    networkConnectionBanner.status === 'unknown' ||
-    networkConnectionBanner.status === 'available'
+    networkConnectionBanner.status === 'degraded' ||
+    networkConnectionBanner.status === 'unavailable'
   ) {
-    return null;
+    const { message, backgroundColor, icon } = getBannerContent(
+      networkConnectionBanner,
+      t,
+    );
+
+    return (
+      <Box
+        width={BlockSize.Full}
+        paddingLeft={4}
+        paddingRight={4}
+        paddingTop={4}
+      >
+        <BannerBase
+          className="network-connection-banner"
+          backgroundColor={backgroundColor}
+          startAccessory={
+            <Icon
+              name={icon.name}
+              size={IconSize.Sm}
+              color={icon.color}
+              className={icon.className}
+              style={{ marginTop: icon.verticalAdjustment }}
+              data-testid="icon"
+            />
+          }
+          actionButtonLabel={t('updateRpc')}
+          actionButtonOnClick={updateRpc}
+        >
+          {message}
+        </BannerBase>
+      </Box>
+    );
   }
 
-  const { message, backgroundColor, icon } = getBannerContent(
-    networkConnectionBanner,
-    t,
-  );
-
-  return (
-    <Box width={BlockSize.Full} paddingLeft={4} paddingRight={4} paddingTop={4}>
-      <BannerBase
-        className="network-connection-banner"
-        backgroundColor={backgroundColor}
-        startAccessory={
-          <Icon
-            name={icon.name}
-            size={IconSize.Sm}
-            color={icon.color}
-            className={icon.className}
-            style={{ marginTop: icon.verticalAdjustment }}
-            data-testid="icon"
-          />
-        }
-        actionButtonLabel={t('updateRpc')}
-        actionButtonOnClick={updateRpc}
-      >
-        {message}
-      </BannerBase>
-    </Box>
-  );
+  return null;
 };
 
 export default NetworkConnectionBanner;

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -46,9 +46,9 @@ const getBannerContent = (
   if (networkConnectionBanner.status === 'degraded') {
     return {
       message: t('stillConnectingTo', [networkConnectionBanner.networkName]),
-      backgroundColor: BackgroundColor.warningMuted,
+      backgroundColor: BackgroundColor.backgroundSection,
       icon: {
-        color: IconColor.warningDefault,
+        color: IconColor.iconDefault,
         name: IconName.Loading,
         verticalAdjustment,
         className: 'animate-spin',
@@ -120,14 +120,17 @@ export const NetworkConnectionBanner = () => {
           }
           actionButtonLabel={t('updateRpc')}
           actionButtonOnClick={updateRpc}
-          borderRadius={BorderRadius.SM}
+          borderRadius={BorderRadius.MD}
           childrenWrapperProps={{
-            variant: TextVariant.inherit,
+            variant: TextVariant.bodyXsMedium,
             style: {
               display: 'inline-block',
               verticalAlign: 'middle',
               paddingRight: '8px',
             },
+          }}
+          actionButtonProps={{
+            variant: TextVariant.bodyXsMedium,
           }}
         >
           {message}

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -1,0 +1,185 @@
+import React, { SVGProps, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { useDispatch } from 'react-redux';
+import { lightTheme, darkTheme } from '@metamask/design-tokens';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  BannerBase,
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+} from '../../component-library';
+import {
+  BackgroundColor,
+  BlockSize,
+  IconColor,
+} from '../../../helpers/constants/design-system';
+import { useNetworkConnectionBanner } from '../../../hooks/useNetworkConnectionBanner';
+import { useTheme } from '../../../hooks/useTheme';
+import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
+import { setEditedNetwork } from '../../../store/actions';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import { ThemeType } from '../../../../shared/constants/preferences';
+import { NetworkConnectionBanner as NetworkConnectionBannerType } from '../../../../shared/constants/app-state';
+
+type BannerIcon =
+  | {
+      type: 'spinner';
+      color: string;
+      verticalAdjustment: string;
+    }
+  | {
+      type: 'static';
+      color: IconColor;
+      name: IconName;
+      verticalAdjustment: string;
+    };
+
+const Spinner = ({
+  color,
+  size,
+  ...rest
+}: {
+  color: string;
+  size: number;
+} & SVGProps<SVGSVGElement>) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...rest}
+  >
+    {/* Draw an arc that covers 60% of the circle */}
+    <path
+      d="M 12 2 A 10 10 0 1 1 2 12"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      fill="none"
+    >
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        values="0 12 12;360 12 12"
+        dur="1.5s"
+        repeatCount="indefinite"
+      />
+    </path>
+  </svg>
+);
+
+const getBannerContent = (
+  networkConnectionBanner: Exclude<
+    NetworkConnectionBannerType,
+    { status: 'unknown' }
+  >,
+  theme: ThemeType,
+  t: ReturnType<typeof useI18nContext>,
+): {
+  message: string;
+  backgroundColor: BackgroundColor;
+  icon: BannerIcon;
+} => {
+  // Align the indicator with the text
+  const verticalAdjustment = '0.2rem';
+
+  if (networkConnectionBanner.status === 'degraded') {
+    const warningColor =
+      theme === 'light'
+        ? lightTheme.colors.warning.default
+        : darkTheme.colors.warning.default;
+    return {
+      message: t('stillConnectingTo', [networkConnectionBanner.networkName]),
+      backgroundColor: BackgroundColor.warningMuted,
+      icon: {
+        type: 'spinner',
+        color: warningColor,
+        verticalAdjustment,
+      },
+    };
+  }
+
+  return {
+    message: t('unableToConnectTo', [networkConnectionBanner.networkName]),
+    backgroundColor: BackgroundColor.errorMuted,
+    icon: {
+      type: 'static',
+      color: IconColor.errorDefault,
+      name: IconName.Danger,
+      verticalAdjustment,
+    },
+  };
+};
+
+export const NetworkConnectionBanner = () => {
+  const t = useI18nContext();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const networkConnectionBanner = useNetworkConnectionBanner();
+
+  const updateRpc = useCallback(() => {
+    if (
+      networkConnectionBanner.status === 'degraded' ||
+      networkConnectionBanner.status === 'unavailable'
+    ) {
+      networkConnectionBanner.trackNetworkBannerEvent({
+        bannerType: networkConnectionBanner.status,
+        eventName: MetaMetricsEventName.NetworkConnectionBannerUpdateRpcClicked,
+        networkClientId: networkConnectionBanner.networkClientId,
+      });
+
+      dispatch(setEditedNetwork({ chainId: networkConnectionBanner.chainId }));
+      navigate(NETWORKS_ROUTE);
+    }
+  }, [networkConnectionBanner, dispatch, navigate]);
+
+  if (
+    networkConnectionBanner.status === 'unknown' ||
+    networkConnectionBanner.status === 'available'
+  ) {
+    return null;
+  }
+
+  const { message, backgroundColor, icon } = getBannerContent(
+    networkConnectionBanner,
+    theme,
+    t,
+  );
+
+  return (
+    <Box width={BlockSize.Full} paddingLeft={4} paddingRight={4} paddingTop={4}>
+      <BannerBase
+        className="network-connection-banner"
+        backgroundColor={backgroundColor}
+        startAccessory={
+          icon.type === 'spinner' ? (
+            <Spinner
+              color={icon.color}
+              size={16}
+              style={{ marginTop: icon.verticalAdjustment }}
+              data-testid="spinner"
+            />
+          ) : (
+            <Icon
+              name={icon.name}
+              size={IconSize.Sm}
+              color={icon.color}
+              style={{ marginTop: icon.verticalAdjustment }}
+              data-testid="icon"
+            />
+          )
+        }
+        actionButtonLabel={t('updateRpc')}
+        actionButtonOnClick={updateRpc}
+      >
+        {message}
+      </BannerBase>
+    </Box>
+  );
+};
+
+export default NetworkConnectionBanner;

--- a/ui/components/multichain/account-overview/account-overview-eth.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-eth.test.tsx
@@ -9,14 +9,17 @@ import {
   AccountOverviewEthProps,
 } from './account-overview-eth';
 
-jest.mock('../../../store/actions', () => ({
-  tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),
-  tokenBalancesStopPollingByPollingToken: jest.fn(),
-  setTokenNetworkFilter: jest.fn(),
-  updateSlides: jest.fn(),
-  removeSlide: jest.fn(),
-  addImportedTokens: jest.fn(),
-}));
+jest.mock('../../../store/actions', () => {
+  return {
+    ...jest.requireActual('../../../store/actions'),
+    tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),
+    tokenBalancesStopPollingByPollingToken: jest.fn(),
+    setTokenNetworkFilter: jest.fn(),
+    updateSlides: jest.fn(),
+    removeSlide: jest.fn(),
+    addImportedTokens: jest.fn(),
+  };
+});
 
 // Mock the dispatch function
 const mockDispatch = jest.fn();

--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -18,6 +18,7 @@ import { useCarouselManagement } from '../../../hooks/useCarouselManagement';
 import { CreateSolanaAccountModal } from '../create-solana-account-modal';
 import { getLastSelectedSolanaAccount } from '../../../selectors/multichain';
 import DownloadMobileAppModal from '../../app/download-mobile-modal/download-mobile-modal';
+import { NetworkConnectionBanner } from '../../app/network-connection-banner';
 import {
   AccountOverviewTabsProps,
   AccountOverviewTabs,
@@ -116,7 +117,10 @@ export const AccountOverviewLayout = ({
 
   return (
     <>
-      <div className="account-overview__balance-wrapper">{children}</div>
+      <div className="account-overview__balance-wrapper">
+        <NetworkConnectionBanner />
+        {children}
+      </div>
       {isCarouselEnabled && (
         <CarouselWithEmptyState
           slides={slides}

--- a/ui/components/multichain/account-overview/account-overview-non-evm.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-non-evm.test.tsx
@@ -9,14 +9,17 @@ import {
   AccountOverviewNonEvmProps,
 } from './account-overview-non-evm';
 
-jest.mock('../../../store/actions', () => ({
-  tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),
-  tokenBalancesStopPollingByPollingToken: jest.fn(),
-  setTokenNetworkFilter: jest.fn(),
-  updateSlides: jest.fn(),
-  removeSlide: jest.fn(),
-  addImportedTokens: jest.fn(),
-}));
+jest.mock('../../../store/actions', () => {
+  return {
+    ...jest.requireActual('../../../store/actions'),
+    tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),
+    tokenBalancesStopPollingByPollingToken: jest.fn(),
+    setTokenNetworkFilter: jest.fn(),
+    updateSlides: jest.fn(),
+    removeSlide: jest.fn(),
+    addImportedTokens: jest.fn(),
+  };
+});
 
 // Mock the dispatch function
 const mockDispatch = jest.fn();

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -103,9 +103,6 @@ describe('useNetworkConnectionBanner', () => {
       mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'available',
-        networkName: 'Ethereum Mainnet',
-        networkClientId: 'mainnet',
-        chainId: '0x1',
       });
 
       renderHookWithProviderTyped(
@@ -205,9 +202,6 @@ describe('useNetworkConnectionBanner', () => {
         });
         mockGetNetworkConnectionBanner.mockReturnValue({
           status: 'available',
-          networkName: '',
-          networkClientId: '',
-          chainId: '0x0' as const,
         });
 
         renderHookWithProviderTyped(

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -318,50 +318,8 @@ describe('useNetworkConnectionBanner', () => {
     });
   });
 
-  describe('when the first unavailable network changes from one non-null value to another', () => {
-    describe('if the status of the banner is "unavailable"', () => {
-      it('updates the status of the banner to "degraded" after 5 seconds', () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
-          networkName: 'Ethereum Mainnet',
-          networkClientId: 'mainnet',
-          chainId: '0x1',
-        });
-        mockGetNetworkConnectionBanner.mockReturnValue({
-          status: 'unavailable',
-          networkName: 'Ethereum Mainnet',
-          networkClientId: 'mainnet',
-          chainId: '0x1',
-        });
-
-        const { rerender } = renderHookWithProviderTyped(
-          () => useNetworkConnectionBanner(),
-          mockState,
-        );
-        act(() => {
-          jest.runOnlyPendingTimers();
-        });
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
-          networkName: 'Sepolia Mainnet',
-          networkClientId: 'sepolia',
-          chainId: '0xaa36a7',
-        });
-        rerender();
-        act(() => {
-          jest.advanceTimersByTime(5000);
-        });
-
-        expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
-          status: 'degraded',
-          networkName: 'Sepolia Mainnet',
-          networkClientId: 'sepolia',
-          chainId: '0xaa36a7',
-        });
-      });
-    });
-  });
-
   describe('on unmount', () => {
-    it('clears both degraded and unavailable timers', () => {
+    it('clears any timers to show the degraded and unavailable banners', () => {
       mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -1,0 +1,349 @@
+import { act } from '@testing-library/react';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { renderHookWithProviderTyped } from '../../test/lib/render-helpers';
+import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { getNetworkConnectionBanner } from '../selectors/selectors';
+import { updateNetworkConnectionBanner } from '../store/actions';
+import mockState from '../../test/data/mock-state.json';
+import { MetaMetricsEventName } from '../../shared/constants/metametrics';
+import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
+import { useNetworkConnectionBanner } from './useNetworkConnectionBanner';
+
+jest.mock('../../shared/constants/network', () => {
+  return {
+    ...jest.requireActual('../../shared/constants/network'),
+    infuraProjectId: 'mock-infura-project-id',
+  };
+});
+
+jest.mock('../selectors/multichain/networks', () => {
+  return {
+    ...jest.requireActual('../selectors/multichain/networks'),
+    selectFirstUnavailableEvmNetwork: jest.fn(),
+  };
+});
+
+jest.mock('../selectors/selectors', () => {
+  return {
+    ...jest.requireActual('../selectors/selectors'),
+    getNetworkConnectionBanner: jest.fn(),
+  };
+});
+
+jest.mock('../store/actions', () => {
+  return {
+    ...jest.requireActual('../store/actions'),
+    updateNetworkConnectionBanner: jest.fn(() => ({
+      type: 'UPDATE_NETWORK_CONNECTION_BANNER',
+    })),
+  };
+});
+
+jest.mock('../../shared/modules/selectors/networks', () => {
+  return {
+    ...jest.requireActual('../../shared/modules/selectors/networks'),
+    getNetworkConfigurationsByChainId: jest.fn(),
+  };
+});
+
+const mockSelectFirstUnavailableEvmNetwork = jest.mocked(
+  selectFirstUnavailableEvmNetwork,
+);
+const mockGetNetworkConnectionBanner = jest.mocked(getNetworkConnectionBanner);
+const mockUpdateNetworkConnectionBanner = jest.mocked(
+  updateNetworkConnectionBanner,
+);
+const mockGetNetworkConfigurationsByChainId = jest.mocked(
+  getNetworkConfigurationsByChainId,
+);
+
+describe('useNetworkConnectionBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockGetNetworkConfigurationsByChainId.mockReturnValue({
+      '0x1': {
+        name: 'Ethereum Mainnet',
+        chainId: '0x1',
+        nativeCurrency: 'ETH',
+        rpcEndpoints: [
+          {
+            networkClientId: 'mainnet',
+            url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+            type: RpcEndpointType.Infura,
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+        blockExplorerUrls: ['https://etherscan.io'],
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('when all networks are available', () => {
+    it("updates the status of the banner to 'available' if not already updated", () => {
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+
+      renderHookWithProviderTyped(
+        () => useNetworkConnectionBanner(),
+        mockState,
+      );
+
+      expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+        status: 'available',
+      });
+    });
+
+    it("does not update the status of the banner to 'available' if already updated", () => {
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockGetNetworkConnectionBanner.mockReturnValue({
+        status: 'available',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+      });
+
+      renderHookWithProviderTyped(
+        () => useNetworkConnectionBanner(),
+        mockState,
+      );
+
+      expect(mockUpdateNetworkConnectionBanner).not.toHaveBeenCalled();
+    });
+
+    it('does not create a MetaMetrics event', () => {
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+      const mockTrackEvent = jest.fn();
+
+      renderHookWithProviderTyped(
+        () => useNetworkConnectionBanner(),
+        mockState,
+        undefined,
+        undefined,
+        () => mockTrackEvent,
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when at least one network is not available yet', () => {
+    describe('if the status of the banner is "unknown"', () => {
+      describe('if at least one network is still not available after 5 seconds', () => {
+        it('updates the status of the banner to "degraded"', () => {
+          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+            networkName: 'Ethereum Mainnet',
+            networkClientId: 'mainnet',
+            chainId: '0x1',
+          });
+          mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+
+          renderHookWithProviderTyped(
+            () => useNetworkConnectionBanner(),
+            mockState,
+          );
+          act(() => {
+            jest.advanceTimersByTime(5000);
+          });
+
+          expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+            status: 'degraded',
+            networkName: 'Ethereum Mainnet',
+            networkClientId: 'mainnet',
+            chainId: '0x1',
+          });
+        });
+
+        it('creates a MetaMetrics event to capture that the status changed', () => {
+          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+            networkName: 'Ethereum Mainnet',
+            networkClientId: 'mainnet',
+            chainId: '0x1',
+          });
+          mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+          const mockTrackEvent = jest.fn();
+
+          renderHookWithProviderTyped(
+            () => useNetworkConnectionBanner(),
+            mockState,
+            undefined,
+            undefined,
+            () => mockTrackEvent,
+          );
+          act(() => {
+            jest.advanceTimersByTime(5000);
+          });
+
+          expect(mockTrackEvent).toHaveBeenCalledWith({
+            category: 'Network',
+            event: MetaMetricsEventName.NetworkConnectionBannerShown,
+            properties: {
+              // The names of Segment properties have a particular case.
+              /* eslint-disable @typescript-eslint/naming-convention */
+              banner_type: 'degraded',
+              chain_id_caip: 'eip155:1',
+              rpc_endpoint_url: 'mainnet.infura.io',
+              /* eslint-enable @typescript-eslint/naming-convention */
+            },
+          });
+        });
+      });
+    });
+
+    describe('if the status of the banner is "available"', () => {
+      it('updates the status of the banner to "degraded" after 5 seconds', () => {
+        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+        mockGetNetworkConnectionBanner.mockReturnValue({
+          status: 'available',
+          networkName: '',
+          networkClientId: '',
+          chainId: '0x0' as const,
+        });
+
+        renderHookWithProviderTyped(
+          () => useNetworkConnectionBanner(),
+          mockState,
+        );
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+
+        expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+          status: 'degraded',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+      });
+    });
+
+    describe('if the status of the banner is "degraded"', () => {
+      it('updates the status of the banner to "unavailable" after 25 seconds', () => {
+        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+        mockGetNetworkConnectionBanner.mockReturnValue({
+          status: 'degraded',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+
+        renderHookWithProviderTyped(
+          () => useNetworkConnectionBanner(),
+          mockState,
+        );
+        act(() => {
+          jest.advanceTimersByTime(25000);
+        });
+
+        expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+          status: 'unavailable',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+      });
+
+      it('creates a MetaMetrics event to capture that the status changed', () => {
+        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+        mockGetNetworkConnectionBanner.mockReturnValue({
+          status: 'degraded',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+        const mockTrackEvent = jest.fn();
+
+        renderHookWithProviderTyped(
+          () => useNetworkConnectionBanner(),
+          mockState,
+          undefined,
+          undefined,
+          () => mockTrackEvent,
+        );
+        act(() => {
+          jest.advanceTimersByTime(25000);
+        });
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          category: 'Network',
+          event: MetaMetricsEventName.NetworkConnectionBannerShown,
+          properties: {
+            // The names of Segment properties have a particular case.
+            /* eslint-disable @typescript-eslint/naming-convention */
+            banner_type: 'unavailable',
+            chain_id_caip: 'eip155:1',
+            rpc_endpoint_url: 'mainnet.infura.io',
+            /* eslint-enable @typescript-eslint/naming-convention */
+          },
+        });
+      });
+    });
+  });
+
+  describe('when some network is unavailable and then all become available', () => {
+    it('clears timers and updates the status of the banner to "available"', () => {
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+      });
+      mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+
+      const { rerender } = renderHookWithProviderTyped(
+        () => useNetworkConnectionBanner(),
+        mockState,
+      );
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      rerender();
+      act(() => {
+        jest.advanceTimersByTime(30000);
+      });
+
+      // Would have updated status to "degraded" if not for resetting timers
+      expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+        status: 'available',
+      });
+    });
+  });
+
+  describe('on unmount', () => {
+    it('clears any timers to show the degraded and unavailable banners', () => {
+      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+      });
+      mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
+
+      const { unmount } = renderHookWithProviderTyped(
+        () => useNetworkConnectionBanner(),
+        mockState,
+      );
+      unmount();
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      // Would have updated status to "degraded" if not for resetting timers
+      expect(mockUpdateNetworkConnectionBanner).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -318,8 +318,50 @@ describe('useNetworkConnectionBanner', () => {
     });
   });
 
+  describe('when the first unavailable network changes from one non-null value to another', () => {
+    describe('if the status of the banner is "unavailable"', () => {
+      it('updates the status of the banner to "degraded" after 5 seconds', () => {
+        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+        mockGetNetworkConnectionBanner.mockReturnValue({
+          status: 'unavailable',
+          networkName: 'Ethereum Mainnet',
+          networkClientId: 'mainnet',
+          chainId: '0x1',
+        });
+
+        const { rerender } = renderHookWithProviderTyped(
+          () => useNetworkConnectionBanner(),
+          mockState,
+        );
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          networkName: 'Sepolia Mainnet',
+          networkClientId: 'sepolia',
+          chainId: '0xaa36a7',
+        });
+        rerender();
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+
+        expect(mockUpdateNetworkConnectionBanner).toHaveBeenCalledWith({
+          status: 'degraded',
+          networkName: 'Sepolia Mainnet',
+          networkClientId: 'sepolia',
+          chainId: '0xaa36a7',
+        });
+      });
+    });
+  });
+
   describe('on unmount', () => {
-    it('clears any timers to show the degraded and unavailable banners', () => {
+    it('clears both degraded and unavailable timers', () => {
       mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -62,7 +62,7 @@ export const useNetworkConnectionBanner =
     const clearTimers = useCallback(() => {
       clearDegradedTimer();
       clearUnavailableTimer();
-    }, []);
+    }, [clearDegradedTimer, clearUnavailableTimer]);
 
     const trackNetworkBannerEvent = useCallback(
       ({
@@ -153,7 +153,7 @@ export const useNetworkConnectionBanner =
     ]);
 
     const startDegradedTimer = useCallback(() => {
-      clearDegradedTimer();
+      clearUnavailableTimer();
 
       timersRef.current.degradedTimer = setTimeout(() => {
         if (firstUnavailableEvmNetwork) {
@@ -179,7 +179,7 @@ export const useNetworkConnectionBanner =
       trackNetworkBannerEvent,
       dispatch,
       startUnavailableTimer,
-      clearDegradedTimer,
+      clearUnavailableTimer,
     ]);
 
     // If the first unavailable network does not change but the status changes, start the degraded or unavailable timer
@@ -188,11 +188,14 @@ export const useNetworkConnectionBanner =
     useEffect(() => {
       if (firstUnavailableEvmNetwork) {
         if (networkConnectionBannerState.status === 'degraded') {
+          clearTimers();
           startUnavailableTimer();
         } else if (
           networkConnectionBannerState.status === 'unknown' ||
-          networkConnectionBannerState.status === 'available'
+          networkConnectionBannerState.status === 'available' ||
+          networkConnectionBannerState.status === 'unavailable'
         ) {
+          clearTimers();
           startDegradedTimer();
         }
       } else if (networkConnectionBannerState.status !== 'available') {

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -13,175 +13,187 @@ import { infuraProjectId } from '../../shared/constants/network';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
 import { onlyKeepHost } from '../../shared/lib/only-keep-host';
 import { isPublicEndpointUrl } from '../../shared/lib/network-utils';
+import { NetworkConnectionBanner } from '../../shared/constants/app-state';
+
+type UseNetworkConnectionBannerResult = NetworkConnectionBanner & {
+  trackNetworkBannerEvent: (event: {
+    bannerType: 'degraded' | 'unavailable';
+    eventName: string;
+    networkClientId: string;
+  }) => void;
+};
 
 const DEGRADED_BANNER_TIMEOUT = 5 * 1000;
 const UNAVAILABLE_BANNER_TIMEOUT = 30 * 1000;
 
-export const useNetworkConnectionBanner = () => {
-  const dispatch = useDispatch();
-  const trackEvent = useContext(MetaMetricsContext);
-  const firstUnavailableEvmNetwork = useSelector(
-    selectFirstUnavailableEvmNetwork,
-  );
-  const networkConnectionBannerState = useSelector(getNetworkConnectionBanner);
-  const networkConfigurationsByChainId = useSelector(
-    getNetworkConfigurationsByChainId,
-  );
+export const useNetworkConnectionBanner =
+  (): UseNetworkConnectionBannerResult => {
+    const dispatch = useDispatch();
+    const trackEvent = useContext(MetaMetricsContext);
+    const firstUnavailableEvmNetwork = useSelector(
+      selectFirstUnavailableEvmNetwork,
+    );
+    const networkConnectionBannerState = useSelector(
+      getNetworkConnectionBanner,
+    );
+    const networkConfigurationsByChainId = useSelector(
+      getNetworkConfigurationsByChainId,
+    );
 
-  const timersRef = useRef<{
-    degradedTimer?: NodeJS.Timeout;
-    unavailableTimer?: NodeJS.Timeout;
-  }>({});
+    const timersRef = useRef<{
+      degradedTimer?: NodeJS.Timeout;
+      unavailableTimer?: NodeJS.Timeout;
+    }>({});
 
-  const clearTimers = useCallback(() => {
-    if (timersRef.current.degradedTimer) {
-      clearTimeout(timersRef.current.degradedTimer);
-      timersRef.current.degradedTimer = undefined;
-    }
-    if (timersRef.current.unavailableTimer) {
-      clearTimeout(timersRef.current.unavailableTimer);
-      timersRef.current.unavailableTimer = undefined;
-    }
-  }, []);
-
-  const trackNetworkBannerEvent = useCallback(
-    ({
-      bannerType,
-      eventName,
-      networkClientId,
-    }: {
-      bannerType: 'degraded' | 'unavailable';
-      eventName: string;
-      networkClientId: string;
-    }) => {
-      if (!infuraProjectId) {
-        console.warn(
-          'Infura project ID not found, cannot track network banner event',
-        );
-        return;
+    const clearTimers = useCallback(() => {
+      if (timersRef.current.degradedTimer) {
+        clearTimeout(timersRef.current.degradedTimer);
+        timersRef.current.degradedTimer = undefined;
       }
+      if (timersRef.current.unavailableTimer) {
+        clearTimeout(timersRef.current.unavailableTimer);
+        timersRef.current.unavailableTimer = undefined;
+      }
+    }, []);
 
-      let foundNetwork: { chainId: Hex; url: string } | undefined;
-      for (const networkConfiguration of Object.values(
-        networkConfigurationsByChainId,
-      )) {
-        const rpcEndpoint = networkConfiguration.rpcEndpoints.find(
-          (endpoint) => endpoint.networkClientId === networkClientId,
-        );
-        if (rpcEndpoint) {
-          foundNetwork = {
-            chainId: networkConfiguration.chainId,
-            url: rpcEndpoint.url,
-          };
-          break;
+    const trackNetworkBannerEvent = useCallback(
+      ({
+        bannerType,
+        eventName,
+        networkClientId,
+      }: {
+        bannerType: 'degraded' | 'unavailable';
+        eventName: string;
+        networkClientId: string;
+      }) => {
+        if (!infuraProjectId) {
+          console.warn(
+            'Infura project ID not found, cannot track network banner event',
+          );
+          return;
         }
-      }
-      if (!foundNetwork) {
-        console.warn(
-          `RPC endpoint not found for network client ID: ${networkClientId}`,
-        );
-        return;
-      }
 
-      const rpcUrl = foundNetwork.url;
-      const chainIdAsDecimal = hexToNumber(foundNetwork.chainId);
-      const sanitizedRpcUrl = isPublicEndpointUrl(rpcUrl, infuraProjectId)
-        ? onlyKeepHost(rpcUrl)
-        : 'custom';
+        let foundNetwork: { chainId: Hex; url: string } | undefined;
+        for (const networkConfiguration of Object.values(
+          networkConfigurationsByChainId,
+        )) {
+          const rpcEndpoint = networkConfiguration.rpcEndpoints.find(
+            (endpoint) => endpoint.networkClientId === networkClientId,
+          );
+          if (rpcEndpoint) {
+            foundNetwork = {
+              chainId: networkConfiguration.chainId,
+              url: rpcEndpoint.url,
+            };
+            break;
+          }
+        }
+        if (!foundNetwork) {
+          console.warn(
+            `RPC endpoint not found for network client ID: ${networkClientId}`,
+          );
+          return;
+        }
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Network,
-        event: eventName,
-        // The names of Segment properties have a particular case.
-        /* eslint-disable @typescript-eslint/naming-convention */
-        properties: {
-          banner_type: bannerType,
-          chain_id_caip: `eip155:${chainIdAsDecimal}`,
-          rpc_endpoint_url: sanitizedRpcUrl,
-        },
-        /* eslint-enable @typescript-eslint/naming-convention */
-      });
-    },
-    [networkConfigurationsByChainId, trackEvent],
-  );
+        const rpcUrl = foundNetwork.url;
+        const chainIdAsDecimal = hexToNumber(foundNetwork.chainId);
+        const sanitizedRpcUrl = isPublicEndpointUrl(rpcUrl, infuraProjectId)
+          ? onlyKeepHost(rpcUrl)
+          : 'custom';
 
-  const startUnavailableTimer = useCallback(() => {
-    timersRef.current.unavailableTimer = setTimeout(() => {
-      if (firstUnavailableEvmNetwork) {
-        trackNetworkBannerEvent({
-          bannerType: 'unavailable',
-          eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-          networkClientId: firstUnavailableEvmNetwork.networkClientId,
+        trackEvent({
+          category: MetaMetricsEventCategory.Network,
+          event: eventName,
+          // The names of Segment properties have a particular case.
+          /* eslint-disable @typescript-eslint/naming-convention */
+          properties: {
+            banner_type: bannerType,
+            chain_id_caip: `eip155:${chainIdAsDecimal}`,
+            rpc_endpoint_url: sanitizedRpcUrl,
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
         });
-        dispatch(
-          updateNetworkConnectionBanner({
-            status: 'unavailable',
-            networkName: firstUnavailableEvmNetwork.networkName,
+      },
+      [networkConfigurationsByChainId, trackEvent],
+    );
+
+    const startUnavailableTimer = useCallback(() => {
+      timersRef.current.unavailableTimer = setTimeout(() => {
+        if (firstUnavailableEvmNetwork) {
+          trackNetworkBannerEvent({
+            bannerType: 'unavailable',
+            eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
             networkClientId: firstUnavailableEvmNetwork.networkClientId,
-            chainId: firstUnavailableEvmNetwork.chainId,
-          }),
-        );
-      }
-    }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
-  }, [firstUnavailableEvmNetwork, trackNetworkBannerEvent, dispatch]);
+          });
+          dispatch(
+            updateNetworkConnectionBanner({
+              status: 'unavailable',
+              networkName: firstUnavailableEvmNetwork.networkName,
+              networkClientId: firstUnavailableEvmNetwork.networkClientId,
+              chainId: firstUnavailableEvmNetwork.chainId,
+            }),
+          );
+        }
+      }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
+    }, [firstUnavailableEvmNetwork, trackNetworkBannerEvent, dispatch]);
 
-  const startDegradedTimer = useCallback(() => {
-    timersRef.current.degradedTimer = setTimeout(() => {
-      if (firstUnavailableEvmNetwork) {
-        trackNetworkBannerEvent({
-          bannerType: 'degraded',
-          eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-          networkClientId: firstUnavailableEvmNetwork.networkClientId,
-        });
-        dispatch(
-          updateNetworkConnectionBanner({
-            status: 'degraded',
-            networkName: firstUnavailableEvmNetwork.networkName,
+    const startDegradedTimer = useCallback(() => {
+      timersRef.current.degradedTimer = setTimeout(() => {
+        if (firstUnavailableEvmNetwork) {
+          trackNetworkBannerEvent({
+            bannerType: 'degraded',
+            eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
             networkClientId: firstUnavailableEvmNetwork.networkClientId,
-            chainId: firstUnavailableEvmNetwork.chainId,
-          }),
-        );
+          });
+          dispatch(
+            updateNetworkConnectionBanner({
+              status: 'degraded',
+              networkName: firstUnavailableEvmNetwork.networkName,
+              networkClientId: firstUnavailableEvmNetwork.networkClientId,
+              chainId: firstUnavailableEvmNetwork.chainId,
+            }),
+          );
 
-        startUnavailableTimer();
-      }
-    }, DEGRADED_BANNER_TIMEOUT);
-  }, [
-    firstUnavailableEvmNetwork,
-    trackNetworkBannerEvent,
-    dispatch,
-    startUnavailableTimer,
-  ]);
+          startUnavailableTimer();
+        }
+      }, DEGRADED_BANNER_TIMEOUT);
+    }, [
+      firstUnavailableEvmNetwork,
+      trackNetworkBannerEvent,
+      dispatch,
+      startUnavailableTimer,
+    ]);
 
-  useEffect(() => {
-    clearTimers();
-
-    if (firstUnavailableEvmNetwork) {
-      if (networkConnectionBannerState.status === 'degraded') {
-        startUnavailableTimer();
-      } else if (
-        networkConnectionBannerState.status === 'unknown' ||
-        networkConnectionBannerState.status === 'available'
-      ) {
-        startDegradedTimer();
-      }
-    } else if (networkConnectionBannerState.status !== 'available') {
-      dispatch(updateNetworkConnectionBanner({ status: 'available' }));
-    }
-
-    return () => {
+    useEffect(() => {
       clearTimers();
-    };
-  }, [
-    firstUnavailableEvmNetwork,
-    clearTimers,
-    dispatch,
-    networkConnectionBannerState.status,
-    startDegradedTimer,
-    startUnavailableTimer,
-  ]);
 
-  return {
-    ...networkConnectionBannerState,
-    trackNetworkBannerEvent,
+      if (firstUnavailableEvmNetwork) {
+        if (networkConnectionBannerState.status === 'degraded') {
+          startUnavailableTimer();
+        } else if (
+          networkConnectionBannerState.status === 'unknown' ||
+          networkConnectionBannerState.status === 'available'
+        ) {
+          startDegradedTimer();
+        }
+      } else if (networkConnectionBannerState.status !== 'available') {
+        dispatch(updateNetworkConnectionBanner({ status: 'available' }));
+      }
+
+      return () => {
+        clearTimers();
+      };
+    }, [
+      firstUnavailableEvmNetwork,
+      clearTimers,
+      dispatch,
+      networkConnectionBannerState.status,
+      startDegradedTimer,
+      startUnavailableTimer,
+    ]);
+
+    return {
+      ...networkConnectionBannerState,
+      trackNetworkBannerEvent,
+    };
   };
-};

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -62,7 +62,7 @@ export const useNetworkConnectionBanner =
     const clearTimers = useCallback(() => {
       clearDegradedTimer();
       clearUnavailableTimer();
-    }, [clearDegradedTimer, clearUnavailableTimer]);
+    }, []);
 
     const trackNetworkBannerEvent = useCallback(
       ({
@@ -153,7 +153,7 @@ export const useNetworkConnectionBanner =
     ]);
 
     const startDegradedTimer = useCallback(() => {
-      clearUnavailableTimer();
+      clearDegradedTimer();
 
       timersRef.current.degradedTimer = setTimeout(() => {
         if (firstUnavailableEvmNetwork) {
@@ -179,7 +179,7 @@ export const useNetworkConnectionBanner =
       trackNetworkBannerEvent,
       dispatch,
       startUnavailableTimer,
-      clearUnavailableTimer,
+      clearDegradedTimer,
     ]);
 
     // If the first unavailable network does not change but the status changes, start the degraded or unavailable timer
@@ -188,14 +188,11 @@ export const useNetworkConnectionBanner =
     useEffect(() => {
       if (firstUnavailableEvmNetwork) {
         if (networkConnectionBannerState.status === 'degraded') {
-          clearTimers();
           startUnavailableTimer();
         } else if (
           networkConnectionBannerState.status === 'unknown' ||
-          networkConnectionBannerState.status === 'available' ||
-          networkConnectionBannerState.status === 'unavailable'
+          networkConnectionBannerState.status === 'available'
         ) {
-          clearTimers();
           startDegradedTimer();
         }
       } else if (networkConnectionBannerState.status !== 'available') {

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -1,0 +1,188 @@
+import { useEffect, useCallback, useRef, useContext } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { Hex, hexToNumber } from '@metamask/utils';
+import { NetworkConfiguration } from '@metamask/network-controller';
+import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { getNetworkConnectionBanner } from '../selectors/selectors';
+import { updateNetworkConnectionBanner } from '../store/actions';
+import { MetaMetricsContext } from '../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../shared/constants/metametrics';
+import { infuraProjectId } from '../../shared/constants/network';
+import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
+import { onlyKeepHost } from '../../shared/lib/only-keep-host';
+import { isPublicEndpointUrl } from '../../shared/lib/network-utils';
+
+const DEGRADED_BANNER_TIMEOUT = 5 * 1000;
+const UNAVAILABLE_BANNER_TIMEOUT = 30 * 1000;
+
+export const useNetworkConnectionBanner = () => {
+  const dispatch = useDispatch();
+  const trackEvent = useContext(MetaMetricsContext);
+  const firstUnavailableEvmNetwork = useSelector(
+    selectFirstUnavailableEvmNetwork,
+  );
+  const networkConnectionBannerState = useSelector(getNetworkConnectionBanner);
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+
+  const timersRef = useRef<{
+    degradedTimer?: NodeJS.Timeout;
+    unavailableTimer?: NodeJS.Timeout;
+  }>({});
+
+  const clearTimers = useCallback(() => {
+    if (timersRef.current.degradedTimer) {
+      clearTimeout(timersRef.current.degradedTimer);
+      timersRef.current.degradedTimer = undefined;
+    }
+    if (timersRef.current.unavailableTimer) {
+      clearTimeout(timersRef.current.unavailableTimer);
+      timersRef.current.unavailableTimer = undefined;
+    }
+  }, []);
+
+  const trackNetworkBannerEvent = useCallback(
+    ({
+      bannerType,
+      eventName,
+      networkClientId,
+    }: {
+      bannerType: 'degraded' | 'unavailable';
+      eventName: string;
+      networkClientId: string;
+    }) => {
+      if (!infuraProjectId) {
+        console.warn(
+          'Infura project ID not found, cannot track network banner event',
+        );
+        return;
+      }
+
+      let foundNetwork: { chainId: Hex; url: string } | undefined;
+      for (const networkConfiguration of Object.values(
+        networkConfigurationsByChainId,
+      )) {
+        const rpcEndpoint = networkConfiguration.rpcEndpoints.find(
+          (endpoint) => endpoint.networkClientId === networkClientId,
+        );
+        if (rpcEndpoint) {
+          foundNetwork = {
+            chainId: networkConfiguration.chainId,
+            url: rpcEndpoint.url,
+          };
+          break;
+        }
+      }
+      if (!foundNetwork) {
+        console.warn(
+          `RPC endpoint not found for network client ID: ${networkClientId}`,
+        );
+        return;
+      }
+
+      const rpcUrl = foundNetwork.url;
+      const chainIdAsDecimal = hexToNumber(foundNetwork.chainId);
+      const sanitizedRpcUrl = isPublicEndpointUrl(rpcUrl, infuraProjectId)
+        ? onlyKeepHost(rpcUrl)
+        : 'custom';
+
+      trackEvent({
+        category: MetaMetricsEventCategory.Network,
+        event: eventName,
+        // The names of Segment properties have a particular case.
+        /* eslint-disable @typescript-eslint/naming-convention */
+        properties: {
+          banner_type: bannerType,
+          chain_id_caip: `eip155:${chainIdAsDecimal}`,
+          rpc_endpoint_url: sanitizedRpcUrl,
+        },
+        /* eslint-enable @typescript-eslint/naming-convention */
+      });
+    },
+    [networkConfigurationsByChainId, trackEvent],
+  );
+
+  const startUnavailableTimer = useCallback(() => {
+    timersRef.current.unavailableTimer = setTimeout(() => {
+      if (firstUnavailableEvmNetwork) {
+        trackNetworkBannerEvent({
+          bannerType: 'unavailable',
+          eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
+          networkClientId: firstUnavailableEvmNetwork.networkClientId,
+        });
+        dispatch(
+          updateNetworkConnectionBanner({
+            status: 'unavailable',
+            networkName: firstUnavailableEvmNetwork.networkName,
+            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            chainId: firstUnavailableEvmNetwork.chainId,
+          }),
+        );
+      }
+    }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
+  }, [firstUnavailableEvmNetwork, trackNetworkBannerEvent, dispatch]);
+
+  const startDegradedTimer = useCallback(() => {
+    timersRef.current.degradedTimer = setTimeout(() => {
+      if (firstUnavailableEvmNetwork) {
+        trackNetworkBannerEvent({
+          bannerType: 'degraded',
+          eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
+          networkClientId: firstUnavailableEvmNetwork.networkClientId,
+        });
+        dispatch(
+          updateNetworkConnectionBanner({
+            status: 'degraded',
+            networkName: firstUnavailableEvmNetwork.networkName,
+            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            chainId: firstUnavailableEvmNetwork.chainId,
+          }),
+        );
+
+        startUnavailableTimer();
+      }
+    }, DEGRADED_BANNER_TIMEOUT);
+  }, [
+    firstUnavailableEvmNetwork,
+    trackNetworkBannerEvent,
+    dispatch,
+    startUnavailableTimer,
+  ]);
+
+  useEffect(() => {
+    clearTimers();
+
+    if (firstUnavailableEvmNetwork) {
+      if (networkConnectionBannerState.status === 'degraded') {
+        startUnavailableTimer();
+      } else if (
+        networkConnectionBannerState.status === 'unknown' ||
+        networkConnectionBannerState.status === 'available'
+      ) {
+        startDegradedTimer();
+      }
+    } else if (networkConnectionBannerState.status !== 'available') {
+      dispatch(updateNetworkConnectionBanner({ status: 'available' }));
+    }
+
+    return () => {
+      clearTimers();
+    };
+  }, [
+    firstUnavailableEvmNetwork,
+    clearTimers,
+    dispatch,
+    networkConnectionBannerState.status,
+    startDegradedTimer,
+    startUnavailableTimer,
+  ]);
+
+  return {
+    ...networkConnectionBannerState,
+    trackNetworkBannerEvent,
+  };
+};

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -1,7 +1,6 @@
 import { useEffect, useCallback, useRef, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Hex, hexToNumber } from '@metamask/utils';
-import { NetworkConfiguration } from '@metamask/network-controller';
 import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
 import { getNetworkConnectionBanner } from '../selectors/selectors';
 import { updateNetworkConnectionBanner } from '../store/actions';

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -11,7 +11,6 @@ import {
 } from '@metamask/utils';
 import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 
-import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
 import { type NetworkState } from '../../../shared/modules/selectors/networks';
 import type { AccountsState } from '../accounts';
 import {

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -349,8 +349,12 @@ export const selectFirstUnavailableEvmNetwork = createSelector(
         const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
 
         if (rpcEndpoint) {
-          const status = networksMetadata[rpcEndpoint.networkClientId]?.status;
-          if (status !== NetworkStatus.Available) {
+          const metadata = networksMetadata[rpcEndpoint.networkClientId];
+
+          if (
+            metadata !== undefined &&
+            metadata.status !== NetworkStatus.Available
+          ) {
             return {
               networkName: name,
               networkClientId: rpcEndpoint.networkClientId,

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -327,3 +327,39 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
     );
   },
 );
+
+export const selectFirstUnavailableEvmNetwork = createSelector(
+  getEnabledNetworks,
+  getNetworkConfigurationsByChainId,
+  getNetworksMetadata,
+  (enabledNetworks, networkConfigurationsByChainId, networksMetadata) => {
+    // Get all enabled EVM networks
+    const enabledEvmNetworks = enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
+    const enabledChainIds = Object.entries(enabledEvmNetworks)
+      .filter(([, isEnabled]) => isEnabled)
+      .map(([chainId]) => chainId as Hex);
+
+    // Find the first network that is not available
+    for (const chainId of enabledChainIds) {
+      const networkConfiguration = networkConfigurationsByChainId[chainId];
+      if (networkConfiguration) {
+        // Get the network client ID directly from the network configuration
+        const { rpcEndpoints, defaultRpcEndpointIndex, name } =
+          networkConfiguration;
+        const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+
+        if (rpcEndpoint) {
+          const status = networksMetadata[rpcEndpoint.networkClientId]?.status;
+          if (status !== NetworkStatus.Available) {
+            return {
+              networkName: name,
+              networkClientId: rpcEndpoint.networkClientId,
+              chainId,
+            };
+          }
+        }
+      }
+    }
+    return null;
+  },
+);

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -4032,3 +4032,11 @@ export const selectNonZeroUnusedApprovalsAllowList = createSelector(
   getRemoteFeatureFlags,
   (remoteFeatureFlags) => remoteFeatureFlags?.nonZeroUnusedApprovals ?? [],
 );
+
+/**
+ * @param {object} state - The Redux state
+ * @returns {import('../../shared/constants/app-state').NetworkConnectionBanner}
+ */
+export function getNetworkConnectionBanner(state) {
+  return state.metamask.networkConnectionBanner;
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -151,6 +151,10 @@ import {
 import { getRemoteFeatureFlags } from './remote-feature-flags';
 import { getApprovalRequestsByType } from './approvals';
 
+/**
+ * @typedef {import('../../ui/store/store').MetaMaskReduxState} MetaMaskReduxState
+ */
+
 // Re-export this file so we don't have to update all references
 // TODO: Update all references
 export { getEnabledNetworks };
@@ -4034,7 +4038,7 @@ export const selectNonZeroUnusedApprovalsAllowList = createSelector(
 );
 
 /**
- * @param {object} state - The Redux state
+ * @param {MetaMaskReduxState} state - The Redux state
  * @returns {import('../../shared/constants/app-state').NetworkConnectionBanner}
  */
 export function getNetworkConnectionBanner(state) {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -165,6 +165,7 @@ import {
 } from '../pages/confirmations/selectors/preferences';
 import { setShowNewSrpAddedToast } from '../components/app/toast-master/utils';
 import { stripWalletTypePrefixFromWalletId } from '../hooks/multichain-accounts/utils';
+import type { NetworkConnectionBanner } from '../../shared/constants/app-state';
 import * as actionConstants from './actionConstants';
 
 import {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6298,6 +6298,16 @@ export function hideNetworkBanner() {
   return submitRequestToBackground('setShowNetworkBanner', [false]);
 }
 
+export function updateNetworkConnectionBanner(
+  networkConnectionBanner: NetworkConnectionBanner,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async () => {
+    await submitRequestToBackground('updateNetworkConnectionBanner', [
+      networkConnectionBanner,
+    ]);
+  };
+}
+
 /**
  * Sends the background state the networkClientId and domain upon network switch
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When the user loads the home screen for the first time or changes the set of enabled networks, we will attempt to verify that requests to those networks are successful, thereby judging whether those networks are available. If verification for any of the enabled networks takes 5 seconds or longer, then we will notify the user by popping up a banner, mentioning which network is slow and advising that the user update the default RPC endpoint for that network. If verification takes 30 seconds or longer, then we will assume that the network is unavailable and inform the user that the connection failed.

We also track metrics for when a user sees these banners and when the user chooses to update the RPC so we can better understand how many people are seeing these issues.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36259?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Notify users on home screen via banner when the selected RPC endpoint for an enabled network is degraded or unavailable, allowing endpoint to be quickly substituted

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34214

## **Manual testing steps**

1. Install [FoxyProxy](https://chromewebstore.google.com/detail/foxyproxy/gcknhkkoolaabfmlnjonogaaifnjlfnp). Pin it.
2. Open the options for FoxyProxy (e.g. right-click on its icon and go to Options) and add a new proxy that points to `127.0.0.1:8080`. (Don't enable it yet, though.)
3. Install [`mitmproxy`](https://docs.mitmproxy.org/stable/overview/installation/).
4. Create a Python script somewhere on your computer with the following contents: https://gist.github.com/mcmire/1d43ce690d3a974217126cd584f79b7d. This script will cause all requests to Infura RPC endpoints to respond with 500, simulating an outage.
5. Run `mitmproxy -s <path to your script>` in an open terminal session. This will run the proxy server.
6. Go back to FoxyProxy and enable the proxy you created earlier (click on the icon, then choose the name of the new proxy).
7. Check out this branch.
8. Run `yarn`, then `yarn start`.
9. If you already have a local build of MetaMask installed in your browser, uninstall it and reinstall it.
10. Open the service worker for the extension.
11. Go through onboarding. (You should be in full-screen view.)
12. After you see the home screen, go to Settings and toggle Basic Functionality. (This is a workaround for a bug where Solana does not appear after installing the extension.)
13. Now, on the home screen proper, you should see Sepolia enabled.
14. Wait 5 seconds. You should see a banner pop up that says "Still connecting to Sepolia..."
15. In the service worker console, look at the Network tab, and search for "batch". You should see a new Segment request that has a payload like the following:
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Shown",
          "messageId": "1759262282972.921",
          "properties": {
            "banner_type": "degraded",
            "chain_id_caip": "eip155:11155111",
            "rpc_endpoint_url": "sepolia.infura.io",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T19:58:02.974Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T19:58:02.975Z",
      "sentAt": "2025-09-30T19:58:02.975Z"
    }
    ```
17. Wait 25 more seconds. You should see the banner change to "Unable to connect to Sepolia".
18. In the service worker console, you should see a new Segment request that has a payload like the following (note the change in `banner_type` from "degraded" to "unavailable"):
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Shown",
          "messageId": "1759262309012.458",
          "properties": {
            "banner_type": "unavailable",
            "chain_id_caip": "eip155:11155111",
            "rpc_endpoint_url": "sepolia.infura.io",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T19:58:29.013Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T19:58:29.014Z",
      "sentAt": "2025-09-30T19:58:29.014Z"
    }
    ```
20. Click on "Send" (or some other action) and then return to the home screen. The banner should still be there.
21. Restart the extension.
22. Open the popup. The banner should still be there.
23. Click on the "Update RPC" link in the banner. A modal should appear to edit the network.
24. In the service worker console, you should see a new Segment request that has a payload like the following:
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Update RPC Clicked",
          "messageId": "1759263840053.9294",
          "properties": {
            "banner_type": "unavailable",
            "chain_id_caip": "eip155:11155111",
            "rpc_endpoint_url": "sepolia.infura.io",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T20:24:00.054Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T20:24:00.054Z",
      "sentAt": "2025-09-30T20:24:00.054Z"
    }
    ```
25. Add `https://sepolia.gateway.tenderly.co` as an RPC endpoint, and set it as the default.
26. The banner should disappear.
27. Now click on the network filter and select "Popular networks".
28. Wait 5 seconds. You should see a banner pop up that says "Still connecting to Ethereum..."
29. Wait 25 more seconds. You should see the banner change to "Unable to connect to Ethereum".
30. Now disable the proxy.
31. Click on "Send", then click back to the home screen.
32. You should see the banner disappear.
33. Enable the proxy again.
34. Click on the network filter and select Solana.
35. Wait 5 seconds. You should not see a banner.
36. Wait 30 seconds. You should not see a banner.
37. Switch to your terminal and run Ganache (`yarn ganache`).
38. Back in MetaMask, add Ganache as a custom network ("Localhost") and switch to it.
39. Now shut down Ganache.
40. Reload the extension to clear the block cache for all networks.
41. Open the popup and open full-screen view. Localhost should be selected.
42. Wait 5 seconds. You should see a banner pop up that says "Still connecting to Localhost..."
43. In the service worker console, you should see a new Segment request that has a payload like the following (note that `rpc_endpoint_url` is now "custom"):
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Shown",
          "messageId": "1759264268698.1738",
          "properties": {
            "banner_type": "degraded",
            "chain_id_caip": "eip155:1337",
            "rpc_endpoint_url": "custom",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T20:31:08.701Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T20:31:08.705Z",
      "sentAt": "2025-09-30T20:31:08.705Z"
    }
    ```
44. Wait 25 more seconds. You should see the banner change to "Unable to connect to Localhost".
45. In the service worker console, you should see a new Segment request that has a payload like the following (note the change in `banner_type` from "degraded" to "unavailable"):
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Shown",
          "messageId": "1759264295005.9326",
          "properties": {
            "banner_type": "unavailable",
            "chain_id_caip": "eip155:1337",
            "rpc_endpoint_url": "custom",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T20:31:35.026Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T20:31:35.026Z",
      "sentAt": "2025-09-30T20:31:35.026Z"
    }
    ```
46. Click on the "Update RPC" link in the banner. A modal should appear to edit the network.
    ```
    {
      "batch": [
        {
          "event": "Network Connection Banner Update RPC Clicked",
          "messageId": "1759264446631.96",
          "properties": {
            "banner_type": "unavailable",
            "chain_id_caip": "eip155:1337",
            "rpc_endpoint_url": "custom",
            "category": "Network",
            "locale": "en",
            "chain_id": null,
            "environment_type": "fullscreen"
          },
          "context": {
            "app": {
              "name": "MetaMask Extension",
              "version": "13.5.0-development"
            },
            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
            "page": {
              "path": "/",
              "title": "Home",
              "url": "/"
            },
            "marketingCampaignCookieId": null,
            "library": {
              "name": "analytics-node"
            }
          },
          "userId": "0xc5131a96990d3102609962814256f54c202e3336dc86cb4e153341940c5a2427",
          "timestamp": "2025-09-30T20:34:06.632Z",
          "type": "track"
        }
      ],
      "timestamp": "2025-09-30T20:34:06.633Z",
      "sentAt": "2025-09-30T20:34:06.633Z"
    }
    ```
46. Make sure to disable the proxy after you're done!

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1607" height="604" alt="Screenshot 2025-10-01 at 12 24 36 PM" src="https://github.com/user-attachments/assets/a3d7ea46-d212-4636-b470-9a1dfa369cc2" />

<img width="1609" height="599" alt="Screenshot 2025-10-01 at 12 24 59 PM" src="https://github.com/user-attachments/assets/8dcce657-f4d3-4b91-a63c-a6b38b0f8e49" />

<img width="425" height="627" alt="Screenshot 2025-10-01 at 12 25 14 PM" src="https://github.com/user-attachments/assets/ea73e166-0b4e-43e4-8041-ce0d571b13d5" />

<img width="420" height="631" alt="Screenshot 2025-10-01 at 12 25 38 PM" src="https://github.com/user-attachments/assets/62294772-d0f3-4ff9-b082-29c2187a8355" />

Note that this video is slightly old. The banner text is smaller and the colors and padding have been adjusted. See the images above.

https://github.com/user-attachments/assets/b407af82-bf4c-4680-9143-9d97fdccd435

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a home screen banner that indicates degraded (5s) or unavailable (30s) network connections, lets users quickly update the RPC, tracks related metrics, and centralizes network URL utilities.
> 
> - **UI**:
>   - `NetworkConnectionBanner` component with "Still connecting…"/"Unable to connect…" messaging and "Update RPC" action; integrated into `AccountOverviewLayout`.
> - **State/Background**:
>   - Add `appState.networkConnectionBanner` and `updateNetworkConnectionBanner` background action; wire through `metamask-controller` and Redux actions/selectors.
> - **Hook/Logic**:
>   - `useNetworkConnectionBanner`: detects first unavailable EVM network; triggers banners at 5s/30s; persists state; tracks events; navigates to network edit.
> - **Selectors**:
>   - `selectFirstUnavailableEvmNetwork`; `getNetworkConnectionBanner`.
> - **Metrics**:
>   - New events: `NetworkConnectionBannerShown`, `NetworkConnectionBannerUpdateRpcClicked`.
> - **i18n**:
>   - Add `stillConnectingTo`, `unableToConnectTo`, `updateRpc` messages.
> - **Shared utils**:
>   - New `shared/lib/network-utils` (`getIsMetaMaskInfuraEndpointUrl`, `getIsQuicknodeEndpointUrl`, `isPublicEndpointUrl`); update imports; remove duplicates from `lib/network-controller/utils`.
> - **Tests/Helpers**:
>   - Add tests for banner component, hook, selectors, and shared utils; adjust test render helpers to mock MetaMetrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6cfa21c715309007ca6d1aec3092cb6416ab5e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->