### PR TITLE
fix: code to check send redesigned flag

### DIFF
--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.test.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.test.ts
@@ -1,4 +1,3 @@
-import { ENVIRONMENT } from '../../../../development/build/constants';
 import mockState from '../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
@@ -30,38 +29,7 @@ describe('useRedesignedSendFlow', () => {
     return result.current;
   };
 
-  it('returns enabled false when development environment override is not active', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'false';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: false },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
-  it('returns enabled false when not in development environment', () => {
-    process.env.SEND_REDESIGN_ENABLED = 'true';
-    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
-
-    mockGetRemoteFeatureFlags.mockReturnValue({
-      sendRedesign: { enabled: false },
-    });
-    mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-
-    const result = renderHook();
-
-    expect(result).toEqual({ enabled: false });
-  });
-
   it('returns enabled true when feature flag is enabled and multichain accounts are enabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: { enabled: true },
     });
@@ -73,9 +41,6 @@ describe('useRedesignedSendFlow', () => {
   });
 
   it('returns enabled false when feature flag is enabled but multichain accounts are disabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: { enabled: true },
     });
@@ -87,9 +52,6 @@ describe('useRedesignedSendFlow', () => {
   });
 
   it('returns enabled false when feature flag is disabled', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: { enabled: false },
     });
@@ -100,22 +62,16 @@ describe('useRedesignedSendFlow', () => {
     expect(result).toEqual({ enabled: false });
   });
 
-  it('returns enabled false when feature flag is undefined', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
+  it('returns enabled true when feature flag is undefined', () => {
     mockGetRemoteFeatureFlags.mockReturnValue({});
     mockGetIsMultichainAccountsState2Enabled.mockReturnValue(true);
 
     const result = renderHook();
 
-    expect(result).toEqual({ enabled: false });
+    expect(result).toEqual({ enabled: true });
   });
 
-  it('returns enabled false when remote feature flags is null', () => {
-    delete process.env.SEND_REDESIGN_ENABLED;
-    delete process.env.METAMASK_ENVIRONMENT;
-
+  it('returns enabled true when remote feature flags is null', () => {
     mockGetRemoteFeatureFlags.mockReturnValue({
       sendRedesign: null,
     });
@@ -123,6 +79,6 @@ describe('useRedesignedSendFlow', () => {
 
     const result = renderHook();
 
-    expect(result).toEqual({ enabled: false });
+    expect(result).toEqual({ enabled: true });
   });
 });

--- a/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
+++ b/ui/pages/confirmations/hooks/useRedesignedSendFlow.ts
@@ -17,7 +17,10 @@ export const useRedesignedSendFlow = () => {
   const { enabled: isSendRedesignEnabled } = (sendRedesignFeatureFlag ??
     {}) as SendRedesignFeatureFlag;
 
-  if (!isSendRedesignEnabled || !isMultichainAccountsState2Enabled) {
+  if (
+    isSendRedesignEnabled === false ||
+    isMultichainAccountsState2Enabled === false
+  ) {
     return {
       enabled: false,
     };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improvement in check for new send designs

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36310

## **Manual testing steps**

1. Trigger send flow
2. It should open new designs
3.

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redesigned send flow now defaults to enabled unless `sendRedesign.enabled` or multichain flag are explicitly false, with tests updated accordingly.
> 
> - **Hook `useRedesignedSendFlow`**:
>   - Change logic to disable only when `sendRedesign.enabled === false` or multichain accounts flag is `false`; otherwise returns `enabled: true` (undefined now treated as enabled).
> - **Tests**:
>   - Remove environment override scenarios.
>   - Update expectations so undefined or null `sendRedesign` yields `enabled: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3c2da2e21a8ff5092f5eab1e48e2d70ebdf61b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->