### PR TITLE
fix(account-tree-controller): re-use computed names for groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,8 +243,7 @@
     "@endo/env-options@npm:^1.1.11": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.7": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
-    "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
-    "@metamask/account-tree-controller@^1.3.0": "npm:@metamask-previews/account-tree-controller@1.3.0-preview-683bbcb0"
+    "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",
@@ -265,7 +264,7 @@
     "@material-ui/core": "^4.12.4",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^0.12.0",
-    "@metamask/account-tree-controller": "^1.3.0",
+    "@metamask/account-tree-controller": "^1.4.0",
     "@metamask/account-watcher": "^4.1.3",
     "@metamask/accounts-controller": "^33.1.0",
     "@metamask/address-book-controller": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,8 @@
     "@endo/env-options@npm:^1.1.11": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.7": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
-    "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
+    "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
+    "@metamask/account-tree-controller@^1.3.0": "npm:@metamask-previews/account-tree-controller@1.3.0-preview-683bbcb0"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
@@ -54,9 +54,7 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
         // Ensure that accounts within the wallets are displayed
         await accountListPage.checkMultichainAccountBalanceDisplayed('$0.00');
         await accountListPage.checkMultichainAccountNameDisplayed('Account 1');
-        await accountListPage.checkMultichainAccountNameDisplayed(
-          'Ledger Account 1',
-        );
+        await accountListPage.checkMultichainAccountNameDisplayed('Ledger 1');
       },
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,15 +5292,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@metamask/account-tree-controller@npm:1.3.0"
+"@metamask/account-tree-controller@npm:@metamask-previews/account-tree-controller@1.3.0-preview-683bbcb0":
+  version: 1.3.0-preview-683bbcb0
+  resolution: "@metamask-previews/account-tree-controller@npm:1.3.0-preview-683bbcb0"
   dependencies:
     "@metamask/base-controller": "npm:^8.4.0"
     "@metamask/snaps-sdk": "npm:^9.0.0"
     "@metamask/snaps-utils": "npm:^11.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.8.0"
+    "@metamask/utils": "npm:^11.8.1"
     fast-deep-equal: "npm:^3.1.3"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -5312,7 +5312,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/06c93e12274fb2ba354259acb00969c16def07ad174e712d37d3696015fcf679a9aebc52476970954683cd5730b08a91c77dab6c09b9c12d92885ccc8b8c1530
+  checksum: 10/6320ccf8e1b9387d3a3f6df316ccccb3256a52963221f8fd48ac9bd984cbeb4d30da3c5f093ee5496ce05e5188a1041e39cb5863e25e0c22083737c77cabacc2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,9 +5292,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:@metamask-previews/account-tree-controller@1.3.0-preview-683bbcb0":
-  version: 1.3.0-preview-683bbcb0
-  resolution: "@metamask-previews/account-tree-controller@npm:1.3.0-preview-683bbcb0"
+"@metamask/account-tree-controller@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@metamask/account-tree-controller@npm:1.4.0"
   dependencies:
     "@metamask/base-controller": "npm:^8.4.0"
     "@metamask/snaps-sdk": "npm:^9.0.0"
@@ -5312,7 +5312,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/6320ccf8e1b9387d3a3f6df316ccccb3256a52963221f8fd48ac9bd984cbeb4d30da3c5f093ee5496ce05e5188a1041e39cb5863e25e0c22083737c77cabacc2
+  checksum: 10/d10e3900e39ba7740935ef0b01935c22132c4ae0817ee25ab5377e2a1e26fa8dcd5572c3f0292a00601b37916d99d4e88503a3df5b9fe15739930446e8f5c438
   languageName: node
   linkType: hard
 
@@ -32103,7 +32103,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.4"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^0.12.0"
-    "@metamask/account-tree-controller": "npm:^1.3.0"
+    "@metamask/account-tree-controller": "npm:^1.4.0"
     "@metamask/account-watcher": "npm:^4.1.3"
     "@metamask/accounts-controller": "npm:^33.1.0"
     "@metamask/address-book-controller": "npm:^6.1.0"


### PR DESCRIPTION
## **Description**

Testing the new fix for account-tree-controller computed names.

See:
- https://github.com/MetaMask/core/pull/6758

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36461?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

- Use an old extension version like `v13.0.0`
  * You should see the old UI or old state 1 UI
  * Disable "Backup & Sync"
- Create EVM accounts and Solana accounts
- Rename them to whatever you want
- Lock
- Disable your extension
- Switch back to this branch
- Restart the extension
  * You should now see state 2 UI and new groups
  * Each groups should be named using the EVM account names you used earlier
    - Solana accounts names are not used at all

## **Screenshots/Recordings**

### **Before**

<img width="363" height="777" alt="Screenshot 2025-09-30 at 17 54 41" src="https://github.com/user-attachments/assets/c8663aef-849e-4241-8786-51a2f5e0c4a6" />

### **After**

<img width="608" height="527" alt="Screenshot 2025-09-30 at 17 58 52" src="https://github.com/user-attachments/assets/6e966402-d32d-4d5b-9fed-c56b87e82b61" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps @metamask/account-tree-controller to ^1.4.0 (and transitive @metamask/utils) and updates e2e test to expect the Ledger account name "Ledger 1".
> 
> - **Dependencies**:
>   - Upgrade `@metamask/account-tree-controller` to `^1.4.0` (lockfile updated; transitive `@metamask/utils` to `^11.8.1`).
> - **Tests (E2E)**:
>   - Adjust `test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts` to expect hardware wallet account name `Ledger 1` (was `Ledger Account 1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68434c7c4973744ebf9001127e845d1536af100f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->