### PR TITLE
chore: bump `@metamask/multichain-account-service` to `^1.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "@metamask/message-manager": "^13.0.0",
     "@metamask/message-signing-snap": "1.1.3",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/multichain-account-service": "^1.4.0",
+    "@metamask/multichain-account-service": "^1.5.0",
     "@metamask/multichain-api-client": "^0.7.0",
     "@metamask/multichain-api-middleware": "1.1.0",
     "@metamask/multichain-network-controller": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6764,9 +6764,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@metamask/multichain-account-service@npm:1.4.0"
+"@metamask/multichain-account-service@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@metamask/multichain-account-service@npm:1.5.0"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/base-controller": "npm:^8.4.0"
@@ -6788,7 +6788,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/d5d3f8c6ddbaf05447009a351a1265ae0873f472dceecda6f6bd6be56c9987f3dfa5e6c26038d772aae0289c19086a61eeec7871f451c5e318b6d284447b7524
+  checksum: 10/3b909a987fce2ccb6a8ebd4338da385d43909a8158fc63b2acd759188b731439d0ce1ab4b81030485e0d114c67b7b07873cfebd337d1de5b9847780fba6c4e9c
   languageName: node
   linkType: hard
 
@@ -32173,7 +32173,7 @@ __metadata:
     "@metamask/message-manager": "npm:^13.0.0"
     "@metamask/message-signing-snap": "npm:1.1.3"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^1.4.0"
+    "@metamask/multichain-account-service": "npm:^1.5.0"
     "@metamask/multichain-api-client": "npm:^0.7.0"
     "@metamask/multichain-api-middleware": "npm:1.1.0"
     "@metamask/multichain-network-controller": "npm:^1.0.0"


### PR DESCRIPTION
## **Description**

This PR bumps @metamask/multichain-account-service to ^1.5.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36525?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1126

## **Manual testing steps**

No manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `@metamask/multichain-account-service` from `^1.4.0` to `^1.5.0` and updates the lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 625c861bca974fa19e293437e2fae0a6ecf2f62b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->