### PR TITLE
chore: add referral user metrics

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5639,6 +5639,16 @@ export default class MetamaskController extends EventEmitter {
 
     if (shouldShowApproval) {
       try {
+        // Track referral viewed event
+        this.metaMetricsController.trackEvent({
+          event: MetaMetricsEventName.ReferralViewed,
+          category: MetaMetricsEventCategory.Referrals,
+          properties: {
+            url: HYPERLIQUID_ORIGIN,
+            trigger_type: triggerType,
+          },
+        });
+
         const approvalResponse = await this.approvalController.add({
           origin: HYPERLIQUID_ORIGIN,
           type: HYPERLIQUID_APPROVAL_TYPE,
@@ -5662,6 +5672,15 @@ export default class MetamaskController extends EventEmitter {
             activePermittedAccount,
           );
         }
+
+        // Track referral confirm button clicked event
+        this.metaMetricsController.trackEvent({
+          event: MetaMetricsEventName.ReferralConfirmButtonClicked,
+          category: MetaMetricsEventCategory.Referrals,
+          properties: {
+            opt_in: Boolean(approvalResponse?.approved),
+          },
+        });
       } catch (error) {
         // Do nothing if the user rejects the request
         if (error.code === errorCodes.provider.userRejectedRequest) {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -765,6 +765,8 @@ export enum MetaMetricsEventName {
   OnrampProviderSelected = 'On-ramp Provider Selected',
   PasswordChanged = 'Password Changed',
   ForgotPasswordClicked = 'Forgot Password Clicked',
+  ReferralViewed = 'Referral Viewed',
+  ReferralConfirmButtonClicked = 'Referral Confirm Button Clicked',
   ResetWallet = 'Reset Wallet',
   PermissionsApproved = 'Permissions Approved',
   PermissionsRejected = 'Permissions Rejected',
@@ -994,6 +996,7 @@ export enum MetaMetricsEventCategory {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   Permissions = 'Permissions',
   Phishing = 'Phishing',
+  Referrals = 'Referrals',
   BackupAndSync = 'Backup And Sync',
   PushNotifications = 'Notifications',
   Retention = 'Retention',


### PR DESCRIPTION
## **Description**

Adds referral metrics for Hyperliquid referral experience to be able to track user behaviour.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36305?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-392

## **Manual testing steps**

- Run the Segment development server `node development/mock-segment.js`
- For each flow listed below, check the logs on the server and check `batch` requests from MM network inspector to see the associated events

### Flow 1: New connection

Connect with a previously unconnected account (or an account which has neither approved nor declined the approval before). Expect to see one `Referral Viewed` metric as below, noting the property `"trigger_type": "new_connection",`.

```
{
    "event": "Referral Viewed",
    "messageId": "lfuejEaPMBTfbXLIziAA",
    "properties": {
        "url": "https://app.hyperliquid.xyz",
        "trigger_type": "new_connection",
        "category": "Referrals",
        "locale": "en",
        "chain_id": "0xaa36a7",
        "environment_type": "background"
    },
    "context": {
        "app": {
            "name": "MetaMask Extension",
            "version": "13.5.0-development"
        },
    "type": "track"
}
```

### Flow 2: Existing connection on navigate to tab

Follow steps for Flow 1. Close the pop-up rather than approving or declining it. See that there is no notification in MM (the approval request fails). Switch to a different tab and then back and see the notification. Expect to see one `Referral Viewed` metric as below, noting the property `"trigger_type": "on_navigate_connected_tab",`. On repeating switching tab back and forth, no further referral metrics are emitted (as the approval already is pending).

```
{
    "event": "Referral Viewed",
    "messageId": "ifRIfZ05CqylRB3z0YZr",
    "properties": {
        "url": "https://app.hyperliquid.xyz",
        "trigger_type": "on_navigate_connected_tab",
        "category": "Referrals",
        "locale": "en",
        "chain_id": "0xaa36a7",
        "environment_type": "background"
    },
    "context": {
        "app": {
            "name": "MetaMask Extension",
            "version": "13.5.0-development"
        },
    "type": "track"
}
```

### Flow 3: Confirm the approval

After flow 1 or 2, confirm the approval with the checkbox checked or unchecked. Expect to see one `Referral Confirm Button Clicked` metric as below, noting the property `"opt_in"` matches what you chose.

```
{
    "event": "Referral Confirm Button Clicked",
    "messageId": "y11OFkiF1Yau5EotVOyY",
    "properties": {
        "opt_in": true,
        "category": "Referrals",
        "locale": "en",
        "chain_id": "0xaa36a7",
        "environment_type": "background"
    },
    "context": {
        "app": {
            "name": "MetaMask Extension",
            "version": "13.5.0-development"
        },
    "type": "track"
}
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
