### PR TITLE
feat: Update NFT empty state to use Import NFT modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2018,9 +2018,7 @@
   "discover": {
     "message": "Discover"
   },
-  "discoverNFTs": {
-    "message": "Discover NFTs"
-  },
+
   "discoverSnaps": {
     "message": "Discover Snaps",
     "description": "Text that links to the Snaps website. Displayed in a banner on Snaps list page in settings."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2018,7 +2018,6 @@
   "discover": {
     "message": "Discover"
   },
-
   "discoverSnaps": {
     "message": "Discover Snaps",
     "description": "Text that links to the Snaps website. Displayed in a banner on Snaps list page in settings."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2018,9 +2018,6 @@
   "discover": {
     "message": "Discover"
   },
-  "discoverNFTs": {
-    "message": "Discover NFTs"
-  },
   "discoverSnaps": {
     "message": "Discover Snaps",
     "description": "Text that links to the Snaps website. Displayed in a banner on Snaps list page in settings."

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
+import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
 import mockState from '../../../../../../test/data/mock-state.json';
 import { ThemeType } from '../../../../../../shared/constants/preferences';
 import { NftEmptyState } from './nft-empty-state';
-
-// Mock global platform
-const mockOpenTab = jest.fn();
-
-// @ts-expect-error mocking platform
-global.platform = {
-  openTab: mockOpenTab,
-};
+import * as actions from '../../../../../store/actions';
 
 describe('NftEmptyState', () => {
-  const mockStore = configureMockStore([]);
+  const mockStore = configureMockStore([thunk]);
+  let store: ReturnType<typeof mockStore>;
 
   const renderComponent = (props = {}, stateOverride = {}) => {
-    const store = mockStore({ ...mockState, ...stateOverride });
+    store = mockStore({ ...mockState, ...stateOverride });
     return renderWithProvider(<NftEmptyState {...props} />, store);
   };
 
@@ -40,10 +35,10 @@ describe('NftEmptyState', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render discover button', () => {
+  it('should render import button', () => {
     renderComponent();
     expect(
-      screen.getByRole('button', { name: 'Discover NFTs' }),
+      screen.getByRole('button', { name: 'Import NFT' }),
     ).toBeInTheDocument();
   });
 
@@ -55,15 +50,16 @@ describe('NftEmptyState', () => {
     expect(emptyState).toHaveClass(customClassName);
   });
 
-  it('should call openTab when discover button is clicked', () => {
+  it('should dispatch showImportNftsModal when import button is clicked', () => {
+    const showImportNftsModalSpy = jest.spyOn(actions, 'showImportNftsModal');
     renderComponent();
 
-    const discoverButton = screen.getByRole('button', {
-      name: 'Discover NFTs',
+    const importButton = screen.getByRole('button', {
+      name: 'Import NFT',
     });
-    fireEvent.click(discoverButton);
+    fireEvent.click(importButton);
 
-    expect(mockOpenTab).toHaveBeenCalledTimes(1);
+    expect(showImportNftsModalSpy).toHaveBeenCalledWith({});
   });
 
   it('should render light theme icon by default', () => {

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.test.tsx
@@ -5,8 +5,8 @@ import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
 import mockState from '../../../../../../test/data/mock-state.json';
 import { ThemeType } from '../../../../../../shared/constants/preferences';
-import { NftEmptyState } from './nft-empty-state';
 import * as actions from '../../../../../store/actions';
+import { NftEmptyState } from './nft-empty-state';
 
 describe('NftEmptyState', () => {
   const mockStore = configureMockStore([thunk]);

--- a/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
+++ b/ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx
@@ -1,21 +1,16 @@
 import React, { useContext, useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { twMerge } from '@metamask/design-system-react';
 import { ThemeType } from '../../../../../../shared/constants/preferences';
 import { TabEmptyState } from '../../../../ui/tab-empty-state';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import {
-  getTheme,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
-  getDataCollectionForMarketing,
-} from '../../../../../selectors';
-import { getPortfolioUrl } from '../../../../../helpers/utils/portfolio';
+import { getTheme } from '../../../../../selectors';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../../shared/constants/metametrics';
+import { showImportNftsModal } from '../../../../../store/actions';
 
 export type NftEmptyStateProps = {
   className?: string;
@@ -25,9 +20,7 @@ export const NftEmptyState = ({ className }: NftEmptyStateProps) => {
   const t = useI18nContext();
   const theme = useSelector(getTheme);
   const trackEvent = useContext(MetaMetricsContext);
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
-  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
+  const dispatch = useDispatch();
 
   // Theme-aware icon
   const nftIcon =
@@ -35,15 +28,8 @@ export const NftEmptyState = ({ className }: NftEmptyStateProps) => {
       ? './images/empty-state-nfts-dark.png'
       : './images/empty-state-nfts-light.png';
 
-  const handleDiscoverNfts = useCallback(() => {
-    const url = getPortfolioUrl(
-      'explore/nfts',
-      'ext_nft_empty_state_button',
-      metaMetricsId,
-      isMetaMetricsEnabled,
-      isMarketingEnabled,
-    );
-    global.platform.openTab({ url });
+  const handleImportNfts = useCallback(() => {
+    dispatch(showImportNftsModal({}));
     trackEvent({
       category: MetaMetricsEventCategory.Navigation,
       event: MetaMetricsEventName.EmptyNFTTabButtonClicked,
@@ -51,14 +37,14 @@ export const NftEmptyState = ({ className }: NftEmptyStateProps) => {
         location: 'NFT_Empty_State',
       },
     });
-  }, [metaMetricsId, isMetaMetricsEnabled, isMarketingEnabled, trackEvent]);
+  }, [dispatch, trackEvent]);
 
   return (
     <TabEmptyState
       icon={<img src={nftIcon} alt={t('nfts')} width={72} height={72} />}
       description={t('nftEmptyDescription')}
-      actionButtonText={t('discoverNFTs')}
-      onAction={handleDiscoverNfts}
+      actionButtonText={t('importNFT')}
+      onAction={handleImportNfts}
       data-testid="nft-tab-empty-state"
       className={twMerge('max-w-64', className)}
     />


### PR DESCRIPTION
## **Description**

This PR updates the NFT empty state component to use the Import NFT modal instead of opening an external discovery page. This is in preparation for hiding the network selector and action toolbar in tab empty state while still providing the same functionality. It also aligns with mobile.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-233

## **Manual testing steps**

1. Navigate to the NFTs tab in MetaMask extension
2. Ensure you have no NFTs in your collection (empty state)
3. Click the "Import NFT" button in the empty state
4. Verify that the Import NFT modal opens instead of redirecting to an external page

## **Screenshots/Recordings**

### **Before**
- Button text: "Discover NFTs"
- Action: Opens external portfolio discovery page

https://github.com/user-attachments/assets/7ceb9215-4942-4c1f-a375-f4aeeca0a539

### **After**
- Button text: "Import NFT" 
- Action: Opens Import NFT modal within the extension

https://github.com/user-attachments/assets/8b09534b-b7c9-4687-9093-bbfacb55dc89

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes NFT empty state CTA to "Import NFT" that opens an in-app modal instead of an external page, with corresponding test updates and locale cleanups.
> 
> - **NFT Empty State (`ui/components/app/assets/nfts/nft-empty-state/nft-empty-state.tsx`)**:
>   - Switch action from opening portfolio URL to dispatching `showImportNftsModal({})`.
>   - Update CTA text from `t('discoverNFTs')` to `t('importNFT')`.
>   - Simplify selectors; add `useDispatch`.
> - **Tests (`nft-empty-state.test.tsx`)**:
>   - Use thunk-enabled mock store; remove `global.platform.openTab` mocking.
>   - Assert presence of "Import NFT" button and dispatch of `showImportNftsModal` on click.
> - **Locales (`app/_locales/en/messages.json`, `app/_locales/en_GB/messages.json`)**:
>   - Remove `discoverNFTs` string entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be3f8e4baf2d60075f69ee37ead9e120b58e4042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->