### PR TITLE
fix: Update styling of tag component for Bitcoin support

### DIFF
--- a/ui/components/component-library/tag/__snapshots__/tag.test.tsx.snap
+++ b/ui/components/component-library/tag/__snapshots__/tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tag should render a tag with an icon and a label 1`] = `
 <div>
   <div
-    class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+    class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
     data-testid="tag"
   >
     <span
@@ -11,7 +11,7 @@ exports[`Tag should render a tag with an icon and a label 1`] = `
       style="mask-image: url('./images/icons/snaps.svg');"
     />
     <p
-      class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
     >
       Snap Name
     </p>
@@ -22,7 +22,7 @@ exports[`Tag should render a tag with an icon and a label 1`] = `
 exports[`Tag should render a tag with an icon and a label and icon props 1`] = `
 <div>
   <div
-    class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+    class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
     data-testid="tag"
   >
     <span
@@ -30,7 +30,7 @@ exports[`Tag should render a tag with an icon and a label and icon props 1`] = `
       style="mask-image: url('./images/icons/snaps.svg');"
     />
     <p
-      class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
     >
       Snap Name
     </p>
@@ -41,11 +41,11 @@ exports[`Tag should render a tag with an icon and a label and icon props 1`] = `
 exports[`Tag should render the label inside the tag and match snapshot 1`] = `
 <div>
   <div
-    class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+    class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
     data-testid="tag"
   >
     <p
-      class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
     >
       Imported
     </p>

--- a/ui/components/component-library/tag/tag.tsx
+++ b/ui/components/component-library/tag/tag.tsx
@@ -6,9 +6,9 @@ import { Box, type BoxProps, type PolymorphicRef } from '../box';
 import {
   AlignItems,
   BackgroundColor,
-  BorderColor,
   BorderRadius,
   Display,
+  TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
@@ -33,21 +33,23 @@ export const Tag: TagComponent = React.forwardRef(
       <Box
         ref={ref}
         className={classnames('mm-tag', className)}
-        backgroundColor={BackgroundColor.backgroundDefault}
-        borderColor={BorderColor.borderDefault}
-        borderWidth={1}
+        backgroundColor={BackgroundColor.backgroundSection}
         alignItems={AlignItems.center}
-        paddingLeft={1}
-        paddingRight={1}
+        paddingLeft={2}
+        paddingRight={2}
         gap={1}
-        borderRadius={BorderRadius.pill}
+        borderRadius={BorderRadius.SM}
         display={Display.Flex}
         {...(props as BoxProps<C>)}
       >
         {startIconName ? (
           <Icon name={startIconName} size={IconSize.Xs} {...startIconProps} />
         ) : null}
-        <Text variant={TextVariant.bodySm} {...labelProps}>
+        <Text
+          variant={TextVariant.bodySm}
+          color={TextColor.textAlternative}
+          {...labelProps}
+        >
           {label}
         </Text>
       </Box>

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -214,7 +214,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           class="mm-box mm-box--flex-direction-row"
         >
           <div
-            class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+            class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
             data-testid="account-list-item-tag-b7893c59-e376-4cc0-93ad-05ddaab574a6-Native SegWit"
           >
             <p

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -850,7 +850,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
             class="mm-box mm-box--flex-direction-row"
           >
             <div
-              class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+              class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
               data-testid="account-list-item-tag-15e69915-2a1a-4019-93b3-916e11fd432f-Ledger"
             >
               <p
@@ -1426,7 +1426,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
             class="mm-box mm-box--flex-direction-row"
           >
             <div
-              class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+              class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
               data-testid="account-list-item-tag-c3deeb99-ba0d-4a4e-a0aa-033fc1f79ae3-mock snap name (Beta)"
             >
               <span


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the `tag` component to match the [design specs](https://www.figma.com/design/9e6RSJCvezaLqDQ3mtE5wB/Home-Page?node-id=6183-23097&t=wKdMTXeiddFvKaNE-4). It is a dependency for adding Bitcoin labels. It updates snapshots in the deprecated Account List Item component used in the old Send flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36437?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensys.slack.com/archives/C091U30T0TU/p1759175341973009?thread_ts=1758002550.471139&cid=C091U30T0TU

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<!-- [screenshots/recordings] -->

<img width="1366" height="581" alt="Screenshot 2025-09-30 at 4 10 45 AM" src="https://github.com/user-attachments/assets/4cf0fa41-2592-45e1-b070-68d7ef83169b" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restyles `Tag` (section background, larger padding, small radius, alt text color) and updates affected snapshots in account list and send pages.
> 
> - **Component Library**
>   - **`ui/components/component-library/tag/tag.tsx`**: Restyles `Tag`
>     - Background: `backgroundDefault` → `backgroundSection`
>     - Padding: `paddingLeft`/`paddingRight` 1 → 2
>     - Border radius: `pill` → `SM`; removes border color/width
>     - Text: adds `TextColor.textAlternative` to label
>     - Imports: drop `BorderColor`; add `TextColor`
>   - **Snapshots**: Update `tag` snapshots to reflect new classes and text color.
> - **Multichain (deprecated send flow)**
>   - Update snapshots in `account-list-item` and `pages/send/components/your-accounts` to reflect new `mm-tag` styles and text color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e7afacba7c635f2b59b733b581f790a5027d662. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->