### PR TITLE
ci: INFRA-2999-Fixes for create release workflows

### DIFF
--- a/.github/scripts/resolve-previous-ref.sh
+++ b/.github/scripts/resolve-previous-ref.sh
@@ -13,7 +13,7 @@ if [ "$patch" -gt 0 ]; then
   exit 0
 fi
 
-# Function to paginate and collect refs for a prefix
+# Function to paginate and collect refs for a prefix (narrow prefixes only)
 fetch_matching_refs() {
   local prefix="$1"
   local temp_file
@@ -43,24 +43,61 @@ fetch_matching_refs() {
   echo "$temp_file"
 }
 
-# Fetch for each prefix
-version_v_file=$(fetch_matching_refs "Version-v")
-release_file=$(fetch_matching_refs "release/")
+# Try immediate previous minor within the same major by direct branch existence checks
+major="${semver%%.*}"
+rest_minor_patch="${semver#*.}"
+minor="${rest_minor_patch%%.*}"
 
-# Combine and process: extract {name, semver} for matches, sort desc by semver
-jq -s 'add | [ .[] | .ref | ltrimstr("refs/heads/") as $name | select($name | test("^Version-v[0-9]+\\.[0-9]+\\.[0-9]+$") or test("^release/[0-9]+\\.[0-9]+\\.[0-9]+$")) | {name: $name, semver: (if $name | test("^Version-v") then $name | ltrimstr("Version-v") else $name | ltrimstr("release/") end) } ] | sort_by( .semver | split(".") | map(tonumber) ) | reverse' "$version_v_file" "$release_file" > all_versions.json
+if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]]; then
+  echo "Error: Unable to parse major/minor from semver: $semver" >&2
+  exit 1
+fi
 
-# Filter to those with semver strictly lower than current and non-hotfix (patch==0)
-jq --arg semver "$semver" '[ .[] | select( .semver as $v | $semver | split(".") as $c | $v | split(".") as $p | ( ($p[0] | tonumber) < ($c[0] | tonumber) or (($p[0] | tonumber) == ($c[0] | tonumber) and (($p[1] | tonumber) < ($c[1] | tonumber) or (($p[1] | tonumber) == ($c[1] | tonumber) and ($p[2] | tonumber) < ($c[2] | tonumber)))) ) and (($p[2] | tonumber) == 0) ) ]' all_versions.json > filtered_versions.json
+if [ "$minor" -gt 0 ]; then
+  cand_minor=$((minor - 1))
+  while [ "$cand_minor" -ge 0 ]; do
+    candidate="release/${major}.${cand_minor}.0"
+    echo "Checking for branch: ${candidate}" >&2
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}/branches/${candidate}")
+    if [ "$http_code" = "200" ]; then
+      echo "Found previous non-hotfix branch: ${candidate}" >&2
+      echo "previous_ref=${candidate}" >> "$GITHUB_OUTPUT"
+      exit 0
+    fi
+    cand_minor=$((cand_minor - 1))
+  done
+fi
 
-# Select the highest lower: first in filtered list. If none found, fail.
+# Fallback: move to previous major and select highest non-hotfix (patch==0)
+prev_major=$((major - 1))
+if [ "$prev_major" -lt 0 ]; then
+  echo "Error: No previous major available for semver: $semver" >&2
+  exit 1
+fi
+
+release_file=$(fetch_matching_refs "release/${prev_major}.")
+
+# From the fetched list for the previous major, keep only patch==0 branches and pick the highest
+jq -s '[ (add // [])
+        | .[]
+        | .ref
+        | ltrimstr("refs/heads/") as $name
+        | select($name | test("^release/[0-9]+\\.[0-9]+\\.[0-9]+$"))
+        | { name: $name, semver: ($name | ltrimstr("release/")) }
+      ]
+      | map(select(.semver | split(".")[2] == "0"))
+      | sort_by( .semver | split(".") | map(tonumber) )
+      | reverse' "$release_file" > filtered_versions.json
+
 if [ "$(jq length filtered_versions.json)" -eq 0 ]; then
-  echo "Error: No lower non-hotfix versions found; cannot determine previous-version-ref." >&2
-  echo "This likely indicates a missing prior minor release branch (e.g., Version-vX.(Y-1).0 or release/X.(Y-1).0)." >&2
+  echo "Error: No non-hotfix branches found for previous major ${prev_major}." >&2
   exit 1
 else
-  highest_lower="$(jq -r '.[0].semver' filtered_versions.json)"
+  selected_semver="$(jq -r '.[0].semver' filtered_versions.json)"
   previous_ref="$(jq -r '.[0].name' filtered_versions.json)"
-  echo "Selected highest lower non-hotfix version: ${highest_lower} (branch: ${previous_ref})"
+  echo "Selected previous major highest non-hotfix: ${selected_semver} (branch: ${previous_ref})"
   echo "previous_ref=${previous_ref}" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tested1: https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18100340079
Tested2: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18165051064/job/51705108936 (failed before change) -> https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18100340079/job/51501418704 (passed after change)

Changed .github/scripts/resolve-previous-ref.sh
Before: Listed all release/* branches via paginated API calls; failed with “Exceeded maximum pagination limit (100 pages)” when too many branches existed.
After:
Tries the immediate previous minor branch directly (e.g., release/X.(Y-1).0) via a single branch check.
If not found, queries only the previous major’s release/<prev_major>.* branches and picks the highest non‑hotfix (patch == 0).
Hotfix behavior unchanged (patch > 0 → previous_ref='null').
Impact: Eliminates pagination failure, speeds up resolution, preserves expected previous_ref output.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36535?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors previous-version resolution to check the immediate prior minor branch first, then fall back to the highest non-hotfix in the previous major, eliminating broad paginated lookups.
> 
> - **CI Script** (`.github/scripts/resolve-previous-ref.sh`):
>   - Parse `semver` into `major`/`minor`; validate inputs; retain hotfix handling (`patch > 0` → `previous_ref='null'`).
>   - New resolution flow:
>     - Try `release/<major>.<minor-1>.0` (and lower minors) via direct branch existence checks.
>     - Fallback: fetch `release/<prev_major>.*`, filter to `patch==0`, pick highest.
>   - Remove broad paginated fetching of `Version-v*` and `release/*`; narrow API calls to avoid 100-page limit.
>   - Update logs/errors and output to reflect new selection path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65b0a2d09d648f1c359447e6ab009f4c8699951a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->