### PR TITLE
fix: Polish Send/Review page

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -35,7 +35,7 @@ class TransactionConfirmation extends Confirmation {
     '[data-testid="custom-nonce-input"]';
 
   private readonly dappInitiatedHeadingTitle: RawLocator = {
-    css: 'h3',
+    css: 'h4',
     text: tEn('transferRequest') as string,
   };
 

--- a/ui/components/app/confirm/info/row/__snapshots__/row.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/row.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ConfirmInfoRow should match snapshot when copy is enabled 1`] = `
   >
     <button
       aria-label="copy-button"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
       style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
     >
       <span

--- a/ui/components/app/confirm/info/row/__snapshots__/section.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/section.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ConfirmInfoSection should match snapshot 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     Test Content
   </div>
@@ -13,7 +13,7 @@ exports[`ConfirmInfoSection should match snapshot 1`] = `
 exports[`ConfirmInfoSection should match snapshot without padding 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     Test Content
   </div>

--- a/ui/components/app/confirm/info/row/row.tsx
+++ b/ui/components/app/confirm/info/row/row.tsx
@@ -112,8 +112,8 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
         alignItems={AlignItems.flexStart}
         backgroundColor={BACKGROUND_COLORS[variant]}
         borderRadius={BorderRadius.LG}
-        marginTop={1}
-        marginBottom={1}
+        marginTop={2}
+        marginBottom={2}
         paddingLeft={2}
         paddingRight={2}
         color={TEXT_COLORS[variant] as TextColor}
@@ -128,12 +128,12 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
           <CopyIcon
             copyText={copyText ?? ''}
             style={{ right: isCollapsible ? 32 : 4 }}
-            color={IconColor.iconMuted}
+            color={IconColor.iconAlternative}
           />
         )}
         {isCollapsible && (
           <ButtonIcon
-            color={IconColor.iconMuted}
+            color={IconColor.iconAlternative}
             iconName={expanded ? IconName.Collapse : IconName.Expand}
             size={ButtonIconSize.Sm}
             style={{

--- a/ui/components/app/confirm/info/row/row.tsx
+++ b/ui/components/app/confirm/info/row/row.tsx
@@ -68,7 +68,7 @@ const TOOLTIP_ICONS = {
 };
 
 const TOOLTIP_ICON_COLORS = {
-  [ConfirmInfoRowVariant.Default]: Color.iconMuted,
+  [ConfirmInfoRowVariant.Default]: Color.iconAlternative,
   [ConfirmInfoRowVariant.Critical]: Color.errorAlternative,
   [ConfirmInfoRowVariant.Warning]: Color.warningDefault,
 };
@@ -112,8 +112,8 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
         alignItems={AlignItems.flexStart}
         backgroundColor={BACKGROUND_COLORS[variant]}
         borderRadius={BorderRadius.LG}
-        marginTop={2}
-        marginBottom={2}
+        marginTop={1}
+        marginBottom={1}
         paddingLeft={2}
         paddingRight={2}
         color={TEXT_COLORS[variant] as TextColor}

--- a/ui/components/app/confirm/info/row/section.tsx
+++ b/ui/components/app/confirm/info/row/section.tsx
@@ -21,8 +21,8 @@ export const ConfirmInfoSection = ({
   return (
     <Box
       data-testid={dataTestId}
-      backgroundColor={BackgroundColor.backgroundDefault}
-      borderRadius={BorderRadius.MD}
+      backgroundColor={BackgroundColor.backgroundSection}
+      borderRadius={BorderRadius.LG}
       padding={noPadding ? 0 : 2}
       marginBottom={4}
       style={style}

--- a/ui/components/app/confirm/info/row/section.tsx
+++ b/ui/components/app/confirm/info/row/section.tsx
@@ -23,7 +23,9 @@ export const ConfirmInfoSection = ({
       data-testid={dataTestId}
       backgroundColor={BackgroundColor.backgroundSection}
       borderRadius={BorderRadius.LG}
-      padding={noPadding ? 0 : 2}
+      paddingInline={noPadding ? 0 : 2}
+      paddingTop={noPadding ? 0 : 1}
+      paddingBottom={noPadding ? 0 : 1}
       marginBottom={4}
       style={style}
     >

--- a/ui/components/app/name/index.scss
+++ b/ui/components/app/name/index.scss
@@ -2,7 +2,7 @@
   border-radius: 36px;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 8px;
   font-size: 12px;
   max-width: 100%;
   color: var(--color-text-default);

--- a/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
+++ b/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`NameDetails renders proposed names 1`] = `
                 class="name name__saved"
               >
                 <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
                 >
                   <div
                     class="flex [&>div]:!rounded-none"
@@ -328,7 +328,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                 class="name name__missing"
               >
                 <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
                 >
                   <div
                     class="flex [&>div]:!rounded-none"
@@ -548,7 +548,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                 class="name name__missing"
               >
                 <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
                 >
                   <div
                     class="flex [&>div]:!rounded-none"
@@ -770,7 +770,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                 class="name name__recognized_unsaved"
               >
                 <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
                 >
                   <div
                     class="flex [&>div]:!rounded-none"
@@ -992,7 +992,7 @@ exports[`NameDetails renders with saved name 1`] = `
                 class="name name__saved"
               >
                 <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
                 >
                   <div
                     class="flex [&>div]:!rounded-none"

--- a/ui/components/app/name/name-details/name-display.tsx
+++ b/ui/components/app/name/name-details/name-display.tsx
@@ -54,7 +54,13 @@ const NameDisplay = memo(
         return <Identicon address={value} diameter={16} image={image} />;
       }
 
-      return <PreferredAvatar address={value} size={AvatarAccountSize.Xs} />;
+      return (
+        <PreferredAvatar
+          className="rounded-md"
+          address={value}
+          size={AvatarAccountSize.Xs}
+        />
+      );
     };
 
     const renderName = () => {

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/dapp-initiated-header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/dapp-initiated-header.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`<DAppInitiatedHeader /> should match snapshot 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-center mm-box--background-color-background-default"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-inline-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-center mm-box--background-color-background-default"
     style="z-index: 2; position: relative;"
   >
-    <h3
-      class="mm-box mm-text mm-text--heading-md mm-box--color-inherit"
+    <h4
+      class="mm-box mm-text mm-text--heading-sm mm-box--color-inherit"
     >
       Transfer request
-    </h3>
+    </h4>
     <div
       class="mm-box mm-box--padding-right-3"
       style="margin-left: auto; position: absolute; right: 0px;"

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -115,14 +115,14 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
 exports[`Header should match snapshot with token transfer confirmation initiated in a dApp 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-center mm-box--background-color-background-default"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-inline-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-center mm-box--background-color-background-default"
     style="z-index: 2; position: relative;"
   >
-    <h3
-      class="mm-box mm-text mm-text--heading-md mm-box--color-inherit"
+    <h4
+      class="mm-box mm-text mm-text--heading-sm mm-box--color-inherit"
     >
       Transfer request
-    </h3>
+    </h4>
     <div
       class="mm-box mm-box--padding-right-3"
       style="margin-left: auto; position: absolute; right: 0px;"
@@ -160,7 +160,7 @@ exports[`Header should match snapshot with token transfer confirmation initiated
 exports[`Header should match snapshot with token transfer confirmation initiated in the wallet 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--background-color-background-default"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-inline-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--background-color-background-default"
     style="z-index: 2;"
   >
     <button

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/wallet-initiated-header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/wallet-initiated-header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<WalletInitiatedHeader /> should match snapshot 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--background-color-background-default"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-inline-3 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center mm-box--background-color-background-default"
     style="z-index: 2;"
   >
     <button

--- a/ui/pages/confirmations/components/confirm/header/dapp-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/dapp-initiated-header.tsx
@@ -22,10 +22,12 @@ export const DAppInitiatedHeader = () => {
       justifyContent={JustifyContent.center}
       alignItems={AlignItems.center}
       backgroundColor={BackgroundColor.backgroundDefault}
-      padding={3}
+      paddingInline={3}
+      paddingTop={4}
+      paddingBottom={4}
       style={{ zIndex: 2, position: 'relative' }}
     >
-      <Text variant={TextVariant.headingMd} color={TextColor.inherit}>
+      <Text variant={TextVariant.headingSm} color={TextColor.inherit}>
         {t('transferRequest')}
       </Text>
       <Box

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -89,7 +89,9 @@ export const WalletInitiatedHeader = () => {
       display={Display.Flex}
       flexDirection={FlexDirection.Row}
       justifyContent={JustifyContent.spaceBetween}
-      padding={3}
+      paddingInline={3}
+      paddingTop={4}
+      paddingBottom={4}
       style={{ zIndex: 2 }}
     >
       <ButtonIcon

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Info renders info section for approve request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`Info renders info section for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -105,7 +105,7 @@ exports[`Info renders info section for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -134,7 +134,7 @@ exports[`Info renders info section for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -197,7 +197,7 @@ exports[`Info renders info section for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -217,7 +217,7 @@ exports[`Info renders info section for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -226,7 +226,7 @@ exports[`Info renders info section for approve request 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -249,7 +249,7 @@ exports[`Info renders info section for approve request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -280,7 +280,7 @@ exports[`Info renders info section for approve request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -306,7 +306,7 @@ exports[`Info renders info section for approve request 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -335,10 +335,10 @@ exports[`Info renders info section for approve request 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>
@@ -362,10 +362,10 @@ exports[`Info renders info section for approve request 1`] = `
 exports[`Info renders info section for contract interaction request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
-      class="mm-box simulation-details-layout mm-box--padding-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      class="mm-box simulation-details-layout mm-box--padding-top-1 mm-box--padding-bottom-2 mm-box--padding-inline-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
       data-testid="simulation-details-layout"
     >
       <div
@@ -399,7 +399,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
                   </div>
@@ -417,7 +417,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="transaction-details-section"
   >
     <div
@@ -446,7 +446,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -490,7 +490,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-recipient-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -522,7 +522,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -531,7 +531,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -554,7 +554,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -585,7 +585,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
             $0.04
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -611,7 +611,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -640,10 +640,10 @@ exports[`Info renders info section for contract interaction request 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>
@@ -667,7 +667,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
 exports[`Info renders info section for personal sign request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -694,7 +694,7 @@ exports[`Info renders info section for personal sign request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -713,7 +713,7 @@ exports[`Info renders info section for personal sign request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -721,7 +721,7 @@ exports[`Info renders info section for personal sign request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -731,7 +731,7 @@ exports[`Info renders info section for personal sign request 1`] = `
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >
@@ -771,7 +771,7 @@ exports[`Info renders info section for personal sign request 1`] = `
 exports[`Info renders info section for setApprovalForAll request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -799,7 +799,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -873,7 +873,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -902,7 +902,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -965,7 +965,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -985,7 +985,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -994,7 +994,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -1017,7 +1017,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1048,7 +1048,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -1074,7 +1074,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -1103,10 +1103,10 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>
@@ -1130,7 +1130,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
 exports[`Info renders info section for typed sign request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -1158,7 +1158,7 @@ exports[`Info renders info section for typed sign request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1200,7 +1200,7 @@ exports[`Info renders info section for typed sign request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1231,7 +1231,7 @@ exports[`Info renders info section for typed sign request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -1240,7 +1240,7 @@ exports[`Info renders info section for typed sign request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -1752,7 +1752,7 @@ exports[`Info renders info section for typed sign request 1`] = `
 exports[`Info renders info section for typed sign request with permission 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -1780,7 +1780,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1820,7 +1820,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1862,7 +1862,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1897,6 +1897,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -1909,7 +1910,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-details-section"
   >
     <div
@@ -1937,7 +1938,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1991,7 +1992,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2045,7 +2046,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2088,7 +2089,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2108,7 +2109,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-stream-rate-section"
   >
     <div
@@ -2136,7 +2137,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2190,7 +2191,7 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ApproveInfo /> renders component for approve request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -115,7 +115,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -144,7 +144,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -207,7 +207,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -251,7 +251,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-recipient-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -283,7 +283,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -292,7 +292,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -315,7 +315,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -346,7 +346,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
             0.0001
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -372,7 +372,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -407,10 +407,10 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>
@@ -453,7 +453,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="gas-fee-details-max-fee-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -478,7 +478,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-nonce-section"
   >
     <div
@@ -506,7 +506,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -538,7 +538,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -547,7 +547,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -629,7 +629,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-0-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -685,7 +685,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-1-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />

--- a/ui/pages/confirmations/components/confirm/info/approve/approve-details/__snapshots__/approve-details.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve-details/__snapshots__/approve-details.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ApproveDetails /> renders component for approve details 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -32,7 +32,7 @@ exports[`<ApproveDetails /> renders component for approve details 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -95,7 +95,7 @@ exports[`<ApproveDetails /> renders component for approve details 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -120,7 +120,7 @@ exports[`<ApproveDetails /> renders component for approve details 1`] = `
 exports[`<ApproveDetails /> renders component for approve details for setApprovalForAll 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -149,7 +149,7 @@ exports[`<ApproveDetails /> renders component for approve details for setApprova
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -212,7 +212,7 @@ exports[`<ApproveDetails /> renders component for approve details for setApprova
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />

--- a/ui/pages/confirmations/components/confirm/info/approve/approve-static-simulation/__snapshots__/approve-static-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve-static-simulation/__snapshots__/approve-static-simulation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ApproveStaticSimulation /> renders component when token is an NFT 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`<ApproveStaticSimulation /> renders component when token is an NFT 1`] 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -110,7 +110,7 @@ exports[`<ApproveStaticSimulation /> renders component when token is an NFT 1`] 
 exports[`<ApproveStaticSimulation /> renders component when token is not an NFT 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -138,7 +138,7 @@ exports[`<ApproveStaticSimulation /> renders component when token is not an NFT 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`<BaseTransactionInfo /> does not render if required data is not present
 exports[`<BaseTransactionInfo /> renders component for contract interaction request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
-      class="mm-box simulation-details-layout mm-box--padding-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      class="mm-box simulation-details-layout mm-box--padding-top-1 mm-box--padding-bottom-2 mm-box--padding-inline-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
       data-testid="simulation-details-layout"
     >
       <div
@@ -42,7 +42,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
                   </div>
@@ -60,7 +60,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="transaction-details-section"
   >
     <div
@@ -89,7 +89,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -133,7 +133,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-recipient-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -165,7 +165,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -174,7 +174,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -197,7 +197,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -228,7 +228,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
             $0.04
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -254,7 +254,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -283,10 +283,10 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -17,11 +17,11 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     </h2>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
     >
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -41,7 +41,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="sender-address"
         >
           <div
@@ -68,7 +68,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
         </div>
       </div>
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-muted"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
         style="mask-image: url('./images/icons/arrow-right.svg');"
       />
       <div
@@ -89,7 +89,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="recipient-address"
         >
           <div
@@ -118,10 +118,10 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
-      class="mm-box simulation-details-layout mm-box--padding-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      class="mm-box simulation-details-layout mm-box--padding-top-1 mm-box--padding-bottom-2 mm-box--padding-inline-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
       data-testid="simulation-details-layout"
     >
       <div
@@ -155,7 +155,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
                   </div>
@@ -173,7 +173,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__token-details-section"
   >
     <div
@@ -198,6 +198,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -234,7 +235,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -284,7 +285,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -315,7 +316,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -324,7 +325,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -347,7 +348,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -378,7 +379,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -404,7 +405,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -433,10 +434,10 @@ exports[`NativeTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -47,11 +47,11 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     />
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
     >
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -71,7 +71,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="sender-address"
         >
           <div
@@ -98,7 +98,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
         </div>
       </div>
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-muted"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
         style="mask-image: url('./images/icons/arrow-right.svg');"
       />
       <div
@@ -119,7 +119,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="recipient-address"
         >
           <div
@@ -148,10 +148,10 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
-      class="mm-box simulation-details-layout mm-box--padding-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      class="mm-box simulation-details-layout mm-box--padding-top-1 mm-box--padding-bottom-2 mm-box--padding-inline-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
       data-testid="simulation-details-layout"
     >
       <div
@@ -185,7 +185,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
                   </div>
@@ -203,7 +203,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__token-details-section"
   >
     <div
@@ -228,6 +228,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -264,7 +265,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -314,7 +315,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -345,7 +346,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -354,7 +355,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -377,7 +378,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -408,7 +409,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -434,7 +435,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -463,10 +464,10 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PersonalSignInfo handle reverse string properly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -30,7 +30,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -49,7 +49,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -57,7 +57,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -67,7 +67,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >
@@ -107,7 +107,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
 exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -134,7 +134,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -153,7 +153,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -161,7 +161,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -171,7 +171,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
   >
     <button
       aria-label="copy-button"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
       style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
     >
       <span
@@ -18,7 +18,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
     </button>
     <button
       aria-label="collapse-button"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
       data-testid="sectionCollapseButton"
       style="cursor: pointer; position: absolute; right: 8px;"
     >
@@ -297,7 +297,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
   >
     <button
       aria-label="copy-button"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
       style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
     >
       <span
@@ -307,7 +307,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
     </button>
     <button
       aria-label="collapse-button"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
       data-testid="sectionCollapseButton"
       style="cursor: pointer; position: absolute; right: 8px;"
     >

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<SetApprovalForAllInfo /> does not render component when no transaction
 exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -33,7 +33,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -107,7 +107,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__approve-details"
   >
     <div
@@ -136,7 +136,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="confirmation__approve-spender-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -199,7 +199,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -219,7 +219,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -228,7 +228,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -251,7 +251,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -282,7 +282,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -308,7 +308,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -337,10 +337,10 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/revoke-set-approval-for-all-static-simulation/__snapshots__/revoke-set-approval-for-all-static-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/revoke-set-approval-for-all-static-simulation/__snapshots__/revoke-set-approval-for-all-static-simulation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<RevokeSetApprovalForAllStaticSimulation /> renders component for setApprovalForAll request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`<RevokeSetApprovalForAllStaticSimulation /> renders component for setAp
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/set-approval-for-all-static-simulation/__snapshots__/set-approval-for-all-static-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/set-approval-for-all-static-simulation/__snapshots__/set-approval-for-all-static-simulation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<SetApprovalForAllStaticSimulation /> renders component for approve request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`<SetApprovalForAllStaticSimulation /> renders component for approve req
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<AdvancedDetails /> does not render component when the state property i
 exports[`<AdvancedDetails /> renders component when the prop override is passed 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-nonce-section"
   >
     <div
@@ -33,7 +33,7 @@ exports[`<AdvancedDetails /> renders component when the prop override is passed 
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -65,7 +65,7 @@ exports[`<AdvancedDetails /> renders component when the prop override is passed 
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -136,7 +136,7 @@ exports[`<AdvancedDetails /> renders component when the prop override is passed 
 exports[`<AdvancedDetails /> renders component when the state property is true 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-nonce-section"
   >
     <div
@@ -164,7 +164,7 @@ exports[`<AdvancedDetails /> renders component when the state property is true 1
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -196,7 +196,7 @@ exports[`<AdvancedDetails /> renders component when the state property is true 1
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
       data-testid="edit-gas-fees-row"
-      style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+      style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
     >
       <div
         class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -31,7 +31,7 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="edit-gas-fees-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -73,7 +73,7 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+          class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
           data-testid="selected-gas-fee-token"
           style="cursor: default; padding-inline-end: 6px; padding: 0px;"
         >
@@ -99,7 +99,7 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
       class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
     >
       <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+        class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
         data-testid="gas-fee-token-fee"
       >
          

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -110,7 +110,7 @@ export const EditGasFeesRow = ({
           data-testid="gas-fee-token-fee"
           variant={TextVariant.bodySm}
           color={TextColor.textAlternative}
-          marginBottom={1}
+          paddingBottom={gasFeeToken ? 2 : 0}
         >
           {gasFeeToken
             ? t('confirmGasFeeTokenMetaMaskFee', [metamaskFeeFiat])

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -110,6 +110,7 @@ export const EditGasFeesRow = ({
           data-testid="gas-fee-token-fee"
           variant={TextVariant.bodySm}
           color={TextColor.textAlternative}
+          marginBottom={1}
         >
           {gasFeeToken
             ? t('confirmGasFeeTokenMetaMaskFee', [metamaskFeeFiat])

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -70,7 +70,7 @@ export const EditGasFeesRow = ({
         data-testid="edit-gas-fees-row"
         label={t('networkFee')}
         tooltip={tooltip}
-        style={{ alignItems: AlignItems.center, marginBottom: '2px' }}
+        style={{ alignItems: AlignItems.center }}
       >
         {isLoadingGasUsed ? (
           <Skeleton height={16} width={128} />

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-toast/index.scss
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-toast/index.scss
@@ -2,9 +2,9 @@
 
 .toast_wrapper {
   bottom: 80px;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-bottom: 10px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-bottom: 4px;
   position: fixed;
   width: 100%;
   z-index: design-system.$modal-z-index;

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/__snapshots__/gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/__snapshots__/gas-fees-row.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`<GasFeesRow /> renders component 1`] = `
             tabindex="0"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+              class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
               style="mask-image: url('./images/icons/question.svg');"
             />
           </div>

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<GasFeesSection /> does not render component for gas fees section 1`] =
 exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -14,7 +14,7 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -37,7 +37,7 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -68,7 +68,7 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
             $0.04
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -94,7 +94,7 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -123,10 +123,10 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/shared/network-row/network-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/network-row/network-row.tsx
@@ -14,7 +14,6 @@ import {
 import {
   AlignItems,
   BlockSize,
-  BorderColor,
   Display,
   FlexWrap,
   TextColor,
@@ -60,10 +59,10 @@ export const NetworkRow = ({
         minWidth={BlockSize.Zero}
       >
         <AvatarNetwork
-          borderColor={BorderColor.backgroundDefault}
           size={AvatarNetworkSize.Xs}
           src={networkImageUrl}
           name={networkName}
+          style={{ borderWidth: 0 }}
         />
         <Text variant={TextVariant.bodyMd} color={TextColor.textDefault}>
           {networkName}

--- a/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
@@ -51,8 +51,6 @@ export function SelectedGasFeeToken() {
     chainId
   ];
 
-  const [isHover, setIsHover] = useState(false);
-
   const handleClick = useCallback(() => {
     if (!hasGasFeeTokens) {
       return;
@@ -84,15 +82,10 @@ export function SelectedGasFeeToken() {
         paddingInlineStart={1}
         marginLeft={1}
         gap={1}
-        onMouseEnter={() => setIsHover(true)}
-        onMouseLeave={() => setIsHover(false)}
         style={{
           cursor: hasGasFeeTokens ? 'pointer' : 'default',
           paddingInlineEnd: '6px',
           padding: hasGasFeeTokens ? '4px 8px' : '0px',
-          background: isHover
-            ? 'var(--color-background-muted-hover)'
-            : 'var(--color-background-muted)',
         }}
       >
         <GasFeeTokenIcon

--- a/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
@@ -51,6 +51,8 @@ export function SelectedGasFeeToken() {
     chainId
   ];
 
+  const [isHover, setIsHover] = useState(false);
+
   const handleClick = useCallback(() => {
     if (!hasGasFeeTokens) {
       return;
@@ -73,18 +75,24 @@ export function SelectedGasFeeToken() {
         onClick={handleClick}
         backgroundColor={
           hasGasFeeTokens
-            ? BackgroundColor.backgroundAlternative
+            ? BackgroundColor.backgroundMuted
             : BackgroundColor.transparent
         }
         borderRadius={BorderRadius.pill}
         display={Display.InlineFlex}
         alignItems={AlignItems.center}
         paddingInlineStart={1}
+        marginLeft={1}
         gap={1}
+        onMouseEnter={() => setIsHover(true)}
+        onMouseLeave={() => setIsHover(false)}
         style={{
           cursor: hasGasFeeTokens ? 'pointer' : 'default',
           paddingInlineEnd: '6px',
           padding: hasGasFeeTokens ? '4px 8px' : '0px',
+          background: isHover
+            ? 'var(--color-background-muted-hover)'
+            : 'var(--color-background-muted)',
         }}
       >
         <GasFeeTokenIcon

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/__snapshots__/send-heading.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/__snapshots__/send-heading.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<SendHeading /> renders component 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
+    class="mm-box mm-box--margin-bottom-2 mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-token mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-muted mm-box--background-color-overlay-default mm-box--rounded-full"

--- a/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/send-heading/send-heading.tsx
@@ -94,6 +94,7 @@ const SendHeading = () => {
       justifyContent={JustifyContent.center}
       alignItems={AlignItems.center}
       padding={4}
+      marginBottom={2}
     >
       {TokenImage}
       {TokenValue}

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TransactionData renders a truncated token id for an NFT with a long token id 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -12,7 +12,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -63,7 +63,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="advanced-details-data-function-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -112,7 +112,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-0-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -168,7 +168,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-1-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -224,7 +224,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-2-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -269,7 +269,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-3-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -314,7 +314,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-4-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -341,7 +341,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
 exports[`TransactionData renders decoded data with names and descriptions 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -350,7 +350,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -454,7 +454,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-0-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -510,7 +510,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-1-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -618,7 +618,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-0-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -674,7 +674,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-1-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -719,7 +719,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-2-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -764,7 +764,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-3-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -886,7 +886,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-4-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -994,7 +994,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-0-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1050,7 +1050,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-1-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1106,7 +1106,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-2-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1214,7 +1214,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-0-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1270,7 +1270,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-1-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1326,7 +1326,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-2-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1355,7 +1355,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
 exports[`TransactionData renders decoded data with no names 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -1364,7 +1364,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -1448,7 +1448,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-0-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1493,7 +1493,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-1-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1549,7 +1549,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-2-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1576,7 +1576,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
 exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -1585,7 +1585,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -1636,7 +1636,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="advanced-details-data-function-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -1685,7 +1685,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-0-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1741,7 +1741,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-1-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -1779,7 +1779,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                   tabindex="0"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                     data-testid="advanced-details-data-param-0-tooltip"
                     style="mask-image: url('./images/icons/question.svg');"
                   />
@@ -1817,7 +1817,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-0-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -1855,7 +1855,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-0-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -1911,7 +1911,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-1-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -1956,7 +1956,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-2-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2001,7 +2001,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-3-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2047,7 +2047,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-1-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -2085,7 +2085,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-0-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2141,7 +2141,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-1-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2186,7 +2186,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-2-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2231,7 +2231,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-3-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2277,7 +2277,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       data-testid="advanced-details-data-param-2-tooltip"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
@@ -2315,7 +2315,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-0-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2371,7 +2371,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-1-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2416,7 +2416,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-2-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2461,7 +2461,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         data-testid="advanced-details-data-param-3-tooltip"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
@@ -2508,7 +2508,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                   tabindex="0"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                     data-testid="advanced-details-data-param-1-tooltip"
                     style="mask-image: url('./images/icons/question.svg');"
                   />
@@ -2564,7 +2564,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                   tabindex="0"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                    class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                     data-testid="advanced-details-data-param-2-tooltip"
                     style="mask-image: url('./images/icons/question.svg');"
                   />
@@ -2610,7 +2610,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="advanced-details-data-param-2-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -2639,7 +2639,7 @@ exports[`TransactionData renders nothing if no transaction data 1`] = `<div />`;
 exports[`TransactionData renders raw hexadecimal if no decoded data 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="advanced-details-data-section"
   >
     <div
@@ -2648,7 +2648,7 @@ exports[`TransactionData renders raw hexadecimal if no decoded data 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/__snapshots__/transaction-details.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/__snapshots__/transaction-details.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Transaction Details <TransactionDetails /> does not render component for transaction details 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="transaction-details-section"
   />
 </div>
@@ -12,7 +12,7 @@ exports[`Transaction Details <TransactionDetails /> does not render component fo
 exports[`Transaction Details <TransactionDetails /> renders component for transaction details 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="transaction-details-section"
   >
     <div
@@ -41,7 +41,7 @@ exports[`Transaction Details <TransactionDetails /> renders component for transa
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -85,7 +85,7 @@ exports[`Transaction Details <TransactionDetails /> renders component for transa
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-recipient-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-details-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-details-section.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TokenDetailsSection renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__token-details-section"
   >
     <div
@@ -28,6 +28,7 @@ exports[`TokenDetailsSection renders correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -64,7 +65,7 @@ exports[`TokenDetailsSection renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -114,7 +115,7 @@ exports[`TokenDetailsSection renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TokenTransferInfo renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
+    class="mm-box mm-box--margin-bottom-2 mm-box--padding-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center"
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-token mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-muted mm-box--background-color-overlay-default mm-box--rounded-full"
@@ -28,11 +28,11 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
     >
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -52,7 +52,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="sender-address"
         >
           <div
@@ -79,7 +79,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
         </div>
       </div>
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-muted"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
         style="mask-image: url('./images/icons/arrow-right.svg');"
       />
       <div
@@ -100,7 +100,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="recipient-address"
         >
           <div
@@ -129,10 +129,10 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-0 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-0 mm-box--padding-bottom-0 mm-box--padding-inline-0 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
-      class="mm-box simulation-details-layout mm-box--padding-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      class="mm-box simulation-details-layout mm-box--padding-top-1 mm-box--padding-bottom-2 mm-box--padding-inline-3 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--rounded-lg mm-box--border-color-transparent box--border-style-solid box--border-width-1"
       data-testid="simulation-details-layout"
     >
       <div
@@ -166,7 +166,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
                     tabindex="0"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                      class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                       style="mask-image: url('./images/icons/question.svg');"
                     />
                   </div>
@@ -184,7 +184,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__token-details-section"
   >
     <div
@@ -209,6 +209,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -245,7 +246,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 data-testid="transaction-details-origin-row-tooltip"
                 style="mask-image: url('./images/icons/question.svg');"
               />
@@ -295,7 +296,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -326,7 +327,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="gas-fee-section"
   >
     <div
@@ -335,7 +336,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
         data-testid="edit-gas-fees-row"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center; margin-bottom: 2px;"
+        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; align-items: center;"
       >
         <div
           class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-flex-start mm-box--color-text-default"
@@ -358,7 +359,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                   data-testid="edit-gas-fees-row-tooltip"
                   style="mask-image: url('./images/icons/question.svg');"
                 />
@@ -389,7 +390,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
             data-testid="selected-gas-fee-token"
             style="cursor: default; padding-inline-end: 6px; padding: 0px;"
           >
@@ -415,7 +416,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--padding-inline-2 mm-box--display-flex mm-box--justify-content-space-between"
       >
         <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+          class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
           data-testid="gas-fee-token-fee"
         >
            
@@ -444,10 +445,10 @@ exports[`TokenTransferInfo renders correctly 1`] = `
         class="mm-box mm-box--display-flex mm-box--align-items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap"
+          class="mm-box mm-box--margin-bottom-1 mm-box--display-flex mm-box--flex-wrap-wrap"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-1 mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
             🦊 Market
           </p>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/transaction-flow-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/transaction-flow-section.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`<TransactionFlowSection /> renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
     >
       <div
         class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -27,7 +27,7 @@ exports[`<TransactionFlowSection /> renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="sender-address"
         >
           <div
@@ -54,7 +54,7 @@ exports[`<TransactionFlowSection /> renders correctly 1`] = `
         </div>
       </div>
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-muted"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
         style="mask-image: url('./images/icons/arrow-right.svg');"
       />
       <div
@@ -75,7 +75,7 @@ exports[`<TransactionFlowSection /> renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box mm-box--margin-top-2"
           data-testid="recipient-address"
         >
           <div

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
@@ -37,6 +37,7 @@ export const TransactionFlowSection = () => {
         flexDirection={FlexDirection.Row}
         justifyContent={JustifyContent.spaceBetween}
         alignItems={AlignItems.center}
+        paddingBottom={1}
       >
         <ConfirmInfoAlertRow
           alertKey={RowAlertKey.SigningInWith}
@@ -46,7 +47,7 @@ export const TransactionFlowSection = () => {
             flexDirection: FlexDirection.Column,
           }}
         >
-          <Box marginTop={1} data-testid="sender-address">
+          <Box marginTop={2} data-testid="sender-address">
             <ConfirmInfoRowAddress
               address={transactionMeta.txParams.from}
               chainId={chainId}
@@ -57,7 +58,7 @@ export const TransactionFlowSection = () => {
         <Icon
           name={IconName.ArrowRight}
           size={IconSize.Md}
-          color={IconColor.iconMuted}
+          color={IconColor.iconAlternative}
         />
         {recipientAddress && (
           <ConfirmInfoAlertRow

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
@@ -69,7 +69,7 @@ export const TransactionFlowSection = () => {
               flexDirection: FlexDirection.Column,
             }}
           >
-            <Box marginTop={1} data-testid="recipient-address">
+            <Box marginTop={2} data-testid="recipient-address">
               <ConfirmInfoRowAddress
                 address={recipientAddress}
                 chainId={chainId}

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -30,7 +30,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -49,7 +49,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
   >
     <div
       class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -57,7 +57,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -67,7 +67,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign-permission.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign-permission.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token periodic permission details correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -71,7 +71,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -113,7 +113,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -148,6 +148,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -160,7 +161,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-periodic-details-section"
   >
     <div
@@ -188,7 +189,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -226,7 +227,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -280,7 +281,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -318,7 +319,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -361,7 +362,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -386,7 +387,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
 exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token periodic permission without expiry 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -414,7 +415,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -454,7 +455,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -496,7 +497,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -531,6 +532,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -543,7 +545,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-periodic-details-section"
   >
     <div
@@ -571,7 +573,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -609,7 +611,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -663,7 +665,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -701,7 +703,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -726,7 +728,7 @@ exports[`TypedSignPermissionInfo erc20-token-periodic renders ERC20 token period
 exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream permission details correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -754,7 +756,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -794,7 +796,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -836,7 +838,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -871,6 +873,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -883,7 +886,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-details-section"
   >
     <div
@@ -911,7 +914,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -949,7 +952,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1003,7 +1006,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1057,7 +1060,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1100,7 +1103,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1120,7 +1123,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-stream-rate-section"
   >
     <div
@@ -1148,7 +1151,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1202,7 +1205,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1238,7 +1241,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
 exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream permission without expiry 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -1266,7 +1269,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1306,7 +1309,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1348,7 +1351,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1383,6 +1386,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -1395,7 +1399,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-details-section"
   >
     <div
@@ -1423,7 +1427,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1461,7 +1465,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1515,7 +1519,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1569,7 +1573,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1589,7 +1593,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-stream-rate-section"
   >
     <div
@@ -1617,7 +1621,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1671,7 +1675,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1707,7 +1711,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
 exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream permission without initial amount 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -1735,7 +1739,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1775,7 +1779,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1817,7 +1821,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1852,6 +1856,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -1864,7 +1869,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-details-section"
   >
     <div
@@ -1892,7 +1897,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1930,7 +1935,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1984,7 +1989,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2027,7 +2032,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2047,7 +2052,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-stream-rate-section"
   >
     <div
@@ -2075,7 +2080,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2129,7 +2134,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2165,7 +2170,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
 exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream permission without max amount 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -2193,7 +2198,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2233,7 +2238,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2275,7 +2280,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2310,6 +2315,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -2322,7 +2328,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-details-section"
   >
     <div
@@ -2350,7 +2356,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2388,7 +2394,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2442,7 +2448,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2485,7 +2491,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2505,7 +2511,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="erc20-token-stream-stream-rate-section"
   >
     <div
@@ -2533,7 +2539,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2587,7 +2593,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2623,7 +2629,7 @@ exports[`TypedSignPermissionInfo erc20-token-stream renders ERC20 token stream p
 exports[`TypedSignPermissionInfo native-token-periodic renders native token periodic permission details correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -2651,7 +2657,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2691,7 +2697,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2733,7 +2739,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2768,6 +2774,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -2780,7 +2787,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-periodic-details-section"
   >
     <div
@@ -2808,7 +2815,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2862,7 +2869,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2900,7 +2907,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2943,7 +2950,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -2968,7 +2975,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
 exports[`TypedSignPermissionInfo native-token-periodic renders native token periodic permission without expiry 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -2996,7 +3003,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3036,7 +3043,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3078,7 +3085,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3113,6 +3120,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -3125,7 +3133,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-periodic-details-section"
   >
     <div
@@ -3153,7 +3161,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3207,7 +3215,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3245,7 +3253,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3270,7 +3278,7 @@ exports[`TypedSignPermissionInfo native-token-periodic renders native token peri
 exports[`TypedSignPermissionInfo native-token-stream renders native token stream permission details correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -3298,7 +3306,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3338,7 +3346,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3380,7 +3388,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3415,6 +3423,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -3427,7 +3436,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-details-section"
   >
     <div
@@ -3455,7 +3464,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3509,7 +3518,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3563,7 +3572,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3606,7 +3615,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3626,7 +3635,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-stream-rate-section"
   >
     <div
@@ -3654,7 +3663,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3708,7 +3717,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3744,7 +3753,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
 exports[`TypedSignPermissionInfo native-token-stream renders native token stream permission without expiry 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -3772,7 +3781,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3812,7 +3821,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3854,7 +3863,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3889,6 +3898,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -3901,7 +3911,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-details-section"
   >
     <div
@@ -3929,7 +3939,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -3983,7 +3993,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4037,7 +4047,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4057,7 +4067,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-stream-rate-section"
   >
     <div
@@ -4085,7 +4095,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4139,7 +4149,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4175,7 +4185,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
 exports[`TypedSignPermissionInfo native-token-stream renders native token stream permission without initial amount 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -4203,7 +4213,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4243,7 +4253,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4285,7 +4295,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4320,6 +4330,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -4332,7 +4343,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-details-section"
   >
     <div
@@ -4360,7 +4371,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4414,7 +4425,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4457,7 +4468,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4477,7 +4488,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-stream-rate-section"
   >
     <div
@@ -4505,7 +4516,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4559,7 +4570,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4595,7 +4606,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
 exports[`TypedSignPermissionInfo native-token-stream renders native token stream permission without max amount 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_permission-section"
   >
     <div
@@ -4623,7 +4634,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4663,7 +4674,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4705,7 +4716,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4740,6 +4751,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+          style="border-width: 0px;"
         >
           G
         </div>
@@ -4752,7 +4764,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-details-section"
   >
     <div
@@ -4780,7 +4792,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4834,7 +4846,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4877,7 +4889,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4897,7 +4909,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="native-token-stream-stream-rate-section"
   >
     <div
@@ -4925,7 +4937,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -4979,7 +4991,7 @@ exports[`TypedSignPermissionInfo native-token-stream renders native token stream
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TypedSignInfo correctly renders permit sign type 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -127,7 +127,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -201,7 +201,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -243,7 +243,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -274,7 +274,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -283,7 +283,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -293,7 +293,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >
@@ -323,7 +323,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
 exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -351,7 +351,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -447,7 +447,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -521,7 +521,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -563,7 +563,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -594,7 +594,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -603,7 +603,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
@@ -613,7 +613,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
       </button>
       <button
         aria-label="collapse-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="sectionCollapseButton"
         style="cursor: pointer; position: absolute; right: 8px;"
       >
@@ -645,7 +645,7 @@ exports[`TypedSignInfo does not render if required data is not present in the tr
 exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -673,7 +673,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -715,7 +715,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -746,7 +746,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -755,7 +755,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -1267,7 +1267,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
 exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -1295,7 +1295,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1337,7 +1337,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1368,7 +1368,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -1377,7 +1377,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
@@ -1660,7 +1660,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
 exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_request-section"
   >
     <div
@@ -1688,7 +1688,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1730,7 +1730,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -1761,7 +1761,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
     </div>
   </div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation_message-section"
   >
     <div
@@ -1770,7 +1770,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
     >
       <button
         aria-label="copy-button"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/permit-simulation/__snapshots__/permit-simulation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PermitSimulation renders component correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -31,7 +31,7 @@ exports[`PermitSimulation renders component correctly 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>
@@ -132,7 +132,7 @@ exports[`PermitSimulation renders component correctly 1`] = `
 exports[`PermitSimulation renders correctly for NFT permit 1`] = `
 <div>
   <div
-    class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+    class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
     data-testid="confirmation__simulation_section"
   >
     <div
@@ -160,7 +160,7 @@ exports[`PermitSimulation renders correctly for NFT permit 1`] = `
               tabindex="0"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                 style="mask-image: url('./images/icons/question.svg');"
               />
             </div>

--- a/ui/pages/confirmations/components/confirm/nav/__snapshots__/nav.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/nav/__snapshots__/nav.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ConfirmNav should match snapshot 1`] = `
     >
       <button
         aria-label="Previous Confirmation"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-button-icon--disabled confirm_nav__left_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-button-icon--disabled confirm_nav__left_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-muted mm-box--rounded-full"
         data-testid="confirm-nav__previous-confirmation"
         disabled=""
       >
@@ -30,7 +30,7 @@ exports[`ConfirmNav should match snapshot 1`] = `
       </p>
       <button
         aria-label="Next Confirmation"
-        class="mm-box mm-button-icon mm-button-icon--size-sm confirm_nav__right_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+        class="mm-box mm-button-icon mm-button-icon--size-sm confirm_nav__right_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-muted mm-box--rounded-full"
         data-testid="confirm-nav__next-confirmation"
       >
         <span

--- a/ui/pages/confirmations/components/confirm/nav/nav.tsx
+++ b/ui/pages/confirmations/components/confirm/nav/nav.tsx
@@ -73,7 +73,7 @@ export const Nav = ({ confirmationId }: NavProps) => {
         <ButtonIcon
           ariaLabel="Previous Confirmation"
           data-testid="confirm-nav__previous-confirmation"
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={BackgroundColor.backgroundMuted}
           borderRadius={BorderRadius.full}
           className="confirm_nav__left_btn"
           color={IconColor.iconAlternative}
@@ -93,7 +93,7 @@ export const Nav = ({ confirmationId }: NavProps) => {
         <ButtonIcon
           ariaLabel="Next Confirmation"
           data-testid="confirm-nav__next-confirmation"
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={BackgroundColor.backgroundMuted}
           borderRadius={BorderRadius.full}
           className="confirm_nav__right_btn"
           color={IconColor.iconAlternative}

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
@@ -89,7 +89,7 @@ const ScrollToBottom = ({ children }: ContentProps) => {
 
   return (
     <Box
-      backgroundColor={BackgroundColor.backgroundAlternative}
+      backgroundColor={BackgroundColor.backgroundDefault}
       width={BlockSize.Full}
       height={BlockSize.Full}
       style={{

--- a/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
+++ b/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
@@ -173,12 +173,12 @@ export default function GasTiming({
   }
 
   return (
-    <Box display={Display.Flex} flexWrap={FlexWrap.Wrap}>
+    <Box display={Display.Flex} marginBottom={1} flexWrap={FlexWrap.Wrap}>
       {text && (
         <Text
           color={TextColor.textAlternative}
           variant={TextVariant.bodyMd}
-          paddingInlineEnd={1}
+          paddingInlineEnd={2}
         >
           {text}
         </Text>

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -214,7 +214,7 @@ const LegacyHeader = () => {
         <Icon
           name={IconName.Question}
           marginLeft={1}
-          color={IconColor.iconMuted}
+          color={IconColor.iconAlternative}
           size={IconSize.Sm}
         />
       </Tooltip>
@@ -278,7 +278,9 @@ const SimulationDetailsLayout: React.FC<{
             ? BorderColor.transparent
             : BorderColor.borderDefault
         }
-        padding={3}
+        paddingInline={3}
+        paddingTop={1}
+        paddingBottom={2}
         margin={isTransactionsRedesign ? null : 4}
         gap={3}
       >
@@ -303,7 +305,9 @@ const SimulationDetailsLayout: React.FC<{
           ? BorderColor.transparent
           : BorderColor.borderDefault
       }
-      padding={3}
+      paddingInline={3}
+      paddingTop={1}
+      paddingBottom={2}
       margin={isTransactionsRedesign ? null : 4}
       gap={3}
     >

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -135,7 +135,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
             Review request details before you confirm.
           </p>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
           >
             <div
               class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -162,7 +162,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -181,7 +181,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
           >
             <div
               class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
@@ -189,7 +189,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
@@ -199,7 +199,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
               </button>
               <button
                 aria-label="collapse-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="sectionCollapseButton"
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
@@ -342,7 +342,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -350,7 +350,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
           style="overflow: auto;"
         >
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation__simulation_section"
           >
             <div
@@ -378,7 +378,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -531,7 +531,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -605,7 +605,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -647,7 +647,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -678,7 +678,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -687,7 +687,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
@@ -697,7 +697,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
               </button>
               <button
                 aria-label="collapse-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="sectionCollapseButton"
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
@@ -830,7 +830,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -838,7 +838,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
           style="overflow: auto;"
         >
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation__simulation_section"
           >
             <div
@@ -866,7 +866,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -966,7 +966,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -1040,7 +1040,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -1082,7 +1082,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -1113,7 +1113,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -1122,7 +1122,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
@@ -1132,7 +1132,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
               </button>
               <button
                 aria-label="collapse-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="sectionCollapseButton"
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
@@ -1300,7 +1300,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -1318,7 +1318,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
             Review request details before you confirm.
           </p>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -1346,7 +1346,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -1388,7 +1388,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -1419,7 +1419,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -1428,7 +1428,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
               >
                 <span
@@ -2076,7 +2076,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -2094,7 +2094,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             This site wants permission to spend your tokens.
           </p>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation__simulation_section"
           >
             <div
@@ -2122,7 +2122,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -2218,7 +2218,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -2292,7 +2292,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -2334,7 +2334,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -2365,7 +2365,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -2374,7 +2374,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
@@ -2384,7 +2384,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
               </button>
               <button
                 aria-label="collapse-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="sectionCollapseButton"
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
@@ -2550,7 +2550,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -2568,7 +2568,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
             Review request details before you confirm.
           </p>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -2596,7 +2596,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -2638,7 +2638,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -2669,7 +2669,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -2678,7 +2678,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
@@ -2688,7 +2688,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
               </button>
               <button
                 aria-label="collapse-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="sectionCollapseButton"
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
@@ -3207,7 +3207,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -3324,7 +3324,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
         </div>
       </div>
       <div
-        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-alternative"
+        class="mm-box mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
         style="min-height: 0; overflow: hidden; position: relative;"
       >
         <div
@@ -3332,7 +3332,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
           style="overflow: auto;"
         >
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_request-section"
           >
             <div
@@ -3360,7 +3360,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -3402,7 +3402,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
                       tabindex="0"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-muted"
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-left-1 mm-box--display-inline-block mm-box--color-icon-alternative"
                         style="mask-image: url('./images/icons/question.svg');"
                       />
                     </div>
@@ -3433,7 +3433,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-bottom-4 mm-box--padding-2 mm-box--background-color-background-default mm-box--rounded-md"
+            class="mm-box mm-box--margin-bottom-4 mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--padding-inline-2 mm-box--background-color-background-section mm-box--rounded-lg"
             data-testid="confirmation_message-section"
           >
             <div
@@ -3442,7 +3442,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             >
               <button
                 aria-label="copy-button"
-                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
+                class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
                 style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
               >
                 <span

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-named-snap-account.test.js.snap
@@ -18,7 +18,7 @@ exports[`create-named-snap-account confirmation matches snapshot 1`] = `
         >
           <button
             aria-label="Previous Confirmation"
-            class="mm-box mm-button-icon mm-button-icon--size-sm mm-button-icon--disabled confirm_nav__left_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+            class="mm-box mm-button-icon mm-button-icon--size-sm mm-button-icon--disabled confirm_nav__left_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-muted mm-box--rounded-full"
             data-testid="confirm-nav__previous-confirmation"
             disabled=""
           >
@@ -37,7 +37,7 @@ exports[`create-named-snap-account confirmation matches snapshot 1`] = `
           </p>
           <button
             aria-label="Next Confirmation"
-            class="mm-box mm-button-icon mm-button-icon--size-sm confirm_nav__right_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+            class="mm-box mm-button-icon mm-button-icon--size-sm confirm_nav__right_btn mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-background-muted mm-box--rounded-full"
             data-testid="confirm-nav__next-confirmation"
           >
             <span

--- a/ui/pages/confirmations/send/send-inner.tsx
+++ b/ui/pages/confirmations/send/send-inner.tsx
@@ -7,6 +7,7 @@ import {
   JustifyContent,
   FlexDirection,
   Display,
+  BorderRadius,
 } from '../../../helpers/constants/design-system';
 import { Box } from '../../../components/component-library';
 import { AmountRecipient } from '../components/send/amount-recipient';
@@ -21,7 +22,7 @@ const SendContainer = ({ children }: { children: React.ReactNode }) => {
   return (
     <Box
       alignItems={AlignItems.center}
-      backgroundColor={BackgroundColor.backgroundAlternative}
+      backgroundColor={BackgroundColor.backgroundDefault}
       className="redesigned__send__container"
       display={Display.Flex}
       flexDirection={FlexDirection.Column}
@@ -31,12 +32,13 @@ const SendContainer = ({ children }: { children: React.ReactNode }) => {
       width={BlockSize.Full}
     >
       <Box
-        backgroundColor={BackgroundColor.backgroundDefault}
+        backgroundColor={BackgroundColor.backgroundSection}
         className="redesigned__send__wrapper"
         display={Display.Flex}
         height={BlockSize.Full}
         justifyContent={JustifyContent.center}
         width={BlockSize.Full}
+        borderRadius={BorderRadius.LG}
       >
         <Box
           className="redesigned__send__content"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR applies the following changes for the `Send` > `Review` screen:

- Updates base and section colors from `alt` > `default` and `default` > `section` to align with the rest of the UI
- Updates icons from muted > alt to improve contrast and accessibility
- Updates `name` and `network` borderRadius so they are aligned
- Fixes overall spacing to improve balance
- Updates `dAppInitiated` headers to match `walletInitiated` header styling

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36418?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adjust styling on the Send Review screen

## **Related issues**

Fixes:

## **Manual testing steps**

1. Test that styles apply to `walletInitiated` and `dAppInitiated` Send transactions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**
<img width="937" height="774" alt="Screenshot 2025-09-29 at 11 26 59 PM" src="https://github.com/user-attachments/assets/7f767e72-cc5d-4bb9-b7b6-f2260c9c0d09" />
<img width="937" height="749" alt="Screenshot 2025-09-29 at 8 56 08 PM" src="https://github.com/user-attachments/assets/c61a210e-f827-4277-b7bb-330d981b8ec0" />
<img width="956" height="761" alt="Screenshot 2025-09-29 at 8 56 58 PM" src="https://github.com/user-attachments/assets/cf38e4da-feb8-47ef-8b8e-76f14b45cf28" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restyles Send/Review and confirmation UIs: new section/default backgrounds, higher contrast icon colors, tighter spacing, larger radii, smaller headers, and updated snapshots/e2e selector.
> 
> - **UI/Design polish (Send/Review + Confirmations)**:
>   - **Colors**: switch containers to `backgroundDefault`/`backgroundSection`; replace `backgroundAlternative`/`backgroundDefault`; nav buttons to `backgroundMuted`.
>   - **Icons/Text**: change many icon colors from `iconMuted` → `iconAlternative`; header size `h3/headingMd` → `h4/headingSm`.
>   - **Layout/Spacing**: adjust paddings (`paddingInline`, top/bottom), margins, gaps; minor min-height/removal of extra margins.
>   - **Radius**: increase many surfaces `rounded-md` → `rounded-lg`; align `name`/`network` avatars; add rounded avatar for `PreferredAvatar`.
>   - **Components touched**: `ConfirmInfoSection/Row`, gas-fee rows/section, network row, selected gas fee token, send heading, simulation details layout, headers (wallet/dapp), nav, scroll container, toast.
>   - **Send page**: outer uses `backgroundDefault`, inner wrapper `backgroundSection` with `LG` radius.
> - **Tests**: update snapshots and one e2e locator (`h3` → `h4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e7188fd1957657bc5046b0ab2ece3fe00f23aee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->