### PR TITLE
feat: Add privacy mode feature to multichain accounts

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -162,4 +162,21 @@ describe('MultichainAccountCell', () => {
       ),
     ).not.toBeInTheDocument();
   });
+
+  it('hides balance value when privacy mode is enabled', () => {
+    const props = {
+      ...defaultProps,
+      privacyMode: true,
+    };
+
+    renderWithProvider(<MultichainAccountCell {...props} />, store);
+
+    expect(screen.queryByText('$2,400.00')).not.toBeInTheDocument();
+
+    const balanceContainer = screen.getByTestId('balance-display');
+
+    expect(balanceContainer).toBeInTheDocument();
+    expect(balanceContainer.textContent).not.toContain('$2,400.00');
+    expect(balanceContainer.textContent).toMatch(/^[•]+$/u);
+  });
 });

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import { getIconSeedAddressByAccountGroupId } from '../../../selectors/multichain-accounts/account-tree';
-import { Box, Text } from '../../component-library';
+import { Box, SensitiveText, Text } from '../../component-library';
 import { PreferredAvatar } from '../../app/preferred-avatar';
 import {
   AlignItems,
@@ -25,6 +25,7 @@ export type MultichainAccountCellProps = {
   selected?: boolean;
   walletName?: string;
   disableHoverEffect?: boolean;
+  privacyMode?: boolean;
 };
 
 export const MultichainAccountCell = ({
@@ -37,6 +38,7 @@ export const MultichainAccountCell = ({
   selected = false,
   walletName,
   disableHoverEffect = false,
+  privacyMode = false,
 }: MultichainAccountCellProps) => {
   const handleClick = () => onClick?.(accountId);
   const seedAddressIcon = useSelector((state) =>
@@ -128,7 +130,9 @@ export const MultichainAccountCell = ({
           variant={TextVariant.bodyMdMedium}
           marginRight={2}
         >
-          {balance}
+          <SensitiveText ellipsis isHidden={privacyMode}>
+            {balance}
+          </SensitiveText>
         </Text>
         <Box
           className="multichain-account-cell__end_accessory"

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -124,16 +124,16 @@ export const MultichainAccountCell = ({
         justifyContent={JustifyContent.center}
         style={{ flexShrink: 0 }}
       >
-        <Text
+        <SensitiveText
           className="multichain-account-cell__account-balance"
           data-testid="balance-display"
           variant={TextVariant.bodyMdMedium}
           marginRight={2}
+          isHidden={privacyMode}
+          ellipsis
         >
-          <SensitiveText ellipsis isHidden={privacyMode}>
-            {balance}
-          </SensitiveText>
-        </Text>
+          {balance}
+        </SensitiveText>
         <Box
           className="multichain-account-cell__end_accessory"
           display={Display.Flex}

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -38,6 +38,7 @@ import {
 import {
   getDefaultHomeActiveTabName,
   getHDEntropyIndex,
+  getPreferences,
 } from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { MultichainAccountMenu } from '../multichain-account-menu';
@@ -72,6 +73,7 @@ export const MultichainAccountList = ({
   const { formatCurrencyWithMinThreshold } = useFormatters();
   const allBalances = useSelector(selectBalanceForAllWallets);
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
+  const { privacyMode } = useSelector(getPreferences);
 
   useEffect(() => {
     endTrace({ name: TraceName.AccountList });
@@ -190,6 +192,7 @@ export const MultichainAccountList = ({
                     groupId as AccountGroupId,
                   )}
                   onClick={handleAccountClickToUse}
+                  privacyMode={privacyMode}
                   startAccessory={
                     showAccountCheckbox ? (
                       <Box marginRight={4}>
@@ -251,6 +254,7 @@ export const MultichainAccountList = ({
     allBalances,
     formatCurrencyWithMinThreshold,
     selectedAccountGroupsSet,
+    privacyMode,
     showAccountCheckbox,
     handleAccountRenameAction,
     handleMenuToggle,

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -178,14 +178,10 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                     style="flex-shrink: 0;"
                   >
                     <p
-                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
+                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-text--ellipsis mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      <p
-                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
-                      >
-                        0.00
-                      </p>
+                      0.00
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"
@@ -424,14 +420,10 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                     style="flex-shrink: 0;"
                   >
                     <p
-                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
+                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-text--ellipsis mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      <p
-                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
-                      >
-                        0.00
-                      </p>
+                      0.00
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"
@@ -670,14 +662,10 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                     style="flex-shrink: 0;"
                   >
                     <p
-                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
+                      class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-text--ellipsis mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      <p
-                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
-                      >
-                        0.00
-                      </p>
+                      0.00
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -181,7 +181,11 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                       class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      0.00
+                      <p
+                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
+                      >
+                        0.00
+                      </p>
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"
@@ -423,7 +427,11 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                       class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      0.00
+                      <p
+                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
+                      >
+                        0.00
+                      </p>
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"
@@ -665,7 +673,11 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                       class="mm-box mm-text multichain-account-cell__account-balance mm-text--body-md-medium mm-box--margin-right-2 mm-box--color-text-default"
                       data-testid="balance-display"
                     >
-                      0.00
+                      <p
+                        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default"
+                      >
+                        0.00
+                      </p>
                     </p>
                     <div
                       aria-label="Test Account Group 1 options"

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
@@ -152,14 +152,14 @@ export const WalletDetailsPage = () => {
             >
               {t('balance')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.bodyMdMedium}
               color={TextColor.textAlternative}
+              isHidden={privacyMode}
+              ellipsis
             >
-              <SensitiveText ellipsis isHidden={privacyMode}>
-                {walletTotalBalance ?? '$ n/a'}
-              </SensitiveText>
-            </Text>
+              {walletTotalBalance ?? '$ n/a'}
+            </SensitiveText>
           </Box>
           {isEntropyWallet ? (
             <MultichainSrpBackup

--- a/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
+++ b/ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx
@@ -12,6 +12,7 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
+  SensitiveText,
   Text,
 } from '../../../components/component-library';
 import {
@@ -40,6 +41,7 @@ import {
   useSingleWalletAccountsBalanceCallback,
   useSingleWalletDisplayBalance,
 } from '../../../hooks/multichain-accounts/useWalletBalance';
+import { getPreferences } from '../../../selectors';
 
 export const WalletDetailsPage = () => {
   const t = useI18nContext();
@@ -53,6 +55,7 @@ export const WalletDetailsPage = () => {
 
   const walletTotalBalance = useSingleWalletDisplayBalance(walletId);
   const walletAccountBalance = useSingleWalletAccountsBalanceCallback(walletId);
+  const { privacyMode } = useSelector(getPreferences);
 
   useEffect(() => {
     if (!wallet) {
@@ -83,9 +86,10 @@ export const WalletDetailsPage = () => {
           accountName={group.metadata.name}
           balance={walletAccountBalance(group.id) ?? ''}
           disableHoverEffect={true}
+          privacyMode={privacyMode}
         />
       )),
-    [multichainAccounts, walletAccountBalance],
+    [multichainAccounts, privacyMode, walletAccountBalance],
   );
 
   const walletDetailsTitle = useMemo(() => {
@@ -152,7 +156,9 @@ export const WalletDetailsPage = () => {
               variant={TextVariant.bodyMdMedium}
               color={TextColor.textAlternative}
             >
-              {walletTotalBalance ?? '$ n/a'}
+              <SensitiveText ellipsis isHidden={privacyMode}>
+                {walletTotalBalance ?? '$ n/a'}
+              </SensitiveText>
             </Text>
           </Box>
           {isEntropyWallet ? (


### PR DESCRIPTION
## **Description**
This PR adds privacy mode feature for new multichain accounts components.

Notes:
- Privacy mode is enabled from the home screen by clicking on the `eye` icon.
- Once enabled on home page, privacy mode will be enabled in account list and wallet details page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36524?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added privacy mode feature for multichain accounts

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1125

## **Manual testing steps**
1. Open extension with multichain accounts enabled.
2. Click on the `eye` icon right to the balance display for the currently selected account.
3. Balance should be hidden. Dots are displayed instead of the real values.
4. Go to the account list and confirm that the real balances are now replaced with dots.
5. Go to the wallet details page and also confirm that the balances are now replaced with dots.
6. Go back to the home page and disable privacy mode by clicking on the `eye` icon again.
7. Make sure that normal balance display have returned to home, account list and wallet details page.

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/d15908b5-900d-4bc4-a145-987a97f00089

### **After**

https://github.com/user-attachments/assets/74ee67aa-6228-447f-83c4-43a00de62b72

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds privacy-mode-controlled hiding of account and wallet balances using SensitiveText across multichain account list and wallet details.
> 
> - **UI/Accounts**:
>   - Multichain balances now respect privacy mode.
>     - `MultichainAccountCell`: add `privacyMode` prop; render balance with `SensitiveText` (`isHidden` + `ellipsis`) in `ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx`.
>     - Wire `privacyMode` from preferences via `getPreferences` in `ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx` and pass to `MultichainAccountCell`.
>     - Wallet details balance row uses `SensitiveText` with `isHidden` from preferences in `ui/pages/multichain-accounts/wallet-details-page/wallet-details-page.tsx`; also passes `privacyMode` to account cells.
> - **Tests**:
>   - Add test to verify balance is hidden when `privacyMode` is enabled in `multichain-account-cell.test.tsx`.
>   - Update snapshots to reflect `SensitiveText` (ellipsis) on balance display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3741f617b31d33c7db412efc249ffeb3eccdd3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->