### PR TITLE
fix: Polish UI for Activity tab

### DIFF
--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -18,7 +18,6 @@ import {
   AvatarNetwork,
   AvatarNetworkSize,
   BadgeWrapper,
-  BadgeWrapperAnchorElementShape,
   Box,
 } from '../../component-library';
 import {
@@ -68,7 +67,6 @@ export default function SmartTransactionListItem({
         onClick={toggleShowDetails}
         icon={
           <BadgeWrapper
-            anchorElementShape={BadgeWrapperAnchorElementShape.circular}
             display={Display.Block}
             badge={
               <AvatarNetwork
@@ -78,6 +76,7 @@ export default function SmartTransactionListItem({
                 name={currentChain?.nickname}
                 src={currentChain?.rpcPrefs?.imageUrl}
                 borderColor={BackgroundColor.backgroundDefault}
+                borderWidth={2}
               />
             }
           >

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -32,7 +32,6 @@ import {
   AvatarNetwork,
   AvatarNetworkSize,
   BadgeWrapper,
-  BadgeWrapperAnchorElementShape,
   Box,
   Text,
 } from '../../component-library';
@@ -302,7 +301,6 @@ function TransactionListItemInner({
         title={title}
         icon={
           <BadgeWrapper
-            anchorElementShape={BadgeWrapperAnchorElementShape.circular}
             display={Display.Block}
             badge={
               <AvatarNetwork
@@ -312,9 +310,11 @@ function TransactionListItemInner({
                 name={NETWORK_TO_NAME_MAP[chainId]}
                 src={CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId]}
                 borderColor={BackgroundColor.backgroundDefault}
+                borderWidth={2}
                 backgroundColor={getTestNetworkBackgroundColor(chainId)}
               />
             }
+            style={{ alignSelf: 'center' }}
           >
             <TransactionIcon category={category} status={displayedStatusKey} />
           </BadgeWrapper>

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -314,6 +314,7 @@ function TransactionListItemInner({
                 backgroundColor={getTestNetworkBackgroundColor(chainId)}
               />
             }
+            style={{ alignSelf: 'center' }}
           >
             <TransactionIcon category={category} status={displayedStatusKey} />
           </BadgeWrapper>

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -314,7 +314,6 @@ function TransactionListItemInner({
                 backgroundColor={getTestNetworkBackgroundColor(chainId)}
               />
             }
-            style={{ alignSelf: 'center' }}
           >
             <TransactionIcon category={category} status={displayedStatusKey} />
           </BadgeWrapper>

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -33,7 +33,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 13
+          May 12
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
@@ -140,7 +140,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 13
+          May 12
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -139,7 +139,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 13
+          May 12
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -33,7 +33,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 12
+          May 13
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
@@ -48,6 +48,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
+                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
@@ -139,7 +140,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 12
+          May 13
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
@@ -154,6 +155,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
+                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -33,10 +33,10 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 12
+          May 13
         </p>
         <div
-          class="mm-box activity-list-item transaction-list-item mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
+          class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
           data-testid="activity-list-item"
           tabindex="0"
         >
@@ -48,6 +48,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
+                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
@@ -58,10 +59,10 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
                   />
                 </div>
                 <div
-                  class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
+                  class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
                 >
                   <div
-                    class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network activity-tx__network-badge mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                    class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network activity-tx__network-badge mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
                     data-testid="activity-tx-network-badge"
                   >
                     G
@@ -86,7 +87,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
                   </p>
                 </div>
                 <div
-                  class="mm-box mm-text mm-text--body-sm-medium mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+                  class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
                 >
                   <div
                     class="transaction-status-label transaction-status-label--confirmed"
@@ -139,10 +140,10 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 12
+          May 13
         </p>
         <div
-          class="mm-box activity-list-item transaction-list-item mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
+          class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
           data-testid="activity-list-item"
           tabindex="0"
         >
@@ -154,6 +155,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
+                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
@@ -164,10 +166,10 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
                   />
                 </div>
                 <div
-                  class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
+                  class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
                 >
                   <div
-                    class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network activity-tx__network-badge mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                    class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network activity-tx__network-badge mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
                     data-testid="activity-tx-network-badge"
                   >
                     G
@@ -192,7 +194,7 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
                   </p>
                 </div>
                 <div
-                  class="mm-box mm-text mm-text--body-sm-medium mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+                  class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
                 >
                   <div
                     class="transaction-status-label transaction-status-label--confirmed"

--- a/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
+++ b/ui/components/app/transaction-list/__snapshots__/transaction-list.test.js.snap
@@ -33,7 +33,7 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--padding-top-2 mm-box--padding-inline-4 mm-box--color-text-alternative"
         >
-          May 13
+          May 12
         </p>
         <div
           class="mm-box activity-list-item transaction-list-item mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
@@ -48,7 +48,6 @@ exports[`TransactionList renders TransactionList component correctly 1`] = `
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
-                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
@@ -155,7 +154,6 @@ exports[`TransactionList renders TransactionList component with props hideNetwor
             >
               <div
                 class="mm-box mm-badge-wrapper mm-box--display-block"
-                style="align-self: center;"
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -653,7 +653,7 @@ export default function TransactionList({
                   (dateGroup) => (
                     <Fragment key={dateGroup.date}>
                       <Text
-                        paddingTop={3}
+                        paddingTop={4}
                         paddingInline={4}
                         variant={TextVariant.bodyMdMedium}
                         color={TextColor.textAlternative}

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -69,7 +69,6 @@ import {
   BadgeWrapper,
   AvatarNetwork,
   AvatarNetworkSize,
-  BadgeWrapperAnchorElementShape,
   ///: END:ONLY_INCLUDE_IF
 } from '../../component-library';
 ///: BEGIN:ONLY_INCLUDE_IF(multichain)
@@ -654,10 +653,10 @@ export default function TransactionList({
                   (dateGroup) => (
                     <Fragment key={dateGroup.date}>
                       <Text
-                        paddingTop={4}
+                        paddingTop={3}
                         paddingInline={4}
-                        variant={TextVariant.bodyMd}
-                        color={TextColor.textDefault}
+                        variant={TextVariant.bodyMdMedium}
+                        color={TextColor.textAlternative}
                       >
                         {dateGroup.date}
                       </Text>
@@ -833,7 +832,7 @@ export default function TransactionList({
               {completedTransactions.length > limit && (
                 <Button
                   className="transaction-list__view-more"
-                  type="secondary"
+                  variant={ButtonVariant.Secondary}
                   onClick={viewMore}
                 >
                   {t('viewMore')}
@@ -871,7 +870,6 @@ const MultichainTransactionListItem = ({
         onClick={() => toggleShowDetails(transaction)}
         icon={
           <BadgeWrapper
-            anchorElementShape={BadgeWrapperAnchorElementShape.circular}
             display={Display.Block}
             badge={
               <AvatarNetwork
@@ -921,7 +919,6 @@ const MultichainTransactionListItem = ({
       onClick={() => toggleShowDetails(transaction)}
       icon={
         <BadgeWrapper
-          anchorElementShape={BadgeWrapperAnchorElementShape.circular}
           display={Display.Block}
           badge={
             <AvatarNetwork
@@ -930,6 +927,7 @@ const MultichainTransactionListItem = ({
               size={AvatarNetworkSize.Xs}
               name={transaction.chain}
               src={networkLogo}
+              borderWidth={2}
               borderColor={BackgroundColor.backgroundDefault}
             />
           }

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -653,7 +653,7 @@ export default function TransactionList({
                   (dateGroup) => (
                     <Fragment key={dateGroup.date}>
                       <Text
-                        paddingTop={4}
+                        paddingTop={3}
                         paddingInline={4}
                         variant={TextVariant.bodyMdMedium}
                         color={TextColor.textAlternative}

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -938,13 +938,12 @@ const MultichainTransactionListItem = ({
       rightContent={
         <Text
           className="activity-list-item__primary-currency"
-          color="text-default"
           data-testid="transaction-list-item-primary-currency"
+          color={TextColor.textDefault}
+          variant={TextVariant.bodyMdMedium}
           ellipsis
-          fontWeight="medium"
           textAlign="right"
           title="Primary Currency"
-          variant="body-md-medium"
         >
           {amount} {unit}
         </Text>

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -743,7 +743,7 @@ export default function UnifiedTransactionList({
               .map((dateGroup) => (
                 <Fragment key={dateGroup.date}>
                   <Text
-                    paddingTop={4}
+                    paddingTop={3}
                     paddingInline={4}
                     variant={TextVariant.bodyMdMedium}
                     color={TextColor.textAlternative}

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -743,7 +743,7 @@ export default function UnifiedTransactionList({
               .map((dateGroup) => (
                 <Fragment key={dateGroup.date}>
                   <Text
-                    paddingTop={3}
+                    paddingTop={4}
                     paddingInline={4}
                     variant={TextVariant.bodyMdMedium}
                     color={TextColor.textAlternative}

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -874,13 +874,12 @@ const MultichainTransactionListItem = ({
       rightContent={
         <Text
           className="activity-list-item__primary-currency"
-          color="text-default"
           data-testid="transaction-list-item-primary-currency"
+          color={TextColor.textDefault}
+          variant={TextVariant.bodyMdMedium}
           ellipsis
-          fontWeight="medium"
           textAlign="right"
           title="Primary Currency"
-          variant="body-lg-medium"
         >
           {amount} {unit}
         </Text>

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -47,12 +47,12 @@ import {
 import {
   Box,
   Button,
+  ButtonVariant,
   Text,
   ///: BEGIN:ONLY_INCLUDE_IF(multichain)
   BadgeWrapper,
   AvatarNetwork,
   AvatarNetworkSize,
-  BadgeWrapperAnchorElementShape,
   ///: END:ONLY_INCLUDE_IF
 } from '../../component-library';
 ///: BEGIN:ONLY_INCLUDE_IF(multichain)
@@ -743,10 +743,10 @@ export default function UnifiedTransactionList({
               .map((dateGroup) => (
                 <Fragment key={dateGroup.date}>
                   <Text
-                    paddingTop={4}
+                    paddingTop={3}
                     paddingInline={4}
-                    variant={TextVariant.bodyMd}
-                    color={TextColor.textDefault}
+                    variant={TextVariant.bodyMdMedium}
+                    color={TextColor.textAlternative}
                   >
                     {dateGroup.date}
                   </Text>
@@ -762,11 +762,12 @@ export default function UnifiedTransactionList({
                 display={Display.Flex}
                 justifyContent={JustifyContent.center}
                 alignItems={AlignItems.center}
-                padding={4}
+                paddingInline={4}
+                paddingBottom={4}
               >
                 <Button
                   className="transaction-list__view-more"
-                  type="secondary"
+                  variant={ButtonVariant.Secondary}
                   onClick={viewMore}
                 >
                   {t('viewMore')}
@@ -804,7 +805,6 @@ const MultichainTransactionListItem = ({
         onClick={() => toggleShowDetails(transaction)}
         icon={
           <BadgeWrapper
-            anchorElementShape={BadgeWrapperAnchorElementShape.circular}
             display={Display.Block}
             badge={
               <AvatarNetwork
@@ -814,6 +814,7 @@ const MultichainTransactionListItem = ({
                 name={transaction.chain}
                 src={networkLogo}
                 borderColor={BackgroundColor.backgroundDefault}
+                borderWidth={2}
               />
             }
           >
@@ -854,7 +855,6 @@ const MultichainTransactionListItem = ({
       onClick={() => toggleShowDetails(transaction)}
       icon={
         <BadgeWrapper
-          anchorElementShape={BadgeWrapperAnchorElementShape.circular}
           display={Display.Block}
           badge={
             <AvatarNetwork
@@ -864,6 +864,7 @@ const MultichainTransactionListItem = ({
               name={transaction.chain}
               src={networkLogo}
               borderColor={BackgroundColor.backgroundDefault}
+              borderWidth={2}
             />
           }
         >

--- a/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
+++ b/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ActivityListItem should match snapshot with no props 1`] = `
 <div>
   <div
-    class="mm-box activity-list-item activity-list-item--single-content-row mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
+    class="mm-box activity-list-item activity-list-item--single-content-row mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
     tabindex="0"
   >
     <div
@@ -33,12 +33,12 @@ exports[`ActivityListItem should match snapshot with no props 1`] = `
 exports[`ActivityListItem should match snapshot with props 1`] = `
 <div>
   <div
-    class="mm-box activity-list-item list-item-test mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
+    class="mm-box activity-list-item list-item-test mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
     data-testid="test-id"
     tabindex="0"
   >
     <p
-      class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--width-full mm-box--color-text-default"
+      class="mm-box mm-text mm-text--body-md-medium mm-box--display-flex mm-box--width-full mm-box--color-text-default"
     >
       <p>
         Content rendered at the top
@@ -72,7 +72,7 @@ exports[`ActivityListItem should match snapshot with props 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-text mm-text--body-sm-medium mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+            class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
           >
             <p>
               I am a list item

--- a/ui/components/multichain/activity-list-item/activity-list-item.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.js
@@ -44,7 +44,9 @@ export const ActivityListItem = ({
         }
       }}
       data-testid={dataTestId}
-      padding={4}
+      paddingInline={4}
+      paddingTop={3}
+      paddingBottom={3}
       display={Display.Flex}
       width={BlockSize.Full}
       flexWrap={FlexWrap.Wrap}
@@ -52,7 +54,7 @@ export const ActivityListItem = ({
     >
       {topContent && (
         <Text
-          variant={TextVariant.bodyMd}
+          variant={TextVariant.bodyMdMedium}
           color={TextColor.textDefault}
           display={Display.Flex}
           width={BlockSize.Full}
@@ -100,7 +102,6 @@ export const ActivityListItem = ({
                 ellipsis
                 textAlign={TextAlign.Left}
                 variant={TextVariant.bodySmMedium}
-                fontWeight={FontWeight.Normal}
               >
                 {subtitle}
               </Text>

--- a/ui/components/multichain/activity-list-item/index.scss
+++ b/ui/components/multichain/activity-list-item/index.scss
@@ -14,4 +14,8 @@
       max-width: max-content;
     }
   }
+
+  &:hover {
+    background-color: var(--color-background-default-hover);
+  }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refines the spacing of the activity components to improve the balance on the screen. It ensures the components are visually similar to components in the tokens tab. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36482?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Activity tab, test that components looks similar to TokenListItem
2. Check that padding is not compromised for all flows: Send, Swap/Bridge, Smart Transactions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<img width="1095" height="808" alt="Screenshot 2025-10-01 at 4 18 27 AM" src="https://github.com/user-attachments/assets/f8bd65ad-dc50-4dba-b453-595ea748f316" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Activity/Transaction list visuals: adjusted paddings/typography, added network badge borders, removed anchor shape prop, updated button variants, and added hover styling.
> 
> - **UI/Styling**
>   - Activity rows: switch from uniform `padding` to `paddingTop/Bottom=3` and `paddingInline=4`; center badge wrapper; add hover background.
>   - Date headers: change `paddingTop` to `3`, `variant` to `bodyMdMedium`, and `color` to `textAlternative`.
>   - Network badge: add `borderWidth={2}` to `AvatarNetwork` and remove `BadgeWrapperAnchorElementShape` usage (badge container shifts from circular to rectangular).
>   - Right-side amounts (non‑EVM): use `TextColor.textDefault` and `TextVariant.bodyMdMedium`.
> - **Buttons**
>   - Replace deprecated `type="secondary"` with `variant={ButtonVariant.Secondary}`; adjust surrounding paddings.
> - **Components Affected**
>   - `ActivityListItem`, `transaction-list[-item]`, `unified-transaction-list`, smart/non‑EVM list items; snapshots updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4e49fb026f549f7ab17e29be8b3cb33bc469690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->