### PR TITLE
fix: site cell text

### DIFF
--- a/ui/components/multichain-accounts/multichain-site-cell/multichain-site-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-site-cell/multichain-site-cell.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { CaipChainId } from '@metamask/utils';
 import { AccountGroupId } from '@metamask/account-api';
 import { AvatarAccountSize } from '@metamask/design-system-react';
@@ -82,6 +82,16 @@ export const MultichainSiteCell: React.FC<MultichainSiteCellProps> = ({
     });
   };
 
+  const accountMessageConnectedState = useMemo(() => {
+    return selectedAccountGroupIds.length === 1
+      ? t('connectedWithAccountName', [
+          supportedAccountGroups.find(
+            (account) => account.id === selectedAccountGroupIds[0],
+          )?.metadata.name || '',
+        ])
+      : t('connectedWithAccount', [selectedAccountGroupIds.length]);
+  }, [selectedAccountGroupIds, supportedAccountGroups, t]);
+
   return (
     <>
       <Box
@@ -93,9 +103,7 @@ export const MultichainSiteCell: React.FC<MultichainSiteCellProps> = ({
         <SiteCellConnectionListItem
           title={t('accountsPermissionsTitle')}
           iconName={IconName.Eye}
-          connectedMessage={t('requestingFor', [
-            selectedAccountGroupIds.length,
-          ])}
+          connectedMessage={accountMessageConnectedState}
           unconnectedMessage={t('requestingFor', [
             selectedAccountGroupIds.length,
           ])}
@@ -126,9 +134,7 @@ export const MultichainSiteCell: React.FC<MultichainSiteCellProps> = ({
           title={t('permission_walletSwitchEthereumChain')}
           iconName={IconName.Global}
           connectedMessage={t('connectedWithNetwork', [selectedChainIdsLength])}
-          unconnectedMessage={t('requestingForNetwork', [
-            selectedChainIdsLength,
-          ])}
+          unconnectedMessage={t('requestingFor')}
           isConnectFlow={isConnectFlow}
           onClick={handleOpenNetworksModal}
           paddingTopValue={2}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the connected site cell copy for connected accounts and networks. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36280?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix site cell connected account / network text

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1065?atlOrigin=eyJpIjoiZGNmNjc3N2E0OGNjNDE1NTk0NjdlODZiYjVlM2MyOGQiLCJwIjoiaiJ9

## **Manual testing steps**


WIth this flag in `.manifest-overrides.json`

``` "enableMultichainAccounts": 
{
        "enabled": true,
        "featureVersion": "2",
        "minimumVersion": "12.19.0"
      }
```

1. Go to a dapp
2. Initiate a connection and click on the permissions tab
3. See that it says `Requesting for` for both networks and accounts.
4. Confirm the connection
5. Open the wallet
6. Go to settings
7. Go to all permissions
8. Click on the new dapp permission
9. Click on permissions
10. See that 
  - It says `# of accounts/networks connected`
  - If there is only one account connect, it would say `Connected with {account name}`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="404" height="621" alt="Screenshot 2025-09-24 at 17 59 22" src="https://github.com/user-attachments/assets/2ccdf0dd-69b1-4063-bcef-046b4b355ec0" />
<img width="411" height="606" alt="Screenshot 2025-09-24 at 17 59 38" src="https://github.com/user-attachments/assets/83e7123e-fca6-437b-b2e9-8351790df2b3" />
<img width="408" height="603" alt="Screenshot 2025-09-24 at 17 59 45" src="https://github.com/user-attachments/assets/fac522c7-23bd-4a2c-8eca-c1e9625fd252" />


### **After**

<img width="407" height="597" alt="Screenshot 2025-09-24 at 16 09 27" src="https://github.com/user-attachments/assets/ad8bf439-fdff-4aae-8887-8d27ed1e7d05" />
<img width="400" height="604" alt="Screenshot 2025-09-24 at 16 09 33" src="https://github.com/user-attachments/assets/6745eada-3440-4bb2-94c2-d7e2d8003810" />
<img width="405" height="620" alt="Screenshot 2025-09-24 at 16 09 43" src="https://github.com/user-attachments/assets/f694a135-8c5c-43a1-b3c5-741379643c70" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
