### PR TITLE
chore: remove deprecated IconColor.iconAlternativeSoft

### DIFF
--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -416,9 +416,6 @@ export enum IconColor {
   iconAlternative = 'icon-alternative',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  iconAlternativeSoft = 'icon-alternative-soft',
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   iconMuted = 'icon-muted',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/bridge/index.scss
+++ b/ui/pages/bridge/index.scss
@@ -18,20 +18,14 @@
 [data-theme='light'],
 .light {
   --color-background-alternative-soft: #f9fafb; // TODO: Needs design token replacement
-  --color-icon-alternative-soft: #6a737d; // TODO: Needs design token replacement
 }
 
 [data-theme='dark'],
 .dark {
   --color-background-alternative-soft: #1f2124; // TODO: Needs design token replacement
-  --color-icon-alternative-soft: #848c96; // TODO: Needs design token replacement
 }
 /* stylelint-enable color-no-hex */
 
-
-.mm-box--color-icon-alternative-soft {
-  color: var(--color-icon-alternative-soft);
-}
 
 .mm-box--background-color-background-alternative-soft {
   background-color: var(--color-background-alternative-soft);

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
@@ -207,9 +207,7 @@ function NativeToggle({
         <Icon
           name={IconName.Wallet}
           size={IconSize.Sm}
-          color={
-            isFuture ? IconColor.iconAlternativeSoft : IconColor.infoDefault
-          }
+          color={isFuture ? IconColor.iconAlternative : IconColor.infoDefault}
           margin={2}
         />
       </NativeToggleOption>

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -191,7 +191,7 @@ const TransactionShield = () => {
           <Icon
             name={IconName.ArrowRight}
             size={IconSize.Lg}
-            color={IconColor.iconAlternativeSoft}
+            color={IconColor.iconAlternative}
           />
         )}
       </Box>


### PR DESCRIPTION
## **Description**

Remove the deprecated `IconColor.iconAlternativeSoft` color and replace all usage with `IconColor.iconAlternative`. This addresses part of the technical debt cleanup by removing another deprecated color that was incorrectly added to the extension.

The changes include:
- Removing `iconAlternativeSoft = 'icon-alternative-soft'` from the IconColor enum
- Replacing all component usage of `IconColor.iconAlternativeSoft` with `IconColor.iconAlternative`
- Updating test snapshots to reflect the CSS class changes from `mm-box--color-icon-alternative-soft` to `mm-box--color-icon-alternative`

**Note:** This PR addresses only the `icon-alternative-soft` token. Other deprecated tokens (`background-alternative-soft`, `text-alternative-soft`) in `ui/pages/bridge/index.scss` still need to be addressed in follow-up work.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Partly fixes: https://github.com/MetaMask/metamask-extension/issues/30144

## **Manual testing steps**

1. Verify all bridge components render correctly with proper icon colors
2. Check tooltip components display icons with appropriate styling 
3. Confirm gas fee modal icons appear as expected
4. Ensure settings page icons styling is unchanged visually

## **Screenshots/Recordings**

Not applicable - this is a technical debt cleanup with no visual changes expected.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the deprecated `iconAlternativeSoft` token and CSS, updating components to use `iconAlternative`.
> 
> - **Design System**:
>   - Remove `IconColor.iconAlternativeSoft` from `ui/helpers/constants/design-system.ts`.
> - **UI Components**:
>   - Update `gas-fee-token-modal.tsx` and `transaction-shield.tsx` to use `IconColor.iconAlternative` instead of `iconAlternativeSoft`.
> - **Styles**:
>   - In `ui/pages/bridge/index.scss`, remove `--color-icon-alternative-soft` variables and `.mm-box--color-icon-alternative-soft` class.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 682c3f1a458090f73e1fd0b5060011b7c307dd80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->