### PR TITLE
fix: Fix send flow metrics

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -789,6 +789,7 @@ export enum MetaMetricsEventName {
   RpcServiceUnavailable = 'RPC Service Unavailable',
   SecretRecoveryPhrasePickerClicked = 'Secret Recovery Phrase Picker Clicked',
   SettingsUpdated = 'Settings Updated',
+  SendStarted = 'Send Started',
   SignatureApproved = 'Signature Approved',
   SignatureFailed = 'Signature Failed',
   SignatureRejected = 'Signature Rejected',

--- a/test/data/send/assets.ts
+++ b/test/data/send/assets.ts
@@ -21,7 +21,6 @@ export const EVM_NATIVE_ASSET = {
 };
 
 export const SOLANA_NATIVE_ASSET = {
-  address: '0x0000000000000000000000000000000000000000',
   assetId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
   aggregators: [],
   balance: '400',

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -257,7 +257,7 @@ const CoinButtons = ({
   const handleSendOnClick = useCallback(async () => {
     trackEvent(
       {
-        event: MetaMetricsEventName.NavSendButtonClicked,
+        event: MetaMetricsEventName.SendStarted,
         category: MetaMetricsEventCategory.Navigation,
         properties: {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -525,7 +525,7 @@ describe('EthOverview', () => {
     expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     expect(mockTrackEvent).toHaveBeenCalledWith(
       {
-        event: MetaMetricsEventName.NavSendButtonClicked,
+        event: MetaMetricsEventName.SendStarted,
         category: MetaMetricsEventCategory.Navigation,
         properties: {
           account_type: mockEvmAccount1.type,

--- a/ui/components/app/wallet-overview/non-evm-overview.test.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.test.tsx
@@ -423,7 +423,7 @@ describe('NonEvmOverview', () => {
     expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     expect(mockTrackEvent).toHaveBeenCalledWith(
       {
-        event: MetaMetricsEventName.NavSendButtonClicked,
+        event: MetaMetricsEventName.SendStarted,
         category: MetaMetricsEventCategory.Navigation,
         properties: {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
@@ -13,6 +13,7 @@ import * as AmountValidation from '../../../hooks/send/useAmountValidation';
 import * as SendActions from '../../../hooks/send/useSendActions';
 import * as SendContext from '../../../context/send';
 import * as RecipientValidation from '../../../hooks/send/useRecipientValidation';
+import * as RecipientSelectionMetrics from '../../../hooks/send/metrics/useRecipientSelectionMetrics';
 import { AmountRecipient } from './amount-recipient';
 
 const MOCK_ADDRESS = '0xdB055877e6c13b6A6B25aBcAA29B393777dD0a73';
@@ -64,6 +65,7 @@ describe('AmountRecipient', () => {
       handleSubmit: mockHandleSubmit,
     } as unknown as ReturnType<typeof SendActions.useSendActions>);
     const mockCaptureAmountSelected = jest.fn();
+    const mockCaptureRecipientSelected = jest.fn();
     jest
       .spyOn(AmountSelectionMetrics, 'useAmountSelectionMetrics')
       .mockReturnValue({
@@ -71,7 +73,14 @@ describe('AmountRecipient', () => {
       } as unknown as ReturnType<
         typeof AmountSelectionMetrics.useAmountSelectionMetrics
       >);
-
+    jest
+      .spyOn(RecipientSelectionMetrics, 'useRecipientSelectionMetrics')
+      .mockReturnValue({
+        captureRecipientSelected: mockCaptureRecipientSelected,
+        setRecipientInputMethodManual: jest.fn(),
+      } as unknown as ReturnType<
+        typeof RecipientSelectionMetrics.useRecipientSelectionMetrics
+      >);
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       toResolved: MOCK_ADDRESS,
       asset: EVM_ASSET,
@@ -108,6 +117,7 @@ describe('AmountRecipient', () => {
     fireEvent.click(getByText('Continue'));
     expect(mockHandleSubmit).toHaveBeenCalled();
     expect(mockCaptureAmountSelected).toHaveBeenCalled();
+    expect(mockCaptureRecipientSelected).toHaveBeenCalled();
   });
 
   it('in case of error in amount submit button displays error and is disabled', async () => {

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
@@ -18,6 +18,7 @@ import { useAmountSelectionMetrics } from '../../../hooks/send/metrics/useAmount
 import { useSendActions } from '../../../hooks/send/useSendActions';
 import { useSendContext } from '../../../context/send';
 import { useRecipientValidation } from '../../../hooks/send/useRecipientValidation';
+import { useRecipientSelectionMetrics } from '../../../hooks/send/metrics/useRecipientSelectionMetrics';
 import { SendHero } from '../../UI/send-hero';
 import { Amount } from '../amount/amount';
 import { Recipient } from '../recipient';
@@ -30,6 +31,7 @@ export const AmountRecipient = () => {
   const { asset, toResolved } = useSendContext();
   const { handleSubmit } = useSendActions();
   const { captureAmountSelected } = useAmountSelectionMetrics();
+  const { captureRecipientSelected } = useRecipientSelectionMetrics();
   const recipientValidationResult = useRecipientValidation();
 
   const hasError =
@@ -41,7 +43,8 @@ export const AmountRecipient = () => {
   const onClick = useCallback(() => {
     handleSubmit();
     captureAmountSelected();
-  }, [captureAmountSelected, handleSubmit]);
+    captureRecipientSelected();
+  }, [captureAmountSelected, captureRecipientSelected, handleSubmit]);
 
   if (!asset) {
     return <LoadingScreen />;

--- a/ui/pages/confirmations/components/send/recipient-input/recipient-input.test.tsx
+++ b/ui/pages/confirmations/components/send/recipient-input/recipient-input.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import configureStore from '../../../../../store/store';
 import mockState from '../../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
@@ -28,6 +29,7 @@ describe('RecipientInput', () => {
   const mockSetRecipientInputMethodManual = jest.fn();
   const mockSetRecipientInputMethodSelectContact = jest.fn();
   const mockSetRecipientInputMethodSelectAccount = jest.fn();
+  const mockSetRecipientInputMethodPasted = jest.fn();
 
   const mockStore = configureStore(mockState);
 
@@ -70,6 +72,7 @@ describe('RecipientInput', () => {
         mockSetRecipientInputMethodSelectContact,
       setRecipientInputMethodSelectAccount:
         mockSetRecipientInputMethodSelectAccount,
+      setRecipientInputMethodPasted: mockSetRecipientInputMethodPasted,
     } as unknown as ReturnType<typeof useRecipientSelectionMetrics>);
     mockUseSendContext.mockReturnValue({
       to: '',
@@ -118,21 +121,6 @@ describe('RecipientInput', () => {
 
     fireEvent.click(getByTestId('open-recipient-modal-btn'));
     expect(mockOpenRecipientModal).toHaveBeenCalled();
-  });
-
-  it('captures metrics on input blur when to value exists', () => {
-    mockUseSendContext.mockReturnValue({
-      to: '0x1234567890abcdef',
-      updateTo: mockUpdateTo,
-      updateToResolved: jest.fn(),
-    } as unknown as ReturnType<typeof useSendContext>);
-
-    const { getByRole } = renderComponent();
-    const input = getByRole('textbox');
-
-    fireEvent.blur(input);
-
-    expect(mockCaptureRecipientSelected).toHaveBeenCalledTimes(1);
   });
 
   it('renders clear button when to has no error', () => {
@@ -190,5 +178,41 @@ describe('RecipientInput', () => {
 
     expect(getByText('0x1234567890abcdefghijk')).toBeInTheDocument();
     expect(queryByText('0x1234567890abcdefghijkl')).toBeNull();
+  });
+
+  describe('metrics', () => {
+    it('sets recipient input method to manual', async () => {
+      mockUseSendContext.mockReturnValue({
+        to: '0x1234567890abcdef',
+        updateTo: mockUpdateTo,
+        updateToResolved: jest.fn(),
+      } as unknown as ReturnType<typeof useSendContext>);
+
+      const { getByRole } = renderComponent();
+      const input = getByRole('textbox');
+      input.focus();
+
+      // Type a single digit
+      await userEvent.type(input, '0');
+      // Verify that the mock was called
+      expect(mockSetRecipientInputMethodManual).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets recipient input method to pasted', async () => {
+      mockUseSendContext.mockReturnValue({
+        to: '0x1234567890abcdef',
+        updateTo: mockUpdateTo,
+        updateToResolved: jest.fn(),
+      } as unknown as ReturnType<typeof useSendContext>);
+
+      const { getByRole } = renderComponent();
+      const input = getByRole('textbox');
+      input.focus();
+
+      // Paste the address
+      await userEvent.paste('0x1234567890abcdef');
+      // Verify that the mock was called
+      expect(mockSetRecipientInputMethodPasted).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
+++ b/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
@@ -42,11 +42,8 @@ export const RecipientInput = ({
   recipientInputRef: React.RefObject<HTMLInputElement>;
   recipientValidationResult: ReturnType<typeof useRecipientValidation>;
 }) => {
-  const {
-    captureRecipientSelected,
-    setRecipientInputMethodManual,
-    setRecipientInputMethodPasted,
-  } = useRecipientSelectionMetrics();
+  const { setRecipientInputMethodManual, setRecipientInputMethodPasted } =
+    useRecipientSelectionMetrics();
   const recipients = useRecipients();
   const t = useI18nContext();
   const { to, updateTo } = useSendContext();
@@ -58,18 +55,18 @@ export const RecipientInput = ({
   } = recipientValidationResult;
 
   const onToChange = useCallback(
-    (address: string) => {
-      updateTo(address);
-      setRecipientInputMethodManual();
-    },
-    [updateTo, setRecipientInputMethodManual],
-  );
+    (e) => {
+      if (e.nativeEvent.inputType === 'insertFromPaste') {
+        setRecipientInputMethodPasted();
+      } else {
+        setRecipientInputMethodManual();
+      }
 
-  const captureRecipientSelectedEvent = useCallback(() => {
-    if (to) {
-      captureRecipientSelected();
-    }
-  }, [captureRecipientSelected, to]);
+      const address = e.target.value;
+      updateTo(address);
+    },
+    [updateTo, setRecipientInputMethodManual, setRecipientInputMethodPasted],
+  );
 
   const clearRecipient = useCallback(() => {
     updateTo('');
@@ -122,7 +119,7 @@ export const RecipientInput = ({
                 />
               ) : (
                 <Text variant={TextVariant.bodyMd}>
-                  (recipientName ?? resolvedAddress)
+                  {recipientName ?? resolvedAddress}
                 </Text>
               )}
               {recipientName && (
@@ -157,9 +154,7 @@ export const RecipientInput = ({
               />
             ) : null
           }
-          onChange={(e) => onToChange(e.target.value)}
-          onBlur={captureRecipientSelectedEvent}
-          onPaste={setRecipientInputMethodPasted}
+          onChange={onToChange}
           placeholder={t('recipientPlaceholder')}
           ref={recipientInputRef}
           value={to}

--- a/ui/pages/confirmations/components/send/recipient/recipient.test.tsx
+++ b/ui/pages/confirmations/components/send/recipient/recipient.test.tsx
@@ -182,21 +182,6 @@ describe('Recipient', () => {
     expect(queryByText('SELECTRECIPIENT')).not.toBeInTheDocument();
   });
 
-  it('captures metrics on input blur when to value exists', () => {
-    mockUseSendContext.mockReturnValue({
-      to: '0x1234567890abcdef',
-      updateTo: mockUpdateTo,
-      updateToResolved: jest.fn(),
-    } as unknown as ReturnType<typeof useSendContext>);
-
-    const { getByRole } = renderComponent();
-    const input = getByRole('textbox');
-
-    fireEvent.blur(input);
-
-    expect(mockCaptureRecipientSelected).toHaveBeenCalledTimes(1);
-  });
-
   it('blurs input when opening modal', () => {
     mockUseRecipients.mockReturnValue(mockRecipients);
     const { getByTestId, getByRole } = renderComponent();
@@ -263,6 +248,7 @@ describe('Recipient', () => {
       expect(mockUpdateTo).toHaveBeenCalledWith(
         '0x1234567890abcdef1234567890abcdef12345678',
       );
+      expect(mockSetRecipientInputMethodSelectAccount).toHaveBeenCalled();
     });
   });
 });

--- a/ui/pages/confirmations/components/send/recipient/recipient.tsx
+++ b/ui/pages/confirmations/components/send/recipient/recipient.tsx
@@ -42,7 +42,6 @@ export const Recipient = ({
   const [isRecipientModalOpen, setIsRecipientModalOpen] = useState(false);
   const { to, updateTo, updateToResolved } = useSendContext();
   const {
-    captureRecipientSelected,
     setRecipientInputMethodSelectContact,
     setRecipientInputMethodSelectAccount,
   } = useRecipientSelectionMetrics();
@@ -62,7 +61,7 @@ export const Recipient = ({
       const isRecipientContact = recipients.some(
         (recipient) =>
           recipient.address.toLowerCase() === address.toLowerCase() &&
-          recipient.contactName,
+          recipient.isContact,
       );
       if (isRecipientContact) {
         setRecipientInputMethodSelectContact();
@@ -71,14 +70,12 @@ export const Recipient = ({
       }
 
       updateTo(address);
-      captureRecipientSelected();
     },
     [
-      captureRecipientSelected,
       recipients,
+      updateTo,
       setRecipientInputMethodSelectContact,
       setRecipientInputMethodSelectAccount,
-      updateTo,
     ],
   );
 

--- a/ui/pages/confirmations/hooks/send/metrics/useAssetSelectionMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/send/metrics/useAssetSelectionMetrics.test.tsx
@@ -6,6 +6,7 @@ import {
   EVM_ASSET,
   EVM_NATIVE_ASSET,
   MOCK_NFT1155,
+  SOLANA_NATIVE_ASSET,
 } from '../../../../../../test/data/send/assets';
 import { renderHookWithProvider } from '../../../../../../test/lib/render-helpers';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
@@ -14,14 +15,12 @@ import {
   useSendMetricsContext,
 } from '../../../context/send-metrics';
 import { useSendAssets } from '../useSendAssets';
-import { useSendType } from '../useSendType';
 import { useAssetSelectionMetrics } from './useAssetSelectionMetrics';
 
 const mockTrackEvent = jest.fn();
 const mockSetAssetFilterMethod = jest.fn();
 const mockUseSendMetricsContext = jest.mocked(useSendMetricsContext);
 const mockUseSendAssets = jest.mocked(useSendAssets);
-const mockUseSendType = jest.mocked(useSendType);
 
 jest.mock('../../../context/send-metrics', () => ({
   ...jest.requireActual('../../../context/send-metrics'),
@@ -58,14 +57,6 @@ describe('useAssetSelectionMetrics', () => {
       tokens: [EVM_ASSET, EVM_NATIVE_ASSET],
       nfts: [MOCK_NFT1155],
     } as unknown as ReturnType<typeof useSendAssets>);
-
-    mockUseSendType.mockReturnValue({
-      isEvmSendType: true,
-      isEvmNativeSendType: false,
-      isNonEvmSendType: false,
-      isNonEvmNativeSendType: false,
-      isSolanaSendType: false,
-    });
   });
 
   describe('addAssetFilterMethod', () => {
@@ -256,7 +247,7 @@ describe('useAssetSelectionMetrics', () => {
           asset_list_position: 1,
           asset_list_size: '5',
           chain_id: 5,
-          chain_id_caip: undefined,
+          chain_id_caip: 'eip155:5',
           filter_method: [AssetFilterMethod.None],
         },
       });
@@ -283,7 +274,7 @@ describe('useAssetSelectionMetrics', () => {
           asset_list_position: 2,
           asset_list_size: '5',
           chain_id: 5,
-          chain_id_caip: undefined,
+          chain_id_caip: 'eip155:5',
           filter_method: [AssetFilterMethod.None],
         },
       });
@@ -308,21 +299,13 @@ describe('useAssetSelectionMetrics', () => {
           asset_list_position: 3,
           asset_list_size: '5',
           chain_id: 8453,
-          chain_id_caip: undefined,
+          chain_id_caip: 'eip155:33875',
           filter_method: [AssetFilterMethod.None],
         },
       });
     });
 
     it('uses chain_id_caip for non-EVM assets', () => {
-      mockUseSendType.mockReturnValue({
-        isEvmSendType: false,
-        isEvmNativeSendType: false,
-        isNonEvmSendType: true,
-        isNonEvmNativeSendType: false,
-        isSolanaSendType: true,
-      });
-
       const { result } = renderHookWithProvider(
         () => useAssetSelectionMetrics(),
         mockState,
@@ -330,18 +313,18 @@ describe('useAssetSelectionMetrics', () => {
         Container,
       );
 
-      result.current.captureAssetSelected(EVM_ASSET);
+      result.current.captureAssetSelected(SOLANA_NATIVE_ASSET);
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
         event: 'Send Asset Selected',
         category: 'Send',
         properties: {
           account_type: 'MetaMask',
-          asset_type: 'token',
-          asset_list_position: 1,
+          asset_type: 'native',
+          asset_list_position: 0,
           asset_list_size: '5',
-          chain_id: undefined,
-          chain_id_caip: 5,
+          chain_id: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          chain_id_caip: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
           filter_method: [AssetFilterMethod.None],
         },
       });
@@ -373,7 +356,7 @@ describe('useAssetSelectionMetrics', () => {
           asset_list_position: 0,
           asset_list_size: '5',
           chain_id: 1,
-          chain_id_caip: undefined,
+          chain_id_caip: 1,
           filter_method: [AssetFilterMethod.None],
         },
       });

--- a/ui/pages/confirmations/hooks/send/metrics/useAssetSelectionMetrics.ts
+++ b/ui/pages/confirmations/hooks/send/metrics/useAssetSelectionMetrics.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { useCallback, useContext } from 'react';
+import { isAddress as isEvmAddress } from 'ethers/lib/utils';
 
 import {
   MetaMetricsEventCategory,
@@ -10,7 +12,6 @@ import {
   useSendMetricsContext,
 } from '../../../context/send-metrics';
 import { Asset } from '../../../types/send';
-import { useSendType } from '../useSendType';
 import { useSendAssets } from '../useSendAssets';
 
 const ASSET_TYPE = {
@@ -29,7 +30,6 @@ export const useAssetSelectionMetrics = () => {
     setAssetFilterMethod,
     setAssetListSize,
   } = useSendMetricsContext();
-  const { isEvmSendType } = useSendType();
 
   const addAssetFilterMethod = useCallback(
     (filterMethod: string) => {
@@ -66,6 +66,9 @@ export const useAssetSelectionMetrics = () => {
         assetType = ASSET_TYPE.NATIVE;
       }
 
+      const tokenAddress = sendAsset?.address || sendAsset?.assetId;
+      const isEvmSend = isEvmAddress(tokenAddress as string);
+
       const allAssets = [...tokens, ...nfts];
       const position =
         allAssets.findIndex((asset) => {
@@ -94,32 +97,19 @@ export const useAssetSelectionMetrics = () => {
         event: MetaMetricsEventName.SendAssetSelected,
         category: MetaMetricsEventCategory.Send,
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           account_type: accountType,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_type: assetType,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_list_position: position,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_list_size: assetListSize,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: isEvmSendType ? sendAsset?.chainId : undefined,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id_caip: isEvmSendType ? undefined : sendAsset?.chainId,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: sendAsset?.chainId,
+          chain_id_caip: isEvmSend
+            ? `eip155:${parseInt(sendAsset?.chainId as string, 16)}`
+            : sendAsset?.chainId,
           filter_method: assetFilterMethod,
         },
       });
     },
-    [
-      accountType,
-      assetFilterMethod,
-      assetListSize,
-      isEvmSendType,
-      trackEvent,
-      tokens,
-      nfts,
-    ],
+    [accountType, assetFilterMethod, assetListSize, trackEvent, tokens, nfts],
   );
 
   return {

--- a/ui/pages/confirmations/hooks/send/metrics/useRecipientSelectionMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/send/metrics/useRecipientSelectionMetrics.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { ReactChildren } from 'react';
 import mockTestState from '../../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../../test/lib/render-helpers';
@@ -120,13 +121,9 @@ describe('useRecipientSelectionMetrics', () => {
         category: 'Send',
         event: 'Send Recipient Selected',
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           account_type: 'EOA',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           chain_id: '0x1',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id_caip: undefined,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id_caip: 'eip155:1',
           input_method: 'manual',
         },
       });

--- a/ui/pages/confirmations/hooks/send/metrics/useRecipientSelectionMetrics.ts
+++ b/ui/pages/confirmations/hooks/send/metrics/useRecipientSelectionMetrics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { useCallback, useContext } from 'react';
 
 import {
@@ -40,14 +41,12 @@ export const useRecipientSelectionMetrics = () => {
       event: MetaMetricsEventName.SendRecipientSelected,
       category: MetaMetricsEventCategory.Send,
       properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         account_type: accountType,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         input_method: recipientInputMethod,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        chain_id: isEvmSendType ? chainId : undefined,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        chain_id_caip: isEvmSendType ? undefined : chainId,
+        chain_id: chainId,
+        chain_id_caip: isEvmSendType
+          ? `eip155:${parseInt(chainId as string, 16)}`
+          : chainId,
       },
     });
   }, [accountType, chainId, isEvmSendType, recipientInputMethod, trackEvent]);

--- a/ui/pages/confirmations/hooks/send/useContactRecipients.test.ts
+++ b/ui/pages/confirmations/hooks/send/useContactRecipients.test.ts
@@ -60,10 +60,12 @@ describe('useContactRecipients', () => {
       {
         address: '0x1234567890abcdef1234567890abcdef12345678',
         contactName: 'John Doe',
+        isContact: true,
       },
       {
         address: '0xabcdef1234567890abcdef1234567890abcdef12',
         contactName: 'Bob Wilson',
+        isContact: true,
       },
     ]);
   });
@@ -84,6 +86,7 @@ describe('useContactRecipients', () => {
       {
         address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
         contactName: 'Jane Smith',
+        isContact: true,
       },
     ]);
   });
@@ -135,6 +138,7 @@ describe('useContactRecipients', () => {
       {
         address: '0x1234567890abcdef1234567890abcdef12345678',
         contactName: 'John Doe',
+        isContact: true,
       },
     ]);
   });

--- a/ui/pages/confirmations/hooks/send/useContactRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useContactRecipients.ts
@@ -16,6 +16,7 @@ export const useContactRecipients = (): Recipient[] => {
     return {
       address: contact.address,
       contactName: contact.name,
+      isContact: true,
     };
   }, []);
 

--- a/ui/pages/confirmations/hooks/send/useRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipients.ts
@@ -5,6 +5,7 @@ export type Recipient = {
   accountGroupName?: string;
   address: string;
   contactName?: string;
+  isContact?: boolean;
   walletName?: string;
 };
 

--- a/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
+++ b/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
@@ -67,7 +67,7 @@ export const useSendQueryParams = () => {
       queryParams.set('amount', value);
     }
     if (asset?.address !== undefined && paramAsset !== asset.address) {
-      queryParams.set('asset', asset.address);
+      queryParams.set('asset', asset.assetId ?? asset.address);
     }
     if (asset?.chainId !== undefined && paramChainId !== asset.chainId) {
       queryParams.set('chainId', asset.chainId.toString());


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix send flow metrics for three cases mentioned in the task:
https://github.com/MetaMask/MetaMask-planning/issues/5927

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36528?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5927

## **Manual testing steps**

No manual QA needed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks send-flow metrics: replaces send start event, fixes chain_id/chain_id_caip (incl. CAIP for EVM/non-EVM), tracks recipient selection/input methods correctly, and updates URL/query params and tests.
> 
> - **Metrics/Events**:
>   - Replace `NavSendButtonClicked` with `SendStarted` in `wallet-overview` send button and related tests.
>   - `useAssetSelectionMetrics`: remove `useSendType` dependency; compute `chain_id` and `chain_id_caip` correctly (use CAIP like `eip155:<dec>` for EVM; use native CAIP for non-EVM); determine EVM via `ethers` `isAddress`; refine asset position logic; add ESLint guards.
>   - `useRecipientSelectionMetrics`: always include `chain_id`; set `chain_id_caip` to `eip155:<dec>` for EVM, else pass-through; tests updated.
>   - `AmountRecipient`: also captures `captureRecipientSelected` on submit.
>   - `RecipientInput`: track input method on type vs paste; remove blur-based capture; fix text rendering; tests updated to assert manual/paste.
>   - `Recipient`: determine contact via `isContact`; remove immediate capture on selection; assert select-account metric.
> - **Data/Types**:
>   - Add `isContact` to recipients (`useContactRecipients`, `useRecipients`); mark contacts accordingly.
>   - Adjust Solana native asset test fixture; add CAIP-based `assetId` usage.
> - **Routing**:
>   - `useSendQueryParams`: write `asset` query param using `asset.assetId ?? asset.address`.
> - **Constants**:
>   - Add `MetaMetricsEventName.SendStarted`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50109dc93da6ac28d51e26623ce68d3798ddc52d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->