### PR TITLE
chore: hide network selectors in empty state for homepage tabs

### DIFF
--- a/ui/components/app/assets/defi-list/defi-list.test.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.test.tsx
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import { screen, act, waitFor } from '@testing-library/react';
 import { DeFiPositionsControllerState } from '@metamask/assets-controllers';
 import mockState from '../../../../../test/data/mock-state.json';
-import { renderWithProvider } from '../../../../../test/jest';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import DeFiList from './defi-list';
 
 const lidoPosition: DeFiPositionsControllerState['allDeFiPositions'] = {

--- a/ui/components/app/assets/defi-list/defi-list.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.tsx
@@ -24,6 +24,7 @@ import { extractUniqueIconAndSymbols } from '../util/extractIconAndSymbol';
 import { getDefiPositions } from '../../../../selectors/assets';
 import { DeFiProtocolPosition } from '../types';
 import { isGlobalNetworkSelectorRemoved } from '../../../../selectors/selectors';
+import AssetListControlBar from '../asset-list/asset-list-control-bar';
 import { DeFiErrorMessage } from './cells/defi-error-message';
 import { DeFiEmptyStateMessage } from './cells/defi-empty-state';
 import DefiProtocolCell from './cells/defi-protocol-cell';
@@ -135,15 +136,16 @@ export default function DefiList({ onClick }: DefiListProps) {
   return (
     <>
       {sortedFilteredDefi && sortedFilteredDefi.length > 0 ? (
-        sortedFilteredDefi.map((position: DeFiProtocolPosition) => {
-          return (
+        <>
+          <AssetListControlBar showImportTokenButton={false} />
+          {sortedFilteredDefi.map((position: DeFiProtocolPosition) => (
             <DefiProtocolCell
               key={`${position.protocolId}#${position.chainId}`}
               position={position}
               onClick={onClick}
             />
-          );
-        })
+          ))}
+        </>
       ) : (
         <DeFiEmptyStateMessage />
       )}

--- a/ui/components/app/assets/defi-list/defi-tab.test.tsx
+++ b/ui/components/app/assets/defi-list/defi-tab.test.tsx
@@ -141,9 +141,6 @@ describe('DefiList', () => {
     await waitFor(() => {
       expect(screen.getByTestId('pulse-loader')).toBeInTheDocument();
 
-      expect(screen.getByTestId('sort-by-popover-toggle')).toBeInTheDocument();
-      expect(screen.getByTestId('sort-by-networks')).toBeInTheDocument();
-
       expect(
         screen.queryByTestId('import-token-button'),
       ).not.toBeInTheDocument();
@@ -161,8 +158,6 @@ describe('DefiList', () => {
       expect(screen.getByTestId('defi-tab-error-message')).toHaveTextContent(
         'Try visiting again later.',
       );
-      expect(screen.getByTestId('sort-by-popover-toggle')).toBeInTheDocument();
-      expect(screen.getByTestId('sort-by-networks')).toBeInTheDocument();
 
       expect(
         screen.queryByTestId('import-token-button'),
@@ -180,9 +175,6 @@ describe('DefiList', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('Explore DeFi')).toBeInTheDocument();
       expect(screen.getByTestId('defi-tab-empty-state')).toBeInTheDocument();
-
-      expect(screen.getByTestId('sort-by-popover-toggle')).toBeInTheDocument();
-      expect(screen.getByTestId('sort-by-networks')).toBeInTheDocument();
 
       expect(
         screen.queryByTestId('import-token-button'),

--- a/ui/components/app/assets/defi-list/defi-tab.tsx
+++ b/ui/components/app/assets/defi-list/defi-tab.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { AssetListProps } from '../asset-list/asset-list';
-import AssetListControlBar from '../asset-list/asset-list-control-bar';
 import DefiList from './defi-list';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function DeFiTab({ onClickAsset }: AssetListProps) {
-  return (
-    <>
-      <AssetListControlBar showImportTokenButton={false} />
-      <DefiList onClick={onClickAsset} />
-    </>
-  );
+  return <DefiList onClick={onClickAsset} />;
 }

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -116,10 +116,6 @@ export default function NftsTab() {
 
   return (
     <>
-      <Box>
-        <AssetListControlBar />
-      </Box>
-
       <Box className="nfts-tab">
         {isMainnet && !useNftDetection ? (
           <Box paddingTop={4} paddingInlineStart={4} paddingInlineEnd={4}>
@@ -127,13 +123,14 @@ export default function NftsTab() {
           </Box>
         ) : null}
         {hasAnyNfts || previouslyOwnedNfts.length > 0 ? (
-          <Box>
+          <>
+            <AssetListControlBar />
             <NftGrid
               nfts={sortedNfts}
               handleNftClick={handleNftClick}
               privacyMode={privacyMode}
             />
-          </Box>
+          </>
         ) : (
           <NftEmptyState className="mx-auto mt-5 mb-6" />
         )}

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -237,25 +237,6 @@ exports[`TransactionList renders TransactionList component with props hideTokenT
     class="mm-box transaction-list"
   >
     <div
-      class="mm-box mm-box--margin-right-2 mm-box--margin-left-2 mm-box--justify-content-flex-start"
-    >
-      <button
-        class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-base--disabled mm-button-base--ellipsis asset-list-control-bar__button asset-list-control-bar__network_control mm-text--body-md-medium mm-text--ellipsis mm-box--margin-right-2 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-xl"
-        data-testid="sort-by-popover-toggle"
-        disabled=""
-      >
-        <span
-          class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-        >
-          Goerli
-        </span>
-        <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-start-1 mm-box--display-inline-block mm-box--color-inherit"
-          style="mask-image: url('./images/icons/arrow-down.svg');"
-        />
-      </button>
-    </div>
-    <div
       class="flex flex-col gap-3 items-center justify-center bg-default max-w-48 mx-auto mt-5 mb-6"
       data-testid="activity-tab-empty-state"
     >

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -733,7 +733,6 @@ export default function TransactionList({
   return (
     <>
       <Box className="transaction-list" {...boxProps}>
-        {renderFilterButton()}
         {showRampsCard ? (
           <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
         ) : null}
@@ -744,23 +743,41 @@ export default function TransactionList({
             account={selectedAccount}
           />
         ) : (
-          <Box className="transaction-list__transactions">
-            {pendingTransactions.length > 0 && (
-              <Box className="transaction-list__pending-transactions">
-                {pendingTransactions.map((dateGroup) => {
-                  return dateGroup.transactionGroups.map(
-                    (transactionGroup, index) => {
-                      if (
-                        transactionGroup.initialTransaction?.isSmartTransaction
-                      ) {
+          <>
+            {renderFilterButton()}
+            <Box className="transaction-list__transactions">
+              {pendingTransactions.length > 0 && (
+                <Box className="transaction-list__pending-transactions">
+                  {pendingTransactions.map((dateGroup) => {
+                    return dateGroup.transactionGroups.map(
+                      (transactionGroup, index) => {
+                        if (
+                          transactionGroup.initialTransaction
+                            ?.isSmartTransaction
+                        ) {
+                          return (
+                            <Fragment
+                              key={`${transactionGroup.nonce}:${index}`}
+                            >
+                              {renderDateStamp(index, dateGroup)}
+                              <SmartTransactionListItem
+                                isEarliestNonce={index === 0}
+                                smartTransaction={
+                                  transactionGroup.initialTransaction
+                                }
+                                transactionGroup={transactionGroup}
+                                chainId={
+                                  transactionGroup.initialTransaction.chainId
+                                }
+                              />
+                            </Fragment>
+                          );
+                        }
                         return (
                           <Fragment key={`${transactionGroup.nonce}:${index}`}>
                             {renderDateStamp(index, dateGroup)}
-                            <SmartTransactionListItem
+                            <TransactionListItem
                               isEarliestNonce={index === 0}
-                              smartTransaction={
-                                transactionGroup.initialTransaction
-                              }
                               transactionGroup={transactionGroup}
                               chainId={
                                 transactionGroup.initialTransaction.chainId
@@ -768,79 +785,69 @@ export default function TransactionList({
                             />
                           </Fragment>
                         );
-                      }
-                      return (
-                        <Fragment key={`${transactionGroup.nonce}:${index}`}>
-                          {renderDateStamp(index, dateGroup)}
-                          <TransactionListItem
-                            isEarliestNonce={index === 0}
-                            transactionGroup={transactionGroup}
-                            chainId={
-                              transactionGroup.initialTransaction.chainId
-                            }
-                          />
-                        </Fragment>
-                      );
-                    },
-                  );
-                })}
-              </Box>
-            )}
-            <Box className="transaction-list__completed-transactions">
-              {completedTransactions.length > 0
-                ? completedTransactions
-                    .map(removeIncomingTxsButToAnotherAddress)
-                    .map(removeTxGroupsWithNoTx)
-                    .filter(dateGroupsWithTransactionGroups)
-                    .slice(0, limit)
-                    .map((dateGroup) => {
-                      return dateGroup.transactionGroups.map(
-                        (transactionGroup, index) => {
-                          return (
-                            <Fragment
-                              key={`${transactionGroup.nonce}:${
-                                transactionGroup.initialTransaction
-                                  ? index
-                                  : limit + index - 10
-                              }`}
-                            >
-                              {renderDateStamp(index, dateGroup)}
-                              {transactionGroup.initialTransaction
-                                ?.isSmartTransaction ? (
-                                <SmartTransactionListItem
-                                  transactionGroup={transactionGroup}
-                                  smartTransaction={
-                                    transactionGroup.initialTransaction
-                                  }
-                                  chainId={
-                                    transactionGroup.initialTransaction.chainId
-                                  }
-                                />
-                              ) : (
-                                <TransactionListItem
-                                  transactionGroup={transactionGroup}
-                                  chainId={
-                                    transactionGroup.initialTransaction.chainId
-                                  }
-                                />
-                              )}
-                            </Fragment>
-                          );
-                        },
-                      );
-                    })
-                : null}
-              {completedTransactions.length > limit && (
-                <Button
-                  className="transaction-list__view-more"
-                  type="secondary"
-                  onClick={viewMore}
-                >
-                  {t('viewMore')}
-                </Button>
+                      },
+                    );
+                  })}
+                </Box>
               )}
+              <Box className="transaction-list__completed-transactions">
+                {completedTransactions.length > 0
+                  ? completedTransactions
+                      .map(removeIncomingTxsButToAnotherAddress)
+                      .map(removeTxGroupsWithNoTx)
+                      .filter(dateGroupsWithTransactionGroups)
+                      .slice(0, limit)
+                      .map((dateGroup) => {
+                        return dateGroup.transactionGroups.map(
+                          (transactionGroup, index) => {
+                            return (
+                              <Fragment
+                                key={`${transactionGroup.nonce}:${
+                                  transactionGroup.initialTransaction
+                                    ? index
+                                    : limit + index - 10
+                                }`}
+                              >
+                                {renderDateStamp(index, dateGroup)}
+                                {transactionGroup.initialTransaction
+                                  ?.isSmartTransaction ? (
+                                  <SmartTransactionListItem
+                                    transactionGroup={transactionGroup}
+                                    smartTransaction={
+                                      transactionGroup.initialTransaction
+                                    }
+                                    chainId={
+                                      transactionGroup.initialTransaction
+                                        .chainId
+                                    }
+                                  />
+                                ) : (
+                                  <TransactionListItem
+                                    transactionGroup={transactionGroup}
+                                    chainId={
+                                      transactionGroup.initialTransaction
+                                        .chainId
+                                    }
+                                  />
+                                )}
+                              </Fragment>
+                            );
+                          },
+                        );
+                      })
+                  : null}
+                {completedTransactions.length > limit && (
+                  <Button
+                    className="transaction-list__view-more"
+                    type="secondary"
+                    onClick={viewMore}
+                  >
+                    {t('viewMore')}
+                  </Button>
+                )}
+              </Box>
             </Box>
-          </Box>
+          </>
         )}
       </Box>
     </>

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -727,7 +727,6 @@ export default function UnifiedTransactionList({
         ))}
 
       <Box className="transaction-list" {...boxProps}>
-        {renderFilterButton()}
         {showRampsCard ? (
           <RampsCard variant={RAMPS_CARD_VARIANT_TYPES.ACTIVITY} />
         ) : null}
@@ -737,43 +736,46 @@ export default function UnifiedTransactionList({
             account={selectedAccount}
           />
         ) : (
-          <Box className="transaction-list__transactions">
-            {processedUnifiedActivityItems
-              .slice(0, daysLimit)
-              .map((dateGroup) => (
-                <Fragment key={dateGroup.date}>
-                  <Text
-                    paddingTop={4}
-                    paddingInline={4}
-                    variant={TextVariant.bodyMd}
-                    color={TextColor.textDefault}
-                  >
-                    {dateGroup.date}
-                  </Text>
-                  {dateGroup.transactionGroups.map((item, index) => (
-                    <Fragment key={item.id ?? index}>
-                      {renderTransaction(item, index)}
-                    </Fragment>
-                  ))}
-                </Fragment>
-              ))}
-            {processedUnifiedActivityItems.length > daysLimit && (
-              <Box
-                display={Display.Flex}
-                justifyContent={JustifyContent.center}
-                alignItems={AlignItems.center}
-                padding={4}
-              >
-                <Button
-                  className="transaction-list__view-more"
-                  type="secondary"
-                  onClick={viewMore}
+          <>
+            {renderFilterButton()}
+            <Box className="transaction-list__transactions">
+              {processedUnifiedActivityItems
+                .slice(0, daysLimit)
+                .map((dateGroup) => (
+                  <Fragment key={dateGroup.date}>
+                    <Text
+                      paddingTop={4}
+                      paddingInline={4}
+                      variant={TextVariant.bodyMd}
+                      color={TextColor.textDefault}
+                    >
+                      {dateGroup.date}
+                    </Text>
+                    {dateGroup.transactionGroups.map((item, index) => (
+                      <Fragment key={item.id ?? index}>
+                        {renderTransaction(item, index)}
+                      </Fragment>
+                    ))}
+                  </Fragment>
+                ))}
+              {processedUnifiedActivityItems.length > daysLimit && (
+                <Box
+                  display={Display.Flex}
+                  justifyContent={JustifyContent.center}
+                  alignItems={AlignItems.center}
+                  padding={4}
                 >
-                  {t('viewMore')}
-                </Button>
-              </Box>
-            )}
-          </Box>
+                  <Button
+                    className="transaction-list__view-more"
+                    type="secondary"
+                    onClick={viewMore}
+                  >
+                    {t('viewMore')}
+                  </Button>
+                </Box>
+              )}
+            </Box>
+          </>
         )}
       </Box>
     </>

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -128,13 +128,11 @@ export const AccountOverviewTabs = ({
           tabKey={AccountOverviewTabKey.DeFi}
           data-testid="account-overview__defi-tab"
         >
-          <Box>
-            <DeFiTab
-              showTokensLinks={showTokensLinks ?? true}
-              onClickAsset={onClickDeFi}
-              safeChains={safeChains}
-            />
-          </Box>
+          <DeFiTab
+            showTokensLinks={showTokensLinks ?? true}
+            onClickAsset={onClickDeFi}
+            safeChains={safeChains}
+          />
         </Tab>
       )}
 


### PR DESCRIPTION
## **Description**

This PR improves the user experience by hiding the network selector and filter buttons during empty states across various tabs (DeFi, NFTs, Activity). When there are no items to display, showing filter and network controls creates visual clutter and provides no value to users.

**Changes made:**
- **DeFi Tab**: Moved AssetListControlBar to only display when DeFi positions exist
- **NFTs Tab**: Moved AssetListControlBar to only display when NFTs are present
- **Activity Tab**: Moved filter button to only display when transactions exist
- **Account Overview**: Cleaned up unnecessary Box wrapper in DeFi tab

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36441?quickstart=1)

## **Changelog**

CHANGELOG entry: Improved UX by hiding network selector and filter buttons during empty states

## **Related issues**

Fixes:
- https://consensyssoftware.atlassian.net/browse/DSYS-230
- https://consensyssoftware.atlassian.net/browse/DSYS-231
- https://consensyssoftware.atlassian.net/browse/DSYS-232

## **Manual testing steps**

1. Navigate to Assets tab in MetaMask
2. Switch to DeFi sub-tab with no DeFi positions
3. Verify network selector and filter buttons are hidden
4. Switch to NFTs sub-tab with no NFTs 
5. Verify AssetListControlBar is hidden
6. Switch to Activity tab with no transactions
7. Verify filter button is hidden
8. Add some assets/transactions and verify controls reappear

## **Screenshots/Recordings**

### **Before**

Controls visible even when no content to filter/control

### **After**

Clean empty states without unnecessary controls

https://github.com/user-attachments/assets/3cdce858-a6cd-47ef-81e2-618f4c1e704e

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide AssetListControlBar and filter/network controls when lists are empty; show them only when items exist, plus minor wrapper cleanup and snapshot updates.
> 
> - **UI/UX**:
>   - **DeFi**: Move `AssetListControlBar` into `defi-list` and render only when `sortedFilteredDefi` has items; remove it from `defi-tab`.
>   - **NFTs**: Render `AssetListControlBar` only when NFTs exist, placed before `NftGrid`; remove unnecessary wrappers.
>   - **Activity**:
>     - `transaction-list.component.js`: Show filter/network controls only in the non-empty branch; preserve behavior for ramps card and empty state.
>     - `unified-transaction-list.component.js`: Same conditional rendering of filter controls as above.
>   - **Account Overview**: Remove redundant `Box` wrapper around `DeFiTab` in `account-overview-tabs.tsx`.
> - **Tests**:
>   - Update snapshots to reflect hidden network selector/filter in empty Activity state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c185612df7ca5a7afe5915336d871c4b6b1d9019. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->