### PR TITLE
fix: fix networks problems

### DIFF
--- a/app/scripts/controller-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/controller-init/assets/network-enablement-controller-init.ts
@@ -6,24 +6,27 @@ import { NetworkState } from '@metamask/network-controller';
 import { MultichainNetworkControllerState } from '@metamask/multichain-network-controller';
 import { NetworkEnablementControllerMessenger } from '../messengers/assets';
 import { ControllerInitFunction } from '../types';
-import { CHAIN_IDS } from '../../../../shared/constants/network';
+import {
+  CHAIN_IDS,
+  FEATURED_NETWORK_CHAIN_IDS,
+} from '../../../../shared/constants/network';
 
 /**
  * Generates a map of EVM chain IDs to their enabled status based on NetworkController state.
  *
  * @param networkConfigurationsByChainId - The network configurations from NetworkController
- * @param enabledChainId - The single chain ID that should be enabled
+ * @param enabledChainIds - Array of chain IDs that should be enabled
  * @returns Record mapping chain IDs to boolean enabled status
  */
 const generateEVMNetworkMap = (
   networkConfigurationsByChainId: NetworkState['networkConfigurationsByChainId'],
-  enabledChainId?: string,
+  enabledChainIds: string[] = [],
 ): Record<string, boolean> => {
   const networkMap: Record<string, boolean> = {};
 
   // Add all available EVM networks from NetworkController with default disabled status
   Object.keys(networkConfigurationsByChainId).forEach((chainId) => {
-    networkMap[chainId] = chainId === enabledChainId;
+    networkMap[chainId] = enabledChainIds.includes(chainId);
   });
 
   return networkMap;
@@ -77,10 +80,9 @@ const generateDefaultNetworkEnablementControllerState = (
   if (process.env.IN_TEST) {
     return {
       enabledNetworkMap: {
-        eip155: generateEVMNetworkMap(
-          networkConfigurationsByChainId,
+        eip155: generateEVMNetworkMap(networkConfigurationsByChainId, [
           CHAIN_IDS.LOCALHOST,
-        ),
+        ]),
         ...multichainMaps,
       },
     };
@@ -90,10 +92,9 @@ const generateDefaultNetworkEnablementControllerState = (
   ) {
     return {
       enabledNetworkMap: {
-        eip155: generateEVMNetworkMap(
-          networkConfigurationsByChainId,
+        eip155: generateEVMNetworkMap(networkConfigurationsByChainId, [
           CHAIN_IDS.SEPOLIA,
-        ),
+        ]),
         ...multichainMaps,
       },
     };
@@ -103,7 +104,7 @@ const generateDefaultNetworkEnablementControllerState = (
     enabledNetworkMap: {
       eip155: generateEVMNetworkMap(
         networkConfigurationsByChainId,
-        CHAIN_IDS.MAINNET,
+        FEATURED_NETWORK_CHAIN_IDS,
       ),
       ...multichainMaps,
     },

--- a/app/scripts/controller-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/controller-init/assets/network-enablement-controller-init.ts
@@ -20,7 +20,7 @@ import {
  */
 const generateEVMNetworkMap = (
   networkConfigurationsByChainId: NetworkState['networkConfigurationsByChainId'],
-  enabledChainIds: string[] = [],
+  enabledChainIds: string[],
 ): Record<string, boolean> => {
   const networkMap: Record<string, boolean> = {};
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -147,7 +147,6 @@ import { TokenStandard } from '../../shared/constants/transaction';
 import {
   CHAIN_IDS,
   CHAIN_SPEC_URL,
-  FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN,
   NetworkStatus,
   UNSUPPORTED_RPC_METHODS,
 } from '../../shared/constants/network';
@@ -1183,51 +1182,6 @@ export default class MetamaskController extends EventEmitter {
         }
       },
     );
-
-    // this.controllerMessenger.subscribe(
-    //   'NetworkController:networkAdded',
-    //   (payload) => {
-    //     const chainId = payload?.chainId;
-    //     console.log('NetworkController:networkAdded ...........', payload);
-    //     if (!chainId) {
-    //       console.warn('[networkAdded] Missing chainId in payload:', payload);
-    //       return;
-    //     }
-
-    //     const eip155Map =
-    //       this.networkEnablementController?.state?.enabledNetworkMap?.eip155 ??
-    //       {};
-
-    //     console.log('eip155Map ...........', eip155Map);
-
-    //     // Count how many EVM networks are currently enabled
-    //     const enabledCount = Object.values(eip155Map).filter(Boolean).length;
-
-    //     console.log('enabledCount ...........', enabledCount);
-
-    //     const isPopular =
-    //       FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN.includes(chainId);
-
-    //     console.log('isPopular ...........', isPopular);
-
-    //     // If the added network is "popular":
-    //     //  - when we already have >1 enabled, flip on all popular networks
-    //     //  - otherwise just enable the newly added network
-    //     if (isPopular) {
-    //       if (enabledCount > 1) {
-    //         console.log('enableAllPopularNetworks ...........');
-    //         this.networkEnablementController.enableAllPopularNetworks();
-    //         return;
-    //       }
-    //       console.log('enableNetwork ...........', chainId);
-    //       this.networkEnablementController.enableNetwork(chainId);
-    //       return;
-    //     }
-
-    //     // Non-featured: just enable the newly added network
-    //     this.networkEnablementController.enableNetwork(chainId);
-    //   },
-    // );
 
     this.controllerMessenger.subscribe(
       `OnboardingController:stateChange`,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -147,6 +147,7 @@ import { TokenStandard } from '../../shared/constants/transaction';
 import {
   CHAIN_IDS,
   CHAIN_SPEC_URL,
+  FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN,
   NetworkStatus,
   UNSUPPORTED_RPC_METHODS,
 } from '../../shared/constants/network';
@@ -1183,15 +1184,50 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
-    this.controllerMessenger.subscribe(
-      'NetworkController:networkAdded',
-      (state) => {
-        this.networkEnablementController.enableNetworkInNamespace(
-          state.chainId,
-          KnownCaipNamespace.Eip155,
-        );
-      },
-    );
+    // this.controllerMessenger.subscribe(
+    //   'NetworkController:networkAdded',
+    //   (payload) => {
+    //     const chainId = payload?.chainId;
+    //     console.log('NetworkController:networkAdded ...........', payload);
+    //     if (!chainId) {
+    //       console.warn('[networkAdded] Missing chainId in payload:', payload);
+    //       return;
+    //     }
+
+    //     const eip155Map =
+    //       this.networkEnablementController?.state?.enabledNetworkMap?.eip155 ??
+    //       {};
+
+    //     console.log('eip155Map ...........', eip155Map);
+
+    //     // Count how many EVM networks are currently enabled
+    //     const enabledCount = Object.values(eip155Map).filter(Boolean).length;
+
+    //     console.log('enabledCount ...........', enabledCount);
+
+    //     const isPopular =
+    //       FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN.includes(chainId);
+
+    //     console.log('isPopular ...........', isPopular);
+
+    //     // If the added network is "popular":
+    //     //  - when we already have >1 enabled, flip on all popular networks
+    //     //  - otherwise just enable the newly added network
+    //     if (isPopular) {
+    //       if (enabledCount > 1) {
+    //         console.log('enableAllPopularNetworks ...........');
+    //         this.networkEnablementController.enableAllPopularNetworks();
+    //         return;
+    //       }
+    //       console.log('enableNetwork ...........', chainId);
+    //       this.networkEnablementController.enableNetwork(chainId);
+    //       return;
+    //     }
+
+    //     // Non-featured: just enable the newly added network
+    //     this.networkEnablementController.enableNetwork(chainId);
+    //   },
+    // );
 
     this.controllerMessenger.subscribe(
       `OnboardingController:stateChange`,

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1599,6 +1599,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
         "@metamask/multichain-network-controller": true,
         "@metamask/utils": true,
         "reselect": true

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1599,6 +1599,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
         "@metamask/multichain-network-controller": true,
         "@metamask/utils": true,
         "reselect": true

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1599,6 +1599,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
         "@metamask/multichain-network-controller": true,
         "@metamask/utils": true,
         "reselect": true

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1599,6 +1599,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
         "@metamask/multichain-network-controller": true,
         "@metamask/utils": true,
         "reselect": true

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "@metamask/multichain-transactions-controller": "^5.0.0",
     "@metamask/name-controller": "^8.0.3",
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A24.1.0#~/.yarn/patches/@metamask-network-controller-npm-24.0.1-d913bfdf67.patch",
-    "@metamask/network-enablement-controller": "^1.2.0",
+    "@metamask/network-enablement-controller": "^2.1.0",
     "@metamask/notification-services-controller": "^18.1.0",
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/obs-store": "^9.0.0",

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -26,6 +26,7 @@ import {
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
+  getMultichainNetworkConfigurationsByChainId,
   getSelectedMultichainNetworkChainId,
 } from '../../../../../selectors/multichain/networks';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
@@ -107,6 +108,11 @@ const AssetListControlBar = ({
   const popoverRef = useRef<HTMLDivElement>(null);
   const useNftDetection = useSelector(getUseNftDetection);
   const currentMultichainNetwork = useSelector(getMultichainNetwork);
+  const multichainNetwork = useSelector(
+    getMultichainNetworkConfigurationsByChainId,
+  );
+  console.log('multichainNetwork ...........', multichainNetwork);
+  console.log('currentMultichainNetwork ...........', currentMultichainNetwork);
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
   const isTokenNetworkFilterEqualCurrentNetwork = useSelector(
     getIsTokenNetworkFilterEqualCurrentNetwork,
@@ -365,6 +371,11 @@ const AssetListControlBar = ({
       isGlobalNetworkSelectorRemoved &&
       Object.keys(allEnabledNetworksForAllNamespaces).length === 1
     ) {
+      console.log(
+        'allEnabledNetworksForAllNamespaces ...........',
+        allEnabledNetworksForAllNamespaces,
+        currentMultichainNetwork,
+      );
       const chainId = allEnabledNetworksForAllNamespaces[0];
       return isStrictHexString(chainId)
         ? (allNetworks[chainId]?.name ?? t('currentNetwork'))

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -26,7 +26,6 @@ import {
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
-  getMultichainNetworkConfigurationsByChainId,
   getSelectedMultichainNetworkChainId,
 } from '../../../../../selectors/multichain/networks';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
@@ -108,11 +107,6 @@ const AssetListControlBar = ({
   const popoverRef = useRef<HTMLDivElement>(null);
   const useNftDetection = useSelector(getUseNftDetection);
   const currentMultichainNetwork = useSelector(getMultichainNetwork);
-  const multichainNetwork = useSelector(
-    getMultichainNetworkConfigurationsByChainId,
-  );
-  console.log('multichainNetwork ...........', multichainNetwork);
-  console.log('currentMultichainNetwork ...........', currentMultichainNetwork);
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
   const isTokenNetworkFilterEqualCurrentNetwork = useSelector(
     getIsTokenNetworkFilterEqualCurrentNetwork,
@@ -371,11 +365,6 @@ const AssetListControlBar = ({
       isGlobalNetworkSelectorRemoved &&
       Object.keys(allEnabledNetworksForAllNamespaces).length === 1
     ) {
-      console.log(
-        'allEnabledNetworksForAllNamespaces ...........',
-        allEnabledNetworksForAllNamespaces,
-        currentMultichainNetwork,
-      );
       const chainId = allEnabledNetworksForAllNamespaces[0];
       return isStrictHexString(chainId)
         ? (allNetworks[chainId]?.name ?? t('currentNetwork'))

--- a/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
@@ -17,9 +17,6 @@ export const useAdditionalNetworkHandlers = () => {
 
       // First add the network to user's configuration
       await dispatch(addNetwork(network));
-
-      // Then enable it in the network list
-      await dispatch(setEnabledNetworks(network.chainId));
     },
     [dispatch],
   );

--- a/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useAdditionalNetworkHandlers.ts
@@ -1,11 +1,7 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { UpdateNetworkFields } from '@metamask/network-controller';
-import {
-  hideModal,
-  setEnabledNetworks,
-  addNetwork,
-} from '../../../../store/actions';
+import { hideModal, addNetwork } from '../../../../store/actions';
 
 export const useAdditionalNetworkHandlers = () => {
   const dispatch = useDispatch();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6955,19 +6955,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@metamask/network-enablement-controller@npm:1.2.0"
+"@metamask/network-enablement-controller@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/network-enablement-controller@npm:2.1.0"
   dependencies:
     "@metamask/base-controller": "npm:^8.4.0"
     "@metamask/controller-utils": "npm:^11.14.0"
-    "@metamask/utils": "npm:^11.8.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/utils": "npm:^11.8.1"
     reselect: "npm:^5.1.1"
   peerDependencies:
-    "@metamask/multichain-network-controller": ^0.11.0
+    "@metamask/multichain-network-controller": ^1.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/transaction-controller": ^60.0.0
-  checksum: 10/0c3a99a57cfb6da8258bacfd684bad26d627f5569d7575a9e8a480db857499b45968ab4da2604b1f91e1ccf5877d26a67221a74243fce857537d62d0a816735f
+  checksum: 10/5c956b358a1b130e5e37d50a7991a7487ec8ccdda2fe43a905c51c1dcc2d3b17135a7d7675b855d6a93eeda66b64aa3089b5e2431bac24396a54b144d9336f24
   languageName: node
   linkType: hard
 
@@ -32179,7 +32180,7 @@ __metadata:
     "@metamask/multichain-transactions-controller": "npm:^5.0.0"
     "@metamask/name-controller": "npm:^8.0.3"
     "@metamask/network-controller": "patch:@metamask/network-controller@npm%3A24.1.0#~/.yarn/patches/@metamask-network-controller-npm-24.0.1-d913bfdf67.patch"
-    "@metamask/network-enablement-controller": "npm:^1.2.0"
+    "@metamask/network-enablement-controller": "npm:^2.1.0"
     "@metamask/notification-services-controller": "npm:^18.1.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/obs-store": "npm:^9.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR mainly addresses two issues:
- When a popular network is added via a dapp or extension, if “All popular networks” is selected, the app should not switch networks automatically.
- During onboarding in production, the default selected network should be “All networks.”

**Reason for change:**  
Users were experiencing unexpected network switches when interacting with dapps/extensions, leading to a confusing UX. Additionally, the onboarding flow in production did not align with the intended behavior, as the default selection was not set to “All networks.”

**Improvement/Solution:**  
- Updated the network selection logic to prevent automatic switching when “All popular networks” is selected.  
- Updated onboarding configuration so that on production builds, the default selection is “All networks.”  

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36497?quickstart=1)

---

## **Changelog**

CHANGELOG entry:   Fixed an issue where adding a popular network via dapp/extension would incorrectly switch the network even when “All popular networks” was selected.  

---

## **Related issues**

Fixes: #36497  
<!-- Add any linked GitHub issues or Linear tickets if applicable -->

---

## **Manual testing steps**

1. Build and run the extension on production mode.  
2. Start the onboarding flow.  
   - **Expected:** The default selected network should be “All networks.”  
3. While “All popular networks” is selected, add a popular network via dapp/extension.  
   - **Expected:** The current network should not switch automatically.  
4. Confirm that manual switching between networks still works as expected.  

---

## **Screenshots/Recordings**

### **Before**
<!-- Add previous behavior screenshots if available -->

### **After**
<!-- Add updated behavior screenshots or short Loom/GIF -->

---

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

---

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches default enabled EVM networks to the featured list and removes auto-enabling when networks are added, updating controller logic, UI handler, policies, and dependency.
> 
> - **Networks**:
>   - **Default enablement**: `network-enablement-controller-init.ts` now enables multiple EVM networks via `FEATURED_NETWORK_CHAIN_IDS` (arrays passed in all envs; replaces single `MAINNET`).
>   - **No auto-enable on add**: Removed `NetworkController:networkAdded` subscription auto-enable in `metamask-controller.js` and dropped `setEnabledNetworks` dispatch in `useAdditionalNetworkHandlers`.
> - **Controllers/Logic**:
>   - `generateEVMNetworkMap` accepts `enabledChainIds: string[]` and callers updated (localhost/sepolia in tests, featured in prod).
> - **Dependencies/Policies**:
>   - Bump `@metamask/network-enablement-controller` to `^2.1.0` and add `@metamask/keyring-api` allowance in LavaMoat policies; update yarn.lock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba04c5c2020da53db25fb1ec8743a3c3e04aa6bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->