### PR TITLE
test: Fix bip44 failures

### DIFF
--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -287,9 +287,16 @@
   },
   "RemoteFeatureFlagController": {
     "remoteFeatureFlags": {
-      "feature1": true,
-      "feature2": false,
-      "feature3": { "name": "groupC", "value": "valueC" }
+      "enableMultichainAccounts": {
+        "enabled": false,
+        "featureVersion": "0",
+        "minimumVersion": "12.19.0"
+      },
+      "enableMultichainAccountsState2": {
+         "enabled": false,
+         "featureVersion": "0",
+         "minimumVersion": "12.19.0"
+       }
     },
     "cacheTimestamp": "number"
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36537?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default-enable multichain accounts when flags are absent, add e2e helpers/mocks to force BIP-44 versions, and update/skip tests and snapshots to stabilize multichain/metrics flows.
> 
> - **Shared/Feature Flags**:
>   - Update `shared/lib/multichain-accounts/remote-feature-flag.ts` to default-enable `isMultichainAccountsFeatureEnabled` when flags/app version are undefined; tighten enabled checks.
>   - Adjust tests to reflect new defaults in `remote-feature-flag.test.ts` and `ui/selectors/multichain-accounts/feature-flags.test.ts`.
> - **E2E Infrastructure**:
>   - Add `test/e2e/tests/multichain-accounts/feature-flag-mocks.ts` (state 0/1/2 and disabled mocks).
>   - Enhance `withFixtures` in `test/e2e/helpers.js` with `forceBip44Version` to control multichain state; apply mocks accordingly.
>   - Seed default disabled flags in `test/integration/data/integration-init-state.json` and `test/lib/render-helpers.js`.
> - **Tests**:
>   - Widespread updates to e2e specs to use `forceBip44Version: 2`, new mocks, or skip flaky multichain suites; remove inline flag mocks where replaced.
>   - Controller/UI tests stub multichain selectors/flags to false for isolation; minor controller tests spy `isMultichainAccountsFeatureState2Enabled`.
>   - Metrics tests use `MOCK_META_METRICS_ID` and `loginWithoutBalanceValidation`.
> - **UI Snapshots**:
>   - Add “Network” row to confirmation info snapshots; adjust account header labels; update font-weight to `500` in account picker labels.
> - **Misc**:
>   - Update feature-flag expectations in state snapshots and mocks; skip certain multichain suites with `describe.skip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae26bde269806ee87afc19abcf8e6da9223fed66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->