### PR TITLE
fix: Show transactions for non-EVM and non-popular networks on the activity list

### DIFF
--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -421,8 +421,8 @@ export default function UnifiedTransactionList({
   ///: BEGIN:ONLY_INCLUDE_IF(multichain)
   const [selectedTransaction, setSelectedTransaction] = useState(null);
 
-  const nonEvmTransactions = useSelector(
-    getSelectedAccountGroupMultichainTransactions,
+  const nonEvmTransactions = useSelector((state) =>
+    getSelectedAccountGroupMultichainTransactions(state, nonEvmChainIds),
   );
 
   const nonEvmTransactionsForToken = useMemo(

--- a/ui/selectors/multichain-transactions.test.ts
+++ b/ui/selectors/multichain-transactions.test.ts
@@ -1,0 +1,129 @@
+import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
+import type { Transaction } from '@metamask/keyring-api';
+import type { DefaultRootState } from 'react-redux';
+import type { MultichainState } from './multichain';
+import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
+import { getSelectedAccountGroupMultichainTransactions } from './multichain-transactions';
+
+// Mock account-tree selectors used by the selector under test
+jest.mock('./multichain-accounts/account-tree', () => ({
+  getSelectedAccountGroup: jest.fn(() => 'group-1'),
+  getAccountGroupWithInternalAccounts: jest.fn(() => [
+    { id: 'group-1', accounts: [{ id: 'acc-1' }, { id: 'acc-2' }] },
+    { id: 'group-2', accounts: [{ id: 'acc-x' }] },
+  ]),
+}));
+
+describe('getSelectedAccountGroupMultichainTransactions', () => {
+  const SOLANA_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+  const SOLANA_DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+
+  type RootState = MultichainState & MultichainAccountsState & DefaultRootState;
+  type NonEvmTransactionsMap =
+    MultichainTransactionsControllerState['nonEvmTransactions'];
+
+  function buildState(nonEvmTransactions: unknown): RootState {
+    return {
+      metamask: {
+        nonEvmTransactions: nonEvmTransactions as NonEvmTransactionsMap,
+      },
+    } as unknown as RootState;
+  }
+
+  it('returns empty transactions when nonEvmChainIds is undefined', () => {
+    const tx1 = { id: 'a1' } as unknown as Transaction;
+    const state = buildState({
+      'acc-1': {
+        [SOLANA_MAINNET]: {
+          transactions: [tx1],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+    });
+
+    const result = getSelectedAccountGroupMultichainTransactions(
+      state,
+      undefined,
+    );
+    expect(result).toEqual({ transactions: [] });
+  });
+
+  it('aggregates transactions for specified chain IDs across accounts in the selected group', () => {
+    const a1 = { id: 'a1' } as unknown as Transaction;
+    const a2 = { id: 'a2' } as unknown as Transaction;
+    const a3 = { id: 'a3' } as unknown as Transaction;
+    const b1 = { id: 'b1' } as unknown as Transaction;
+    const other = { id: 'other' } as unknown as Transaction;
+
+    const state = buildState({
+      'acc-1': {
+        [SOLANA_MAINNET]: {
+          transactions: [a1, a2],
+          next: null,
+          lastUpdated: 0,
+        },
+        [SOLANA_DEVNET]: {
+          transactions: [a3],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+      'acc-2': {
+        [SOLANA_MAINNET]: {
+          transactions: [b1],
+          next: null,
+          lastUpdated: 0,
+        },
+        'bitcoin:mainnet': {
+          transactions: [other],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+      // This account is not in the selected group and should be ignored
+      'acc-3': {
+        [SOLANA_MAINNET]: {
+          transactions: [{ id: 'ignored' } as unknown as Transaction],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+    });
+
+    const result = getSelectedAccountGroupMultichainTransactions(state, [
+      SOLANA_MAINNET,
+    ]);
+
+    expect(result.transactions).toEqual([a1, a2, b1]);
+  });
+
+  it('ignores unknown chain IDs and missing entries gracefully', () => {
+    const a1 = { id: 'a1' } as unknown as Transaction;
+    const state = buildState({
+      'acc-1': {
+        [SOLANA_MAINNET]: {
+          transactions: [a1],
+          next: null,
+          lastUpdated: 0,
+        },
+        // entry without transactions
+        'unknown:chain': {
+          transactions: [],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+      'acc-2': {
+        // no chains for this account
+      },
+    });
+
+    const result = getSelectedAccountGroupMultichainTransactions(state, [
+      SOLANA_MAINNET,
+      'unknown:chain',
+      'nonexistent:chain',
+    ]);
+    expect(result.transactions).toEqual([a1]);
+  });
+});

--- a/ui/selectors/multichain-transactions.ts
+++ b/ui/selectors/multichain-transactions.ts
@@ -11,15 +11,20 @@ import type {
 } from './multichain-accounts/account-tree.types';
 
 // Lightweight shape for nonEvmTransactions state map
+// accountId -> chainId -> TransactionStateEntry
 type NonEvmTransactionsMap = Record<
   string,
-  { transactions?: Transaction[]; next?: string | null; lastUpdated?: number }
+  Record<
+    string,
+    { transactions?: Transaction[]; next?: string | null; lastUpdated?: number }
+  >
 >;
 
 type RootState = MultichainState & MultichainAccountsState & DefaultRootState;
 
 export function getSelectedAccountGroupMultichainTransactions(
   state: RootState,
+  nonEvmChainIds?: string[],
 ): { transactions: Transaction[] } {
   const nonEvmTransactionsByAccount = (state as MultichainState).metamask
     .nonEvmTransactions as NonEvmTransactionsMap;
@@ -40,10 +45,20 @@ export function getSelectedAccountGroupMultichainTransactions(
     (account) => account.id,
   );
 
-  const transactions =
-    selectedGroupAccountIds?.flatMap(
-      (accountId) => nonEvmTransactionsByAccount[accountId]?.transactions ?? [],
-    ) ?? [];
+  const transactions: Transaction[] = [];
+
+  if (selectedGroupAccountIds && selectedGroupAccountIds.length > 0) {
+    for (const accountId of selectedGroupAccountIds) {
+      const byChain = nonEvmTransactionsByAccount?.[accountId] ?? {};
+
+      for (const chainId of nonEvmChainIds ?? []) {
+        const entry = byChain?.[chainId];
+        if (entry?.transactions && Array.isArray(entry.transactions)) {
+          transactions.push(...entry.transactions);
+        }
+      }
+    }
+  }
 
   return { transactions };
 }

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -20,7 +20,6 @@ import {
   createDeepEqualSelector,
   filterAndShapeUnapprovedTransactions,
 } from '../../shared/modules/selectors/util';
-import { FEATURED_NETWORK_CHAIN_IDS } from '../../shared/constants/network';
 import { getSelectedInternalAccount } from './accounts';
 import { hasPendingApprovals, getApprovalRequestsByType } from './approvals';
 
@@ -62,10 +61,7 @@ export const getAllNetworkTransactions = createDeepEqualSelector(
     if (!transactions.length) {
       return [];
     }
-    const popularNetworks = FEATURED_NETWORK_CHAIN_IDS;
-    return transactions.filter((transaction) =>
-      popularNetworks.includes(transaction.chainId),
-    );
+    return transactions;
   },
 );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The activity list was not showing transactions on the Solana network. This is because in https://github.com/MetaMask/metamask-extension/pull/35689/ the multichain-transactions-controller version was updated with a breaking change. The MultichainTransactionControllerState was updated to nest TransactionStateEntry per chain as well as the preexisting accountId:

```
export type MultichainTransactionsControllerState = {
    nonEvmTransactions: {
        [accountId: string]: {
            [chain: CaipChainId]: TransactionStateEntry;
        };
    };
};
```

See app/scripts/migrations/176.ts for more details.

This means that on `getSelectedAccountGroupMultichainTransactions`, transactions need to be checked knowing that nonEvmTransactionsByAccount is keyed by accountId but also by chainIds. In unified-transaction-list.component we pass nonEvmChainIds to this selector

Additionally, the activity list was not showing transactions on the sepolia network. The root cause is that getAllNetworkTransactions (that is used by nonceSortedCompletedTransactionsSelectorAllChains -> nonceSortedTransactionsSelectorAllChains -> selectedAddressTxListSelectorAllChain) filters transactions by chainid of popular networks.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36288?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36205

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
