### PR TITLE
fix: update `t` function type and wrap arg in array in `getBlockExplorerInfo`

### DIFF
--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -94,7 +94,7 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
 
   // Get block explorer info from network configuration
   const explorerInfo = getBlockExplorerInfo(
-    t as (key: string, ...args: string[]) => string,
+    t as (key: string, args: string[]) => string,
     address,
     { networkName, chainId },
   );

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.test.ts
@@ -2,7 +2,7 @@ import { MultichainNetworks } from '../../../../shared/constants/multichain/netw
 import { getBlockExplorerInfo } from './getBlockExplorerInfo';
 
 describe('getBlockExplorerInfo utility functions', () => {
-  const mockT = (key: string, ...args: string[]) =>
+  const mockT = (key: string, args: string[]) =>
     `translated_${key}_${args.join('_')}`;
   const testAddress = '0x1234567890abcdef';
 
@@ -114,18 +114,18 @@ describe('getBlockExplorerInfo utility functions', () => {
 
   describe('Translation function integration', () => {
     it('formats translation keys correctly', () => {
-      const mockT2 = (key: string, ...args: string[]) =>
+      const mockT2 = (key: string, args: string[]) =>
         `translated_${key}_${args.join('_')}`;
 
-      const result = mockT2('viewAddressOnExplorer', 'Etherscan');
+      const result = mockT2('viewAddressOnExplorer', ['Etherscan']);
       expect(result).toBe('translated_viewAddressOnExplorer_Etherscan');
     });
 
     it('handles multiple translation arguments', () => {
-      const mockT3 = (key: string, ...args: string[]) =>
+      const mockT3 = (key: string, args: string[]) =>
         `translated_${key}_${args.join('_')}`;
 
-      const result = mockT3('viewAddressOnExplorer', 'PolygonScan');
+      const result = mockT3('viewAddressOnExplorer', ['PolygonScan']);
       expect(result).toBe('translated_viewAddressOnExplorer_PolygonScan');
     });
   });

--- a/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
+++ b/ui/helpers/utils/multichain/getBlockExplorerInfo.ts
@@ -30,7 +30,7 @@ export type NetworkInfo = {
  * @returns BlockExplorerInfo or null if no explorer available
  */
 export const getBlockExplorerInfo = (
-  t: (key: string, ...args: string[]) => string,
+  t: (key: string, args: string[]) => string,
   address: string,
   networkInfo: NetworkInfo,
 ): BlockExplorerInfo | null => {
@@ -55,7 +55,7 @@ export const getBlockExplorerInfo = (
         return {
           addressUrl,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', explorerName),
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
         };
       }
     }
@@ -77,7 +77,7 @@ export const getBlockExplorerInfo = (
         return {
           addressUrl,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', explorerName),
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
         };
       }
     }
@@ -98,7 +98,7 @@ export const getBlockExplorerInfo = (
       return {
         addressUrl,
         name: explorerName,
-        buttonText: t('viewAddressOnExplorer', explorerName),
+        buttonText: t('viewAddressOnExplorer', [explorerName]),
       };
     }
 
@@ -114,7 +114,7 @@ export const getBlockExplorerInfo = (
         return {
           addressUrl: `${baseUrl}/address/${address}`,
           name: explorerName,
-          buttonText: t('viewAddressOnExplorer', explorerName),
+          buttonText: t('viewAddressOnExplorer', [explorerName]),
         };
       }
     }


### PR DESCRIPTION
## **Description**

The `AddressQRCodeModal` component was broken because the `t` function in `getBlockExplorerInfo` was incorrectly typed and the arg that we were passing to it was not wrapped in an array. I updated the type and wrapped the arg. 

## **Changelog**

CHANGELOG entry: Fixed the `AddressQRModal` component from breaking due to incorrect usage of the translation function. 

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Build from this branch.
2. Navigate to the addresses section in an account's details page.
3. Click through the various address's QR code page and observe that it doesn't crash.

## **Screenshots/Recordings**

### **After**

https://github.com/user-attachments/assets/d1dc6768-18ef-4042-b32f-19343816e4a6

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
