### PR TITLE
fix: speedup button display on transaction details popup

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -250,7 +250,7 @@ function TransactionListItemInner({
     });
   }, [isUnapproved, history, id, trackEvent, category]);
 
-  const speedUpButton = useMemo(() => {
+  const isSpeedUpButtonVisible = useMemo(() => {
     if (
       !shouldShowSpeedUp ||
       !isPending ||
@@ -258,6 +258,14 @@ function TransactionListItemInner({
       isSigning ||
       isSubmitting
     ) {
+      return false;
+    }
+
+    return true;
+  }, [shouldShowSpeedUp, isUnapproved, isPending, isSigning, isSubmitting]);
+
+  const speedUpButton = useMemo(() => {
+    if (!isSpeedUpButtonVisible) {
       return null;
     }
 
@@ -272,12 +280,8 @@ function TransactionListItemInner({
       </Button>
     );
   }, [
-    shouldShowSpeedUp,
-    isUnapproved,
+    isSpeedUpButtonVisible,
     t,
-    isPending,
-    isSigning,
-    isSubmitting,
     hasCancelled,
     retryTransaction,
     cancelTransaction,
@@ -395,7 +399,7 @@ function TransactionListItemInner({
           recipientAddress={recipientAddress}
           onRetry={retryTransaction}
           // showRetry={showRetry}
-          showSpeedUp={shouldShowSpeedUp}
+          showSpeedUp={isSpeedUpButtonVisible}
           isEarliestNonce={isEarliestNonce}
           onCancel={cancelTransaction}
           transactionStatus={() => (


### PR DESCRIPTION
## **Description**

Fix for issue that speedup button is always displayed on transaction details modal, in the transaction list.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36198

## **Manual testing steps**

1. Submit a send
2. Open transaction details in transaction list
3. Check that speedup button is not visible after transaction is confirmed

## **Screenshots/Recordings**
<img width="1201" height="822" alt="Screenshot 2025-09-29 at 10 40 47 AM" src="https://github.com/user-attachments/assets/a8780869-a182-4825-99b9-faf55caf3ee5" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows the Speed Up button only when eligible and passes that state to the transaction details modal.
> 
> - **UI**:
>   - **`ui/components/app/transaction-list-item/transaction-list-item.component.js`**:
>     - Extracts visibility logic into `isSpeedUpButtonVisible` (`useMemo`) for Speed Up button.
>     - Uses `isSpeedUpButtonVisible` to conditionally render the Speed Up button and as `showSpeedUp` for `TransactionListItemDetails`.
>     - Simplifies `speedUpButton` memo dependencies by relying on `isSpeedUpButtonVisible`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0bf608a4e2f25902651f47d3b26871c5214abb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->