### PR TITLE
fix: update text in toast

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2946,7 +2946,7 @@
     "message": "Import a wallet or account"
   },
   "importWalletSuccess": {
-    "message": "Secret Recovery Phrase $1 imported",
+    "message": "Wallet $1 imported",
     "description": "$1 is the index of the secret recovery phrase"
   },
   "importWithCount": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2954,7 +2954,7 @@
     "message": "Import a wallet or account"
   },
   "importWalletSuccess": {
-    "message": "Secret Recovery Phrase $1 imported",
+    "message": "Wallet $1 imported",
     "description": "$1 is the index of the secret recovery phrase"
   },
   "importWithCount": {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -358,7 +358,7 @@ class HomePage {
 
   async checkNewSrpAddedToastIsDisplayed(srpNumber: number = 2): Promise<void> {
     await this.driver.waitForSelector({
-      text: `Secret Recovery Phrase ${srpNumber} imported`,
+      text: `Wallet ${srpNumber} imported`,
     });
   }
 

--- a/ui/pages/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.test.tsx
@@ -22,12 +22,30 @@ const VALID_SECRET_RECOVERY_PHRASE =
   'input turtle oil scorpion exile useless dry foster vessel knee area label';
 
 jest.mock('../../../store/actions', () => ({
-  importMnemonicToVault: jest
-    .fn()
-    .mockReturnValue(jest.fn().mockResolvedValue(null)),
+  importMnemonicToVault: jest.fn().mockReturnValue(
+    jest.fn().mockResolvedValue({
+      newAccountAddress: '0x123',
+      discoveredAccounts: { Bitcoin: 0, Solana: 0 },
+    }),
+  ),
   showAlert: jest.fn().mockReturnValue({ type: 'ALERT_OPEN' }),
   hideAlert: jest.fn().mockReturnValue({ type: 'ALERT_CLOSE' }),
   hideWarning: jest.fn().mockReturnValue({ type: 'HIDE_WARNING' }),
+}));
+
+jest.mock('../../../components/app/toast-master/utils', () => ({
+  setShowNewSrpAddedToast: jest.fn().mockImplementation((value: boolean) => ({
+    type: 'SET_SHOW_NEW_SRP_ADDED_TOAST',
+    payload: value,
+  })),
+}));
+
+const mockHistoryPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
 }));
 
 const pasteSrpIntoFirstInput = (render: RenderResult, srp: string) => {
@@ -314,5 +332,29 @@ describe('ImportSrp', () => {
     }
 
     expect(getByText('Import wallet')).not.toBeEnabled();
+  });
+
+  it('shows successful toast message after successful import', async () => {
+    const render = renderWithProvider(<ImportSrp />, store);
+    const { getByText } = render;
+    const importButton = getByText('Import wallet');
+
+    expect(importButton).not.toBeEnabled();
+    pasteSrpIntoFirstInput(render, VALID_SECRET_RECOVERY_PHRASE);
+
+    fireEvent.click(importButton);
+
+    await waitFor(() => {
+      expect(importMnemonicToVault).toHaveBeenCalledWith(
+        VALID_SECRET_RECOVERY_PHRASE,
+      );
+    });
+
+    // Verify that the toast action was dispatched
+    const dispatchedActions = store.getActions();
+    expect(dispatchedActions).toContainEqual({
+      type: 'SET_SHOW_NEW_SRP_ADDED_TOAST',
+      payload: true,
+    });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the text in the import srp toast. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36458?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update text in import srp success toast.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-982?atlOrigin=eyJpIjoiNzRhOWJmODRmZDViNGMzMThjYWFlMzY5MTU1MmYxYmMiLCJwIjoiaiJ9

## **Manual testing steps**

1. Add a new srp
2. See that the toast message says `Wallet {number} imported`


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes the import success message to "Wallet {n} imported" and updates tests to expect it and assert the toast action is dispatched.
> 
> - **i18n**:
>   - Update `importWalletSuccess` in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json` from `"Secret Recovery Phrase $1 imported"` to `"Wallet $1 imported"`.
> - **E2E**:
>   - Adjust `checkNewSrpAddedToastIsDisplayed` in `test/e2e/page-objects/pages/home/homepage.ts` to expect `"Wallet ${srpNumber} imported"`.
> - **Unit Tests**:
>   - In `ui/pages/multi-srp/import-srp/import-srp.test.tsx`:
>     - Enhance `importMnemonicToVault` mock to return account info.
>     - Mock toast utils (`setShowNewSrpAddedToast`) and `useHistory`.
>     - Add test asserting successful import dispatches `SET_SHOW_NEW_SRP_ADDED_TOAST` and keeps existing button/validation behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a00462ac6c11b29d3227c1289a14cf5bfd0037b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->