### PR TITLE
fix: UI in headers for permission connect features

### DIFF
--- a/ui/components/multichain-accounts/permissions/multichain-edit-accounts-page/multichain-edit-accounts-page.tsx
+++ b/ui/components/multichain-accounts/permissions/multichain-edit-accounts-page/multichain-edit-accounts-page.tsx
@@ -131,8 +131,9 @@ export const MultichainEditAccountsPage: React.FC<
       backgroundColor={BackgroundColor.backgroundDefault}
     >
       <Header
-        paddingTop={8}
-        paddingBottom={0}
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
         startAccessory={
           <ButtonIcon
             size={ButtonIconSize.Md}
@@ -142,9 +143,6 @@ export const MultichainEditAccountsPage: React.FC<
             data-testid="back-button"
           />
         }
-        textProps={{
-          variant: TextVariant.headingSm,
-        }}
       >
         {title ?? t('editAccounts')}
       </Header>

--- a/ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx
+++ b/ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx
@@ -102,8 +102,9 @@ export const MultichainEditNetworksPage: React.FC<
       backgroundColor={BackgroundColor.backgroundDefault}
     >
       <Header
-        paddingTop={8}
-        paddingBottom={0}
+        textProps={{
+          variant: TextVariant.headingSm,
+        }}
         startAccessory={
           <ButtonIcon
             size={ButtonIconSize.Md}
@@ -113,9 +114,6 @@ export const MultichainEditNetworksPage: React.FC<
             data-testid="back-button"
           />
         }
-        textProps={{
-          variant: TextVariant.headingSm,
-        }}
       >
         {t('editNetworksTitle')}
       </Header>

--- a/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/review-permissions-page/__snapshots__/review-permissions-page.test.tsx.snap
@@ -19,10 +19,11 @@ exports[`ReviewPermissions should render correctly 1`] = `
         >
           <button
             aria-label="Back"
-            class="mm-box mm-button-icon mm-button-icon--size-sm connections-header__start-accessory mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            class="mm-box mm-button-icon mm-button-icon--size-md connections-header__start-accessory mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            data-testid="back-button"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/arrow-left.svg');"
             />
           </button>
@@ -30,8 +31,8 @@ exports[`ReviewPermissions should render correctly 1`] = `
         <div
           class="mm-box"
         >
-          <p
-            class="mm-box mm-text mm-text--body-md-bold mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-2 mm-box--padding-inline-end-2 mm-box--display-block mm-box--color-text-default"
+          <h4
+            class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--padding-inline-start-2 mm-box--padding-inline-end-2 mm-box--display-block mm-box--color-text-default"
           >
             <div
               class="mm-box connections-header__title mm-box--display-flex mm-box--gap-2 mm-box--justify-content-center mm-box--align-items-center"
@@ -41,10 +42,10 @@ exports[`ReviewPermissions should render correctly 1`] = `
                 style="mask-image: url('./images/icons/global.svg');"
               />
               <span
-                class="mm-box mm-text mm-text--heading-md mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
+                class="mm-box mm-text mm-text--heading-sm mm-text--ellipsis mm-text--text-align-center mm-box--color-text-default"
               />
             </div>
-          </p>
+          </h4>
         </div>
       </div>
       <div

--- a/ui/components/multichain/permissions-header/permissions-header.tsx
+++ b/ui/components/multichain/permissions-header/permissions-header.tsx
@@ -36,17 +36,19 @@ export const PermissionsHeader = ({
 
   return (
     <Header
+      textProps={{
+        variant: TextVariant.headingSm,
+      }}
       backgroundColor={BackgroundColor.backgroundDefault}
       startAccessory={
         <ButtonIcon
+          size={ButtonIconSize.Md}
           ariaLabel={t('back')}
           iconName={IconName.ArrowLeft}
           className="connections-header__start-accessory"
           color={IconColor.iconDefault}
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          onClick={() => (history as any).goBack()}
-          size={ButtonIconSize.Sm}
+          onClick={() => history.goBack()}
+          data-testid="back-button"
         />
       }
     >
@@ -72,7 +74,7 @@ export const PermissionsHeader = ({
         )}
         <Text
           as="span"
-          variant={TextVariant.headingMd}
+          variant={TextVariant.headingSm}
           textAlign={TextAlign.Center}
           ellipsis
         >


### PR DESCRIPTION
## **Description**
This PR adds changes to fix inconsistencies in headers between multichain accounts pages and multichain permission connect pages.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36412?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed headers UI inconsistencies for permission connect pages

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-922

## **Manual testing steps**
1. Go to test dapp https://metamask.github.io/test-dapp/
2. Connect extension to the test dapp and inspect page headers.
3. Open extension while on the same page and check permissions allowed for the current web page (manage permissions).
4. Inspect headers within manage permissions page.
5. Open some of the regular multichain accounts pages, like account list or account details. Then compare headers of these pages to the headers on the permission-connect related pages, etc.

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/e5566557-16e1-4d2f-aa42-27085eb181e3

### **After**
https://github.com/user-attachments/assets/428d35e6-0782-40d6-a461-6fbde2fa1ab7

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies permissions headers across multichain pages: headingSm titles, Md back button with test id, removed extra padding, and simplified goBack handling.
> 
> - **UI/Headers**:
>   - `multichain-edit-accounts-page.tsx` and `multichain-edit-networks-page.tsx`:
>     - Use `textProps: { variant: TextVariant.headingSm }` for `Header` titles.
>     - Set back `ButtonIcon` to `size=Md` and add `data-testid="back-button"`.
>     - Remove `paddingTop`/`paddingBottom` from `Header`.
>   - `permissions-header.tsx`:
>     - Add `textProps: { variant: TextVariant.headingSm }`.
>     - Set back `ButtonIcon` to `size=Md`, add `data-testid`, and call `history.goBack()`.
>     - Change title `Text` variant from `headingMd` to `headingSm`.
> - **Tests**:
>   - Update snapshot for `review-permissions-page` to reflect Md back button and `heading-sm` title (now rendered as `h4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca2774e0c579ee0370119022627889271287c6af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->