### PR TITLE
feat: Add swap button to activity tab empty state

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -173,7 +173,7 @@
     "message": "Activity"
   },
   "activityEmptyDescription": {
-    "message": "Nothing to see yet. Check the explorer for more recent activity."
+    "message": "Nothing to see yet. Swap your first token today."
   },
   "activityLog": {
     "message": "Activity log"
@@ -7037,6 +7037,9 @@
   "swapTokenVerifiedSources": {
     "message": "Confirmed by $1 sources. Verify on $2.",
     "description": "$1 the number of sources that have verified the token, $2 points the user to a block explorer as a place they can verify information about the token."
+  },
+  "swapTokens": {
+    "message": "Swap tokens"
   },
   "swapTooManyDecimalsError": {
     "message": "$1 allows up to $2 decimals",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -173,7 +173,7 @@
     "message": "Activity"
   },
   "activityEmptyDescription": {
-    "message": "Nothing to see yet. Check the explorer for more recent activity."
+    "message": "Nothing to see yet. Swap your first token today."
   },
   "activityLog": {
     "message": "Activity log"
@@ -7037,6 +7037,9 @@
   "swapTokenVerifiedSources": {
     "message": "Confirmed by $1 sources. Verify on $2.",
     "description": "$1 the number of sources that have verified the token, $2 points the user to a block explorer as a place they can verify information about the token."
+  },
+  "swapTokens": {
+    "message": "Swap tokens"
   },
   "swapTooManyDecimalsError": {
     "message": "$1 allows up to $2 decimals",

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1038,6 +1038,7 @@ export enum MetaMetricsNetworkEventSource {
 export enum MetaMetricsSwapsEventSource {
   MainView = 'Main View',
   TokenView = 'Token View',
+  ActivityTabEmptyState = 'Activity Tab Empty State',
 }
 
 export enum MetaMetricsTokenEventSource {

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.stories.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.stories.tsx
@@ -1,9 +1,34 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 import { TransactionActivityEmptyState } from './transaction-activity-empty-state';
+
+const mockAccount: InternalAccount = {
+  id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+  address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+  type: 'eip155:eoa',
+  options: {},
+  scopes: ['eip155:1'],
+  methods: [
+    'personal_sign',
+    'eth_sign',
+    'eth_signTransaction',
+    'eth_signTypedData_v1',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ],
+  metadata: {
+    name: 'Account 1',
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+};
 
 const meta: Meta<typeof TransactionActivityEmptyState> = {
   title: 'Components/App/TransactionActivityEmptyState',
   component: TransactionActivityEmptyState,
+  args: {
+    account: mockAccount,
+  },
 };
 
 export default meta;

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -1,4 +1,3 @@
-// / <reference types="jest" />
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -161,10 +161,8 @@ describe('TransactionActivityEmptyState', () => {
   });
 
   it('applies custom className', () => {
-    renderComponent({ className: 'custom-class' });
-    const { container } = renderComponent({ className: 'custom-class' });
-
-    expect(container.firstChild).toHaveClass('custom-class');
+    const { getByTestId } = renderComponent({ className: 'custom-class' });
+    expect(getByTestId('activity-tab-empty-state')).toHaveClass('custom-class');
   });
 
   it('renders light theme image by default', () => {

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -1,20 +1,68 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { EthMethod } from '@metamask/keyring-api';
 import { renderWithProvider } from '../../../../test/jest';
 import mockState from '../../../../test/data/mock-state.json';
 import { ThemeType } from '../../../../shared/constants/preferences';
+import useBridging from '../../../hooks/bridge/useBridging';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import * as useMultichainSelectorHook from '../../../hooks/useMultichainSelector';
 import {
   TransactionActivityEmptyState,
   type TransactionActivityEmptyStateProps,
 } from './transaction-activity-empty-state';
 
+// Mock the useBridging hook
+jest.mock('../../../hooks/bridge/useBridging');
+
+const mockAccount: InternalAccount = {
+  id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+  address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+  type: 'eip155:eoa',
+  options: {},
+  scopes: ['eip155:1'],
+  methods: [
+    'personal_sign',
+    'eth_sign',
+    'eth_signTransaction',
+    'eth_signTypedData_v1',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ],
+  metadata: {
+    name: 'Account 1',
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+};
+
 describe('TransactionActivityEmptyState', () => {
   const middleware = [thunk];
+  const mockOpenBridgeExperience = jest.fn();
+  const mockUseBridging = useBridging as jest.MockedFunction<
+    typeof useBridging
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseBridging.mockReturnValue({
+      openBridgeExperience: mockOpenBridgeExperience,
+    });
+
+    // Mock useMultichainSelector to return EVM network by default
+    jest
+      .spyOn(useMultichainSelectorHook, 'useMultichainSelector')
+      .mockReturnValue({
+        chainId: '0x1', // Default to mainnet (EVM)
+        isEvmNetwork: true,
+      });
+  });
 
   const renderComponent = (
-    props: TransactionActivityEmptyStateProps = {},
+    props: Partial<TransactionActivityEmptyStateProps> = {},
     stateOverrides = {},
   ) => {
     const store = configureMockStore(middleware)({
@@ -23,7 +71,7 @@ describe('TransactionActivityEmptyState', () => {
     });
 
     return renderWithProvider(
-      <TransactionActivityEmptyState {...props} />,
+      <TransactionActivityEmptyState account={mockAccount} {...props} />,
       store,
     );
   };
@@ -36,9 +84,7 @@ describe('TransactionActivityEmptyState', () => {
   it('renders description text', () => {
     renderComponent();
     expect(
-      screen.getByText(
-        'Nothing to see yet. Check the explorer for more recent activity.',
-      ),
+      screen.getByText('Nothing to see yet. Swap your first token today.'),
     ).toBeInTheDocument();
   });
 
@@ -66,5 +112,129 @@ describe('TransactionActivityEmptyState', () => {
       'src',
       './images/empty-state-activity-dark.png',
     );
+  });
+
+  describe('Swap button functionality', () => {
+    const accountWithoutSigning: InternalAccount = {
+      ...mockAccount,
+      methods: ['personal_sign'], // No eth_signTransaction or eth_signUserOperation
+    };
+
+    const accountWithSigning: InternalAccount = {
+      ...mockAccount,
+      methods: [EthMethod.SignTransaction, 'personal_sign'],
+    };
+
+    it('disables swap button when not a swaps chain', () => {
+      // Override state to simulate testnet (non-swaps chain)
+      const testnetState = {
+        metamask: {
+          ...mockState.metamask,
+          useExternalServices: true,
+          selectedNetworkClientId: 'goerli',
+          networkConfigurationsByChainId: {
+            ...mockState.metamask.networkConfigurationsByChainId,
+            '0x5': {
+              // Goerli testnet - not in allowed swaps chains
+              chainId: '0x5',
+              name: 'Goerli',
+              nativeCurrency: 'ETH',
+              defaultRpcEndpointIndex: 0,
+              rpcEndpoints: [
+                {
+                  type: 'infura',
+                  url: 'https://goerli.infura.io/v3/test',
+                  networkClientId: 'goerli',
+                },
+              ],
+              blockExplorerUrls: [],
+            },
+          },
+        },
+      };
+
+      renderComponent({ account: accountWithSigning }, testnetState);
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+      expect(swapButton).toBeDisabled();
+    });
+
+    it('disables swap button when external services are disabled', () => {
+      const stateWithoutExternalServices = {
+        metamask: {
+          ...mockState.metamask,
+          useExternalServices: false,
+        },
+      };
+
+      renderComponent(
+        { account: accountWithSigning },
+        stateWithoutExternalServices,
+      );
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+      expect(swapButton).toBeDisabled();
+    });
+
+    it('disables swap button when account cannot sign transactions', () => {
+      renderComponent({ account: accountWithoutSigning });
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+      expect(swapButton).toBeDisabled();
+    });
+
+    it('enables swap button when all conditions are met', () => {
+      const validState = {
+        metamask: {
+          ...mockState.metamask,
+          useExternalServices: true,
+          selectedNetworkClientId: 'testNetworkConfigurationId', // This points to mainnet in mock state
+        },
+      };
+
+      renderComponent({ account: accountWithSigning }, validState);
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+      expect(swapButton).not.toBeDisabled();
+    });
+
+    it('enables swap button for Solana networks even when isSwapsChain is false', () => {
+      // Mock multichain selector to return Solana
+      jest
+        .spyOn(useMultichainSelectorHook, 'useMultichainSelector')
+        .mockReturnValue({
+          chainId: MultichainNetworks.SOLANA,
+          isEvmNetwork: false,
+        });
+
+      const testnetState = {
+        metamask: {
+          ...mockState.metamask,
+          useExternalServices: true,
+          selectedNetworkClientId: 'goerli', // This makes isSwapsChain false
+        },
+      };
+
+      renderComponent({ account: accountWithSigning }, testnetState);
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+      expect(swapButton).not.toBeDisabled(); // Should be enabled due to Solana logic
+    });
+
+    it('calls openBridgeExperience when swap button is clicked', () => {
+      const validState = {
+        metamask: {
+          ...mockState.metamask,
+          useExternalServices: true,
+          selectedNetworkClientId: 'testNetworkConfigurationId', // This points to mainnet in mock state
+        },
+      };
+
+      renderComponent({ account: accountWithSigning }, validState);
+      const swapButton = screen.getByRole('button', { name: 'Swap tokens' });
+
+      fireEvent.click(swapButton);
+
+      expect(mockOpenBridgeExperience).toHaveBeenCalledWith(
+        'Activity Tab Empty State',
+        undefined, // No specific token
+        true, // isSwap = true
+      );
+    });
   });
 });

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
@@ -1,22 +1,50 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { twMerge } from '@metamask/design-system-react';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { EthMethod } from '@metamask/keyring-api';
 import { TabEmptyState } from '../../ui/tab-empty-state';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTheme } from '../../../hooks/useTheme';
+import { getUseExternalServices, getIsSwapsChain } from '../../../selectors';
+import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
+import { MetaMetricsSwapsEventSource } from '../../../../shared/constants/metametrics';
+import useBridging from '../../../hooks/bridge/useBridging';
 import { ThemeType } from '../../../../shared/constants/preferences';
+import { getMultichainNetwork } from '../../../selectors/multichain';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 
 export type TransactionActivityEmptyStateProps = {
   /**
    * Additional className to apply to the component
    */
   className?: string;
+  /**
+   * The account to use for swap logic
+   */
+  account: InternalAccount;
 };
 
 export const TransactionActivityEmptyState: React.FC<
   TransactionActivityEmptyStateProps
-> = ({ className }) => {
+> = ({ className, account }) => {
   const t = useI18nContext();
   const theme = useTheme();
+  const isSigningEnabled =
+    account.methods.includes(EthMethod.SignTransaction) ||
+    account.methods.includes(EthMethod.SignUserOperation);
+  const isExternalServicesEnabled = useSelector(getUseExternalServices);
+  const chainId = useSelector(getCurrentChainId);
+  const isSwapsChain = useSelector((state) => getIsSwapsChain(state, chainId));
+
+  // Get multichain network info for Solana detection (same as coin-buttons)
+  const { chainId: multichainChainId } = useMultichainSelector(
+    getMultichainNetwork,
+    account,
+  );
+
+  const { openBridgeExperience } = useBridging();
 
   // Theme-aware icon selection
   const activityIcon =
@@ -24,14 +52,32 @@ export const TransactionActivityEmptyState: React.FC<
       ? './images/empty-state-activity-dark.png'
       : './images/empty-state-activity-light.png';
 
+  const handleSwapOnClick = useCallback(async () => {
+    openBridgeExperience(
+      MetaMetricsSwapsEventSource.ActivityTabEmptyState,
+      undefined, // No specific token
+      true, // isSwap = true
+    );
+  }, [openBridgeExperience]);
+
   return (
     <TabEmptyState
       icon={
         <img src={activityIcon} alt={t('activity')} width={72} height={72} />
       }
       description={t('activityEmptyDescription')}
+      actionButtonText={t('swapTokens')}
+      actionButtonProps={{
+        isDisabled:
+          // Disable for all non-swap chains but enable EVM and nonEVM(e.g. Solana) networks
+          // Same logic as coin-buttons.tsx
+          multichainChainId === MultichainNetworks.SOLANA
+            ? false
+            : !isSwapsChain || !isSigningEnabled || !isExternalServicesEnabled,
+      }}
+      onAction={handleSwapOnClick}
       data-testid="activity-tab-empty-state"
-      className={twMerge('max-w-64', className)}
+      className={twMerge('max-w-48', className)}
     />
   );
 };

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
@@ -38,7 +38,6 @@ export const TransactionActivityEmptyState: React.FC<
   const chainId = useSelector(getCurrentChainId);
   const isSwapsChain = useSelector((state) => getIsSwapsChain(state, chainId));
 
-  // Get multichain network info for Solana detection (same as coin-buttons)
   const { chainId: multichainChainId } = useMultichainSelector(
     getMultichainNetwork,
     account,
@@ -46,7 +45,6 @@ export const TransactionActivityEmptyState: React.FC<
 
   const { openBridgeExperience } = useBridging();
 
-  // Theme-aware icon selection
   const activityIcon =
     theme === ThemeType.dark
       ? './images/empty-state-activity-dark.png'
@@ -60,6 +58,11 @@ export const TransactionActivityEmptyState: React.FC<
     );
   }, [openBridgeExperience]);
 
+  // Determine if swap button should be enabled
+  const isSwapButtonEnabled =
+    multichainChainId === MultichainNetworks.SOLANA ||
+    (isSwapsChain && isSigningEnabled && isExternalServicesEnabled);
+
   return (
     <TabEmptyState
       icon={
@@ -68,12 +71,7 @@ export const TransactionActivityEmptyState: React.FC<
       description={t('activityEmptyDescription')}
       actionButtonText={t('swapTokens')}
       actionButtonProps={{
-        isDisabled:
-          // Disable for all non-swap chains but enable EVM and nonEVM(e.g. Solana) networks
-          // Same logic as coin-buttons.tsx
-          multichainChainId === MultichainNetworks.SOLANA
-            ? false
-            : !isSwapsChain || !isSigningEnabled || !isExternalServicesEnabled,
+        isDisabled: !isSwapButtonEnabled,
       }}
       onAction={handleSwapOnClick}
       data-testid="activity-tab-empty-state"

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -256,7 +256,7 @@ exports[`TransactionList renders TransactionList component with props hideTokenT
       </button>
     </div>
     <div
-      class="flex flex-col gap-3 items-center justify-center bg-default max-w-64 mx-auto mt-5 mb-6"
+      class="flex flex-col gap-3 items-center justify-center bg-default max-w-48 mx-auto mt-5 mb-6"
       data-testid="activity-tab-empty-state"
     >
       <img
@@ -268,8 +268,21 @@ exports[`TransactionList renders TransactionList component with props hideTokenT
       <p
         class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-center"
       >
-        Nothing to see yet. Check the explorer for more recent activity.
+        Nothing to see yet. Swap your first token today.
       </p>
+      <button
+        aria-disabled="true"
+        class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 bg-muted text-default focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default opacity-50 cursor-not-allowed"
+        disabled=""
+        role="button"
+        tabindex="-1"
+      >
+        <span
+          class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+        >
+          Swap tokens
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -737,7 +737,10 @@ export default function TransactionList({
         ) : null}
         {pendingTransactions.length === 0 &&
         completedTransactions.length === 0 ? (
-          <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
+          <TransactionActivityEmptyState
+            className="mx-auto mt-5 mb-6"
+            account={selectedAccount}
+          />
         ) : (
           <Box className="transaction-list__transactions">
             {pendingTransactions.length > 0 && (

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -719,7 +719,10 @@ export default function TransactionList({
                 )}
               </Box>
             ) : (
-              <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
+              <TransactionActivityEmptyState
+                className="mx-auto mt-5 mb-6"
+                account={selectedAccount}
+              />
             )}
           </Box>
         </Box>

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -734,7 +734,10 @@ export default function UnifiedTransactionList({
           <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
         ) : null}
         {processedUnifiedActivityItems.length === 0 ? (
-          <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
+          <TransactionActivityEmptyState
+            className="mx-auto mt-5 mb-6"
+            account={selectedAccount}
+          />
         ) : (
           <Box className="transaction-list__transactions">
             {processedUnifiedActivityItems

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`AssetPage should render a native asset 1`] = `
               </button>
             </div>
             <div
-              class="flex flex-col gap-3 items-center justify-center bg-default max-w-64 mx-auto mt-5 mb-6"
+              class="flex flex-col gap-3 items-center justify-center bg-default max-w-48 mx-auto mt-5 mb-6"
               data-testid="activity-tab-empty-state"
             >
               <img
@@ -449,8 +449,21 @@ exports[`AssetPage should render a native asset 1`] = `
               <p
                 class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-center"
               >
-                Nothing to see yet. Check the explorer for more recent activity.
+                Nothing to see yet. Swap your first token today.
               </p>
+              <button
+                aria-disabled="true"
+                class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 bg-muted text-default focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default opacity-50 cursor-not-allowed"
+                disabled=""
+                role="button"
+                tabindex="-1"
+              >
+                <span
+                  class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+                >
+                  Swap tokens
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -923,7 +936,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
               </button>
             </div>
             <div
-              class="flex flex-col gap-3 items-center justify-center bg-default max-w-64 mx-auto mt-5 mb-6"
+              class="flex flex-col gap-3 items-center justify-center bg-default max-w-48 mx-auto mt-5 mb-6"
               data-testid="activity-tab-empty-state"
             >
               <img
@@ -935,8 +948,21 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
               <p
                 class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-center"
               >
-                Nothing to see yet. Check the explorer for more recent activity.
+                Nothing to see yet. Swap your first token today.
               </p>
+              <button
+                aria-disabled="true"
+                class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 bg-muted text-default focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default opacity-50 cursor-not-allowed"
+                disabled=""
+                role="button"
+                tabindex="-1"
+              >
+                <span
+                  class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+                >
+                  Swap tokens
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -1438,7 +1464,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               </button>
             </div>
             <div
-              class="flex flex-col gap-3 items-center justify-center bg-default max-w-64 mx-auto mt-5 mb-6"
+              class="flex flex-col gap-3 items-center justify-center bg-default max-w-48 mx-auto mt-5 mb-6"
               data-testid="activity-tab-empty-state"
             >
               <img
@@ -1450,8 +1476,21 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               <p
                 class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-center"
               >
-                Nothing to see yet. Check the explorer for more recent activity.
+                Nothing to see yet. Swap your first token today.
               </p>
+              <button
+                aria-disabled="true"
+                class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 bg-muted text-default focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default opacity-50 cursor-not-allowed"
+                disabled=""
+                role="button"
+                tabindex="-1"
+              >
+                <span
+                  class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+                >
+                  Swap tokens
+                </span>
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## **Description**

This PR adds a swap button to the activity tab empty state as part of a larger initiative to align the empty states of the tabs across the extension and mobile applications. The empty state now includes a "Swap tokens" button that provides users with a clear call-to-action when they have no transaction activity.

This approach was taken to maintain consistency with existing swap entry points while meeting the immediate need for empty state alignment.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36319?quickstart=1)

## **Changelog**

CHANGELOG entry: Added swap button to activity tab empty state

## **Related issues**

Part of larger empty state alignment initiative across extension and mobile.

## **Manual testing steps**

1. Navigate to the Activity tab with no transaction history
2. Verify the empty state shows "Nothing to see yet. Swap your first token today."
3. Verify the "Swap tokens" button is present
4. Click the button to ensure it navigates to the swap flow correctly
5. Test with different account types (hardware wallet, etc.) to ensure proper behavior

## **Screenshots/Recordings**

<!-- Screenshots will be added after PR creation -->

### **Before**

Empty state with only description text

https://github.com/user-attachments/assets/1c88c348-134e-40b5-8a89-0bc72ddb0db2

### **After**

Empty state with description text and swap button

https://github.com/user-attachments/assets/8ecc57f3-e49f-4e51-a32a-19fb6a0e1c2d

Swapping between all tabs after update


https://github.com/user-attachments/assets/a2913cf7-eecf-4731-a567-1719adab55d7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.