### PR TITLE
chore: use button loading indicator

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Konto hinzufügen"
   },
-  "addingCustomNetwork": {
-    "message": "Netzwerk wird hinzugefügt"
-  },
   "additionalNetworks": {
     "message": "Zusätzliche Netzwerke"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Προσθήκη λογαριασμού"
   },
-  "addingCustomNetwork": {
-    "message": "Προσθήκη δικτύου"
-  },
   "additionalNetworks": {
     "message": "Επιπλέον δίκτυα"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -331,9 +331,6 @@
   "addingAccount": {
     "message": "Adding account"
   },
-  "addingCustomNetwork": {
-    "message": "Adding Network"
-  },
   "additionalNetworks": {
     "message": "Additional networks"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -331,9 +331,6 @@
   "addingAccount": {
     "message": "Adding account"
   },
-  "addingCustomNetwork": {
-    "message": "Adding Network"
-  },
   "additionalNetworks": {
     "message": "Additional networks"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Añadiendo cuenta"
   },
-  "addingCustomNetwork": {
-    "message": "Agregando red"
-  },
   "additionalNetworks": {
     "message": "Redes adicionales"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -300,9 +300,6 @@
   "addingAccount": {
     "message": "Ajouter un compte"
   },
-  "addingCustomNetwork": {
-    "message": "Ajout de réseau"
-  },
   "additionalNetworks": {
     "message": "Réseaux supplémentaires"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "अकाउंट जोड़ा जा रहा है"
   },
-  "addingCustomNetwork": {
-    "message": "नेटवर्क जोड़ रहे हैं"
-  },
   "additionalNetworks": {
     "message": "अतिरिक्त नेटवर्क"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Menambahkan akun"
   },
-  "addingCustomNetwork": {
-    "message": "Menambahkan Jaringan"
-  },
   "additionalNetworks": {
     "message": "Jaringan tambahan"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -300,9 +300,6 @@
   "addingAccount": {
     "message": "アカウントの追加"
   },
-  "addingCustomNetwork": {
-    "message": "ネットワークを追加中"
-  },
   "additionalNetworks": {
     "message": "他のネットワーク"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "계정 추가"
   },
-  "addingCustomNetwork": {
-    "message": "네트워크 추가"
-  },
   "additionalNetworks": {
     "message": "추가 네트워크"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -300,9 +300,6 @@
   "addingAccount": {
     "message": "Adicionando conta"
   },
-  "addingCustomNetwork": {
-    "message": "Adicionar rede"
-  },
   "additionalNetworks": {
     "message": "Redes adicionais"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Добавление счет..."
   },
-  "addingCustomNetwork": {
-    "message": "Добавление сети"
-  },
   "additionalNetworks": {
     "message": "Дополнительные сети"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -300,9 +300,6 @@
   "addingAccount": {
     "message": "Idinaragdag ang account"
   },
-  "addingCustomNetwork": {
-    "message": "Nagdaragdag ng Network"
-  },
   "additionalNetworks": {
     "message": "Mga karagdagang network"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -300,9 +300,6 @@
   "addingAccount": {
     "message": "Hesap ekleniyor"
   },
-  "addingCustomNetwork": {
-    "message": "Ağ Ekleniyor"
-  },
   "additionalNetworks": {
     "message": "İlave ağlar"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "Thêm tài khoản"
   },
-  "addingCustomNetwork": {
-    "message": "Thêm mạng"
-  },
   "additionalNetworks": {
     "message": "Mạng bổ sung"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -308,9 +308,6 @@
   "addingAccount": {
     "message": "添加账户"
   },
-  "addingCustomNetwork": {
-    "message": "正在添加网络"
-  },
   "additionalNetworks": {
     "message": "其他网络"
   },

--- a/ui/pages/confirmations/confirmation/components/confirmation-footer/confirmation-footer.js
+++ b/ui/pages/confirmations/confirmation/components/confirmation-footer/confirmation-footer.js
@@ -14,7 +14,6 @@ export default function ConfirmationFooter({
   onCancel,
   submitText,
   cancelText,
-  loadingText,
   alerts,
   loading,
   submitAlerts,
@@ -43,6 +42,7 @@ export default function ConfirmationFooter({
           {onSubmit && submitText ? (
             <Button
               block
+              loading={Boolean(loading)}
               data-testid="confirmation-submit-button"
               disabled={Boolean(loading)}
               onClick={hasAlerts ? showAlertsModal : onSubmit}
@@ -52,7 +52,7 @@ export default function ConfirmationFooter({
               startIconName={hasAlerts ? IconName.Info : undefined}
               size={ButtonSize.Lg}
             >
-              {loading ? loadingText : submitText}
+              {submitText}
             </Button>
           ) : null}
         </div>
@@ -67,7 +67,6 @@ ConfirmationFooter.propTypes = {
   cancelText: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   submitText: PropTypes.string.isRequired,
-  loadingText: PropTypes.string,
   loading: PropTypes.bool,
   submitAlerts: PropTypes.node,
   style: PropTypes.object,

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -274,7 +274,6 @@ export default function ConfirmationPage({
     setInputStates((currentState) => ({ ...currentState, [key]: value }));
   };
   const [loading, setLoading] = useState(false);
-  const [loadingText, setLoadingText] = useState();
 
   const [submitAlerts, setSubmitAlerts] = useState([]);
 
@@ -461,7 +460,6 @@ export default function ConfirmationPage({
 
   const handleSubmitResult = (submitResult) => {
     if (submitResult?.length > 0) {
-      setLoadingText(templatedValues.submitText);
       setSubmitAlerts(submitResult);
       setLoading(true);
     } else {
@@ -596,7 +594,6 @@ export default function ConfirmationPage({
               onCancel={templatedValues.onCancel}
               submitText={templatedValues.submitText}
               cancelText={templatedValues.cancelText}
-              loadingText={loadingText || templatedValues.loadingText}
               loading={loading}
               submitAlerts={submitAlerts.map((alert, idx) => (
                 <Callout

--- a/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmations/confirmation/templates/add-ethereum-chain.js
@@ -357,7 +357,6 @@ function getValues(pendingApproval, t, actions, history, data) {
     ],
     cancelText: t('cancel'),
     submitText: t('approveButtonText'),
-    loadingText: t('addingCustomNetwork'),
     onSubmit: async () => {
       let endpointChainId;
       try {


### PR DESCRIPTION
## **Description**

Use button loading indicator instead of changing the text

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36403?quickstart=1)

## **Changelog**

CHANGELOG entry: use loading indicator when approving an add network

## **Related issues**

Fixes: CEUX-398

## **Manual testing steps**

1. Chainlist.org
2. Add a network that hasn't been added
3. Click Approve

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="346" height="74" alt="image" src="https://github.com/user-attachments/assets/4d429cf7-a397-45cf-8e16-4a280cf8e47e" />



### **After**

<img width="341" height="62" alt="image" src="https://github.com/user-attachments/assets/ed4837d9-5ad4-4cd9-8e12-29d8f68e2325" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
