### PR TITLE
fix: enforce single menu open and resolve layout scroll issues in multichain account menus

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -74,6 +74,10 @@ export const MultichainAccountList = ({
 
   const [renameAccountGroupId, setRenameAccountGroupId] = useState(undefined);
 
+  // State to track which account menu is open (only one at a time)
+  const [openMenuAccountId, setOpenMenuAccountId] =
+    useState<AccountGroupId | null>(null);
+
   const handleAccountRenameActionModalClose = useCallback(() => {
     setIsAccountRenameModalOpen(false);
     setRenameAccountGroupId(undefined);
@@ -83,8 +87,20 @@ export const MultichainAccountList = ({
     (accountGroupId) => {
       setRenameAccountGroupId(accountGroupId);
       setIsAccountRenameModalOpen(true);
+      // Close any open menu when rename action is triggered
+      setOpenMenuAccountId(null);
     },
     [setIsAccountRenameModalOpen, setRenameAccountGroupId],
+  );
+
+  const handleMenuToggle = useCallback(
+    (accountGroupId: AccountGroupId) => {
+      // If the same menu is clicked, close it; otherwise, open the new one
+      setOpenMenuAccountId((current) =>
+        current === accountGroupId ? null : accountGroupId,
+      );
+    },
+    [],
   );
 
   // Convert selectedAccountGroups array to Set for O(1) lookup
@@ -191,6 +207,10 @@ export const MultichainAccountList = ({
                       accountGroupId={groupId as AccountGroupId}
                       isRemovable={isRemovable}
                       handleAccountRenameAction={handleAccountRenameAction}
+                      isOpen={openMenuAccountId === groupId}
+                      onToggle={() =>
+                        handleMenuToggle(groupId as AccountGroupId)
+                      }
                     />
                   }
                 />
@@ -230,6 +250,8 @@ export const MultichainAccountList = ({
     selectedAccountGroupsSet,
     showAccountCheckbox,
     handleAccountRenameAction,
+    handleMenuToggle,
+    openMenuAccountId,
   ]);
 
   return (

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -93,15 +93,12 @@ export const MultichainAccountList = ({
     [setIsAccountRenameModalOpen, setRenameAccountGroupId],
   );
 
-  const handleMenuToggle = useCallback(
-    (accountGroupId: AccountGroupId) => {
-      // If the same menu is clicked, close it; otherwise, open the new one
-      setOpenMenuAccountId((current) =>
-        current === accountGroupId ? null : accountGroupId,
-      );
-    },
-    [],
-  );
+  const handleMenuToggle = useCallback((accountGroupId: AccountGroupId) => {
+    // If the same menu is clicked, close it; otherwise, open the new one
+    setOpenMenuAccountId((current) =>
+      current === accountGroupId ? null : accountGroupId,
+    );
+  }, []);
 
   // Convert selectedAccountGroups array to Set for O(1) lookup
   const selectedAccountGroupsSet = useMemo(

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -74,7 +74,6 @@ export const MultichainAccountList = ({
 
   const [renameAccountGroupId, setRenameAccountGroupId] = useState(undefined);
 
-  // State to track which account menu is open (only one at a time)
   const [openMenuAccountId, setOpenMenuAccountId] =
     useState<AccountGroupId | null>(null);
 
@@ -87,14 +86,13 @@ export const MultichainAccountList = ({
     (accountGroupId) => {
       setRenameAccountGroupId(accountGroupId);
       setIsAccountRenameModalOpen(true);
-      // Close any open menu when rename action is triggered
       setOpenMenuAccountId(null);
     },
     [setIsAccountRenameModalOpen, setRenameAccountGroupId],
   );
 
   const handleMenuToggle = useCallback((accountGroupId: AccountGroupId) => {
-    // If the same menu is clicked, close it; otherwise, open the new one
+    // If the same menu is clicked, close it, otherwise open the new one
     setOpenMenuAccountId((current) =>
       current === accountGroupId ? null : accountGroupId,
     );

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -160,36 +160,5 @@ describe('MultichainAccountMenu', () => {
     }
 
     expect(mockHandleAccountRenameAction).toHaveBeenCalledWith(accountGroupId);
-    expect(mockOnToggle).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onToggle when rename action is performed with controlled props', async () => {
-    const mockHandleAccountRenameAction = jest.fn();
-    const mockOnToggle = jest.fn();
-    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
-
-    renderComponent({
-      accountGroupId,
-      isRemovable: false,
-      isOpen: true,
-      onToggle: mockOnToggle,
-      handleAccountRenameAction: mockHandleAccountRenameAction,
-    });
-
-    // Rename option should be the second menu item
-    const menuItems = document.querySelectorAll(menuItemSelector);
-    expect(menuItems.length).toBe(3);
-
-    const renameOption = menuItems[1];
-    expect(renameOption).not.toBeNull();
-
-    if (renameOption) {
-      await act(async () => {
-        fireEvent.click(renameOption);
-      });
-    }
-
-    expect(mockHandleAccountRenameAction).toHaveBeenCalledWith(accountGroupId);
-    expect(mockOnToggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -12,7 +12,9 @@ const errorColorSelector = '.mm-box--color-error-default';
 
 describe('MultichainAccountMenu', () => {
   // Test wrapper component that manages state like the parent component does
-  const TestWrapper = (props: Omit<MultichainAccountMenuProps, 'isOpen' | 'onToggle'>) => {
+  const TestWrapper = (
+    props: Omit<MultichainAccountMenuProps, 'isOpen' | 'onToggle'>,
+  ) => {
     const [isOpen, setIsOpen] = useState(false);
     const handleToggle = () => setIsOpen(!isOpen);
 

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -95,7 +95,7 @@ describe('MultichainAccountMenu', () => {
     expect(menuItems.length).toBe(3);
   });
 
-  it('shows 4 menu items including remove option when isRemovable is true', () => {
+  it('adds the remove option to menu when isRemovable is true', () => {
     renderComponent({
       accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
       isRemovable: true,

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -120,13 +120,7 @@ export const MultichainAccountMenu = ({
     }
 
     return baseMenuItems;
-  }, [
-    accountGroupId,
-    handleAccountRenameAction,
-    history,
-    isRemovable,
-    onToggle,
-  ]);
+  }, [accountGroupId, handleAccountRenameAction, history, isRemovable]);
 
   return (
     <>

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -34,23 +34,11 @@ export const MultichainAccountMenu = ({
 }: MultichainAccountMenuProps) => {
   const history = useHistory();
   const popoverRef = useRef<HTMLDivElement>(null);
-  const popoverDialogRef = useRef<HTMLDivElement>(null);
 
-  const togglePopover = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
+  const togglePopover = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     onToggle?.();
   };
-
-  // Handle Tab key press for accessibility inside the popover
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Tab' || event.key === 'Escape') {
-        // Close popover on Tab or Escape key
-        onToggle?.();
-      }
-    },
-    [onToggle],
-  );
 
   const menuConfig = useMemo(() => {
     const handleAccountDetailsClick = (mouseEvent: React.MouseEvent) => {
@@ -175,9 +163,7 @@ export const MultichainAccountMenu = ({
         onPressEscKey={onToggle}
       >
         <ModalFocus restoreFocus initialFocusRef={popoverRef}>
-          <div onKeyDown={handleKeyDown} ref={popoverDialogRef}>
-            <MultichainAccountMenuItems menuConfig={menuConfig} />
-          </div>
+          <MultichainAccountMenuItems menuConfig={menuConfig} />
         </ModalFocus>
       </Popover>
     </>

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -52,7 +52,6 @@ export const MultichainAccountMenu = ({
       mouseEvent.preventDefault();
       if (handleAccountRenameAction) {
         handleAccountRenameAction(accountGroupId);
-        onToggle?.();
       }
     };
 

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Box,
@@ -157,10 +157,8 @@ export const MultichainAccountMenu = ({
         matchWidth={false}
         borderRadius={BorderRadius.LG}
         isPortal
-        preventOverflow
         flip
         onClickOutside={onToggle}
-        onPressEscKey={onToggle}
       >
         <ModalFocus restoreFocus initialFocusRef={popoverRef}>
           <MultichainAccountMenuItems menuConfig={menuConfig} />

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Box,
@@ -28,14 +28,15 @@ export const MultichainAccountMenu = ({
   isRemovable,
   buttonBackgroundColor,
   handleAccountRenameAction,
+  isOpen = false,
+  onToggle,
 }: MultichainAccountMenuProps) => {
   const history = useHistory();
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const togglePopover = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
-    setIsPopoverOpen(!isPopoverOpen);
+    onToggle?.();
   };
 
   const menuConfig = useMemo(() => {
@@ -50,7 +51,7 @@ export const MultichainAccountMenu = ({
       mouseEvent.preventDefault();
       if (handleAccountRenameAction) {
         handleAccountRenameAction(accountGroupId);
-        setIsPopoverOpen(false);
+        onToggle?.();
       }
     };
 
@@ -119,7 +120,7 @@ export const MultichainAccountMenu = ({
     }
 
     return baseMenuItems;
-  }, [accountGroupId, handleAccountRenameAction, history, isRemovable]);
+  }, [accountGroupId, handleAccountRenameAction, history, isRemovable, onToggle]);
 
   return (
     <>
@@ -143,11 +144,14 @@ export const MultichainAccountMenu = ({
       </Box>
       <Popover
         className="multichain-account-cell-popover-menu"
-        isOpen={isPopoverOpen}
+        isOpen={isOpen}
         position={PopoverPosition.LeftStart}
         referenceElement={popoverRef.current}
         matchWidth={false}
         borderRadius={BorderRadius.LG}
+        isPortal
+        preventOverflow
+        flip
       >
         <MultichainAccountMenuItems menuConfig={menuConfig} />
       </Popover>

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Box,
   Icon,
   IconName,
+  ModalFocus,
   Popover,
   PopoverPosition,
 } from '../../component-library';
@@ -33,11 +34,23 @@ export const MultichainAccountMenu = ({
 }: MultichainAccountMenuProps) => {
   const history = useHistory();
   const popoverRef = useRef<HTMLDivElement>(null);
+  const popoverDialogRef = useRef<HTMLDivElement>(null);
 
   const togglePopover = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
     onToggle?.();
   };
+
+  // Handle Tab key press for accessibility inside the popover
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Tab' || event.key === 'Escape') {
+        // Close popover on Tab or Escape key
+        onToggle?.();
+      }
+    },
+    [onToggle],
+  );
 
   const menuConfig = useMemo(() => {
     const handleAccountDetailsClick = (mouseEvent: React.MouseEvent) => {
@@ -158,8 +171,14 @@ export const MultichainAccountMenu = ({
         isPortal
         preventOverflow
         flip
+        onClickOutside={onToggle}
+        onPressEscKey={onToggle}
       >
-        <MultichainAccountMenuItems menuConfig={menuConfig} />
+        <ModalFocus restoreFocus initialFocusRef={popoverRef}>
+          <div onKeyDown={handleKeyDown} ref={popoverDialogRef}>
+            <MultichainAccountMenuItems menuConfig={menuConfig} />
+          </div>
+        </ModalFocus>
       </Popover>
     </>
   );

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -120,7 +120,13 @@ export const MultichainAccountMenu = ({
     }
 
     return baseMenuItems;
-  }, [accountGroupId, handleAccountRenameAction, history, isRemovable, onToggle]);
+  }, [
+    accountGroupId,
+    handleAccountRenameAction,
+    history,
+    isRemovable,
+    onToggle,
+  ]);
 
   return (
     <>

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.types.ts
@@ -22,4 +22,14 @@ export type MultichainAccountMenuProps = {
    * Optional callback for account rename action.
    */
   handleAccountRenameAction?: (accountGroupId: AccountGroupId) => void;
+
+  /**
+   * Whether the menu popover is open.
+   */
+  isOpen?: boolean;
+
+  /**
+   * Callback to toggle the menu popover open/closed state.
+   */
+  onToggle?: () => void;
 };


### PR DESCRIPTION
## **Description**

Fixed layout issues in multichain account menus where multiple menus could be opened simultaneously, causing multiple scroll bars and layout conflicts. This change implements single-menu enforcement and improves popover positioning to prevent scroll bar issues.

**What is the reason for the change?**
- When account menus opened, they created multiple scroll bars and visual conflicts
- Multiple account menus could be opened at the same time, causing UI layout issues
- The popover positioning was causing layout shifts in the parent containers

**What is the improvement/solution?**
- Moved menu state management from individual components to the parent `MultichainAccountList` 
- Implemented single menu enforcement (only one menu can be open at a time)
- Enhanced popover configuration with `isPortal`, `onClickOutside`, `flip` for better positioning
- Added `ModalFocus` wrapper with proper focus management and accessibility

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36260?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed account menu layout issues that caused multiple scroll bars and E2E test failures

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-809

## **Manual testing steps**

1. Go to the Accounts page in MetaMask extension
2. Click on the three dots menu (⋮) next to any account to open its menu
3. Try clicking on another account's three dots menu
4. Verify that only one menu is open at a time (the previous one closes automatically)
5. Verify that no multiple scroll bars appear when menus are open and scrolling up and down
6. Test menu positioning to ensure it doesn't cause layout shifts
7. Test clicking outside menus to close them

## **Screenshots/Recordings**

### **Before**
Multiple menus could be opened simultaneously causing layout issues, multiple scroll bars

https://github.com/user-attachments/assets/2cd31465-652e-41de-b716-f45ac83194e3

### **After** 
Only one menu can be open at a time, with improved positioning, proper focus management, and no scroll bar conflicts.

https://github.com/user-attachments/assets/0edea450-69c5-4463-a033-2d8cbc348504

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.