### PR TITLE
fix: carousel flickering issue after closing all cards cp-13.5.0

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -51,11 +51,6 @@ export const AccountOverviewLayout = ({
     enabled: isCarouselEnabled,
   });
 
-  // Check if there are any visible (non-dismissed) slides
-  const hasVisibleSlides = useMemo(() => {
-    return slides.some((slide: CarouselSlide) => !slide.dismissed);
-  }, [slides]);
-
   const slideById = useMemo(() => {
     const m = new Map<string, CarouselSlide>();
     slides.forEach((s: CarouselSlide) => m.set(s.id, s));
@@ -126,7 +121,7 @@ export const AccountOverviewLayout = ({
         <NetworkConnectionBanner />
         {children}
       </div>
-      {isCarouselEnabled && hasVisibleSlides && (
+      {isCarouselEnabled && (
         <CarouselWithEmptyState
           slides={slides}
           isLoading={isLoading}

--- a/ui/components/multichain/account-overview/account-overview-layout.tsx
+++ b/ui/components/multichain/account-overview/account-overview-layout.tsx
@@ -51,6 +51,11 @@ export const AccountOverviewLayout = ({
     enabled: isCarouselEnabled,
   });
 
+  // Check if there are any visible (non-dismissed) slides
+  const hasVisibleSlides = useMemo(() => {
+    return slides.some((slide: CarouselSlide) => !slide.dismissed);
+  }, [slides]);
+
   const slideById = useMemo(() => {
     const m = new Map<string, CarouselSlide>();
     slides.forEach((s: CarouselSlide) => m.set(s.id, s));
@@ -121,7 +126,7 @@ export const AccountOverviewLayout = ({
         <NetworkConnectionBanner />
         {children}
       </div>
-      {isCarouselEnabled && (
+      {isCarouselEnabled && hasVisibleSlides && (
         <CarouselWithEmptyState
           slides={slides}
           isLoading={isLoading}

--- a/ui/components/multichain/carousel/__tests__/carousel.test.tsx
+++ b/ui/components/multichain/carousel/__tests__/carousel.test.tsx
@@ -75,11 +75,11 @@ describe('Carousel', () => {
     expect(screen.getByText('Test description 1')).toBeInTheDocument();
   });
 
-  it('renders empty state when no slides', () => {
-    render(<Carousel {...defaultProps} slides={[]} />);
+  it('returns null when no slides (initial load)', () => {
+    const { container } = render(<Carousel {...defaultProps} slides={[]} />);
 
-    // Should show empty state message
-    expect(screen.getByText('carouselAllCaughtUp')).toBeInTheDocument();
+    // Should not render anything when there are no slides initially
+    expect(container.firstChild).toBeNull();
   });
 
   it('shows loading state when loading', () => {

--- a/ui/components/multichain/carousel/carousel-wrapper.tsx
+++ b/ui/components/multichain/carousel/carousel-wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Carousel } from './carousel';
 import { EmptyStateComponent } from './stack-card-empty';
 import type { CarouselProps } from './types';
@@ -6,6 +6,11 @@ import type { CarouselProps } from './types';
 export const CarouselWithEmptyState: React.FC<CarouselProps> = (props) => {
   const [showFoldAnimation, setShowFoldAnimation] = useState(false);
   const [hasCompletedEmptyState, setHasCompletedEmptyState] = useState(false);
+
+  // Calculate visible slides (non-dismissed) to prevent infinite loop
+  const visibleSlidesCount = useMemo(() => {
+    return (props.slides || []).filter((slide) => !slide.dismissed).length;
+  }, [props.slides]);
 
   const handleEmptyState = () => {
     if (!hasCompletedEmptyState && !showFoldAnimation) {
@@ -18,20 +23,21 @@ export const CarouselWithEmptyState: React.FC<CarouselProps> = (props) => {
     setHasCompletedEmptyState(true); // Mark as completed to prevent re-triggering
   };
 
-  // Reset when new slides become available
+  // Reset when new visible slides become available (not just any slides)
   React.useEffect(() => {
-    if ((props.slides?.length || 0) > 0 && hasCompletedEmptyState) {
+    if (visibleSlidesCount > 0 && hasCompletedEmptyState) {
       setHasCompletedEmptyState(false);
     }
-  }, [props.slides?.length, hasCompletedEmptyState]);
+  }, [visibleSlidesCount, hasCompletedEmptyState]);
 
   // Show the fold-up animation when triggered by carousel
   if (showFoldAnimation) {
     return <EmptyStateComponent onComplete={handleEmptyStateComplete} />;
   }
 
-  // If empty state was completed, don't show carousel at all
-  if (hasCompletedEmptyState) {
+  // If empty state was completed and there are no visible slides, don't show carousel at all
+  // This prevents infinite loops where dismissed slides cause the carousel to re-appear
+  if (hasCompletedEmptyState && visibleSlidesCount === 0) {
     return null;
   }
 

--- a/ui/components/multichain/carousel/carousel-wrapper.tsx
+++ b/ui/components/multichain/carousel/carousel-wrapper.tsx
@@ -6,11 +6,19 @@ import type { CarouselProps } from './types';
 export const CarouselWithEmptyState: React.FC<CarouselProps> = (props) => {
   const [showFoldAnimation, setShowFoldAnimation] = useState(false);
   const [hasCompletedEmptyState, setHasCompletedEmptyState] = useState(false);
+  const [hasEverHadSlides, setHasEverHadSlides] = useState(false);
 
   // Calculate visible slides (non-dismissed) to prevent infinite loop
   const visibleSlidesCount = useMemo(() => {
     return (props.slides || []).filter((slide) => !slide.dismissed).length;
   }, [props.slides]);
+
+  // Track if user has ever seen slides
+  React.useEffect(() => {
+    if (visibleSlidesCount > 0 && !hasEverHadSlides) {
+      setHasEverHadSlides(true);
+    }
+  }, [visibleSlidesCount, hasEverHadSlides]);
 
   const handleEmptyState = () => {
     if (!hasCompletedEmptyState && !showFoldAnimation) {
@@ -38,6 +46,11 @@ export const CarouselWithEmptyState: React.FC<CarouselProps> = (props) => {
   // If empty state was completed and there are no visible slides, don't show carousel at all
   // This prevents infinite loops where dismissed slides cause the carousel to re-appear
   if (hasCompletedEmptyState && visibleSlidesCount === 0) {
+    return null;
+  }
+
+  // If we never had slides and there are no slides, don't show anything
+  if (!hasEverHadSlides && visibleSlidesCount === 0) {
     return null;
   }
 

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -59,6 +59,13 @@ export const Carousel = React.forwardRef(
         if (onSlideClose) {
           onSlideClose(slideId, isLastSlide);
         }
+
+        // If this was the last slide, trigger empty state after animation
+        if (isLastSlide && onEmptyState) {
+          setTimeout(() => {
+            onEmptyState();
+          }, 300); // Wait for slide exit animation to complete
+        }
       },
       isTransitioning: state.isTransitioning,
       setIsTransitioning: (transitioning: boolean) => {
@@ -141,44 +148,9 @@ export const Carousel = React.forwardRef(
       );
     }
 
-    // When no slides, show empty state as current card (but only trigger fold once)
+    // When no slides, don't show anything - let the wrapper handle this case
     if (visibleSlides.length === 0) {
-      return (
-        <Box
-          className={`carousel-container ${className}`}
-          ref={ref}
-          {...(props as BoxProps<'div'>)}
-        >
-          <div className="carousel-cards-wrapper">
-            <TransitionGroup>
-              <CSSTransitionComponent
-                key="empty-state-as-current"
-                timeout={300}
-                classNames="card"
-                appear={true}
-                onEntered={() => {
-                  // Only trigger empty state once
-                  if (state.hasTriggeredEmptyState) {
-                    return;
-                  }
-
-                  setState((prev) => ({
-                    ...prev,
-                    hasTriggeredEmptyState: true,
-                  }));
-                  setTimeout(() => {
-                    if (onEmptyState) {
-                      onEmptyState();
-                    }
-                  }, 1000); // Exactly 1 second after empty state card is fully visible
-                }}
-              >
-                <StackCardEmpty isBackground={false} />
-              </CSSTransitionComponent>
-            </TransitionGroup>
-          </div>
-        </Box>
-      );
+      return null;
     }
 
     return (

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { SolAccountType } from '@metamask/keyring-api';
 import {
@@ -34,6 +34,16 @@ export const Carousel = React.forwardRef(
     });
 
     const selectedAccount = useSelector(getSelectedAccount);
+    const emptyStateTimeoutRef = useRef<NodeJS.Timeout>();
+
+    // Cleanup timeout on unmount
+    useEffect(() => {
+      return () => {
+        if (emptyStateTimeoutRef.current) {
+          clearTimeout(emptyStateTimeoutRef.current);
+        }
+      };
+    }, []);
 
     // Filter visible slides
     const visibleSlides = slides
@@ -62,7 +72,12 @@ export const Carousel = React.forwardRef(
 
         // If this was the last slide, trigger empty state after animation
         if (isLastSlide && onEmptyState) {
-          setTimeout(() => {
+          // Clear any existing timeout first
+          if (emptyStateTimeoutRef.current) {
+            clearTimeout(emptyStateTimeoutRef.current);
+          }
+
+          emptyStateTimeoutRef.current = setTimeout(() => {
             onEmptyState();
           }, 300); // Wait for slide exit animation to complete
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes the carousel flickering issue after all cards are closed. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36533?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the carousel flickering issue after all cards are closed. 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Wallet with promotion banners
2. Close all cards 
3. Observe

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
When all slides are dismissed

https://github.com/user-attachments/assets/e37301a0-c017-4e27-94dc-f52201d865ed

When there are no slides

https://github.com/user-attachments/assets/4b5382f9-37d6-440b-842f-bd1319892034

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent flicker by deferring empty-state trigger and not rendering when no visible slides; wrapper tracks slide history to avoid reappearing carousel; tests updated.
> 
> - **UI/Carousel**:
>   - Return `null` when `visibleSlides` is empty; remove inline empty-state rendering.
>   - Defer `onEmptyState` until 300ms after last slide removal using `useRef` timeout; clear on unmount.
> - **Wrapper (`carousel-wrapper.tsx`)**:
>   - Track `visibleSlidesCount` and `hasEverHadSlides` to control rendering and avoid loops with dismissed slides.
>   - Render `null` when empty state completed with no visible slides or on initial load with zero slides; reset completion when new visible slides appear.
> - **Tests**:
>   - Update "no slides" case to expect `null` (initial load) instead of empty-state message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8220c83769fe2a1eb025577149cddec2ba44f58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->