### PR TITLE
fix: network manager default tab behaviour

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -1,6 +1,6 @@
 import type { AddNetworkFields } from '@metamask/network-controller';
 import { RpcEndpointType } from '@metamask/network-controller';
-import { BtcScope, SolScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { capitalize, pick } from 'lodash';
 import { Hex, hexToNumber } from '@metamask/utils';
 import { MultichainNetworks } from './multichain/networks';
@@ -1504,6 +1504,7 @@ export const FEATURED_NETWORK_CHAIN_IDS = [
 export const FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN = [
   SolScope.Mainnet,
   BtcScope.Mainnet,
+  TrxScope.Mainnet,
   CHAIN_IDS.MAINNET,
   ...FEATURED_RPCS.map((rpc) => rpc.chainId),
 ];

--- a/ui/components/multichain/network-manager/hooks/useNetworkManagerState.test.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkManagerState.test.ts
@@ -32,18 +32,20 @@ describe('useNetworkManagerInitialTab() tests', () => {
       expectedTab: 'networks',
     },
     {
-      scenario: 'some enabled networks are not featured',
-      enabledNetworks: ['eip155:1', 'eip155:137', 'eip155:999'],
-      expectedTab: 'custom-networks',
-    },
-    {
-      scenario: 'all enabled networks are non-featured',
-      enabledNetworks: ['eip155:999', 'eip155:1000'],
+      scenario: 'enable network is non-featured',
+      enabledNetworks: ['eip155:999'],
       expectedTab: 'custom-networks',
     },
     {
       scenario: 'no networks are enabled (empty subset)',
       enabledNetworks: [],
+      expectedTab: 'networks',
+    },
+    {
+      scenario: 'more than 1 network selected should defaults to popular',
+      // contains an unknown chain, but defaulting to popular tab
+      // this should never happen, but better to default to popular tab than custom tab
+      enabledNetworks: ['eip155:1', 'eip155:137', 'eip155:999'],
       expectedTab: 'networks',
     },
   ];

--- a/ui/components/multichain/network-manager/hooks/useNetworkManagerState.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkManagerState.ts
@@ -114,7 +114,12 @@ export const useNetworkManagerInitialTab = () => {
     getAllEnabledNetworksForAllNamespaces,
   );
 
-  const initialTab = useMemo(() => {
+  const initialTab: 'networks' | 'custom-networks' = useMemo(() => {
+    // Default - if more than 1 network selected, this must be a popular network button pressed
+    if (allEnabledNetworksForAllNamespaces.length > 1) {
+      return 'networks';
+    }
+
     const isSubset = (subset: string[], superset: string[]) => {
       const supersetSet = new Set(superset);
       return subset.every((x) => supersetSet.has(x));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The addition of TRON broke the popular networks subset (which has been fixed by extending the constants).
I've also made the condition a little looser as the only time a user can have more than 1 network enabled is on popular networks view.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36519?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click popular networks & close network manager
2. Open network manager
3. Expected - should be on popular tab, not custom tab.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TRON to featured multichain IDs and updates initial tab logic to default to Popular when multiple networks are enabled; adjusts tests accordingly.
> 
> - **Shared constants**:
>   - Add `TrxScope` import and include `TrxScope.Mainnet` in `FEATURED_NETWORK_CHAIN_IDS_MULTICHAIN`.
> - **Network Manager (hook)**:
>   - Update `useNetworkManagerInitialTab` to return `"networks"` when more than one network is enabled; types `initialTab` explicitly.
> - **Tests**:
>   - Revise scenarios in `useNetworkManagerState.test.ts` to reflect new defaulting behavior and single non-featured selection mapping to `"custom-networks"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f432f2037d1e12c11bf3fe8873c75a9ea6ce8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->