### PR TITLE
fix: Redirect activity after non-evm transaction submission

### DIFF
--- a/ui/pages/confirmations/hooks/send/useSendActions.ts
+++ b/ui/pages/confirmations/hooks/send/useSendActions.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_ROUTE,
   SEND_ROUTE,
 } from '../../../../helpers/constants/routes';
+import { setDefaultHomeActiveTabName } from '../../../../store/actions';
 import { SendPages } from '../../constants/send';
 import { sendMultichainTransactionForReview } from '../../utils/multichain-snaps';
 import { addLeadingZeroIfNeeded, submitEvmTransaction } from '../../utils/send';
@@ -52,12 +53,21 @@ export const useSendActions = () => {
       history.push(route);
     } else {
       history.push(`${SEND_ROUTE}/${SendPages.LOADER}`);
-      await sendMultichainTransactionForReview(fromAccount as InternalAccount, {
-        fromAccountId: fromAccount?.id as string,
-        toAddress: toAddress as string,
-        assetId: asset.assetId as CaipAssetType,
-        amount: addLeadingZeroIfNeeded(value) as string,
-      });
+      await dispatch(setDefaultHomeActiveTabName('activity'));
+      try {
+        await sendMultichainTransactionForReview(
+          fromAccount as InternalAccount,
+          {
+            fromAccountId: fromAccount?.id as string,
+            toAddress: toAddress as string,
+            assetId: asset.assetId as CaipAssetType,
+            amount: addLeadingZeroIfNeeded(value) as string,
+          },
+        );
+        history.push(DEFAULT_ROUTE);
+      } catch (error) {
+        // intentional empty catch
+      }
     }
   }, [
     asset,

--- a/ui/pages/confirmations/utils/multichain-snaps.ts
+++ b/ui/pages/confirmations/utils/multichain-snaps.ts
@@ -13,7 +13,7 @@ export async function sendMultichainTransactionForReview(
     amount: string;
   },
 ) {
-  await handleSnapRequest({
+  return await handleSnapRequest({
     snapId: fromAccount.metadata?.snap?.id as SnapId,
     origin: 'metamask',
     handler: HandlerType.OnClientRequest,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Similar what's done in https://github.com/MetaMask/metamask-mobile/pull/20387 , we also want to redirect user to activity tab after successful non-evm submission.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36381?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36364

## **Manual testing steps**

1. Do Solana send flow
2. After you confirm transaction - you should be redirected to activity tab.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
