### PR TITLE
chore: use `gator-permissions` feature exclusively for gating Readable Permissions functionality

### DIFF
--- a/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
+++ b/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.test.ts
@@ -2,7 +2,7 @@ import { GatorPermissionsController } from '@metamask/gator-permissions-controll
 import { Messenger } from '@metamask/base-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import type { ControllerInitRequest } from '../types';
-import { isGatorPermissionsFeatureEnabled } from '../../../../shared/modules/environment';
+
 import {
   getGatorPermissionsControllerMessenger,
   GatorPermissionsControllerMessenger,
@@ -36,7 +36,6 @@ describe('GatorPermissionsControllerInit', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
     process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
       MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
   });
@@ -57,30 +56,16 @@ describe('GatorPermissionsControllerInit', () => {
     ).toBeInstanceOf(GatorPermissionsController);
   });
 
-  it('initializes with correct messenger and state(gator permissions feature enabled)', () => {
+  // todo: it would be nice to test this where the gator-permissions feature is disabled
+  it('initializes with correct messenger and state', () => {
     const requestMock = buildInitRequestMock();
-    jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
+
     GatorPermissionsControllerInit(requestMock);
 
     expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
       messenger: requestMock.controllerMessenger,
       state: {
         isGatorPermissionsEnabled: true,
-        gatorPermissionsProviderSnapId: MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID,
-        ...requestMock.persistedState.GatorPermissionsController,
-      },
-    });
-  });
-
-  it('initializes with correct messenger and state(gator permissions feature disabled)', () => {
-    const requestMock = buildInitRequestMock();
-    jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(false);
-    GatorPermissionsControllerInit(requestMock);
-
-    expect(GatorPermissionsControllerClassMock).toHaveBeenCalledWith({
-      messenger: requestMock.controllerMessenger,
-      state: {
-        isGatorPermissionsEnabled: false,
         gatorPermissionsProviderSnapId: MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID,
         ...requestMock.persistedState.GatorPermissionsController,
       },
@@ -99,7 +84,6 @@ describe('GatorPermissionsControllerInit', () => {
   it('handles undefined persistedState.GatorPermissionsController', () => {
     const requestMock = buildInitRequestMock();
     requestMock.persistedState.GatorPermissionsController = undefined;
-    jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(true);
 
     GatorPermissionsControllerInit(requestMock);
 

--- a/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.ts
+++ b/app/scripts/controller-init/gator-permissions/gator-permissions-controller-init.ts
@@ -4,15 +4,24 @@ import {
 } from '@metamask/gator-permissions-controller';
 import { assertIsValidSnapId } from '@metamask/snaps-utils';
 import { ControllerInitFunction } from '../types';
-import { isGatorPermissionsFeatureEnabled } from '../../../../shared/modules/environment';
 import { GatorPermissionsControllerMessenger } from '../messengers/gator-permissions';
 
 const generateDefaultGatorPermissionsControllerState =
   (): Partial<GatorPermissionsControllerState> => {
+    let isGatorPermissionsEnabled = false;
+    ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
+    isGatorPermissionsEnabled = true;
+    ///: END:ONLY_INCLUDE_IF
+
+    const state: Partial<GatorPermissionsControllerState> = {
+      isGatorPermissionsEnabled,
+    };
+
     const gatorPermissionsProviderSnapId =
       process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID;
 
-    // if GATOR_PERMISSIONS_PROVIDER_SNAP_ID is not specified, GatorPermissionsController will initialize it's default
+    // if GATOR_PERMISSIONS_PROVIDER_SNAP_ID is not specified,
+    // GatorPermissionsController will initialize it's default
     if (gatorPermissionsProviderSnapId !== undefined) {
       try {
         assertIsValidSnapId(gatorPermissionsProviderSnapId);
@@ -24,15 +33,7 @@ const generateDefaultGatorPermissionsControllerState =
           },
         );
       }
-    }
 
-    const isGatorPermissionsEnabled = isGatorPermissionsFeatureEnabled();
-
-    const state: Partial<GatorPermissionsControllerState> = {
-      isGatorPermissionsEnabled,
-    };
-
-    if (gatorPermissionsProviderSnapId) {
       state.gatorPermissionsProviderSnapId = gatorPermissionsProviderSnapId;
     }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -213,10 +213,7 @@ import { BITCOIN_WALLET_SNAP_ID } from '../../shared/lib/accounts/bitcoin-wallet
 import { SOLANA_WALLET_SNAP_ID } from '../../shared/lib/accounts/solana-wallet-snap';
 import { FirstTimeFlowType } from '../../shared/constants/onboarding';
 import { updateCurrentLocale } from '../../shared/lib/translate';
-import {
-  getIsSeedlessOnboardingFeatureEnabled,
-  isGatorPermissionsFeatureEnabled,
-} from '../../shared/modules/environment';
+import { getIsSeedlessOnboardingFeatureEnabled } from '../../shared/modules/environment';
 import { isSnapPreinstalled } from '../../shared/lib/snaps/snaps';
 import { getShieldGatewayConfig } from '../../shared/modules/shield';
 import {
@@ -369,7 +366,9 @@ import {
 import { ShieldControllerInit } from './controller-init/shield/shield-controller-init';
 import { GatorPermissionsControllerInit } from './controller-init/gator-permissions/gator-permissions-controller-init';
 
+///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
 import { forwardRequestToSnap } from './lib/forwardRequestToSnap';
+///: END:ONLY_INCLUDE_IF
 import { MetaMetricsControllerInit } from './controller-init/metametrics-controller-init';
 import { TokenListControllerInit } from './controller-init/token-list-controller-init';
 import { TokenDetectionControllerInit } from './controller-init/token-detection-controller-init';
@@ -1352,12 +1351,12 @@ export default class MetamaskController extends EventEmitter {
           (meta) =>
             meta.hash === hash && meta.status === TransactionStatus.submitted,
         ),
-      processRequestExecutionPermissions: isGatorPermissionsFeatureEnabled()
-        ? forwardRequestToSnap.bind(null, {
-            snapId: process.env.PERMISSIONS_KERNEL_SNAP_ID,
-            handleRequest: this.handleSnapRequest.bind(this),
-          })
-        : undefined,
+      ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
+      processRequestExecutionPermissions: forwardRequestToSnap.bind(null, {
+        snapId: process.env.PERMISSIONS_KERNEL_SNAP_ID,
+        handleRequest: this.handleSnapRequest.bind(this),
+      }),
+      ///: END:ONLY_INCLUDE_IF
     });
 
     // ensure isClientOpenAndUnlocked is updated when memState updates

--- a/builds.yml
+++ b/builds.yml
@@ -108,7 +108,6 @@ buildTypes:
       - APPLE_FLASK_CLIENT_ID
       - GOOGLE_CLIENT_ID_REF: GOOGLE_FLASK_CLIENT_ID
       - APPLE_CLIENT_ID_REF: APPLE_FLASK_CLIENT_ID
-      - GATOR_PERMISSIONS_ENABLED: true
 
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
@@ -335,7 +334,6 @@ env:
   - METAMASK_RAMP_API_CONTENT_BASE_URL: https://on-ramp-content.api.cx.metamask.io
 
   # EIP-7715 Readable Permissions
-  - GATOR_PERMISSIONS_ENABLED: false
   - PERMISSIONS_KERNEL_SNAP_ID: 'npm:@metamask/permissions-kernel-snap'
   - GATOR_PERMISSIONS_PROVIDER_SNAP_ID: 'npm:@metamask/gator-permissions-snap'
 

--- a/shared/modules/environment.test.ts
+++ b/shared/modules/environment.test.ts
@@ -1,5 +1,5 @@
 import { ENVIRONMENT } from '../../development/build/constants';
-import { isGatorPermissionsFeatureEnabled, isProduction } from './environment';
+import { isProduction } from './environment';
 
 describe('isProduction', () => {
   let originalMetaMaskEnvironment: string | undefined;
@@ -25,22 +25,5 @@ describe('isProduction', () => {
   it('should return false when ENVIRONMENT is "testing"', () => {
     process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.TESTING;
     expect(isProduction()).toBe(false);
-  });
-});
-
-describe('isGatorPermissionsFeatureEnabled', () => {
-  it('should return true when GATOR_PERMISSIONS_ENABLED is "true"', () => {
-    process.env.GATOR_PERMISSIONS_ENABLED = 'true';
-    expect(isGatorPermissionsFeatureEnabled()).toBe(true);
-  });
-
-  it('should return false when GATOR_PERMISSIONS_ENABLED is "false"', () => {
-    process.env.GATOR_PERMISSIONS_ENABLED = 'false';
-    expect(isGatorPermissionsFeatureEnabled()).toBe(false);
-  });
-
-  it('should return false when GATOR_PERMISSIONS_ENABLED is undefined', () => {
-    delete process.env.GATOR_PERMISSIONS_ENABLED;
-    expect(isGatorPermissionsFeatureEnabled()).toBe(false);
   });
 });

--- a/shared/modules/environment.ts
+++ b/shared/modules/environment.ts
@@ -18,7 +18,3 @@ export const getIsMetaMaskShieldFeatureEnabled = (): boolean => {
 export const getIsSettingsPageDevOptionsEnabled = (): boolean => {
   return process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS?.toString() === 'true';
 };
-
-export const isGatorPermissionsFeatureEnabled = (): boolean => {
-  return process.env.GATOR_PERMISSIONS_ENABLED?.toString() === 'true';
-};

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useAssetDetails } from '../../../hooks/useAssetDetails';
-import { isGatorPermissionsFeatureEnabled } from '../../../../../../shared/modules/environment';
 import Info from './info';
 
 jest.mock('../../simulation-details/useBalanceChanges', () => ({
@@ -46,11 +45,6 @@ jest.mock('../../../hooks/useTransactionFocusEffect', () => ({
   useTransactionFocusEffect: jest.fn(),
 }));
 
-jest.mock('../../../../../../shared/modules/environment', () => ({
-  ...jest.requireActual('../../../../../../shared/modules/environment'),
-  isGatorPermissionsFeatureEnabled: jest.fn().mockReturnValue(true),
-}));
-
 describe('Info', () => {
   const mockedAssetDetails = jest.mocked(useAssetDetails);
 
@@ -81,16 +75,6 @@ describe('Info', () => {
     const mockStore = configureMockStore([])(state);
     const { container } = renderWithConfirmContextProvider(<Info />, mockStore);
     expect(container).toMatchSnapshot();
-  });
-
-  it('throws an error if gator permissions feature is not enabled', () => {
-    jest.mocked(isGatorPermissionsFeatureEnabled).mockReturnValue(false);
-
-    const state = getMockTypedSignPermissionConfirmState();
-    const mockStore = configureMockStore([])(state);
-    expect(() => renderWithConfirmContextProvider(<Info />, mockStore)).toThrow(
-      'Gator permissions feature is not enabled',
-    );
   });
 
   it('renders info section for contract interaction request', () => {

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -4,7 +4,6 @@ import { useConfirmContext } from '../../../context/confirm';
 import { SignatureRequestType } from '../../../types/confirm';
 import { useSmartTransactionFeatureFlags } from '../../../hooks/useSmartTransactionFeatureFlags';
 import { useTransactionFocusEffect } from '../../../hooks/useTransactionFocusEffect';
-import { isGatorPermissionsFeatureEnabled } from '../../../../../../shared/modules/environment';
 import ApproveInfo from './approve/approve';
 import BaseTransactionInfo from './base-transaction-info/base-transaction-info';
 import NativeTransferInfo from './native-transfer/native-transfer';
@@ -14,7 +13,9 @@ import SetApprovalForAllInfo from './set-approval-for-all-info/set-approval-for-
 import TokenTransferInfo from './token-transfer/token-transfer';
 import TypedSignV1Info from './typed-sign-v1/typed-sign-v1';
 import TypedSignInfo from './typed-sign/typed-sign';
+///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
 import TypedSignPermissionInfo from './typed-sign/typed-sign-permission';
+///: END:ONLY_INCLUDE_IF
 
 const Info = () => {
   const { currentConfirmation } = useConfirmContext();
@@ -39,11 +40,10 @@ const Info = () => {
           return TypedSignV1Info;
         }
         if (signatureRequest?.decodedPermission) {
-          if (!isGatorPermissionsFeatureEnabled()) {
-            throw new Error('Gator permissions feature is not enabled');
-          }
-
+          ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
           return TypedSignPermissionInfo;
+          ///: END:ONLY_INCLUDE_IF
+          throw new Error('Gator permissions feature is not enabled');
         }
         return TypedSignInfo;
       },

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -162,7 +162,6 @@ import { AddWalletPage } from '../multichain-accounts/add-wallet-page';
 import { WalletDetailsPage } from '../multichain-accounts/wallet-details-page';
 import { ReviewPermissions } from '../../components/multichain/pages/review-permissions-page/review-permissions-page';
 import { MultichainReviewPermissions } from '../../components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page';
-// import { isGatorPermissionsFeatureEnabled } from '../../../shared/modules/environment';
 import { useRedesignedSendFlow } from '../confirmations/hooks/useRedesignedSendFlow';
 import {
   getConnectingLabel,
@@ -291,13 +290,16 @@ const PermissionsPage = mmLazy(
       '../../components/multichain/pages/permissions-page/permissions-page.js'
     )) as unknown as DynamicImportType,
 );
-// const GatorPermissionsPage = mmLazy(
-//   // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-//   (() =>
-//     import(
-//       '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
-//     )) as unknown as DynamicImportType,
-// );
+
+///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
+const GatorPermissionsPage = mmLazy(
+  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
+  (() =>
+    import(
+      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
+    )) as unknown as DynamicImportType,
+);
+///: END:ONLY_INCLUDE_IF
 const Connections = mmLazy(
   // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
   (() =>
@@ -545,6 +547,14 @@ export default function Routes() {
   const renderRoutes = useCallback(() => {
     const RestoreVaultComponent = forgottenPassword ? Route : Initialized;
 
+    // the permissionsComponent will use GatorPermissionsPage only if the
+    // gator-permissions feature is enabled
+    let permissionsComponent = PermissionsPage;
+
+    ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
+    permissionsComponent = GatorPermissionsPage;
+    ///: END:ONLY_INCLUDE_IF
+
     const routes = (
       <Suspense fallback={null}>
         {/* since the loading time is less than 200ms, we decided not to show a spinner fallback or anything */}
@@ -647,13 +657,7 @@ export default function Routes() {
           />
           <Authenticated
             path={PERMISSIONS}
-            component={
-              // TODO: enable this when gator permission page is implemented
-              // isGatorPermissionsFeatureEnabled()
-              //   ? GatorPermissionsPage
-              //   : PermissionsPage
-              PermissionsPage
-            }
+            component={permissionsComponent}
             exact
           />
           <Authenticated


### PR DESCRIPTION
## **Description**

Previously the Readable Permissions functionality depended on a combination of `gator-permissions` feature and the `GATOR_PERMISSIONS_FEATURE_ENABLED` environment variable, making it difficult to switch between enabled and disabled, and making it more prone to being partially enabled. 

This change switches to using the `gator-permissions` feature exclusively for gating the overall Readable Permissions feature. It leaves the existing `GATOR_GRANTED_PERMISSIONS_VIEW_ENABLED` to gate the in-progress Granted Permission view feature.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36324?quickstart=1)

## **Changelog**

CHANGELOG entry: no changelog - internal concern only

## **Related issues**

Fixes:

## **Manual testing steps**

Flask build has the gator permissions feature 
Main build does _not_ have the gator permissions feature

### Permissions picker is shown in flask

1. Build flask
2. Request a permission 
3. Expect: permission picker is shown
4. View permissions page
5. Expect: old permissions view

### Permissions feature is not shown in main 

1. Build main
2. Request a permission
3. Expect: error is returned
4. View permissions page
5. Expect: old permissions view

### Granted permissions view is shown in Flask

1. Build flask with `GATOR_GRANTED_PERMISSIONS_VIEW_ENABLED=true`
2. View permissions in extension
3. Expect: new permissions view

### Granted permissions view is not shown in main (even when the environment variable is enabled)

1. Build main with `GATOR_GRANTED_PERMISSIONS_VIEW_ENABLED=true`
2. View permissions in extension
3. Expect: old permissions view

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
