### PR TITLE
fix: multichain address copy color

### DIFF
--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -25,6 +25,7 @@ import {
 import { shortenAddress } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 
 type CopyParams = {
   /**
@@ -84,6 +85,7 @@ export const MultichainAddressRow = ({
   qrActionParams,
   className = '',
 }: MultichainAddressRowProps) => {
+  const t = useI18nContext();
   const networkImageSrc = getImageForChainId(
     chainId.startsWith(KnownCaipNamespace.Eip155)
       ? convertCaipToHexChainId(chainId as CaipChainId)
@@ -93,6 +95,7 @@ export const MultichainAddressRow = ({
   const truncatedAddress = shortenAddress(address); // Shorten address for display
   const [subText, setSubText] = useState(truncatedAddress); // Message below the network name
   const [copyIcon, setCopyIcon] = useState(IconName.Copy); // Default copy icon state
+  const [addressCopied, setAddressCopied] = useState(false);
 
   // Track timeout ID for managing `setTimeout`
   const timeoutRef = useRef<number | null>(null);
@@ -119,6 +122,8 @@ export const MultichainAddressRow = ({
       clearTimeout(timeoutRef.current);
     }
 
+    setAddressCopied(true);
+
     // Trigger copy callback and update UI state
     copyActionParams.callback();
     setSubText(copyActionParams.message);
@@ -129,6 +134,7 @@ export const MultichainAddressRow = ({
       setSubText(truncatedAddress);
       setCopyIcon(IconName.Copy);
       timeoutRef.current = null; // Clear the reference after timeout resolves
+      setAddressCopied(false);
     }, 1000);
   };
 
@@ -148,11 +154,14 @@ export const MultichainAddressRow = ({
       display={Display.Flex}
       alignItems={AlignItems.center}
       justifyContent={JustifyContent.spaceBetween}
-      paddingTop={4}
-      paddingBottom={4}
+      padding={4}
       gap={4}
       data-testid="multichain-address-row"
-      backgroundColor={BackgroundColor.backgroundDefault}
+      backgroundColor={
+        addressCopied
+          ? BackgroundColor.successMuted
+          : BackgroundColor.backgroundDefault
+      }
     >
       <AvatarNetwork
         size={AvatarNetworkSize.Md}
@@ -165,7 +174,7 @@ export const MultichainAddressRow = ({
         display={Display.Flex}
         flexDirection={FlexDirection.Column}
         alignItems={AlignItems.flexStart}
-        style={{ flex: 1, minWidth: 0 }} // Ensure text shrinks properly
+        style={{ flex: 1, minWidth: 0 }} // Ensure the text shrinks properly
       >
         <Text
           variant={TextVariant.bodyMdMedium}
@@ -178,19 +187,23 @@ export const MultichainAddressRow = ({
         </Text>
         <Text
           variant={TextVariant.bodySm}
-          color={TextColor.textAlternative}
+          color={
+            addressCopied ? TextColor.successDefault : TextColor.textAlternative
+          }
           data-testid="multichain-address-row-address"
         >
-          {subText} {/* Dynamically updating subText */}
+          {subText}
         </Text>
       </Box>
       <Box display={Display.Flex} alignItems={AlignItems.center} gap={2}>
         <ButtonIcon
           iconName={copyIcon}
           size={ButtonIconSize.Md}
-          onClick={handleCopyClick} // Trigger copy logic
-          ariaLabel="Copy address"
-          color={IconColor.iconDefault}
+          onClick={handleCopyClick}
+          ariaLabel={t('copyAddressShort')}
+          color={
+            addressCopied ? IconColor.successDefault : IconColor.iconDefault
+          }
           data-testid="multichain-address-row-copy-button"
         />
         {qrActionParams ? (

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -120,19 +120,21 @@ export const MultichainAddressRowsList = ({
       flexDirection={FlexDirection.Column}
       data-testid="multichain-address-rows-list"
     >
-      <TextFieldSearch
-        size={TextFieldSearchSize.Lg}
-        placeholder={t('searchNetworks')}
-        value={searchPattern}
-        onChange={handleSearchChange}
-        clearButtonOnClick={handleClearSearch}
-        width={BlockSize.Full}
-        borderWidth={0}
-        marginBottom={2}
-        backgroundColor={BackgroundColor.backgroundMuted}
-        borderRadius={BorderRadius.LG}
-        data-testid="multichain-address-rows-list-search"
-      />
+      <Box paddingLeft={4} paddingRight={4}>
+        <TextFieldSearch
+          size={TextFieldSearchSize.Lg}
+          placeholder={t('searchNetworks')}
+          value={searchPattern}
+          onChange={handleSearchChange}
+          clearButtonOnClick={handleClearSearch}
+          width={BlockSize.Full}
+          borderWidth={0}
+          marginBottom={2}
+          backgroundColor={BackgroundColor.backgroundMuted}
+          borderRadius={BorderRadius.LG}
+          data-testid="multichain-address-rows-list-search"
+        />
+      </Box>
 
       <Box>
         {filteredItems.length > 0 ? (

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -97,7 +97,7 @@ export const MultichainAccountAddressListPage = () => {
       >
         {pageTitle}
       </Header>
-      <Content>
+      <Content padding={0}>
         <Box flexDirection={BoxFlexDirection.Column}>
           {decodedAccountGroupId ? (
             <MultichainAddressRowsList


### PR DESCRIPTION
## **Description**
This PR adds fix (UI adjustment) to the multichain address list and its components to handle copy behavior correctly. On copy address row changes its background color to green alongside text message and the copy button.

Notes:
- Some other minor adjustments are made to the paddings of the page content and address list row because by design address row needs to fill the entire width from edge to edge of the popup, which was not the case previously and becomes noticeable when green background is added on copy action.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36424?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed UI behavior for address copy action

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-785

Figma design used as reference: https://www.figma.com/design/G88ChchQ8FINCBI9BBkrAG/BIP-44-Extension?node-id=93-19100&m=dev

## **Manual testing steps**
1. Go to address list page under multichain accounts.
2. Try to copy some of the addresses.
3. Check background color changes alongside text and icon.
4. Background of the copied address row should be success muted, while the icon and text should be success default.

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/4f5d8831-3663-4aa3-8535-9a787e8f5a35


### **After**

https://github.com/user-attachments/assets/6ff85107-aade-41ce-b6ed-65fee6ab280b

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows success feedback when copying an address (background/text/icon) and adjusts padding for edge-to-edge rows; adds localized copy aria label.
> 
> - **Multichain Address Row (`ui/components/.../multichain-address-row.tsx`)**:
>   - Copy feedback: toggles success background, text color, and icon (`CopySuccess`) for 1s after copy; resets thereafter.
>   - Adds `useI18nContext` and uses `t('copyAddressShort')` for the copy button `ariaLabel`.
>   - Consolidates padding to `padding={4}` and tweaks inline comments.
> - **Address Rows List (`ui/components/.../multichain-address-rows-list.tsx`)**:
>   - Wraps search input in a padded `Box` to add horizontal spacing.
> - **Address List Page (`ui/pages/.../multichain-account-address-list-page.tsx`)**:
>   - Sets `<Content>` `padding={0}` to allow rows to span edge-to-edge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d81bef826c944adafab1f4b3bdee84fa38c1f96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->