### PR TITLE
fix: Fix infinite loader in confirmations due to undefined `from`

### DIFF
--- a/ui/pages/confirmations/context/send/index.tsx
+++ b/ui/pages/confirmations/context/send/index.tsx
@@ -17,7 +17,6 @@ import {
   getSelectedAccountGroup,
   getAccountGroupWithInternalAccounts,
 } from '../../../../selectors/multichain-accounts/account-tree';
-import { getSelectedAccount } from '../../../../selectors';
 import { Asset } from '../../types/send';
 import { SendPages } from '../../constants/send';
 
@@ -26,7 +25,7 @@ export type SendContextType = {
   chainId?: string;
   currentPage?: SendPages;
   fromAccount?: InternalAccount;
-  from: string;
+  from?: string;
   maxValueMode?: boolean;
   to?: string;
   toResolved?: string;
@@ -59,7 +58,6 @@ export const SendContextProvider: React.FC<{
   children: ReactElement[] | ReactElement;
 }> = ({ children }) => {
   const [asset, setAsset] = useState<Asset>();
-  const from = useSelector(getSelectedAccount);
   const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
   const accountGroupWithInternalAccounts = useSelector(
     getAccountGroupWithInternalAccounts,
@@ -126,7 +124,7 @@ export const SendContextProvider: React.FC<{
         chainId,
         currentPage,
         fromAccount,
-        from: from?.address as string,
+        from: fromAccount?.address,
         maxValueMode,
         to,
         toResolved: toResolved ?? to,

--- a/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSelectedAccountAlerts.ts
@@ -2,10 +2,13 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import {
+  getAccountGroupWithInternalAccounts,
+  getSelectedAccountGroup,
+} from '../../../../selectors/multichain-accounts/account-tree';
 import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
 import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../helpers/constants/design-system';
-import { getSelectedAccount } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { SignatureRequestType } from '../../types/confirm';
 import { useConfirmContext } from '../../context/confirm';
@@ -14,14 +17,26 @@ export const useSelectedAccountAlerts = (): Alert[] => {
   const t = useI18nContext();
 
   const { currentConfirmation } = useConfirmContext();
-  const selectedAccount = useSelector(getSelectedAccount);
+  const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
+  const accountGroupWithInternalAccounts = useSelector(
+    getAccountGroupWithInternalAccounts,
+  );
+  const selectedAccountGroupWithInternalAccounts =
+    accountGroupWithInternalAccounts.find(
+      (accountGroup) => accountGroup.id === selectedAccountGroupId,
+    )?.accounts;
 
   const fromAccount =
     (currentConfirmation as SignatureRequestType)?.msgParams?.from ??
     (currentConfirmation as TransactionMeta)?.txParams?.from;
+
+  const isAccountFromSelectedAccountGroup =
+    selectedAccountGroupWithInternalAccounts?.find(
+      (account) => account.address.toLowerCase() === fromAccount?.toLowerCase(),
+    );
+
   const confirmationAccountSameAsSelectedAccount =
-    !fromAccount ||
-    fromAccount.toLowerCase() === selectedAccount?.address?.toLowerCase();
+    !fromAccount || isAccountFromSelectedAccountGroup;
 
   return useMemo<Alert[]>((): Alert[] => {
     if (confirmationAccountSameAsSelectedAccount) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix undefined `from` causing infinite loader in confirmations. This issue was happening when network selector picked "nonEVM" and do a transaction on "evm" or vice versa. Because that dropdown was changing the selected account state. 

The alert for selected account now also changed - now it looks up for all the accounts from account group. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36333?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36250

## **Manual testing steps**

See the recording in task

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/7e053604-ac9c-4913-aea7-bc34974fc9f2



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
