### PR TITLE
fix: market cap formatting

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Beta-Nutzungsbedingungen"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Konto",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Metriken"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "verifizieren Sie die Netzwerkdetails",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Überweisungsanfrage"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Wir haben Probleme mit der Verbindung zu Ihrem Ledger. $1",

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Όροι Χρήσης της Δοκιμαστικής Έκδοσης"
   },
-  "billionAbbreviation": {
-    "message": "Δ",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Λογαριασμός",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Μετρήσεις"
-  },
-  "millionAbbreviation": {
-    "message": "Ε",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "επαλήθευση των στοιχείων του δικτύου",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Αίτημα μεταφοράς"
-  },
-  "trillionAbbreviation": {
-    "message": "Τ",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Έχουμε πρόβλημα με τη σύνδεσή σας στο Ledger. $1",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -795,10 +795,6 @@
   "betaTerms": {
     "message": "Beta Terms of use"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Account",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3469,10 +3465,6 @@
   },
   "metrics": {
     "message": "Metrics"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "minimumReceivedExplanation": {
     "message": "The minimum you'll get if the price changes while your transaction processes, based on your slippage setting. The estimate comes from liquidity providers, so the final amount may differ."
@@ -7333,10 +7325,6 @@
   },
   "transferRequest": {
     "message": "Transfer request"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "We're having trouble connecting your Ledger. $1",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -795,10 +795,6 @@
   "betaTerms": {
     "message": "Beta Terms of use"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Account",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3469,10 +3465,6 @@
   },
   "metrics": {
     "message": "Metrics"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "minimumReceivedExplanation": {
     "message": "The minimum you'll get if the price changes while your transaction processes, based on your slippage setting. The estimate comes from liquidity providers, so the final amount may differ."
@@ -7333,10 +7325,6 @@
   },
   "transferRequest": {
     "message": "Transfer request"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "We're having trouble connecting your Ledger. $1",

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Términos de uso de beta"
   },
-  "billionAbbreviation": {
-    "message": "mm",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Cuenta",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Indicadores"
-  },
-  "millionAbbreviation": {
-    "message": "m",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "verifique los detalles de la red",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Solicitud de transferencia"
-  },
-  "trillionAbbreviation": {
-    "message": "b",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Tenemos problemas para conectarnos con su Ledger. $1",

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -731,10 +731,6 @@
   "betaTerms": {
     "message": "Conditions d’utilisation de la version bêta"
   },
-  "billionAbbreviation": {
-    "message": "Mrd",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Compte",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3288,10 +3284,6 @@
   },
   "metrics": {
     "message": "Indicateurs"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "vérifier les détails du réseau",
@@ -6738,10 +6730,6 @@
   },
   "transferRequest": {
     "message": "Demande de transfert"
-  },
-  "trillionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Nous avons des difficultés à connecter votre Ledger. $1",

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "बीटा के इस्तेमाल की शर्तें"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "अकाउंट",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "मेट्रिक्स"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "नेटवर्क विवरण वेरीफ़ाई करें",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "अनुरोध ट्रांसफर करें"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "हमें आपके Ledger को जोड़ने में समस्या आ रही है। $1",

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Ketentuan penggunaan Beta"
   },
-  "billionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Akun",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Metrik"
-  },
-  "millionAbbreviation": {
-    "message": "Jt",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "verifikasi detail jaringan",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Permintaan transfer"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Kami mengalami masalah saat menghubungkan Ledger Anda. $1",

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -731,10 +731,6 @@
   "betaTerms": {
     "message": "ベータ版利用規約"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "アカウント",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3288,10 +3284,6 @@
   },
   "metrics": {
     "message": "メトリクス"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "ネットワークの詳細の確認",
@@ -6738,10 +6730,6 @@
   },
   "transferRequest": {
     "message": "送金要求"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Ledgerの接続に問題が発生しました。$1",

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "베타 이용약관"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "계정",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "메트릭"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "네트워크 세부 정보 검증",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "전송 요청"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Ledger 연결에 오류가 발생했습니다. $1",

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -731,10 +731,6 @@
   "betaTerms": {
     "message": "Termos de uso do Beta"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Conta",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3288,10 +3284,6 @@
   },
   "metrics": {
     "message": "Métricas"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "verifique os detalhes da rede",
@@ -6738,10 +6730,6 @@
   },
   "transferRequest": {
     "message": "Solicitação de transferência"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Estamos com problemas para conectar o seu Ledger. $1",

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Условия использования бета-версии"
   },
-  "billionAbbreviation": {
-    "message": "Б",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Счет",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Показатели"
-  },
-  "millionAbbreviation": {
-    "message": "млн",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "проверить сведения о сети",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Запрос на перевод"
-  },
-  "trillionAbbreviation": {
-    "message": "трлн",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "У нас возникли проблемы с подключением вашего Ledger. $1",

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -731,10 +731,6 @@
   "betaTerms": {
     "message": "Mga tuntunin sa paggamit ng Beta"
   },
-  "billionAbbreviation": {
-    "message": "B",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Account",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3288,10 +3284,6 @@
   },
   "metrics": {
     "message": "Metrics"
-  },
-  "millionAbbreviation": {
-    "message": "M",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "i-verify ang mga detalye ng network",
@@ -6738,10 +6730,6 @@
   },
   "transferRequest": {
     "message": "Kahilingan na paglilipat"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Nagkakaproblema kami sa pagkonekta ng iyong Ledger. $1",

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -731,10 +731,6 @@
   "betaTerms": {
     "message": "Beta Kullanım koşulları"
   },
-  "billionAbbreviation": {
-    "message": "MR",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Hesap",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3288,10 +3284,6 @@
   },
   "metrics": {
     "message": "Metrikler"
-  },
-  "millionAbbreviation": {
-    "message": "MN",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "ağ bilgilerini doğrula",
@@ -6738,10 +6730,6 @@
   },
   "transferRequest": {
     "message": "Transfer talebi"
-  },
-  "trillionAbbreviation": {
-    "message": "T",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Ledger'ınıza bağlanırken sorun yaşıyoruz. $1",

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "Điều khoản sử dụng phiên bản Beta"
   },
-  "billionAbbreviation": {
-    "message": "Tỷ",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "Tài khoản",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "Chỉ số"
-  },
-  "millionAbbreviation": {
-    "message": "Triệu",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "xác minh thông tin về mạng",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "Yêu cầu chuyển tiền"
-  },
-  "trillionAbbreviation": {
-    "message": "Nghìn Tỷ",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "Chúng tôi đang gặp sự cố khi kết nối với Ledger của bạn. $1",

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -743,10 +743,6 @@
   "betaTerms": {
     "message": "测试版使用条款"
   },
-  "billionAbbreviation": {
-    "message": "十亿",
-    "description": "Shortened form of 'billion'"
-  },
   "blockExplorerAccountAction": {
     "message": "账户",
     "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
@@ -3318,10 +3314,6 @@
   },
   "metrics": {
     "message": "指标"
-  },
-  "millionAbbreviation": {
-    "message": "百万",
-    "description": "Shortened form of 'million'"
   },
   "mismatchedChainLinkText": {
     "message": "验证网络信息",
@@ -6785,10 +6777,6 @@
   },
   "transferRequest": {
     "message": "转账请求"
-  },
-  "trillionAbbreviation": {
-    "message": "万亿",
-    "description": "Shortened form of 'trillion'"
   },
   "troubleConnectingToLedgerU2FOnFirefox": {
     "message": "我们在连接您的 Ledger 时遇到问题。$1",

--- a/test/e2e/tests/tokens/token-details.spec.ts
+++ b/test/e2e/tests/tokens/token-details.spec.ts
@@ -67,6 +67,13 @@ describe('Token Details', function () {
       marketCap: 12,
     };
 
+    const expectedPrice = formatCurrency(
+      `${marketData.price * ethConversionInUsd}`,
+      'USD',
+    );
+
+    const expectedMarketCap = '$120.00K';
+
     await withFixtures(
       {
         ...fixtures,
@@ -104,14 +111,6 @@ describe('Token Details', function () {
           symbol,
           tokenAddress,
         );
-
-        const expectedPrice = formatCurrency(
-          `${marketData.price * ethConversionInUsd}`,
-          'USD',
-        );
-        const expectedMarketCap = `${
-          marketData.marketCap * ethConversionInUsd
-        }.00`;
 
         await assetListPage.checkTokenPriceAndMarketCap(
           expectedPrice,

--- a/ui/hooks/useFormatters.ts
+++ b/ui/hooks/useFormatters.ts
@@ -34,7 +34,11 @@ function formatCompact(
   formatNumber: (value: Value, options?: Intl.NumberFormatOptions) => string,
   value: Value,
 ) {
-  return formatNumber(value, { notation: 'compact' });
+  return formatNumber(value, {
+    notation: 'compact',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 export function useFormatters() {

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -1410,7 +1410,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
                 class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
                 data-testid="asset-market-cap"
               >
-                56K
+                $56.09K
               </p>
             </div>
           </div>

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -1410,7 +1410,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
                 class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
                 data-testid="asset-market-cap"
               >
-                56088.00
+                56K
               </p>
             </div>
           </div>

--- a/ui/pages/asset/components/asset-market-details.test.tsx
+++ b/ui/pages/asset/components/asset-market-details.test.tsx
@@ -24,7 +24,6 @@ jest.mock('../../../hooks/useMultichainSelector', () => ({
 
 jest.mock('../util', () => ({
   getPricePrecision: jest.fn(() => 2),
-  localizeLargeNumber: jest.fn((_t, value) => value.toLocaleString()),
 }));
 
 jest.mock('../../../helpers/utils/confirm-tx.util', () => ({

--- a/ui/pages/asset/components/asset-market-details.test.tsx
+++ b/ui/pages/asset/components/asset-market-details.test.tsx
@@ -130,10 +130,11 @@ describe('AssetMarketDetails', () => {
     );
 
     // Market cap should be multiplied by exchange rate: 50,000 * 1,000 = 50,000,000
+    // And formatted as compact: $50.00M
     const marketCapElement = container.querySelector(
       '[data-testid="asset-market-cap"]',
     );
-    expect(marketCapElement).toHaveTextContent('50,000,000');
+    expect(marketCapElement).toHaveTextContent('$50.00M');
   });
 
   it('should NOT multiply circulating supply by exchange rate for EVM tokens', () => {
@@ -143,11 +144,12 @@ describe('AssetMarketDetails', () => {
 
     // Circulating supply should NOT be multiplied by exchange rate
     // It should remain as the original token count: 15,000,000,000
+    // And formatted as compact: 15.00B
     const circulatingSupplyRow = getByText('circulatingSupply').parentElement;
-    expect(circulatingSupplyRow).toHaveTextContent('15,000,000,000');
+    expect(circulatingSupplyRow).toHaveTextContent('15.00B');
 
     // Verify it's NOT the multiplied value (15B * 1000 = 15T)
-    expect(circulatingSupplyRow).not.toHaveTextContent('15,000,000,000,000');
+    expect(circulatingSupplyRow).not.toHaveTextContent('15000.00B');
   });
 
   it('should multiply allTimeHigh and allTimeLow by exchange rate for EVM tokens', () => {

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -44,7 +44,7 @@ export const AssetMarketDetails = ({
   const evmMarketData = useSelector(getMarketData);
   const currencyRates = useSelector(getCurrencyRates);
   const nonEvmConversionRates = useSelector(getAssetsRates);
-  const { formatCompact } = useFormatters();
+  const { formatCurrencyCompact, formatCompact } = useFormatters();
 
   const isEvm = isEvmChainId(asset.chainId);
   const nativeCurrency = useMultichainSelector(getMultichainNativeCurrency);
@@ -137,14 +137,14 @@ export const AssetMarketDetails = ({
               variant={TextVariant.bodyMdMedium}
               data-testid="asset-market-cap"
             >
-              {formatCompact(marketCap)}
+              {formatCurrencyCompact(marketCap, currency)}
             </Text>,
           )}
         {totalVolume > 0 &&
           renderRow(
             t('totalVolume'),
             <Text variant={TextVariant.bodyMdMedium}>
-              {formatCompact(totalVolume)}
+              {formatCurrencyCompact(totalVolume, currency)}
             </Text>,
           )}
         {circulatingSupply > 0 &&

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -4,7 +4,7 @@ import { CaipAssetType } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 
-import { getPricePrecision, localizeLargeNumber } from '../util';
+import { getPricePrecision } from '../util';
 
 import { Box, Text } from '../../../components/component-library';
 import {
@@ -29,6 +29,7 @@ import { Asset } from '../types/asset';
 // eslint-disable-next-line import/no-restricted-paths
 import { getConversionRatesForNativeAsset } from '../../../../app/scripts/lib/util';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+import { useFormatters } from '../../../hooks/useFormatters';
 
 export const AssetMarketDetails = ({
   asset,
@@ -43,6 +44,7 @@ export const AssetMarketDetails = ({
   const evmMarketData = useSelector(getMarketData);
   const currencyRates = useSelector(getCurrencyRates);
   const nonEvmConversionRates = useSelector(getAssetsRates);
+  const { formatNumber } = useFormatters();
 
   const isEvm = isEvmChainId(asset.chainId);
   const nativeCurrency = useMultichainSelector(getMultichainNativeCurrency);
@@ -135,21 +137,21 @@ export const AssetMarketDetails = ({
               variant={TextVariant.bodyMdMedium}
               data-testid="asset-market-cap"
             >
-              {localizeLargeNumber(t, marketCap)}
+              {formatNumber(marketCap, { notation: 'compact' })}
             </Text>,
           )}
         {totalVolume > 0 &&
           renderRow(
             t('totalVolume'),
             <Text variant={TextVariant.bodyMdMedium}>
-              {localizeLargeNumber(t, totalVolume)}
+              {formatNumber(totalVolume, { notation: 'compact' })}
             </Text>,
           )}
         {circulatingSupply > 0 &&
           renderRow(
             t('circulatingSupply'),
             <Text variant={TextVariant.bodyMdMedium}>
-              {localizeLargeNumber(t, circulatingSupply)}
+              {formatNumber(circulatingSupply, { notation: 'compact' })}
             </Text>,
           )}
         {allTimeHigh > 0 &&

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -44,7 +44,7 @@ export const AssetMarketDetails = ({
   const evmMarketData = useSelector(getMarketData);
   const currencyRates = useSelector(getCurrencyRates);
   const nonEvmConversionRates = useSelector(getAssetsRates);
-  const { formatNumber } = useFormatters();
+  const { formatCompact } = useFormatters();
 
   const isEvm = isEvmChainId(asset.chainId);
   const nativeCurrency = useMultichainSelector(getMultichainNativeCurrency);
@@ -137,21 +137,21 @@ export const AssetMarketDetails = ({
               variant={TextVariant.bodyMdMedium}
               data-testid="asset-market-cap"
             >
-              {formatNumber(marketCap, { notation: 'compact' })}
+              {formatCompact(marketCap)}
             </Text>,
           )}
         {totalVolume > 0 &&
           renderRow(
             t('totalVolume'),
             <Text variant={TextVariant.bodyMdMedium}>
-              {formatNumber(totalVolume, { notation: 'compact' })}
+              {formatCompact(totalVolume)}
             </Text>,
           )}
         {circulatingSupply > 0 &&
           renderRow(
             t('circulatingSupply'),
             <Text variant={TextVariant.bodyMdMedium}>
-              {formatNumber(circulatingSupply, { notation: 'compact' })}
+              {formatCompact(circulatingSupply)}
             </Text>,
           )}
         {allTimeHigh > 0 &&

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -492,7 +492,7 @@ describe('AssetPage', () => {
 
     // Verify market data is rendered
     const marketCapElement = queryByTestId('asset-market-cap');
-    expect(marketCapElement).toHaveTextContent('56K');
+    expect(marketCapElement).toHaveTextContent('$56.09K');
 
     const dynamicImages = container.querySelectorAll('img[alt*="logo"]');
     dynamicImages.forEach((img) => {

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -492,9 +492,7 @@ describe('AssetPage', () => {
 
     // Verify market data is rendered
     const marketCapElement = queryByTestId('asset-market-cap');
-    expect(marketCapElement).toHaveTextContent(
-      `${marketCap * mockStore.metamask.currencyRates.ETH.conversionRate}`,
-    );
+    expect(marketCapElement).toHaveTextContent('56K');
 
     const dynamicImages = container.querySelectorAll('img[alt*="logo"]');
     dynamicImages.forEach((img) => {

--- a/ui/pages/asset/util.ts
+++ b/ui/pages/asset/util.ts
@@ -21,26 +21,6 @@ export const getShortDateFormatterV2 = () =>
   });
 
 /**
- * Formats a potentially large number to the nearest unit.
- * e.g. 1T for trillions, 2.3B for billions, 4.56M for millions, 7,890 for thousands, etc.
- *
- * @param t - An I18nContext translator.
- * @param number - The number to format.
- * @returns A localized string of the formatted number + unit.
- */
-// eslint-disable-next-line
-export const localizeLargeNumber = (t: any, number: number) => {
-  if (number >= 1000000000000) {
-    return `${(number / 1000000000000).toFixed(2)}${t('trillionAbbreviation')}`;
-  } else if (number >= 1000000000) {
-    return `${(number / 1000000000).toFixed(2)}${t('billionAbbreviation')}`;
-  } else if (number >= 1000000) {
-    return `${(number / 1000000).toFixed(2)}${t('millionAbbreviation')}`;
-  }
-  return number.toFixed(2);
-};
-
-/**
  * Returns the number of decimals the fiat price should be formatted to.
  * This tells `currency-formatter` to render prices < 1 cent like $0.00001234
  *


### PR DESCRIPTION
## **Description**

- Fix the missing currency symbol that should be in market cap and total volume.
- Use the the Intl-based formatters from metamask/core instead of manually adding abbreviations.
- Cleanup unused locale messages

## **Changelog**


CHANGELOG entry: use formatters for market cap

## **Related issues**

Fixes:

## **Manual testing steps**

1. Token list
2. Click token
3. Market details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="384" height="103" alt="image" src="https://github.com/user-attachments/assets/8ea84450-72a9-4529-8639-e6d77fd8bcac" />


### **After**

<img width="387" height="104" alt="image" src="https://github.com/user-attachments/assets/11d39345-f64e-48e6-abfb-c14930252b87" />




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches market cap, volume, and supply to Intl-based compact formatting and removes locale abbreviation strings, updating tests accordingly.
> 
> - **UI/Formatting**:
>   - `AssetMarketDetails`: use `useFormatters` to format `marketCap`/`totalVolume` with `formatCurrencyCompact` and `circulatingSupply` with `formatCompact`; remove `localizeLargeNumber`; keep ATH/ATL via `formatCurrency` and apply correct EVM conversion.
>   - `useFormatters`: add `formatCompact`; refactor `formatPercentWithMinThreshold` to use `base.formatNumber`; remove custom `Intl.NumberFormat` cache.
> - **Tests**:
>   - Update unit/e2e expectations and snapshots to compact currency (e.g., `$56.09K`, `$50.00M`); adjust mocks accordingly.
> - **i18n cleanup**:
>   - Remove `millionAbbreviation`, `billionAbbreviation`, `trillionAbbreviation` from all locale files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846634df71014c4fb56b28e71a6c1874287ec9f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->