### PR TITLE
fix(AddressQRCodeModal): updated modal to show blockexplorer button f…

### DIFF
--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.test.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { openBlockExplorer } from '../../multichain/menu-items/view-explorer-menu-item';
+import { getBlockExplorerInfo } from '../../../helpers/utils/multichain/getBlockExplorerInfo';
 import { AddressQRCodeModal } from './address-qr-code-modal';
+
+// Import the mocked function
 
 // Mock only the essential dependencies that the component actually uses
 jest.mock('../../../hooks/useCopyToClipboard', () => ({
@@ -26,8 +29,6 @@ const mockUseCopyToClipboard = useCopyToClipboard as jest.MockedFunction<
 >;
 const mockOpenBlockExplorer = openBlockExplorer as jest.Mock;
 
-// Import the mocked function
-const { getBlockExplorerInfo } = require('../../../helpers/utils/multichain/getBlockExplorerInfo');
 const mockGetBlockExplorerInfo = getBlockExplorerInfo as jest.Mock;
 
 describe('AddressQRCodeModal', () => {
@@ -74,7 +75,9 @@ describe('AddressQRCodeModal', () => {
       />,
     );
 
-    expect(screen.queryByText('Test Account / Ethereum')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Test Account / Ethereum'),
+    ).not.toBeInTheDocument();
   });
 
   it('should render the address and copy button', () => {
@@ -98,7 +101,8 @@ describe('AddressQRCodeModal', () => {
   it('should render the view on explorer button for Ethereum', () => {
     // Mock the getBlockExplorerInfo to return Ethereum explorer info
     mockGetBlockExplorerInfo.mockReturnValue({
-      addressUrl: 'https://etherscan.io/address/0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      addressUrl:
+        'https://etherscan.io/address/0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
       name: 'Etherscan',
       buttonText: 'View on Etherscan',
     });
@@ -300,6 +304,8 @@ describe('AddressQRCodeModal', () => {
     );
 
     // Should not render explorer button for unknown network
-    expect(screen.queryByRole('button', { name: /View on/ })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /View on/u }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useMemo } from 'react';
 import qrCode from 'qrcode-generator';
+import { CaipChainId } from '@metamask/utils';
 import {
   Text,
   TextVariant,
@@ -28,6 +29,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { openBlockExplorer } from '../../multichain/menu-items/view-explorer-menu-item';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { getBlockExplorerInfo } from '../../../helpers/utils/multichain/getBlockExplorerInfo';
 
 // Constants for QR code generation
 const QR_CODE_TYPE_NUMBER = 4;
@@ -48,6 +50,7 @@ export type AddressQRCodeModalProps = Omit<
   address: string;
   accountName: string;
   networkName: string;
+  chainId: CaipChainId;
   networkImageSrc?: string | undefined;
 };
 
@@ -57,6 +60,7 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
   address,
   accountName,
   networkName,
+  chainId,
   networkImageSrc,
 }) => {
   const t = useI18nContext();
@@ -88,47 +92,20 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
     handleCopy(address);
   }, [address, handleCopy]);
 
-  // TODO: Move this out into a utility or selector
-  // Centralized explorer configuration
-  const explorerInfo = useMemo(() => {
-    const networkNameLower = networkName.toLowerCase();
-
-    if (networkNameLower.includes('ethereum')) {
-      return {
-        url: 'https://etherscan.io',
-        name: 'Etherscan',
-        buttonText: t('viewAddressOnExplorer', ['Etherscan']),
-      };
-    }
-
-    if (networkNameLower.includes('solana')) {
-      return {
-        url: 'https://solscan.io',
-        name: 'Solscan',
-        buttonText: t('viewAddressOnExplorer', ['Solscan']),
-      };
-    }
-
-    if (networkNameLower.includes('bitcoin')) {
-      return {
-        url: 'https://blockstream.info',
-        name: 'Blockstream',
-        buttonText: t('viewAddressOnExplorer', ['Blockstream']),
-      };
-    }
-
-    // Return null if no valid explorer found - button won't be shown
-    return null;
-  }, [networkName, t]);
+  // Get block explorer info from network configuration
+  const explorerInfo = getBlockExplorerInfo(
+    t as (key: string, ...args: any[]) => string,
+    address,
+    { networkName, chainId }
+  );
 
   const handleExplorerNavigation = useCallback(() => {
     if (!explorerInfo) {
       return;
     }
 
-    const addressLink = `${explorerInfo.url}/address/${address}`;
-    openBlockExplorer(addressLink, 'Address QR Code Modal', trackEvent);
-  }, [address, explorerInfo, trackEvent]);
+    openBlockExplorer(explorerInfo.addressUrl, 'Address QR Code Modal', trackEvent);
+  }, [explorerInfo, trackEvent]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -94,9 +94,9 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
 
   // Get block explorer info from network configuration
   const explorerInfo = getBlockExplorerInfo(
-    t as (key: string, ...args: any[]) => string,
+    t as (key: string, ...args: string[]) => string,
     address,
-    { networkName, chainId }
+    { networkName, chainId },
   );
 
   const handleExplorerNavigation = useCallback(() => {
@@ -104,7 +104,11 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
       return;
     }
 
-    openBlockExplorer(explorerInfo.addressUrl, 'Address QR Code Modal', trackEvent);
+    openBlockExplorer(
+      explorerInfo.addressUrl,
+      'Address QR Code Modal',
+      trackEvent,
+    );
   }, [explorerInfo, trackEvent]);
 
   return (

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -105,6 +105,7 @@ describe('MultichainAddressRow', () => {
     expect(mockQrCallback).toHaveBeenCalledWith(
       '0x1234567890123456789012345678901234567890',
       'Ethereum',
+      '0x1',
       expect.anything(),
     );
   });

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, screen, render } from '@testing-library/react';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { MultichainAddressRow } from './multichain-address-row';
 
@@ -7,8 +8,14 @@ jest.mock('../../../hooks/useCopyToClipboard', () => ({
   useCopyToClipboard: jest.fn(),
 }));
 
+jest.mock('@metamask/bridge-controller', () => ({
+  formatChainIdToCaip: jest.fn(),
+}));
+
 const mockCopyCallback = jest.fn();
 const mockQrCallback = jest.fn();
+
+const mockFormatChainIdToCaip = formatChainIdToCaip as jest.Mock;
 
 const defaultProps = {
   chainId: '0x1',
@@ -41,6 +48,7 @@ describe('MultichainAddressRow', () => {
   beforeEach(() => {
     mockCopyCallback.mockClear();
     mockQrCallback.mockClear();
+    mockFormatChainIdToCaip.mockClear();
     (useCopyToClipboard as jest.Mock).mockReturnValue([
       false,
       mockCopyCallback,
@@ -99,13 +107,18 @@ describe('MultichainAddressRow', () => {
   });
 
   it('handles QR button click with onQrClick callback', () => {
+    // Mock the formatChainIdToCaip function to return the expected CAIP format
+    mockFormatChainIdToCaip.mockReturnValue('eip155:1');
+
     renderComponent(propsWithQrCode);
     const qrButton = screen.getByTestId('multichain-address-row-qr-button');
     fireEvent.click(qrButton);
+
+    expect(mockFormatChainIdToCaip).toHaveBeenCalledWith('0x1');
     expect(mockQrCallback).toHaveBeenCalledWith(
       '0x1234567890123456789012345678901234567890',
       'Ethereum',
-      '0x1',
+      'eip155:1', // Should be converted to CAIP format
       expect.anything(),
     );
   });
@@ -124,5 +137,45 @@ describe('MultichainAddressRow', () => {
     renderComponent({ className: 'custom-class' });
     const addressRow = screen.getByTestId('multichain-address-row');
     expect(addressRow).toHaveClass('custom-class');
+  });
+
+  it('converts decimal chainId to CAIP format in QR callback', () => {
+    // Mock the formatChainIdToCaip function to return the expected CAIP format
+    mockFormatChainIdToCaip.mockReturnValue('eip155:137');
+
+    renderComponent({
+      ...propsWithQrCode,
+      chainId: '137', // Polygon chain ID as decimal
+    });
+    const qrButton = screen.getByTestId('multichain-address-row-qr-button');
+    fireEvent.click(qrButton);
+
+    expect(mockFormatChainIdToCaip).toHaveBeenCalledWith('137');
+    expect(mockQrCallback).toHaveBeenCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      'Ethereum',
+      'eip155:137', // Should be converted to CAIP format
+      undefined,
+    );
+  });
+
+  it('preserves CAIP format chainId in QR callback', () => {
+    // Mock the formatChainIdToCaip function to return the same CAIP format
+    mockFormatChainIdToCaip.mockReturnValue('eip155:42161');
+
+    renderComponent({
+      ...propsWithQrCode,
+      chainId: 'eip155:42161', // Arbitrum chain ID already in CAIP format
+    });
+    const qrButton = screen.getByTestId('multichain-address-row-qr-button');
+    fireEvent.click(qrButton);
+
+    expect(mockFormatChainIdToCaip).toHaveBeenCalledWith('eip155:42161');
+    expect(mockQrCallback).toHaveBeenCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      'Ethereum',
+      'eip155:42161', // Should remain unchanged
+      expect.anything(),
+    );
   });
 });

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   AlignItems,
   BlockSize,
@@ -136,7 +137,7 @@ export const MultichainAddressRow = ({
     qrActionParams?.callback(
       address,
       networkName,
-      chainId as CaipChainId,
+      formatChainIdToCaip(chainId),
       networkImageSrc,
     );
   };

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -43,6 +43,7 @@ type QrParams = {
   callback: (
     address: string,
     networkName: string,
+    chainId: CaipChainId,
     networkImageSrc?: string,
   ) => void;
 };
@@ -132,7 +133,12 @@ export const MultichainAddressRow = ({
 
   // Handle "QR Code" button click
   const handleQrClick = () => {
-    qrActionParams?.callback(address, networkName, networkImageSrc);
+    qrActionParams?.callback(
+      address,
+      networkName,
+      chainId as CaipChainId,
+      networkImageSrc,
+    );
   };
 
   return (

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.test.tsx
@@ -279,6 +279,7 @@ describe('MultichainAddressRowsList', () => {
     expect(mockOnQrClick).toHaveBeenCalledWith(
       '0x1234567890abcdef1234567890abcdef12345678',
       'Ethereum',
+      'eip155:1',
       './images/eth_logo.svg',
     );
   });

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.test.tsx
@@ -4,8 +4,14 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AccountGroupId } from '@metamask/account-api';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { MultichainAddressRowsList } from './multichain-address-rows-list';
 
+jest.mock('@metamask/bridge-controller', () => ({
+  formatChainIdToCaip: jest.fn(),
+}));
+
+const mockFormatChainIdToCaip = formatChainIdToCaip as jest.Mock;
 const mockStore = configureStore([]);
 
 const WALLET_ID_MOCK = 'entropy:01K437Z7EJ0VCMFDE9TQKRV60A';
@@ -266,6 +272,9 @@ describe('MultichainAddressRowsList', () => {
   });
 
   it('passes onQrClick callback to child components', () => {
+    // Mock the formatChainIdToCaip function to return the expected CAIP format
+    mockFormatChainIdToCaip.mockReturnValue('eip155:1');
+
     const mockOnQrClick = jest.fn();
     renderComponent(GROUP_ID_MOCK, mockOnQrClick);
 

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -35,6 +35,7 @@ export type MultichainAddressRowsListProps = {
   onQrClick: (
     address: string,
     networkName: string,
+    chainId: CaipChainId,
     networkImageSrc?: string,
   ) => void;
 };

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
@@ -1,0 +1,209 @@
+import { getBlockExplorerInfo } from './getBlockExplorerInfo';
+
+
+// Mock the multichain constants
+jest.mock('../../../../shared/constants/multichain/networks', () => ({
+  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: {
+    'bitcoin:0': {
+      url: 'https://blockstream.info',
+      address: 'https://blockstream.info/address/{address}',
+      transaction: 'https://blockstream.info/tx/{txId}',
+    },
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+      url: 'https://solscan.io',
+      address: 'https://solscan.io/account/{address}',
+      transaction: 'https://solscan.io/tx/{txId}',
+    },
+  },
+  MultichainNetworks: {
+    BITCOIN: 'bitcoin:0',
+    SOLANA: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  },
+}));
+
+// Mock the common constants
+jest.mock('../../../../shared/constants/common', () => ({
+  CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP: {
+    '0x1': 'Etherscan',
+    '0x89': 'PolygonScan',
+    '0xa': 'Optimism Explorer',
+  },
+  CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP: {
+    '0x1': 'https://etherscan.io/',
+    '0x89': 'https://polygonscan.com/',
+    '0xa': 'https://optimistic.etherscan.io/',
+  },
+}));
+
+// Mock the multichain URL formatting
+jest.mock('../../../../shared/lib/multichain/networks', () => ({
+  formatBlockExplorerAddressUrl: jest.fn((urls, address) =>
+    urls.address.replace('{address}', address)
+  ),
+}));
+
+describe('getBlockExplorerInfo utility functions', () => {
+  const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+  const testAddress = '0x1234567890abcdef';
+
+  describe('getBlockExplorerInfo function', () => {
+    it('returns correct info for Bitcoin network', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Bitcoin',
+        chainId: 'bitcoin:0'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://blockstream.info/address/0x1234567890abcdef',
+        name: 'Blockstream',
+        buttonText: 'translated_viewAddressOnExplorer_Blockstream',
+      });
+    });
+
+    it('returns correct info for Solana network', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Solana',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://solscan.io/account/0x1234567890abcdef',
+        name: 'Solscan',
+        buttonText: 'translated_viewAddressOnExplorer_Solscan',
+      });
+    });
+
+    it('returns correct info for Ethereum EVM network', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Ethereum Mainnet',
+        chainId: 'eip155:1'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://etherscan.io/address/0x1234567890abcdef',
+        name: 'Etherscan',
+        buttonText: 'translated_viewAddressOnExplorer_Etherscan',
+      });
+    });
+
+    it('returns correct info for Polygon EVM network', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Polygon',
+        chainId: 'eip155:137'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://polygonscan.com/address/0x1234567890abcdef',
+        name: 'PolygonScan',
+        buttonText: 'translated_viewAddressOnExplorer_PolygonScan',
+      });
+    });
+
+    it('returns correct info for EVM network with custom block explorer URL', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Custom Network',
+        chainId: 'eip155:1',
+        blockExplorerUrl: 'https://custom-explorer.com'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://custom-explorer.com/address/0x1234567890abcdef',
+        name: 'Etherscan',
+        buttonText: 'translated_viewAddressOnExplorer_Etherscan',
+      });
+    });
+
+    it('returns null for unknown network without chainId', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Unknown Network'
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for unknown chainId', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Unknown Network',
+        chainId: 'unknown:123'
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('CaipChainId conversion logic', () => {
+    it('converts EVM CaipChainId to hex correctly', () => {
+      const eip155ChainId = 'eip155:1';
+      const hexChainId = `0x${parseInt(eip155ChainId.split(':')[1]).toString(16)}`;
+      expect(hexChainId).toBe('0x1');
+    });
+
+    it('converts different EVM chain IDs correctly', () => {
+      const testCases = [
+        { caip: 'eip155:137', expected: '0x89' }, // Polygon
+        { caip: 'eip155:10', expected: '0xa' },   // Optimism
+        { caip: 'eip155:42161', expected: '0xa4b1' }, // Arbitrum
+      ];
+
+      testCases.forEach(({ caip, expected }) => {
+        const hexChainId = `0x${parseInt(caip.split(':')[1]).toString(16)}`;
+        expect(hexChainId).toBe(expected);
+      });
+    });
+  });
+
+  describe('Translation function integration', () => {
+    it('formats translation keys correctly', () => {
+      const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+
+      const result = mockT('viewAddressOnExplorer', ['Etherscan']);
+      expect(result).toBe('translated_viewAddressOnExplorer_Etherscan');
+    });
+
+    it('handles multiple translation arguments', () => {
+      const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+
+      const result = mockT('viewAddressOnExplorer', ['PolygonScan']);
+      expect(result).toBe('translated_viewAddressOnExplorer_PolygonScan');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles missing chainId gracefully', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Some Network'
+      });
+      expect(result).toBeNull();
+    });
+
+    it('handles EVM network without block explorer URL', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Ethereum Mainnet',
+        chainId: 'eip155:999999' // Unknown chain ID
+      });
+      expect(result).toBeNull();
+    });
+
+    it('handles multichain network without format URLs', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Bitcoin',
+        chainId: 'bitcoin:999999' // Unknown Bitcoin chain ID
+      });
+      expect(result).toBeNull();
+    });
+
+    it('handles custom block explorer URL without chainId mapping', () => {
+      const result = getBlockExplorerInfo(mockT, testAddress, {
+        networkName: 'Custom Network',
+        chainId: 'eip155:999999',
+        blockExplorerUrl: 'https://custom-explorer.com'
+      });
+
+      expect(result).toEqual({
+        addressUrl: 'https://custom-explorer.com/address/0x1234567890abcdef',
+        name: 'Block Explorer',
+        buttonText: 'translated_viewAddressOnExplorer_Block Explorer',
+      });
+    });
+  });
+});

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
@@ -1,5 +1,5 @@
-import { getBlockExplorerInfo } from './getBlockExplorerInfo';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import { getBlockExplorerInfo } from './getBlockExplorerInfo';
 
 describe('getBlockExplorerInfo utility functions', () => {
   const mockT = (key: string, ...args: string[]) =>

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
@@ -1,6 +1,5 @@
 import { getBlockExplorerInfo } from './getBlockExplorerInfo';
 
-
 // Mock the multichain constants
 jest.mock('../../../../shared/constants/multichain/networks', () => ({
   MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: {
@@ -38,19 +37,20 @@ jest.mock('../../../../shared/constants/common', () => ({
 // Mock the multichain URL formatting
 jest.mock('../../../../shared/lib/multichain/networks', () => ({
   formatBlockExplorerAddressUrl: jest.fn((urls, address) =>
-    urls.address.replace('{address}', address)
+    urls.address.replace('{address}', address),
   ),
 }));
 
 describe('getBlockExplorerInfo utility functions', () => {
-  const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+  const mockT = (key: string, ...args: string[]) =>
+    `translated_${key}_${args.join('_')}`;
   const testAddress = '0x1234567890abcdef';
 
   describe('getBlockExplorerInfo function', () => {
     it('returns correct info for Bitcoin network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Bitcoin',
-        chainId: 'bitcoin:0'
+        chainId: 'bitcoin:0',
       });
 
       expect(result).toEqual({
@@ -63,7 +63,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns correct info for Solana network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Solana',
-        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       });
 
       expect(result).toEqual({
@@ -76,7 +76,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns correct info for Ethereum EVM network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Ethereum Mainnet',
-        chainId: 'eip155:1'
+        chainId: 'eip155:1',
       });
 
       expect(result).toEqual({
@@ -89,7 +89,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns correct info for Polygon EVM network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Polygon',
-        chainId: 'eip155:137'
+        chainId: 'eip155:137',
       });
 
       expect(result).toEqual({
@@ -103,7 +103,7 @@ describe('getBlockExplorerInfo utility functions', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Custom Network',
         chainId: 'eip155:1',
-        blockExplorerUrl: 'https://custom-explorer.com'
+        blockExplorerUrl: 'https://custom-explorer.com',
       });
 
       expect(result).toEqual({
@@ -115,7 +115,7 @@ describe('getBlockExplorerInfo utility functions', () => {
 
     it('returns null for unknown network without chainId', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
-        networkName: 'Unknown Network'
+        networkName: 'Unknown Network',
       });
 
       expect(result).toBeNull();
@@ -124,7 +124,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns null for unknown chainId', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Unknown Network',
-        chainId: 'unknown:123'
+        chainId: 'unknown:123',
       });
 
       expect(result).toBeNull();
@@ -134,19 +134,19 @@ describe('getBlockExplorerInfo utility functions', () => {
   describe('CaipChainId conversion logic', () => {
     it('converts EVM CaipChainId to hex correctly', () => {
       const eip155ChainId = 'eip155:1';
-      const hexChainId = `0x${parseInt(eip155ChainId.split(':')[1]).toString(16)}`;
+      const hexChainId = `0x${parseInt(eip155ChainId.split(':')[1], 10).toString(16)}`;
       expect(hexChainId).toBe('0x1');
     });
 
     it('converts different EVM chain IDs correctly', () => {
       const testCases = [
         { caip: 'eip155:137', expected: '0x89' }, // Polygon
-        { caip: 'eip155:10', expected: '0xa' },   // Optimism
+        { caip: 'eip155:10', expected: '0xa' }, // Optimism
         { caip: 'eip155:42161', expected: '0xa4b1' }, // Arbitrum
       ];
 
       testCases.forEach(({ caip, expected }) => {
-        const hexChainId = `0x${parseInt(caip.split(':')[1]).toString(16)}`;
+        const hexChainId = `0x${parseInt(caip.split(':')[1], 10).toString(16)}`;
         expect(hexChainId).toBe(expected);
       });
     });
@@ -154,16 +154,18 @@ describe('getBlockExplorerInfo utility functions', () => {
 
   describe('Translation function integration', () => {
     it('formats translation keys correctly', () => {
-      const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+      const mockT2 = (key: string, ...args: string[]) =>
+        `translated_${key}_${args.join('_')}`;
 
-      const result = mockT('viewAddressOnExplorer', ['Etherscan']);
+      const result = mockT2('viewAddressOnExplorer', 'Etherscan');
       expect(result).toBe('translated_viewAddressOnExplorer_Etherscan');
     });
 
     it('handles multiple translation arguments', () => {
-      const mockT = (key: string, ...args: any[]) => `translated_${key}_${args.join('_')}`;
+      const mockT3 = (key: string, ...args: string[]) =>
+        `translated_${key}_${args.join('_')}`;
 
-      const result = mockT('viewAddressOnExplorer', ['PolygonScan']);
+      const result = mockT3('viewAddressOnExplorer', 'PolygonScan');
       expect(result).toBe('translated_viewAddressOnExplorer_PolygonScan');
     });
   });
@@ -171,7 +173,7 @@ describe('getBlockExplorerInfo utility functions', () => {
   describe('Edge cases', () => {
     it('handles missing chainId gracefully', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
-        networkName: 'Some Network'
+        networkName: 'Some Network',
       });
       expect(result).toBeNull();
     });
@@ -179,7 +181,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('handles EVM network without block explorer URL', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Ethereum Mainnet',
-        chainId: 'eip155:999999' // Unknown chain ID
+        chainId: 'eip155:999999', // Unknown chain ID
       });
       expect(result).toBeNull();
     });
@@ -187,7 +189,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('handles multichain network without format URLs', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Bitcoin',
-        chainId: 'bitcoin:999999' // Unknown Bitcoin chain ID
+        chainId: 'bitcoin:999999', // Unknown Bitcoin chain ID
       });
       expect(result).toBeNull();
     });
@@ -196,7 +198,7 @@ describe('getBlockExplorerInfo utility functions', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Custom Network',
         chainId: 'eip155:999999',
-        blockExplorerUrl: 'https://custom-explorer.com'
+        blockExplorerUrl: 'https://custom-explorer.com',
       });
 
       expect(result).toEqual({

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
@@ -1,45 +1,5 @@
 import { getBlockExplorerInfo } from './getBlockExplorerInfo';
-
-// Mock the multichain constants
-jest.mock('../../../../shared/constants/multichain/networks', () => ({
-  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: {
-    'bitcoin:0': {
-      url: 'https://blockstream.info',
-      address: 'https://blockstream.info/address/{address}',
-      transaction: 'https://blockstream.info/tx/{txId}',
-    },
-    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
-      url: 'https://solscan.io',
-      address: 'https://solscan.io/account/{address}',
-      transaction: 'https://solscan.io/tx/{txId}',
-    },
-  },
-  MultichainNetworks: {
-    BITCOIN: 'bitcoin:0',
-    SOLANA: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-  },
-}));
-
-// Mock the common constants
-jest.mock('../../../../shared/constants/common', () => ({
-  CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP: {
-    '0x1': 'Etherscan',
-    '0x89': 'PolygonScan',
-    '0xa': 'Optimism Explorer',
-  },
-  CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP: {
-    '0x1': 'https://etherscan.io/',
-    '0x89': 'https://polygonscan.com/',
-    '0xa': 'https://optimistic.etherscan.io/',
-  },
-}));
-
-// Mock the multichain URL formatting
-jest.mock('../../../../shared/lib/multichain/networks', () => ({
-  formatBlockExplorerAddressUrl: jest.fn((urls, address) =>
-    urls.address.replace('{address}', address),
-  ),
-}));
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 
 describe('getBlockExplorerInfo utility functions', () => {
   const mockT = (key: string, ...args: string[]) =>
@@ -50,11 +10,11 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns correct info for Bitcoin network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Bitcoin',
-        chainId: 'bitcoin:0',
+        chainId: MultichainNetworks.BITCOIN,
       });
 
       expect(result).toEqual({
-        addressUrl: 'https://blockstream.info/address/0x1234567890abcdef',
+        addressUrl: 'https://mempool.space/address/0x1234567890abcdef',
         name: 'Blockstream',
         buttonText: 'translated_viewAddressOnExplorer_Blockstream',
       });
@@ -63,7 +23,7 @@ describe('getBlockExplorerInfo utility functions', () => {
     it('returns correct info for Solana network', () => {
       const result = getBlockExplorerInfo(mockT, testAddress, {
         networkName: 'Solana',
-        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        chainId: MultichainNetworks.SOLANA,
       });
 
       expect(result).toEqual({

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
@@ -1,103 +1,124 @@
-import { CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP, CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/common';
-import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../../../shared/constants/multichain/networks';
-import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
-import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
 import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import {
+  CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP,
+  CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
+} from '../../../../shared/constants/common';
+import {
+  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP,
+  MultichainNetworks,
+} from '../../../../shared/constants/multichain/networks';
+import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
 
-export interface BlockExplorerInfo {
+export type BlockExplorerInfo = {
   addressUrl: string;
   name: string;
   buttonText: string;
-}
+};
 
-export interface NetworkInfo {
+export type NetworkInfo = {
   chainId?: CaipChainId;
   blockExplorerUrl?: string;
   networkName: string;
-}
+};
 
 /**
  * Gets block explorer information for a specific network
+ *
  * @param t - Translation function
  * @param address - The address to create the URL for
  * @param networkInfo - Information about the network including chainId, blockExplorerUrl, and networkName
  * @returns BlockExplorerInfo or null if no explorer available
  */
 export const getBlockExplorerInfo = (
-  t: (key: string, ...args: any[]) => string,
+  t: (key: string, ...args: string[]) => string,
   address: string,
-  networkInfo: NetworkInfo
+  networkInfo: NetworkInfo,
 ): BlockExplorerInfo | null => {
   const { chainId, blockExplorerUrl } = networkInfo;
 
   // For multichain networks (Bitcoin, Solana), use CaipChainId for reliable detection
   if (chainId) {
     // Bitcoin networks
-    if (chainId === MultichainNetworks.BITCOIN ||
-        chainId === MultichainNetworks.BITCOIN_TESTNET ||
-        chainId === MultichainNetworks.BITCOIN_SIGNET) {
-      const blockExplorerFormatUrls = MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
+    if (
+      chainId === MultichainNetworks.BITCOIN ||
+      chainId === MultichainNetworks.BITCOIN_TESTNET ||
+      chainId === MultichainNetworks.BITCOIN_SIGNET
+    ) {
+      const blockExplorerFormatUrls =
+        MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
       if (blockExplorerFormatUrls) {
         const explorerName = 'Blockstream';
-        const addressUrl = formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
+        const addressUrl = formatBlockExplorerAddressUrl(
+          blockExplorerFormatUrls,
+          address,
+        );
         return {
           addressUrl,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', [explorerName]),
+          buttonText: t('viewAddressOnExplorer', explorerName),
         };
       }
     }
 
     // Solana networks
-    if (chainId === MultichainNetworks.SOLANA ||
-        chainId === MultichainNetworks.SOLANA_DEVNET ||
-        chainId === MultichainNetworks.SOLANA_TESTNET) {
-      const blockExplorerFormatUrls = MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
+    if (
+      chainId === MultichainNetworks.SOLANA ||
+      chainId === MultichainNetworks.SOLANA_DEVNET ||
+      chainId === MultichainNetworks.SOLANA_TESTNET
+    ) {
+      const blockExplorerFormatUrls =
+        MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
       if (blockExplorerFormatUrls) {
         const explorerName = 'Solscan';
-        const addressUrl = formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
+        const addressUrl = formatBlockExplorerAddressUrl(
+          blockExplorerFormatUrls,
+          address,
+        );
         return {
           addressUrl,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', [explorerName]),
+          buttonText: t('viewAddressOnExplorer', explorerName),
         };
       }
     }
   }
 
-
   // For EVM networks, use CaipChainId for reliable detection
-  if (chainId && chainId.startsWith(KnownCaipNamespace.Eip155)) {
+  if (chainId?.startsWith(KnownCaipNamespace.Eip155)) {
     // Convert CaipChainId to hex for EVM networks
-    const hexChainId = `0x${parseInt(chainId.split(':')[1]).toString(16)}`;
+    const hexChainId = `0x${parseInt(chainId.split(':')[1], 10).toString(16)}`;
 
     // Use the provided block explorer URL if available
     if (blockExplorerUrl) {
-      const explorerName = CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId] || 'Block Explorer';
+      const explorerName =
+        CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId] ||
+        'Block Explorer';
       const addressUrl = `${blockExplorerUrl}/address/${address}`;
 
       return {
         addressUrl,
         name: explorerName,
-        buttonText: t('viewAddressOnExplorer', [explorerName]),
+        buttonText: t('viewAddressOnExplorer', explorerName),
       };
     }
 
     // Use known EVM network mappings
-    const explorerName = CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId];
+    const explorerName =
+      CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId];
     if (explorerName) {
       // Get the base URL from the mapping (remove trailing slash)
-      const baseUrl = CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP[hexChainId]?.replace(/\/$/, '');
+      const baseUrl = CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP[
+        hexChainId
+      ]?.replace(/\/$/u, '');
       if (baseUrl) {
         return {
           addressUrl: `${baseUrl}/address/${address}`,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', [explorerName]),
+          buttonText: t('viewAddressOnExplorer', explorerName),
         };
       }
     }
   }
-
 
   return null;
 };

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
@@ -1,0 +1,103 @@
+import { CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP, CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/common';
+import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../../../shared/constants/multichain/networks';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
+import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+
+export interface BlockExplorerInfo {
+  addressUrl: string;
+  name: string;
+  buttonText: string;
+}
+
+export interface NetworkInfo {
+  chainId?: CaipChainId;
+  blockExplorerUrl?: string;
+  networkName: string;
+}
+
+/**
+ * Gets block explorer information for a specific network
+ * @param t - Translation function
+ * @param address - The address to create the URL for
+ * @param networkInfo - Information about the network including chainId, blockExplorerUrl, and networkName
+ * @returns BlockExplorerInfo or null if no explorer available
+ */
+export const getBlockExplorerInfo = (
+  t: (key: string, ...args: any[]) => string,
+  address: string,
+  networkInfo: NetworkInfo
+): BlockExplorerInfo | null => {
+  const { chainId, blockExplorerUrl } = networkInfo;
+
+  // For multichain networks (Bitcoin, Solana), use CaipChainId for reliable detection
+  if (chainId) {
+    // Bitcoin networks
+    if (chainId === MultichainNetworks.BITCOIN ||
+        chainId === MultichainNetworks.BITCOIN_TESTNET ||
+        chainId === MultichainNetworks.BITCOIN_SIGNET) {
+      const blockExplorerFormatUrls = MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
+      if (blockExplorerFormatUrls) {
+        const explorerName = 'Blockstream';
+        const addressUrl = formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
+        return {
+          addressUrl,
+          name: explorerName,
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
+        };
+      }
+    }
+
+    // Solana networks
+    if (chainId === MultichainNetworks.SOLANA ||
+        chainId === MultichainNetworks.SOLANA_DEVNET ||
+        chainId === MultichainNetworks.SOLANA_TESTNET) {
+      const blockExplorerFormatUrls = MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
+      if (blockExplorerFormatUrls) {
+        const explorerName = 'Solscan';
+        const addressUrl = formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
+        return {
+          addressUrl,
+          name: explorerName,
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
+        };
+      }
+    }
+  }
+
+
+  // For EVM networks, use CaipChainId for reliable detection
+  if (chainId && chainId.startsWith(KnownCaipNamespace.Eip155)) {
+    // Convert CaipChainId to hex for EVM networks
+    const hexChainId = `0x${parseInt(chainId.split(':')[1]).toString(16)}`;
+
+    // Use the provided block explorer URL if available
+    if (blockExplorerUrl) {
+      const explorerName = CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId] || 'Block Explorer';
+      const addressUrl = `${blockExplorerUrl}/address/${address}`;
+
+      return {
+        addressUrl,
+        name: explorerName,
+        buttonText: t('viewAddressOnExplorer', [explorerName]),
+      };
+    }
+
+    // Use known EVM network mappings
+    const explorerName = CHAINID_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL_MAP[hexChainId];
+    if (explorerName) {
+      // Get the base URL from the mapping (remove trailing slash)
+      const baseUrl = CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP[hexChainId]?.replace(/\/$/, '');
+      if (baseUrl) {
+        return {
+          addressUrl: `${baseUrl}/address/${address}`,
+          name: explorerName,
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
+        };
+      }
+    }
+  }
+
+
+  return null;
+};

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -62,7 +62,12 @@ export const MultichainAccountAddressListPage = () => {
 
   // QR Modal handlers
   const handleShowQR = useCallback(
-    (address: string, networkName: string, chainId: CaipChainId, networkImageSrc?: string) => {
+    (
+      address: string,
+      networkName: string,
+      chainId: CaipChainId,
+      networkImageSrc?: string,
+    ) => {
       setSelectedQRData({ address, networkName, chainId, networkImageSrc });
       setIsQRModalOpen(true);
     },

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { CaipChainId } from '@metamask/utils';
 import {
   Box,
   BoxFlexDirection,
@@ -55,13 +56,14 @@ export const MultichainAccountAddressListPage = () => {
   const [selectedQRData, setSelectedQRData] = useState<{
     address: string;
     networkName: string;
+    chainId: CaipChainId;
     networkImageSrc?: string;
   } | null>(null);
 
   // QR Modal handlers
   const handleShowQR = useCallback(
-    (address: string, networkName: string, networkImageSrc?: string) => {
-      setSelectedQRData({ address, networkName, networkImageSrc });
+    (address: string, networkName: string, chainId: CaipChainId, networkImageSrc?: string) => {
+      setSelectedQRData({ address, networkName, chainId, networkImageSrc });
       setIsQRModalOpen(true);
     },
     [],
@@ -109,6 +111,7 @@ export const MultichainAccountAddressListPage = () => {
           address={selectedQRData.address}
           accountName={accountGroup?.metadata?.name || t('account')}
           networkName={selectedQRData.networkName}
+          chainId={selectedQRData.chainId}
           networkImageSrc={selectedQRData.networkImageSrc}
         />
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds `getBlockExplorerInfo` utility that provides proper block explorer URLs and names for Bitcoin (Blockstream), Solana (Solscan), and EVM networks (Etherscan, PolygonScan, etc.)
The implementation supports both EVM and non-EVM networks with proper CAIP chain ID handling and provides a consistent user experience across all supported blockchain networks.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was preventing to show block explorer button for some networks

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-889

## **Manual testing steps**

1. Navigate to the multichain account address list page
2. Verify that addresses from different networks (Bitcoin, Solana, EVM) are displayed correctly
3. Click the QR code button and verify the QR modal opens with the correct address and network information
4. Test block explorer links by verifying they open the correct explorer for each network type

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="398" height="595" alt="Screenshot 2025-09-24 at 09 29 40" src="https://github.com/user-attachments/assets/2853c1a7-68ac-470e-b805-89762cfe1716" />
<img width="398" height="597" alt="Screenshot 2025-09-24 at 09 29 47" src="https://github.com/user-attachments/assets/3817ecc9-ee2a-4ff7-905c-54298d380a69" />

<!-- [screenshots/recordings] -->

### **After**
<img width="400" height="599" alt="Screenshot 2025-09-24 at 09 32 16" src="https://github.com/user-attachments/assets/1052dd48-f569-4a10-be0b-262d947f65fb" />
<img width="400" height="599" alt="Screenshot 2025-09-24 at 09 32 24" src="https://github.com/user-attachments/assets/ab59a652-7b60-4fa0-8956-87bb5c0df7f3" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
