### PR TITLE
fix: revert "fix: add `cross_origin_opener_policy` to chrome manifest (#35922)" cp-13.4.1

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,8 +1,5 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
-  "cross_origin_opener_policy": {
-    "value": "same-origin"
-  },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -3,9 +3,6 @@
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none'; font-src 'self';",
     "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none'; default-src 'none'; connect-src *; font-src 'self';"
   },
-  "cross_origin_opener_policy": {
-    "value": "same-origin"
-  },
   "externally_connectable": {
     "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import type { Mockttp } from 'mockttp';
-import { Browser } from 'selenium-webdriver';
-import { WINDOW_TITLES, withFixtures } from '../../helpers';
+import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import DeepLink from '../../page-objects/pages/deep-link-page';
 import LoginPage from '../../page-objects/pages/login-page';
@@ -18,8 +17,6 @@ import {
   signDeepLink,
   generateECDSAKeyPair,
 } from './helpers';
-
-const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
 type LocalNode = Ganache | Anvil;
 
@@ -423,74 +420,6 @@ and we'll take you to the right place.`
         // make sure the home page has loaded!
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-      },
-    );
-  });
-
-  it('handles dapps that open MM via window.open', async function () {
-    await withFixtures(
-      await getConfig(this.test?.fullTitle()),
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
-        const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
-
-        // use our dummy page to drive the new window
-        await driver.openNewURL(TEST_PAGE);
-
-        const dappWindowHandle = await driver.driver.getWindowHandle();
-        // simulate a dapp calling `window.open('https://link.metamask.io/home')`
-        const windowOpened = await driver.executeScript(
-          `
-          globalThis.testWindow = window.open('https://link.metamask.io/home', '_blank');
-          return globalThis.testWindow != null;
-          `,
-        );
-        assert.strictEqual(windowOpened, true, 'window.open failed');
-
-        driver.delay(1000); // give the window a second to open
-
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
-
-        const metamaskWindowHandle = await driver.driver.getWindowHandle();
-
-        // wait for the homepage to load in this new window
-        const deepLink = new DeepLink(driver);
-        await deepLink.checkPageIsLoaded();
-        const initialUrlStr = await driver.getCurrentUrl();
-        const initialUrl = new URL(initialUrlStr);
-        assert.equal(initialUrl.pathname, `/home.html`);
-        assert.equal(initialUrl.hash, '#link?u=%2Fhome');
-        assert.equal(initialUrl.search, '');
-
-        await driver.switchToWindow(dappWindowHandle);
-
-        const hackUrl = new URL(initialUrl);
-        hackUrl.hash = '#notifications';
-        // if we are testing Firefox, make sure `testWindow` is unset, FF
-        // doesn't allow cross-origin access to the extension's window by
-        // default
-        if (isFirefox) {
-          // globalThis.testWindow is unset in Firefox. Neat!
-          await driver.executeScript(`return globalThis.testWindow == null;`);
-        } else {
-          // on chrome, the location change is ignored due to the
-          // `cross_origin_opener_policy` set in the manifest.json
-          await driver.executeScript(
-            `globalThis.testWindow.location.href = ${JSON.stringify(hackUrl)};`,
-          );
-        }
-
-        // go back to the Metamask window.
-        await driver.switchToWindow(metamaskWindowHandle);
-
-        const finalUrlStr = await driver.getCurrentUrl();
-        assert.equal(finalUrlStr, initialUrlStr);
       },
     );
   });


### PR DESCRIPTION
This reverts commit a997ec1dd326c6b8d2dd0eba5729607dfbff2418.


Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.

## **Description**


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36425?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove cross_origin_opener_policy from Chrome manifests and delete the window.open deep link e2e test with related references.
> 
> - **Manifests (Chrome)**:
>   - Remove `cross_origin_opener_policy` from `app/manifest/v2/chrome.json` and `app/manifest/v3/chrome.json`.
> - **E2E Tests**:
>   - Delete deep link test handling dapps opening via `window.open` and related code in `test/e2e/tests/deep-link/deep-link.spec.ts`.
>   - Clean up imports and vars tied to the removed test (e.g., `Browser`, `WINDOW_TITLES`, `isFirefox`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96982551425dca91cff17bcc7d7b6de3ef34f799. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->