### PR TITLE
fix: fixes in check for new send flow

### DIFF
--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
+import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 
 type SendRedesignFeatureFlag = {
   enabled: boolean;
@@ -17,13 +17,13 @@ export const useRedesignedSendFlow = () => {
   const { enabled: isSendRedesignEnabled } = (sendRedesignFeatureFlag ??
     {}) as SendRedesignFeatureFlag;
 
-  if (isSendRedesignEnabled && isMultichainAccountsState2Enabled) {
+  if (!isSendRedesignEnabled || !isMultichainAccountsState2Enabled) {
     return {
-      enabled: true,
+      enabled: false,
     };
   }
 
   return {
-    enabled: false,
+    enabled: true,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improvements in code in `useRedesignedSendFlow` hook to check if new send flow is enabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36310

## **Manual testing steps**

1. Trigger send
2. It should new send implementation always

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
