### PR TITLE
feat: Add param to `MetamaskController.privateSendUpdate` for only sending pending patches

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7753,12 +7753,18 @@ export default class MetamaskController extends EventEmitter {
   // misc
 
   /**
-   * A method for emitting the full MetaMask state to all registered listeners.
+   * A method for emitting either the full MetaMask state or pending patches to all registered listeners of the 'update' event.
+   * This method can be used to force UI updates in response to background actions or events e.g. state updates.
    *
-   * @private
+   * @param sendFullState - If set to true, the full MetaMask state is sent. If set to false, only pending patches are sent.
+   * @see {@link {import('../../ui/store/actions.ts').forceUpdateMetamaskState}} also force-syncs UI state with background state, but in response to UI events or user actions.
    */
-  privateSendUpdate() {
-    this.emit('update', this.getState());
+  privateSendUpdate(sendFullState = true) {
+    if (sendFullState) {
+      this.emit('update', this.getState());
+    } else {
+      this.emit('update');
+    }
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -88,6 +88,7 @@ import {
   hexToBytes,
   bytesToHex,
   KnownCaipNamespace,
+  isObject,
 } from '@metamask/utils';
 import { normalize } from '@metamask/eth-sig-util';
 
@@ -1010,6 +1011,9 @@ export default class MetamaskController extends EventEmitter {
       this.networkController.getProviderAndBlockTracker().blockTracker;
 
     this.on('update', (update) => {
+      if (!isObject(update)) {
+        return;
+      }
       this.metaMetricsController.handleMetaMaskStateUpdate(update);
     });
 
@@ -1336,7 +1340,12 @@ export default class MetamaskController extends EventEmitter {
     });
 
     // ensure isClientOpenAndUnlocked is updated when memState updates
-    this.on('update', (memState) => this._onStateUpdate(memState));
+    this.on('update', (memState) => {
+      if (!isObject(memState) || !('isUnlocked' in memState)) {
+        return;
+      }
+      this._onStateUpdate(memState);
+    });
 
     /**
      * All controllers in Memstore but not in store. They are not persisted.
@@ -2282,6 +2291,13 @@ export default class MetamaskController extends EventEmitter {
     };
 
     const updatePublicConfigStore = async (memState) => {
+      if (
+        !isObject(memState) ||
+        !('networksMetadata' in memState) ||
+        !('selectedNetworkId' in memState)
+      ) {
+        return;
+      }
       const networkStatus =
         memState.networksMetadata[memState.selectedNetworkClientId]?.status;
       if (networkStatus === NetworkStatus.Available) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `MetamaskController.privateSendUpdate` method is currently not used anywhere, but is a useful wrapper for the uncommon scenario where a forced UI state update needs to be triggered in response to background events or actions. In the more usual case where a UI state update needs to be triggered in response to user actions, [`forceUpdateMetamaskState`](https://github.com/MetaMask/metamask-extension/blob/621846e991485278713de340466093a77aba28f3/ui/store/actions.ts#L4208-L4222) is used. 

This commit adds a boolean flag parameter to `privateSendUpdate` for optionally triggering state updates only with pending patches, which is [the default behavior of the `update` event](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/metamask-controller.js#L6513-L6525) that is used by the method.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36536?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `privateSendUpdate` now accepts a `sendFullState` flag to either emit the full MetaMask state or just trigger an 'update' for pending patches, with updated JSDoc.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 072725631bee0b1b21e17a8555cfc7b1b982ba07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->