### PR TITLE
fix: correct message validation logic in Lattice offscreen connector cp-13.4.1

### DIFF
--- a/offscreen/scripts/lattice.ts
+++ b/offscreen/scripts/lattice.ts
@@ -53,10 +53,11 @@ export default function init() {
       window.addEventListener(
         'message',
         (event) => {
-          // Ensure origin
+          // Ensure origin, source is the browser tab, and data is a string (JSON to be parsed)
           if (
-            event.origin !== KnownOrigins.lattice &&
-            event.source === browserTab
+            event.origin !== KnownOrigins.lattice ||
+            event.source !== browserTab ||
+            typeof event.data !== 'string'
           ) {
             return;
           }
@@ -76,6 +77,7 @@ export default function init() {
               result: creds,
             });
           } catch (err) {
+            console.error('Error parsing Lattice credentials', err);
             sendResponse({
               error: err,
             });


### PR DESCRIPTION
## **Description**
When a user tries to connect Lattice1 hardware wallet to MetaMask, it fails to connect with the message "Failed to get accounts. Please forget the device and try again. Make sure you do not have a locked SafeCard inserted.". Since the issue is happening intermittently, the user might connect his HW wallet on one of his consecutive attempts. A similar issue is happening when a user tries to sign a transaction (again intermittent).

During our investigation at GridPlus, we observed that an additional event was being intercepted between `lattice.ts` and `lattice-offscreen-keyring.ts`, which should normally be ignored.  
Example:  
`{ target: "parent", data: "SYN" }`

As a fix, this PR filters out such unexpected events and improves error handling.

It will correct message validation logic in Lattice offscreen connector
- Fix boolean logic in event validation (AND -> OR)
- Add data type validation for message parsing
- Resolves "Failed to get accounts" error for Lattice hardware wallets

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36306?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed intermittent connection and signing errors with Lattice1 hardware wallets by improving message validation.

## **Related issues**

Fixes: #36279

## **Manual testing steps**

1. Connect a Lattice1 hardware wallet to MetaMask.
2. Attempt to retrieve accounts multiple times and verify no intermittent "Failed to get accounts" error appears.
3. Attempt to sign transactions multiple times and verify consistent success.

## **Screenshots/Recordings**

### **Before**
https://www.loom.com/share/664d4f04e02845c2a527ed11b9f62672?sid=454b322f-60cd-4287-b9ea-ad7e214cb9af


<img width="1972" height="1772" alt="image" src="https://github.com/user-attachments/assets/0922eced-c99f-4a01-923b-fce5c93dcf3a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="1005" height="909" alt="image" src="https://github.com/user-attachments/assets/7427acd9-48c9-4f49-8337-1c1c50eb42ae" />
<img width="1109" height="678" alt="image" src="https://github.com/user-attachments/assets/a706966b-02b4-4a07-b642-8ddd555a1109" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Lattice offscreen message filtering by validating origin, source, and data type, and adds error logging on JSON parse failures.
> 
> - **Lattice offscreen connector (`offscreen/scripts/lattice.ts`)**:
>   - **Message validation**: Return early unless `event.origin === KnownOrigins.lattice`, `event.source === browserTab`, and `typeof event.data === 'string'` (replaces previous incorrect boolean check; adds data type guard).
>   - **Error handling**: Log parse errors with `console.error` and propagate via `sendResponse`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e3c9a4b78305eb4a68182a0aaa4ae4ff65f5bb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->