### PR TITLE
fix(multichain-accounts): use Basic Functionnality alignment trigger

### DIFF
--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -42,7 +42,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
           'RemoteFeatureFlagController:getState',
         );
         const multichainAccountsFeatureFlag =
-          remoteFeatureFlags?.enableMultichainAccounts as
+          remoteFeatureFlags?.enableMultichainAccountsState2 as
             | MultichainAccountsFeatureFlag
             | undefined;
 


### PR DESCRIPTION
## **Description**

We recently made a change to this `enableMultichainAccounts`  feature flag and introduced `enableMultichainAccountsState2`. This one was missing in the BF logic (and since we don't have any e2e test covering this case, we didn't see that coming 😅).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36530?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

- Onboard with "Basic Functionality" OFF
- Check your addresses (on "Account 1")
  * You should not have any Solana address
- Go to: Settings > Security & Privacy > Turn on "Basic functionality"
- Check your addresses (on "Account 1")
  * You should have a Solana address this time

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/3bac5959-c4da-441c-a0a2-eb28ac8bd02b

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the feature flag check to `enableMultichainAccountsState2` when gating basic functionality alignment for multichain accounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e020282dee254d610d38610f700aaab3e88c39a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->