### PR TITLE
fix: update migration 105.ts to keep internal account scopes

### DIFF
--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -71,6 +71,7 @@ function expectedInternalAccount(
     options: {},
     methods: ETH_EOA_METHODS,
     type: 'eip155:eoa',
+    scopes: ['eip155:0'],
   };
 }
 

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -1,4 +1,4 @@
-import { EthAccountType } from '@metamask/keyring-api';
+import { EthAccountType, EthScope } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { sha256FromString } from 'ethereumjs-util';
 import { v4 as uuid } from 'uuid';
@@ -17,8 +17,11 @@ export type Identity = {
 };
 
 // The `InternalAccount` has been updated with `@metamask/keyring-api@13.0.0`, so we
-// omit the new field to re-use the original type for that migration.
-export type InternalAccountV1 = Omit<InternalAccount, 'scopes'>;
+// re-use the original types for this migration.
+export type InternalAccountV1 = Pick<
+  InternalAccount,
+  'address' | 'id' | 'options' | 'metadata' | 'methods' | 'type' | 'scopes'
+>;
 
 export const version = 105;
 
@@ -112,6 +115,7 @@ function createInternalAccountsForAccountsController(
       },
       methods: ETH_EOA_METHODS,
       type: EthAccountType.Eoa,
+      scopes: [EthScope.Eoa],
     };
   });
 

--- a/shared/modules/selectors/networks.ts
+++ b/shared/modules/selectors/networks.ts
@@ -133,7 +133,7 @@ export const getNetworkConfigurationsByCaipChainId = ({
     ([caipChainId, networkConfig]) => {
       const matchesAccount = Object.values(internalAccounts.accounts).some(
         (account) => {
-          const matchesScope = account.scopes?.some((scope) => {
+          const matchesScope = account.scopes.some((scope) => {
             return scope === caipChainId;
           });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Uncovered when running E2E tests. It seems that this 105.ts migration ended up removing/not adding the `scopes` property on our internal accounts.

This ensures we add back the scopes property.

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/0ed66cf144c140fc84868d95e3500bb8?sid=20a77514-b5b6-40fe-9e3b-7a245955914d

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
