### PR TITLE
chore: remove deprecated TextColor.textAlternativeSoft

### DIFF
--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -320,9 +320,6 @@ export enum TextColor {
   textAlternative = 'text-alternative',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  textAlternativeSoft = 'text-alternative-soft',
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   textMuted = 'text-muted',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`Bridge renders the component with initial props 1`] = `
               style="height: 24px;"
             >
               <p
-                class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
               />
             </div>
           </div>
@@ -236,10 +236,10 @@ exports[`Bridge renders the component with initial props 1`] = `
                 style="height: 24px;"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
                 />
                 <a
-                  class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"
+                  class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative"
                   style="cursor: pointer; text-decoration: underline;"
                 >
                   0xac...35da
@@ -256,7 +256,7 @@ exports[`Bridge renders the component with initial props 1`] = `
                   class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
                 >
                   <p
-                    class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+                    class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
                   >
                     Select amount
                   </p>

--- a/ui/pages/bridge/index.scss
+++ b/ui/pages/bridge/index.scss
@@ -18,21 +18,16 @@
 [data-theme='light'],
 .light {
   --color-background-alternative-soft: #f9fafb; // TODO: Needs design token replacement
-  --color-text-alternative-soft: #6a737d; // TODO: Needs design token replacement
   --color-icon-alternative-soft: #6a737d; // TODO: Needs design token replacement
 }
 
 [data-theme='dark'],
 .dark {
   --color-background-alternative-soft: #1f2124; // TODO: Needs design token replacement
-  --color-text-alternative-soft: #848c96; // TODO: Needs design token replacement
   --color-icon-alternative-soft: #848c96; // TODO: Needs design token replacement
 }
 /* stylelint-enable color-no-hex */
 
-.mm-box--color-text-alternative-soft {
-  color: var(--color-text-alternative-soft);
-}
 
 .mm-box--color-icon-alternative-soft {
   color: var(--color-icon-alternative-soft);

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-cta-button.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-cta-button.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`BridgeCTAButton should disable the component when quotes are loading an
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
     />
   </div>
 </div>
