### PR TITLE
chore: update navigation button icon sizes for visual consistency

### DIFF
--- a/ui/pages/multichain-accounts/wallet-details/wallet-details.component.tsx
+++ b/ui/pages/multichain-accounts/wallet-details/wallet-details.component.tsx
@@ -123,7 +123,7 @@ const WalletDetails = () => {
           }}
           startAccessory={
             <ButtonIcon
-              size={ButtonIconSize.Sm}
+              size={ButtonIconSize.Md}
               ariaLabel={t('back')}
               iconName={IconName.ArrowLeft}
               onClick={handleBack}
@@ -266,7 +266,7 @@ const WalletDetails = () => {
         }}
         startAccessory={
           <ButtonIcon
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
             onClick={handleBack}

--- a/ui/pages/notification-details/notification-details-header/notification-details-header.tsx
+++ b/ui/pages/notification-details/notification-details-header/notification-details-header.tsx
@@ -20,7 +20,7 @@ export const NotificationDetailsHeader = ({
         <ButtonIcon
           ariaLabel="Back"
           iconName={IconName.ArrowLeft}
-          size={ButtonIconSize.Sm}
+          size={ButtonIconSize.Md}
           onClick={onClickBack}
           data-testid="notification-details-back-button"
         />

--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -96,7 +96,7 @@ export default function NotificationsSettings() {
           <ButtonIcon
             ariaLabel="Back"
             iconName={IconName.ArrowLeft}
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             onClick={() =>
               previousPage
                 ? navigate(previousPage)

--- a/ui/pages/notifications/notifications.tsx
+++ b/ui/pages/notifications/notifications.tsx
@@ -166,7 +166,7 @@ export default function Notifications() {
           <ButtonIcon
             ariaLabel="Back"
             iconName={IconName.ArrowLeft}
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             onClick={() => {
               navigate(DEFAULT_ROUTE);
             }}
@@ -177,7 +177,7 @@ export default function Notifications() {
           <ButtonIcon
             ariaLabel="Notifications Settings"
             iconName={IconName.Setting}
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             onClick={() => {
               navigate(NOTIFICATIONS_SETTINGS_ROUTE);
             }}

--- a/ui/pages/notifications/notifications.tsx
+++ b/ui/pages/notifications/notifications.tsx
@@ -5,6 +5,7 @@ import { NotificationServicesController } from '@metamask/notification-services-
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   IconName,
+  IconSize,
   ButtonIcon,
   ButtonIconSize,
   Box,
@@ -178,6 +179,9 @@ export default function Notifications() {
             ariaLabel="Notifications Settings"
             iconName={IconName.Setting}
             size={ButtonIconSize.Md}
+            iconProps={{
+              size: IconSize.Lg,
+            }}
             onClick={() => {
               navigate(NOTIFICATIONS_SETTINGS_ROUTE);
             }}

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -202,7 +202,7 @@ class SettingsPage extends PureComponent {
                     color={Color.iconDefault}
                     onClick={() => navigate(backRoute)}
                     display={[Display.Flex, Display.None]}
-                    size={ButtonIconSize.Sm}
+                    size={ButtonIconSize.Md}
                   />
                 )}
               </>
@@ -220,7 +220,7 @@ class SettingsPage extends PureComponent {
                   navigate(mostRecentOverviewPage);
                 }
               }}
-              size={ButtonIconSize.Sm}
+              size={ButtonIconSize.Md}
               marginLeft="auto"
             />
           </div>

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -220,7 +220,7 @@ const ShieldPlan = () => {
         }}
         startAccessory={
           <ButtonIcon
-            size={ButtonIconSize.Sm}
+            size={ButtonIconSize.Md}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
             onClick={handleBack}


### PR DESCRIPTION
Dependency: https://github.com/MetaMask/metamask-extension/pull/36400

## **Description**
This PR is a fast follow to https://github.com/MetaMask/metamask-extension/pull/36400 to update the modal button icon sizes so we are consistent across the extension it updates button size from sm to md to ensure visual consistency.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: https://consensyssoftware.atlassian.net/browse/DSYS-225
Related: https://consensys.slack.com/archives/C0354T27M5M/p1758912397636659

## **Manual testing steps**

1. Navigate through different sections of the app
2. Verify that navigation button icons are visually consistent in size
3. Check notification area icons for proper sizing
4. Test various navigation elements to ensure uniform appearance
5. Compare with modal header icons to verify consistency across the app

## **Screenshots/Recordings**

<!-- Screenshots showing before/after navigation icon changes would be helpful -->

### **Before**

Navigation icons had inconsistent sizing 


https://github.com/user-attachments/assets/559812b7-33c2-45b5-9f71-9a11ea25b62c

### **After**

Navigation icons now have consistent sizing

https://github.com/user-attachments/assets/eeb4de4b-7468-4343-88d6-9ff29ffba4fa

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates multiple navigation ButtonIcons from Sm to Md and enlarges the notifications settings glyph, aligning icon sizing across pages.
> 
> - **UI/Navigation**:
>   - Set `ButtonIcon` size to `ButtonIconSize.Md` for back/close/actions in:
>     - `ui/pages/multichain-accounts/wallet-details/wallet-details.component.tsx`
>     - `ui/pages/notification-details/notification-details-header/notification-details-header.tsx`
>     - `ui/pages/notifications-settings/notifications-settings.tsx`
>     - `ui/pages/settings/settings.component.js`
>     - `ui/pages/shield-plan/shield-plan.tsx`
>   - Notifications page (`ui/pages/notifications/notifications.tsx`):
>     - Update back and settings `ButtonIcon` to `Md`.
>     - Add `iconProps={{ size: IconSize.Lg }}` to the settings button icon and import `IconSize`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 237d9e03390db69236269800e020079d9ef2842f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->