### PR TITLE
fix: send > assets list number formatting

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -51,11 +51,7 @@ const mockNFTERC1155Asset = {
   },
 };
 
-const store = createMockStore()({
-  localeMessages: {
-    currentLocale: 'en',
-  },
-});
+const store = createMockStore()();
 
 function render(ui: React.ReactElement) {
   return renderWithProvider(ui, store);

--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import createMockStore from 'redux-mock-store';
 
+import { renderWithProvider } from '../../../../../../test/jest';
 import { useNftImageUrl } from '../../../hooks/useNftImageUrl';
 import { AssetStandard } from '../../../types/send';
 import { Asset } from './asset';
@@ -9,8 +11,11 @@ const mockTokenAsset = {
   name: 'Test Token',
   symbol: 'TEST',
   standard: AssetStandard.ERC20,
-  balanceInSelectedCurrency: '$100.00',
-  shortenedBalance: '10.5',
+  balance: '10.5',
+  fiat: {
+    balance: 100,
+    currency: 'USD',
+  },
   chainId: '0x1',
   image: 'https://example.com/token.png',
   networkName: 'Ethereum',
@@ -45,6 +50,16 @@ const mockNFTERC1155Asset = {
     imageUrl: 'https://example.com/collection1155.png',
   },
 };
+
+const store = createMockStore()({
+  localeMessages: {
+    currentLocale: 'en',
+  },
+});
+
+function render(ui: React.ReactElement) {
+  return renderWithProvider(ui, store);
+}
 
 jest.mock('../../../hooks/useNftImageUrl', () => ({
   useNftImageUrl: jest.fn().mockReturnValue('https://example.com/nft.png'),

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -179,7 +179,10 @@ const TokenAsset = ({ asset, onClick, isSelected }: AssetProps) => {
         marginLeft={2}
       >
         <Text variant={TextVariant.bodyMdMedium}>
-          {formatCurrencyWithMinThreshold(fiat?.balance ?? 0, fiat?.currency)}
+          {formatCurrencyWithMinThreshold(
+            fiat?.balance ?? 0,
+            fiat?.currency || '',
+          )}
         </Text>
         <Text
           variant={TextVariant.bodySmMedium}

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -22,6 +22,7 @@ import {
   NFT_STANDARDS,
 } from '../../../types/send';
 import { useNftImageUrl } from '../../../hooks/useNftImageUrl';
+import { useFormatters } from '../../../../../hooks/useFormatters';
 
 type AssetProps = {
   asset: AssetType;
@@ -114,14 +115,9 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
 
 const TokenAsset = ({ asset, onClick, isSelected }: AssetProps) => {
   const tokenData = asset;
-  const {
-    balanceInSelectedCurrency,
-    chainId,
-    image,
-    name,
-    shortenedBalance,
-    symbol,
-  } = tokenData;
+  const { chainId, image, name, balance, symbol = '', fiat } = tokenData;
+  const { formatCurrencyWithMinThreshold, formatTokenQuantity } =
+    useFormatters();
 
   return (
     <Box
@@ -183,13 +179,13 @@ const TokenAsset = ({ asset, onClick, isSelected }: AssetProps) => {
         marginLeft={2}
       >
         <Text variant={TextVariant.bodyMdMedium}>
-          {balanceInSelectedCurrency}
+          {formatCurrencyWithMinThreshold(fiat?.balance ?? 0, fiat?.currency)}
         </Text>
         <Text
           variant={TextVariant.bodySmMedium}
           color={TextColor.textAlternative}
         >
-          {shortenedBalance} {symbol}
+          {formatTokenQuantity(Number(balance ?? 0), symbol)}
         </Text>
       </Box>
     </Box>

--- a/ui/pages/confirmations/components/confirm/utils.ts
+++ b/ui/pages/confirmations/components/confirm/utils.ts
@@ -20,17 +20,6 @@ export const getConfirmationSender = (
   return { from };
 };
 
-export const formatNumber = (value: number, decimals: number) => {
-  if (value === undefined) {
-    return value;
-  }
-  const formatter = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  });
-  return formatter.format(value);
-};
-
 export const getIsRevokeDAIPermit = (confirmation: SignatureRequestType) => {
   const msgData = confirmation?.msgParams?.data;
   const {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -152,25 +152,6 @@ describe('useSendTokens', () => {
     expect(result.current[1].fiat?.balance).toBe(500);
   });
 
-  it('adds formatted balance in selected currency', async () => {
-    mockFormatter.mockReturnValue('$2,000.00');
-
-    const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
-
-    expect(mockFormatter).toHaveBeenCalledWith(2000, { shorten: true });
-    expect(result.current[0].balanceInSelectedCurrency).toBe('$2,000.00');
-  });
-
-  it('handles formatter error gracefully', async () => {
-    mockFormatter.mockImplementation(() => {
-      throw new Error('Formatter error');
-    });
-
-    const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
-
-    expect(result.current[0].balanceInSelectedCurrency).toBe('2000 USD');
-  });
-
   it('sets correct standard for native tokens', async () => {
     const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
 
@@ -233,40 +214,6 @@ describe('useSendTokens', () => {
     const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
 
     expect(result.current).toEqual([]);
-  });
-
-  it('handles assets without fiat data', async () => {
-    const assetsWithoutFiat = [
-      {
-        address: '0xToken',
-        chainId: '0x5',
-        balance: '1000000000000000000',
-        rawBalance: '0xde0b6b3a7640000',
-        isNative: false,
-        symbol: 'TOKEN',
-        decimals: 18,
-        fiat: {
-          balance: 100,
-          currency: 'USD',
-        },
-      },
-    ];
-
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === getAssetsBySelectedAccountGroup) {
-        return assetsWithoutFiat;
-      }
-      return undefined;
-    });
-
-    mockFormatter.mockImplementation(() => {
-      throw new Error('Formatter error');
-    });
-
-    const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
-
-    const asset = result.current[0];
-    expect(asset?.balanceInSelectedCurrency).toBe('100 USD');
   });
 
   it('updates when dependencies change', async () => {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -6,7 +6,6 @@ import {
   CHAIN_ID_TOKEN_IMAGE_MAP,
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
 } from '../../../../../shared/constants/network';
-import { useFiatFormatter } from '../../../../hooks/useFiatFormatter';
 import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
 import { AssetStandard, type Asset } from '../../types/send';
 import { useChainNetworkNameAndImageMap } from '../useChainNetworkNameAndImage';
@@ -14,7 +13,6 @@ import { useChainNetworkNameAndImageMap } from '../useChainNetworkNameAndImage';
 export const useSendTokens = (): Asset[] => {
   const chainNetworkNAmeAndImageMap = useChainNetworkNameAndImageMap();
   const assets = useSelector(getAssetsBySelectedAccountGroup);
-  const formatter = useFiatFormatter();
 
   const flatAssets = useMemo(() => Object.values(assets).flat(), [assets]);
 
@@ -27,8 +25,6 @@ export const useSendTokens = (): Asset[] => {
 
   const processedAssets = useMemo(() => {
     return assetsWithBalance.map((asset) => {
-      const fiatBalance = asset.fiat?.balance || 0;
-      const fiatCurrency = asset.fiat?.currency;
       const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
         asset.chainId as Hex,
       );
@@ -44,17 +40,8 @@ export const useSendTokens = (): Asset[] => {
         imageSource = asset.image;
       }
 
-      let balanceInSelectedCurrency: string;
-      try {
-        balanceInSelectedCurrency = formatter(fiatBalance, {
-          shorten: true,
-        });
-      } catch (error) {
-        balanceInSelectedCurrency = `${fiatBalance.toFixed()} ${fiatCurrency}`;
-      }
       return {
         ...asset,
-        balanceInSelectedCurrency,
         image: imageSource,
         networkImage: chainNetworkNameAndImage?.networkImage,
         networkName: chainNetworkNameAndImage?.networkName,
@@ -62,7 +49,7 @@ export const useSendTokens = (): Asset[] => {
         standard: asset.isNative ? AssetStandard.Native : AssetStandard.ERC20,
       };
     });
-  }, [assetsWithBalance, chainNetworkNAmeAndImageMap, formatter]);
+  }, [assetsWithBalance, chainNetworkNAmeAndImageMap]);
 
   return useMemo(() => {
     return processedAssets.sort(

--- a/ui/pages/confirmations/types/send.ts
+++ b/ui/pages/confirmations/types/send.ts
@@ -1,4 +1,3 @@
-import BN from 'bn.js';
 import { Hex } from '@metamask/utils';
 
 export enum AssetStandard {
@@ -15,8 +14,7 @@ export type Asset = {
   accountId?: string;
   address?: string;
   assetId?: string;
-  balance?: BN | string | number | undefined;
-  balanceInSelectedCurrency?: string;
+  balance?: string | number | undefined;
   chainId?: string | number;
   collection?: {
     name?: string;


### PR DESCRIPTION
## **Description**

Updates the Send > Asset list fiat and token formatting to use the Intl shared formatters.

Part of the effort to align and consolidate number formatting across the wallet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36489?quickstart=1)

## **Changelog**

CHANGELOG entry: refactor send assets list fiat and token formatting

## **Related issues**

Fixes:

## **Manual testing steps**

1. Home screen > click Send
2. Observe Assets list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="338" height="133" alt="image" src="https://github.com/user-attachments/assets/d50d3c6f-3c1d-45a0-a282-9943ba55d3cd" />

### **After**

<img width="338" height="129" alt="image" src="https://github.com/user-attachments/assets/ba5ce963-1195-457d-ad78-cc67b155ba6a" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Send asset list to shared currency/token formatters, removes legacy per-item formatting, updates types/hooks/tests accordingly.
> 
> - **Send UI**:
>   - Use shared `useFormatters` in `ui/pages/confirmations/components/UI/asset/asset.tsx` to format fiat (`formatCurrencyWithMinThreshold`) and token amounts (`formatTokenQuantity`).
>   - Token display now reads from `asset.balance` and `asset.fiat` instead of `balanceInSelectedCurrency`/`shortenedBalance`.
> - **Hook**:
>   - `useSendTokens` removes `useFiatFormatter` and no longer computes `balanceInSelectedCurrency`; keeps sorting by `fiat.balance` and enriches assets with network/image data.
> - **Types**:
>   - Simplify `Asset.balance` to `string | number`; remove `balanceInSelectedCurrency`; drop `BN` import.
> - **Utils**:
>   - Remove unused `formatNumber` from `components/confirm/utils.ts`.
> - **Tests**:
>   - Update `asset.test.tsx` to use `renderWithProvider` and new asset shape; adjust expectations.
>   - Remove formatter-dependent tests in `useSendTokens.test.ts`; keep sorting/standards/network/image tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c68a3d77c957948c2b85f7d79982373bfc30990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->