### PR TITLE
fix: add back cross_origin_opener_policy

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,5 +1,8 @@
 {
   "content_security_policy": "frame-ancestors 'none'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; font-src 'self';",
+  "cross_origin_opener_policy": {
+    "value": "same-origin-allow-popups"
+  },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -3,6 +3,9 @@
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none'; font-src 'self';",
     "sandbox": "sandbox allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval'; object-src 'none'; default-src 'none'; connect-src *; font-src 'self';"
   },
+  "cross_origin_opener_policy": {
+    "value": "same-origin-allow-popups"
+  },
   "externally_connectable": {
     "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -144,7 +144,16 @@ describe('Deep Link', function () {
           if (isInvalidRoute) {
             console.log('Getting error text for invalid route');
             const text = await deepLink.getDescriptionText();
-            assert.equal(text, "We can't find the page you are looking for.");
+            assert.equal(
+              text,
+              `We can't find the page you are looking for.${
+                isSigned
+                  ? `
+Update to the latest version of MetaMask
+and we'll take you to the right place.`
+                  : ''
+              }`,
+            );
           }
 
           console.log('Clicking continue button');

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import type { Mockttp } from 'mockttp';
-import { withFixtures } from '../../helpers';
+import { Browser } from 'selenium-webdriver';
+import { WINDOW_TITLES, withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import DeepLink from '../../page-objects/pages/deep-link-page';
 import LoginPage from '../../page-objects/pages/login-page';
@@ -17,6 +18,8 @@ import {
   signDeepLink,
   generateECDSAKeyPair,
 } from './helpers';
+
+const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
 
 type LocalNode = Ganache | Anvil;
 
@@ -141,16 +144,7 @@ describe('Deep Link', function () {
           if (isInvalidRoute) {
             console.log('Getting error text for invalid route');
             const text = await deepLink.getDescriptionText();
-            assert.equal(
-              text,
-              `We can't find the page you are looking for.${
-                isSigned
-                  ? `
-Update to the latest version of MetaMask
-and we'll take you to the right place.`
-                  : ''
-              }`,
-            );
+            assert.equal(text, "We can't find the page you are looking for.");
           }
 
           console.log('Clicking continue button');
@@ -420,6 +414,74 @@ and we'll take you to the right place.`
         // make sure the home page has loaded!
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
+      },
+    );
+  });
+
+  it('handles dapps that open MM via window.open', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        // use our dummy page to drive the new window
+        await driver.openNewURL(TEST_PAGE);
+
+        const dappWindowHandle = await driver.driver.getWindowHandle();
+        // simulate a dapp calling `window.open('https://link.metamask.io/home')`
+        const windowOpened = await driver.executeScript(
+          `
+          globalThis.testWindow = window.open('https://link.metamask.io/home', '_blank');
+          return globalThis.testWindow != null;
+          `,
+        );
+        assert.strictEqual(windowOpened, true, 'window.open failed');
+
+        driver.delay(1000); // give the window a second to open
+
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        const metamaskWindowHandle = await driver.driver.getWindowHandle();
+
+        // wait for the homepage to load in this new window
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        const initialUrlStr = await driver.getCurrentUrl();
+        const initialUrl = new URL(initialUrlStr);
+        assert.equal(initialUrl.pathname, `/home.html`);
+        assert.equal(initialUrl.hash, '#link?u=%2Fhome');
+        assert.equal(initialUrl.search, '');
+
+        await driver.switchToWindow(dappWindowHandle);
+
+        const hackUrl = new URL(initialUrl);
+        hackUrl.hash = '#notifications';
+        // if we are testing Firefox, make sure `testWindow` is unset, FF
+        // doesn't allow cross-origin access to the extension's window by
+        // default
+        if (isFirefox) {
+          // globalThis.testWindow is unset in Firefox. Neat!
+          await driver.executeScript(`return globalThis.testWindow == null;`);
+        } else {
+          // on chrome, the location change is ignored due to the
+          // `cross_origin_opener_policy` set in the manifest.json
+          await driver.executeScript(
+            `globalThis.testWindow.location.href = ${JSON.stringify(hackUrl)};`,
+          );
+        }
+
+        // go back to the Metamask window.
+        await driver.switchToWindow(metamaskWindowHandle);
+
+        const finalUrlStr = await driver.getCurrentUrl();
+        assert.equal(finalUrlStr, initialUrlStr);
       },
     );
   });


### PR DESCRIPTION
## **Description**

Put back the security fix added here https://github.com/MetaMask/metamask-extension/pull/35922 as the previous one was breaking some hardware wallet communication.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36500?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: increase our security posture by locking down `cross_origin_opener_policy` to `same-origin-allow-popups` openers only.


## **Manual testing steps**

1. Add a new hardware wallet account
2. Select either Lattice or Trezor type and connect device
3. Check that account list is still displayed


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores `cross_origin_opener_policy` in Chrome manifests and adds an e2e test validating deep-link handling when dapps open MetaMask via `window.open`.
> 
> - **Security/Manifest**:
>   - Add `cross_origin_opener_policy: { value: "same-origin-allow-popups" }` to `app/manifest/v2/chrome.json` and `app/manifest/v3/chrome.json`.
> - **E2E Tests (deep link)**:
>   - New test `handles dapps that open MM via window.open` in `test/e2e/tests/deep-link/deep-link.spec.ts`:
>     - Simulates `window.open('https://link.metamask.io/home')`, verifies extension window loads and URL cannot be altered; includes Firefox-specific handling.
>   - Imports updated to use `Browser` and `WINDOW_TITLES`; introduces `isFirefox` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e1456f5d5962e353cdf4aabf5e3d3297a715500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->