### PR TITLE
feat: Add a new feature for saving account name on enter key press

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
@@ -267,4 +267,24 @@ describe('MultichainAccountEditModal', () => {
       'Duplicate Account Name',
     );
   });
+
+  it('saves account name when Enter key is pressed in the input field', async () => {
+    const store = configureStore(mockDefaultState);
+    store.dispatch = jest.fn().mockResolvedValue(true);
+
+    renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
+
+    const input = screen.getByPlaceholderText('Account 1');
+
+    fireEvent.change(input, { target: { value: 'New Account Name' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(setAccountGroupName).toHaveBeenCalledWith(
+        mockProps.accountGroupId,
+        'New Account Name',
+      );
+      expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -57,6 +57,15 @@ export const MultichainAccountEditModal = ({
     }
   }, [accountName, currentAccountName, accountGroupId, dispatch, onClose, t]);
 
+  const handleKeyDown = useCallback(
+    async (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && accountName.trim()) {
+        await handleSave();
+      }
+    },
+    [accountName, handleSave],
+  );
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -77,6 +86,7 @@ export const MultichainAccountEditModal = ({
                 data-testid="account-name-input"
                 value={accountName}
                 onChange={(e) => setAccountName(e.target.value)}
+                onKeyDown={handleKeyDown}
                 placeholder={currentAccountName}
                 error={showErrorMessage}
                 helpText={helpText}


### PR DESCRIPTION
## **Description**
This PR adds small improvement for saving account names on `Enter` keypress inside multichain account rename modal.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36454?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a new feature for saving multichain account name on Enter key press

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-936

## **Manual testing steps**
1. Go to multichain account list or multichain account details and trigger the multichain account rename modal.
2. Edit account name.
3. Press enter while cursor is in the input field.
4. Check that new account name is saved and modal closed.

## **Screenshots/Recordings**

### **Before**
Saving an account name on `Enter` key press was not available before. Nothing to show here that can compare. All previous features remain the same as displayed on the recording in "_After_" section.

### **After**

https://github.com/user-attachments/assets/0ec5285b-c514-4f03-a1df-3b28ec05a28e

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable saving the multichain account name by pressing Enter in the rename modal and add a test for it.
> 
> - **UI**:
>   - In `ui/components/multichain-accounts/.../multichain-account-edit-modal.tsx`, add `handleKeyDown` to trigger `handleSave` on `Enter` and wire it via `onKeyDown` on the `FormTextField` input.
> - **Tests**:
>   - In `.../multichain-account-edit-modal.test.tsx`, add test to verify saving and closing the modal when pressing `Enter` in the input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84b31820b6883553dad0a742d48abdff8244eaba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->