@@ -30,7 +30,7 @@ exports[`BridgeCTAButton should render the component when amount and dest token 
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
     >
       Select amount
     </p>
@@ -44,7 +44,7 @@ exports[`BridgeCTAButton should render the component when amount, dest chain and
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
     >
       Select amount
     </p>
@@ -58,7 +58,7 @@ exports[`BridgeCTAButton should render the component's initial state 1`] = `
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
     >
       Select token
     </p>

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
         style="height: 24px;"
       >
         <p
-          class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+          class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
         />
       </div>
     </div>
@@ -184,10 +184,10 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
           style="height: 24px;"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+            class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
           />
           <a
-            class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"
+            class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative"
             style="cursor: pointer; text-decoration: underline;"
           >
             0xac...35da
@@ -204,7 +204,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
             class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
           >
             <p
-              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
             >
               Select amount
             </p>
@@ -302,7 +302,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
         style="height: 24px;"
       >
         <p
-          class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+          class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
         />
       </div>
     </div>
@@ -405,10 +405,10 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
           style="height: 24px;"
         >
           <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative-soft"
+            class="mm-box mm-text mm-text--body-md mm-text--font-weight-normal mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
           />
           <a
-            class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative-soft"
+            class="mm-box mm-text mm-text--body-md mm-box--display-flex mm-box--gap-1 mm-box--color-text-alternative"
             style="cursor: pointer; text-decoration: underline;"
           >
             0xac...35da
@@ -425,7 +425,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
             class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
           >
             <p
-              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative-soft"
+              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
             >
               Select amount
             </p>

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -168,7 +168,7 @@ export const BridgeCTAButton = ({
       <Text
         variant={TextVariant.bodyMd}
         textAlign={TextAlign.Center}
-        color={TextColor.textAlternativeSoft}
+        color={TextColor.textAlternative}
       >
         {label ? t(label) : ''}
       </Text>

--- a/ui/pages/bridge/prepare/bridge-cta-info-text.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-info-text.tsx
@@ -57,7 +57,7 @@ export const BridgeCTAInfoText = () => {
 
   return hasMMFee || hasApproval ? (
     <Row gap={1} justifyContent={JustifyContent.center}>
-      <Text variant={TextVariant.bodyXs} color={TextColor.textAlternativeSoft}>
+      <Text variant={TextVariant.bodyXs} color={TextColor.textAlternative}>
         {[
           hasMMFee ? t('rateIncludesMMFee', [feePercentage]) : null,
           hasApproval &&

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -278,7 +278,7 @@ export const BridgeInputGroup = ({
           color={
             isAmountReadOnly && isEstimatedReturnLow
               ? TextColor.warningDefault
-              : TextColor.textAlternativeSoft
+              : TextColor.textAlternative
           }
           textAlign={TextAlign.End}
           ellipsis
@@ -296,7 +296,7 @@ export const BridgeInputGroup = ({
             color={
               isInsufficientBalance
                 ? TextColor.errorDefault
-                : TextColor.textAlternativeSoft
+                : TextColor.textAlternative
             }
             style={{
               cursor: 'default',
@@ -322,7 +322,7 @@ export const BridgeInputGroup = ({
               display={Display.Flex}
               gap={1}
               variant={TextVariant.bodyMd}
-              color={TextColor.textAlternativeSoft}
+              color={TextColor.textAlternative}
               onClick={() => {
                 handleAddressClick();
               }}

--- a/ui/pages/bridge/prepare/bridge-no-fee-message.tsx
+++ b/ui/pages/bridge/prepare/bridge-no-fee-message.tsx
@@ -38,7 +38,7 @@ export const BridgeNoFeeMessage = () => {
 
   return (
     <Row gap={1} justifyContent={JustifyContent.center}>
-      <Text variant={TextVariant.bodyXs} color={TextColor.textAlternativeSoft}>
+      <Text variant={TextVariant.bodyXs} color={TextColor.textAlternative}>
         {t('noMMFeeSwapping', [destSymbol])}
       </Text>
     </Row>

--- a/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </svg>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc
@@ -255,7 +255,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0xC5b8d...10aCb
@@ -353,7 +353,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x2f8D4...6572D
@@ -462,7 +462,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </svg>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc
@@ -560,7 +560,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x95222...BAfe6
@@ -669,7 +669,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 </svg>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc
@@ -859,7 +859,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc
@@ -957,7 +957,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0xC5b8d...10aCb
@@ -1055,7 +1055,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x2f8D4...6572D
@@ -1153,7 +1153,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc
@@ -1251,7 +1251,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x95222...BAfe6
@@ -1349,7 +1349,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 data-testid="account-list-address"
               >
                 0x0DCD5...3E7bc

--- a/ui/pages/bridge/prepare/components/destination-account-list-item.tsx
+++ b/ui/pages/bridge/prepare/components/destination-account-list-item.tsx
@@ -150,7 +150,7 @@ const DestinationAccountListItem: React.FC<DestinationAccountListItemProps> = ({
         </Row>
         <Text
           variant={TextVariant.bodySm}
-          color={TextColor.textAlternativeSoft}
+          color={TextColor.textAlternative}
           data-testid="account-list-address"
         >
           {shortenAddress(normalizeSafeAddress(account.address))}

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -781,7 +781,7 @@ const PrepareBridgePage = ({
               <>
                 <Text
                   textAlign={TextAlign.Center}
-                  color={TextColor.textAlternativeSoft}
+                  color={TextColor.textAlternative}
                 >
                   {t('swapFetchingQuotes')}
                 </Text>

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
@@ -77,13 +77,13 @@ exports[`BridgeQuotesModal should render the modal 1`] = `
               />
             </button>
             <button
-              class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative-soft mm-box--background-color-transparent"
+              class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-transparent"
             >
               <span
-                class="mm-box mm-text mm-text--inherit mm-box--color-text-alternative-soft"
+                class="mm-box mm-text mm-text--inherit mm-box--color-text-alternative"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative-soft"
+                  class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
                 >
                   Time
                 </p>

--- a/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`MultichainBridgeQuoteCard should render a quote with MM fee 1`] = `
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative"
     >
       Includes 0.875% MM fee. Approves token for bridge.
     </p>
@@ -348,7 +348,7 @@ exports[`MultichainBridgeQuoteCard should render the recommended quote (no MM fe
     class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
   >
     <p
-      class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative-soft"
+      class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative"
     >
       Approves token for bridge.
     </p>

--- a/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
+++ b/ui/pages/bridge/quotes/bridge-quotes-modal.tsx
@@ -164,7 +164,7 @@ export const BridgeQuotesModal = ({
               color={
                 sortOrder === sortOrderOption
                   ? TextColor.primaryDefault
-                  : TextColor.textAlternativeSoft
+                  : TextColor.textAlternative
               }
             >
               <Text
@@ -176,7 +176,7 @@ export const BridgeQuotesModal = ({
                 color={
                   sortOrder === sortOrderOption
                     ? TextColor.primaryDefault
-                    : TextColor.textAlternativeSoft
+                    : TextColor.textAlternative
                 }
               >
                 {label}

--- a/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
+++ b/ui/pages/confirmations/components/modals/simulation-settings-modal/simulation-settings-modal.tsx
@@ -83,7 +83,7 @@ const EnforceToggle = ({
           onToggle={() => onChange?.(!enabled)}
         />
       </Box>
-      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternativeSoft}>
+      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
         {t('simulationSettingsModalEnforceToggleDescription')}
       </Text>
     </Section>
@@ -111,7 +111,7 @@ const Slippage = ({
         value={slippage}
         endAccessory={'%'}
       />
-      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternativeSoft}>
+      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
         {t('simulationSettingsModalEnforceSlippageDescription')}
       </Text>
     </Section>

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
@@ -42,8 +42,8 @@ export function NestedTransactionTag() {
           paddingRight={2}
           display={Display.InlineFlex}
           backgroundColor={BackgroundColor.backgroundMuted}
-          color={TextColor.textAlternativeSoft}
-          labelProps={{ color: TextColor.textAlternativeSoft }}
+          color={TextColor.textAlternative}
+          labelProps={{ color: TextColor.textAlternative }}
         />
       </Tooltip>
     </Box>

--- a/ui/pages/defi/components/__snapshots__/defi-details-list.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-list.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DeFiDetailsPage renders defi details list 1`] = `
       class="mm-box"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative-soft"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"
         data-testid="defi-details-list-supply-position"
       >
         Supplied
@@ -100,7 +100,7 @@ exports[`DeFiDetailsPage renders defi details list 1`] = `
       class="mm-box"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative-soft"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"
         data-testid="defi-details-list-supply-position"
       >
         Reward

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
       class="mm-box mm-box--padding-bottom-4 mm-box--padding-left-4"
     >
       <span
-        class="mm-box mm-text mm-box--color-text-alternative-soft mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
+        class="mm-box mm-text mm-box--color-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
         data-testid="defi-details-page-market-value"
       >
         $20,000.00
@@ -81,7 +81,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
           class="mm-box"
         >
           <p
-            class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative-soft"
+            class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"
             data-testid="defi-details-list-stake-position"
           >
             Staked

--- a/ui/pages/defi/components/defi-details-list.tsx
+++ b/ui/pages/defi/components/defi-details-list.tsx
@@ -118,7 +118,7 @@ const DefiDetailsList = React.memo(
                     <Text
                       variant={TextVariant.bodyMdMedium}
                       paddingLeft={4}
-                      color={TextColor.textAlternativeSoft}
+                      color={TextColor.textAlternative}
                       data-testid={`defi-details-list-${positionType}-position`}
                     >
                       {label}

--- a/ui/pages/defi/components/defi-details-page.tsx
+++ b/ui/pages/defi/components/defi-details-page.tsx
@@ -128,7 +128,7 @@ const DeFiPage = () => {
       <Box paddingLeft={4} paddingBottom={4}>
         <SensitiveText
           data-testid="defi-details-page-market-value"
-          className="mm-box--color-text-alternative-soft"
+          className="mm-box--color-text-alternative"
           ellipsis
           variant={TextVariant.inherit}
           isHidden={privacyMode}

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -423,7 +423,7 @@ const TransactionShield = () => {
                     label={t('shieldTxMembershipFreeTrial')}
                     labelProps={{
                       variant: TextVariant.bodySmMedium,
-                      color: TextColor.textAlternativeSoft,
+                      color: TextColor.textAlternative,
                     }}
                     borderStyle={BorderStyle.none}
                     borderRadius={BorderRadius.SM}
@@ -435,7 +435,7 @@ const TransactionShield = () => {
                     label={t('shieldTxMembershipPaused')}
                     labelProps={{
                       variant: TextVariant.bodySmMedium,
-                      color: TextColor.textAlternativeSoft,
+                      color: TextColor.textAlternative,
                     }}
                     borderStyle={BorderStyle.none}
                     borderRadius={BorderRadius.SM}


### PR DESCRIPTION
## **Description**

Remove the deprecated `TextColor.textAlternativeSoft` color and replace all usage with `TextColor.textAlternative`. This addresses part of the technical debt cleanup by removing one of several colors that were incorrectly added to the extension.

The changes include:
- Removing `textAlternativeSoft = 'text-alternative-soft'` from the TextColor enum
- Replacing all component usage of `TextColor.textAlternativeSoft` with `TextColor.textAlternative`
- Removing associated CSS custom properties and classes for `text-alternative-soft`
- Updating test snapshots to reflect the CSS class changes

**Note:** This PR addresses only the `text-alternative-soft` token. Other deprecated tokens (`background-alternative-soft`, `icon-alternative-soft`) in `ui/pages/bridge/index.scss` still need to be addressed in follow-up work.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Partly fixes: https://github.com/MetaMask/metamask-extension/issues/30144

## **Manual testing steps**

1. Verify all bridge components render correctly with proper text colors
2. Check defi components display text with appropriate styling 
3. Confirm confirmation modal text appears as expected
4. Ensure settings page text styling is unchanged visually

## **Screenshots/Recordings**

Not applicable - this is a technical debt cleanup with no visual changes expected.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.