### PR TITLE
chore: remove deprecated BackgroundColor.backgroundAlternativeSoft

### DIFF
--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -155,9 +155,6 @@ export enum BackgroundColor {
   backgroundSubsection = 'background-subsection',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  backgroundAlternativeSoft = 'background-alternative-soft',
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   backgroundHover = 'background-hover',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/bridge/index.scss
+++ b/ui/pages/bridge/index.scss
@@ -13,24 +13,6 @@
   --size: 12px;
 }
 
-// TODO: Replace with design tokens @MetaMask/swaps-engineer - temporary theme-specific colors
-/* stylelint-disable color-no-hex */
-[data-theme='light'],
-.light {
-  --color-background-alternative-soft: #f9fafb; // TODO: Needs design token replacement
-}
-
-[data-theme='dark'],
-.dark {
-  --color-background-alternative-soft: #1f2124; // TODO: Needs design token replacement
-}
-/* stylelint-enable color-no-hex */
-
-
-.mm-box--background-color-background-alternative-soft {
-  background-color: var(--color-background-alternative-soft);
-}
-
 .bridge__container {
   height: 100%;
   min-width: 360px;


### PR DESCRIPTION
## **Description**

Remove the deprecated `BackgroundColor.backgroundAlternativeSoft` design token and replace all usage with `BackgroundColor.backgroundAlternative`. This addresses part of the technical debt cleanup by removing the final deprecated design token that was incorrectly added to the design system.

The changes include:
- Removing `backgroundAlternativeSoft = 'background-alternative-soft'` from the BackgroundColor enum
- Replacing all component usage of `BackgroundColor.backgroundAlternativeSoft` with `BackgroundColor.backgroundAlternative` 
- Removing associated CSS custom properties and classes for `background-alternative-soft`
- Updating test snapshots to reflect the CSS class changes from `mm-box--background-color-background-alternative-soft` to `mm-box--background-color-background-alternative`

**Note:** This PR completes the cleanup of deprecated alternative-soft tokens. Previous PRs addressed `textAlternativeSoft` and `iconAlternativeSoft`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/30144

## **Manual testing steps**

1. Verify all bridge components render correctly with proper background colors
2. Check prepare bridge page displays backgrounds with appropriate styling 
3. Confirm switch tokens button background appears as expected
4. Ensure overall bridge page styling is unchanged visually

## **Screenshots/Recordings**

Not applicable - this is a technical debt cleanup with no visual changes expected.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `BackgroundColor.backgroundAlternativeSoft` and deletes related `background-alternative-soft` CSS vars/classes from bridge styles.
> 
> - **Design System**:
>   - Remove `BackgroundColor.backgroundAlternativeSoft` from `ui/helpers/constants/design-system.ts`.
> - **Bridge Styles** (`ui/pages/bridge/index.scss`):
>   - Delete theme-specific CSS variables for `--color-background-alternative-soft` (light/dark).
>   - Remove `.mm-box--background-color-background-alternative-soft` rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82cfbb07ffa0c9e2e0053a4d581ce1524ee748b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->