### PR TITLE
fix: Fix max value refresher

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
@@ -1,12 +1,13 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useSearchParams } from 'react-router-dom-v5-compat';
+import { merge } from 'lodash';
 
 import { updateEditableParams } from '../../../../../../store/actions';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useTransactionEventFragment } from '../../../../hooks/useTransactionEventFragment';
 import {
-  getSelectedAccountCachedBalance,
+  getCrossChainMetaMaskCachedBalances,
   selectMaxValueModeForTransaction,
 } from '../../../../../../selectors';
 import { useMaxValueRefresher } from './useMaxValueRefresher';
@@ -31,7 +32,7 @@ jest.mock('../../../../../../store/actions', () => ({
 }));
 
 jest.mock('../../../../../../selectors', () => ({
-  getSelectedAccountCachedBalance: jest.fn(),
+  getCrossChainMetaMaskCachedBalances: jest.fn(),
   selectMaxValueModeForTransaction: jest.fn(),
 }));
 
@@ -52,8 +53,8 @@ describe('useMaxValueRefresher', () => {
   const useTransactionEventFragmentMock = jest.mocked(
     useTransactionEventFragment,
   );
-  const getSelectedAccountCachedBalanceMock = jest.mocked(
-    getSelectedAccountCachedBalance,
+  const getCrossChainNativeBalancesMock = jest.mocked(
+    getCrossChainMetaMaskCachedBalances,
   );
   const selectMaxValueModeForTransactionMock = jest.mocked(
     selectMaxValueModeForTransaction,
@@ -64,7 +65,9 @@ describe('useMaxValueRefresher', () => {
   const baseTransactionMeta = {
     id: 'test-transaction-id',
     type: TransactionType.simpleSend,
+    chainId: '0x1',
     txParams: {
+      from: '0x12345',
       gas: '0x5208', // 21000 in hex
       gasPrice: '0x3b9aca00', // 1 gwei in hex
       maxFeePerGas: '0x3b9aca00', // 1 gwei in hex
@@ -84,7 +87,11 @@ describe('useMaxValueRefresher', () => {
       supportsEIP1559: true,
     });
 
-    getSelectedAccountCachedBalanceMock.mockReturnValue(defaultBalance);
+    getCrossChainNativeBalancesMock.mockReturnValue({
+      [baseTransactionMeta.chainId]: {
+        [baseTransactionMeta.txParams.from]: defaultBalance,
+      },
+    });
     selectMaxValueModeForTransactionMock.mockReturnValue(true);
 
     useTransactionEventFragmentMock.mockReturnValue({
@@ -164,10 +171,9 @@ describe('useMaxValueRefresher', () => {
   });
 
   it('does not update transaction value for non-simpleSend transactions', () => {
-    const contractInteractionMeta = {
-      ...baseTransactionMeta,
+    const contractInteractionMeta = merge({}, baseTransactionMeta, {
       type: TransactionType.contractInteraction,
-    };
+    });
 
     useConfirmContextMock.mockReturnValue({
       currentConfirmation: contractInteractionMeta,
@@ -179,10 +185,9 @@ describe('useMaxValueRefresher', () => {
   });
 
   it('does not update transaction value for token transfer transactions', () => {
-    const tokenTransferMeta = {
-      ...baseTransactionMeta,
+    const tokenTransferMeta = merge({}, baseTransactionMeta, {
       type: TransactionType.tokenMethodTransfer,
-    };
+    });
 
     useConfirmContextMock.mockReturnValue({
       currentConfirmation: tokenTransferMeta,
@@ -216,7 +221,11 @@ describe('useMaxValueRefresher', () => {
   describe('Transaction Value Updates - Edge Cases', () => {
     it('does not update when remaining balance is zero', () => {
       // Set balance equal to gas fee (21000 * 1 gwei = 0x4c4b40)
-      getSelectedAccountCachedBalanceMock.mockReturnValue('0x4c4b40');
+      getCrossChainNativeBalancesMock.mockReturnValue({
+        [baseTransactionMeta.chainId]: {
+          [baseTransactionMeta.txParams.from]: '0x4c4b40',
+        },
+      });
 
       renderHook(() => useMaxValueRefresher());
 
@@ -224,7 +233,11 @@ describe('useMaxValueRefresher', () => {
     });
 
     it('does not update when remaining balance is negative', () => {
-      getSelectedAccountCachedBalanceMock.mockReturnValue('0x1000');
+      getCrossChainNativeBalancesMock.mockReturnValue({
+        [baseTransactionMeta.chainId]: {
+          [baseTransactionMeta.txParams.from]: '0x1000',
+        },
+      });
 
       renderHook(() => useMaxValueRefresher());
 
@@ -232,7 +245,11 @@ describe('useMaxValueRefresher', () => {
     });
 
     it('handles zero balance gracefully', () => {
-      getSelectedAccountCachedBalanceMock.mockReturnValue('0x0');
+      getCrossChainNativeBalancesMock.mockReturnValue({
+        [baseTransactionMeta.chainId]: {
+          [baseTransactionMeta.txParams.from]: '0x0',
+        },
+      });
 
       renderHook(() => useMaxValueRefresher());
 
@@ -240,7 +257,11 @@ describe('useMaxValueRefresher', () => {
     });
 
     it('handles null balance gracefully', () => {
-      getSelectedAccountCachedBalanceMock.mockReturnValue(null);
+      getCrossChainNativeBalancesMock.mockReturnValue({
+        [baseTransactionMeta.chainId]: {
+          [baseTransactionMeta.txParams.from]: null,
+        },
+      });
 
       renderHook(() => useMaxValueRefresher());
 
@@ -248,7 +269,11 @@ describe('useMaxValueRefresher', () => {
     });
 
     it('handles undefined balance gracefully', () => {
-      getSelectedAccountCachedBalanceMock.mockReturnValue(undefined);
+      getCrossChainNativeBalancesMock.mockReturnValue({
+        [baseTransactionMeta.chainId]: {
+          [baseTransactionMeta.txParams.from]: undefined,
+        },
+      });
 
       renderHook(() => useMaxValueRefresher());
 
@@ -263,13 +288,12 @@ describe('useMaxValueRefresher', () => {
       });
 
       it('calculates value using maxFeePerGas for EIP-1559 transactions', () => {
-        const transactionMeta = {
-          ...baseTransactionMeta,
+        const transactionMeta = merge({}, baseTransactionMeta, {
           txParams: {
             gas: '0x5208', // 21000
             maxFeePerGas: '0x77359400', // 2 gwei
           },
-        };
+        });
 
         useConfirmContextMock.mockReturnValue({
           currentConfirmation: transactionMeta,
@@ -292,6 +316,7 @@ describe('useMaxValueRefresher', () => {
         const transactionMeta = {
           ...baseTransactionMeta,
           txParams: {
+            from: baseTransactionMeta.txParams.from,
             gas: '0x5208',
           },
         };
@@ -318,13 +343,12 @@ describe('useMaxValueRefresher', () => {
       });
 
       it('calculates value using gasPrice for legacy transactions', () => {
-        const transactionMeta = {
-          ...baseTransactionMeta,
+        const transactionMeta = merge({}, baseTransactionMeta, {
           txParams: {
             gas: '0x5208', // 21000
             gasPrice: '0x77359400', // 2 gwei
           },
-        };
+        });
 
         useConfirmContextMock.mockReturnValue({
           currentConfirmation: transactionMeta,
@@ -345,7 +369,9 @@ describe('useMaxValueRefresher', () => {
         const transactionMeta = {
           ...baseTransactionMeta,
           txParams: {
+            from: baseTransactionMeta.txParams.from,
             gas: '0x5208',
+            gasPrice: undefined,
           },
         };
 
@@ -366,14 +392,13 @@ describe('useMaxValueRefresher', () => {
 
     describe('Layer 1 Gas Fees (L2 Networks)', () => {
       it('includes layer1GasFee in gas fee calculation', () => {
-        const transactionMeta = {
-          ...baseTransactionMeta,
+        const transactionMeta = merge({}, baseTransactionMeta, {
           txParams: {
             gas: '0x5208', // 21000
             maxFeePerGas: '0x3b9aca00', // 1 gwei
           },
           layer1GasFee: '0x2540be400', // 10 gwei
-        };
+        });
 
         useConfirmContextMock.mockReturnValue({
           currentConfirmation: transactionMeta,
@@ -392,13 +417,12 @@ describe('useMaxValueRefresher', () => {
       });
 
       it('handles missing layer1GasFee', () => {
-        const transactionMeta = {
-          ...baseTransactionMeta,
+        const transactionMeta = merge({}, baseTransactionMeta, {
           txParams: {
             gas: '0x5208',
             maxFeePerGas: '0x3b9aca00',
           },
-        };
+        });
 
         useConfirmContextMock.mockReturnValue({
           currentConfirmation: transactionMeta,
@@ -421,6 +445,7 @@ describe('useMaxValueRefresher', () => {
       const transactionMeta = {
         ...baseTransactionMeta,
         txParams: {
+          from: baseTransactionMeta.txParams.from,
           maxFeePerGas: '0x3b9aca00',
         },
       };
@@ -445,7 +470,11 @@ describe('useMaxValueRefresher', () => {
 
     expect(updateEditableParamsMock).toHaveBeenCalledTimes(1);
 
-    getSelectedAccountCachedBalanceMock.mockReturnValue('0x2386f26fc10000'); // 0.01 ETH
+    getCrossChainNativeBalancesMock.mockReturnValue({
+      [baseTransactionMeta.chainId]: {
+        [baseTransactionMeta.txParams.from]: '0x2386f26fc10000',
+      },
+    });
     rerender();
 
     expect(updateEditableParamsMock).toHaveBeenCalledTimes(2);
@@ -466,7 +495,7 @@ describe('useMaxValueRefresher', () => {
     const updatedTransactionMeta = {
       ...baseTransactionMeta,
       txParams: {
-        ...baseTransactionMeta.txParams,
+        from: baseTransactionMeta.txParams.from,
         maxFeePerGas: '0x77359400', // 2 gwei instead of 1
       },
     };
@@ -502,42 +531,11 @@ describe('useMaxValueRefresher', () => {
     expect(updateEditableParamsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('handles complete transaction flow with realistic values', () => {
-    const realisticTransactionMeta = {
-      id: 'realistic-tx-id',
-      type: TransactionType.simpleSend,
-      txParams: {
-        gas: '0x5208', // 21000 gas
-        maxFeePerGas: '0x12a05f200', // 5 gwei
-      },
-      layer1GasFee: '0x5af3107a4000', // 0.0001 ETH L1 fee
-    };
-
-    useConfirmContextMock.mockReturnValue({
-      currentConfirmation: realisticTransactionMeta,
-    } as unknown as ReturnType<typeof useConfirmContext>);
-
-    // 1 ETH balance
-    getSelectedAccountCachedBalanceMock.mockReturnValue('0xde0b6b3a7640000');
-
-    renderHook(() => useMaxValueRefresher());
-
-    // Gas fee: 21000 * 5 gwei + 0.0001 ETH = 0x18e946000000000 + 0x5af3107a4000 = 0x19495b07a4000
-    // Remaining: 0xde0b6b3a7640000 - 0x19495b07a4000 = 0xddffc415f363000
-    expect(updateEditableParamsMock).toHaveBeenCalledWith(
-      realisticTransactionMeta.id,
-      {
-        value: '0xddffc415f363000',
-      },
-    );
-  });
-
   it('dispatches updateEditableParams with correct transaction ID', () => {
     const customTransactionId = 'custom-transaction-123';
-    const transactionMeta = {
-      ...baseTransactionMeta,
+    const transactionMeta = merge({}, baseTransactionMeta, {
       id: customTransactionId,
-    };
+    });
 
     useConfirmContextMock.mockReturnValue({
       currentConfirmation: transactionMeta,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -8,7 +8,7 @@ import { Hex } from '@metamask/utils';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 
 import {
-  getSelectedAccountCachedBalance,
+  getCrossChainMetaMaskCachedBalances,
   selectMaxValueModeForTransaction,
 } from '../../../../../../selectors';
 import {
@@ -41,7 +41,11 @@ export const useMaxValueRefresher = () => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const dispatch = useDispatch();
-  const { id: transactionId } = transactionMeta;
+  const {
+    chainId,
+    id: transactionId,
+    txParams: { from },
+  } = transactionMeta;
   const isMaxAmountMode = useSelector((state) =>
     selectMaxValueModeForTransaction(state, transactionMeta?.id),
   );
@@ -49,8 +53,10 @@ export const useMaxValueRefresher = () => {
   const [searchParams] = useSearchParams();
   const paramMaxValueMode = searchParams.get('maxValueMode') === 'true';
   const isMaxValueMode = isMaxAmountMode || paramMaxValueMode;
-
-  const balance = useSelector(getSelectedAccountCachedBalance);
+  const crossChainNativeBalances = useSelector(
+    getCrossChainMetaMaskCachedBalances,
+  ) as { [chainId: string]: { [from: string]: string } };
+  const balance = crossChainNativeBalances?.[chainId]?.[from] ?? HEX_ZERO;
   const { supportsEIP1559 } = useSupportsEIP1559(transactionMeta);
   const gas = (transactionMeta.txParams.gas as Hex) || HEX_ZERO;
   const gasPrice = (transactionMeta.txParams.gasPrice as Hex) || HEX_ZERO;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix max value refresher on transaction confirmation when other network selected in asset list. Having different network selector in asset list was causing balance selector to read incorrect balance from another network.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36273?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36194

## **Manual testing steps**

See task details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
