### PR TITLE
chore: default to maskicon at the avatar level

### DIFF
--- a/ui/components/app/preferred-avatar/preferred-avatar.tsx
+++ b/ui/components/app/preferred-avatar/preferred-avatar.tsx
@@ -26,5 +26,5 @@ const avatarTypeMap = {
 
 function getAvatarType({ metamask: { preferences } }: MetaMaskReduxState) {
   const avatarType = preferences?.avatarType;
-  return avatarType ? avatarTypeMap[avatarType] : undefined;
+  return avatarType ? avatarTypeMap[avatarType] : AvatarAccountVariant.Maskicon;
 }

--- a/ui/components/app/preferred-avatar/preferred-avatar.tsx
+++ b/ui/components/app/preferred-avatar/preferred-avatar.tsx
@@ -25,6 +25,6 @@ const avatarTypeMap = {
 };
 
 function getAvatarType({ metamask: { preferences } }: MetaMaskReduxState) {
-  const avatarType = preferences?.avatarType;
-  return avatarType ? avatarTypeMap[avatarType] : AvatarAccountVariant.Maskicon;
+  const avatarType = preferences?.avatarType || 'maskicon';
+  return avatarTypeMap[avatarType];
 }

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -9,45 +9,12 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(35, 83, 225);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#03475E"
-              height="32"
-              transform="translate(2.93051364518973 1.22614695259726) rotate(127.9 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F95801"
-              height="32"
-              transform="translate(7.17183210118496 11.07980552300802) rotate(153.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#017B8E"
-              height="32"
-              transform="translate(8.45143442708077 22.46860174935927) rotate(146.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -68,45 +35,12 @@ exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(35, 83, 225);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#03475E"
-              height="32"
-              transform="translate(2.93051364518973 1.22614695259726) rotate(127.9 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F95801"
-              height="32"
-              transform="translate(7.17183210118496 11.07980552300802) rotate(153.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#017B8E"
-              height="32"
-              transform="translate(8.45143442708077 22.46860174935927) rotate(146.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -127,45 +61,12 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 59, 94);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#2339E1"
-              height="32"
-              transform="translate(-10.57709536850356 1.27788532664115) rotate(258.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#FB182B"
-              height="32"
-              transform="translate(5.67733727066244 9.94368742032136) rotate(189.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#EDF500"
-              height="32"
-              transform="translate(-25.62998642818306 -17.79040578649136) rotate(296.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -186,45 +87,12 @@ exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 59, 94);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#2339E1"
-              height="32"
-              transform="translate(-10.57709536850356 1.27788532664115) rotate(258.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#FB182B"
-              height="32"
-              transform="translate(5.67733727066244 9.94368742032136) rotate(189.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#EDF500"
-              height="32"
-              transform="translate(-25.62998642818306 -17.79040578649136) rotate(296.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -245,45 +113,12 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 83);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#F29602"
-              height="32"
-              transform="translate(-2.81750896228304 4.95191654400623) rotate(230.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#236CE1"
-              height="32"
-              transform="translate(-13.49865029263281 -9.44191867669309) rotate(245.3 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#018E8E"
-              height="32"
-              transform="translate(18.42469405222943 23.24877720627808) rotate(173.9 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -304,45 +139,12 @@ exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 83);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#F29602"
-              height="32"
-              transform="translate(-2.81750896228304 4.95191654400623) rotate(230.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#236CE1"
-              height="32"
-              transform="translate(-13.49865029263281 -9.44191867669309) rotate(245.3 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#018E8E"
-              height="32"
-              transform="translate(18.42469405222943 23.24877720627808) rotate(173.9 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -363,45 +165,12 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(251, 24, 81);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#C81441"
-              height="32"
-              transform="translate(7.89293039869636 3.81505315001625) rotate(81.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F95001"
-              height="32"
-              transform="translate(-15.11553225410416 5.65823114066517) rotate(249.8 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#034A5E"
-              height="32"
-              transform="translate(18.78211641009715 -20.96644138082799) rotate(321.3 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -422,45 +191,12 @@ exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(251, 24, 81);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#C81441"
-              height="32"
-              transform="translate(7.89293039869636 3.81505315001625) rotate(81.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F95001"
-              height="32"
-              transform="translate(-15.11553225410416 5.65823114066517) rotate(249.8 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#034A5E"
-              height="32"
-              transform="translate(18.78211641009715 -20.96644138082799) rotate(321.3 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -481,45 +217,12 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 198, 242);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#238CE1"
-              height="32"
-              transform="translate(-0.93263597805800 -0.77609792173980) rotate(228.7 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#018E77"
-              height="32"
-              transform="translate(14.63385912762450 0.17102681763595) rotate(175.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F26E02"
-              height="32"
-              transform="translate(22.33401116585189 0.64465270748203) rotate(17.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -540,45 +243,12 @@ exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 198, 242);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#238CE1"
-              height="32"
-              transform="translate(-0.93263597805800 -0.77609792173980) rotate(228.7 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#018E77"
-              height="32"
-              transform="translate(14.63385912762450 0.17102681763595) rotate(175.0 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F26E02"
-              height="32"
-              transform="translate(22.33401116585189 0.64465270748203) rotate(17.6 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -599,45 +269,12 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 162, 0);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#03405E"
-              height="32"
-              transform="translate(2.06481943493039 4.67251827463514) rotate(110.8 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#FB1836"
-              height="32"
-              transform="translate(-11.72229395562091 -7.60164355296404) rotate(323.2 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F96C01"
-              height="32"
-              transform="translate(-21.47761817022074 15.26919418349953) rotate(281.7 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -658,45 +295,12 @@ exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 162, 0);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#03405E"
-              height="32"
-              transform="translate(2.06481943493039 4.67251827463514) rotate(110.8 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#FB1836"
-              height="32"
-              transform="translate(-11.72229395562091 -7.60164355296404) rotate(323.2 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#F96C01"
-              height="32"
-              transform="translate(-21.47761817022074 15.26919418349953) rotate(281.7 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
@@ -717,45 +321,12 @@ exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
     <div
       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
     >
-      <div
-        class="flex [&>div]:!rounded-none"
-      >
-        <div
-          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 83);"
-        >
-          <svg
-            height="32"
-            width="32"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#F29602"
-              height="32"
-              transform="translate(-2.81750896228304 4.95191654400623) rotate(230.4 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#236CE1"
-              height="32"
-              transform="translate(-13.49865029263281 -9.44191867669309) rotate(245.3 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-            <rect
-              fill="#018E8E"
-              height="32"
-              transform="translate(18.42469405222943 23.24877720627808) rotate(173.9 16.00000000000000 16.00000000000000)"
-              width="32"
-              x="0"
-              y="0"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        alt="maskicon"
+        height="32"
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+        width="32"
+      />
     </div>
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -44,45 +44,12 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                         <div
                           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                         >
-                          <div
-                            class="flex [&>div]:!rounded-none"
-                          >
-                            <div
-                              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                            >
-                              <svg
-                                height="32"
-                                width="32"
-                                x="0"
-                                y="0"
-                              >
-                                <rect
-                                  fill="#18CDF2"
-                                  height="32"
-                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#035E56"
-                                  height="32"
-                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#F26602"
-                                  height="32"
-                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                          <img
+                            alt="maskicon"
+                            height="32"
+                            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                            width="32"
+                          />
                         </div>
                         <div
                           class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -96,45 +63,12 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                     <div
                       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                     >
-                      <div
-                        class="flex [&>div]:!rounded-none"
-                      >
-                        <div
-                          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                        >
-                          <svg
-                            height="32"
-                            width="32"
-                            x="0"
-                            y="0"
-                          >
-                            <rect
-                              fill="#18CDF2"
-                              height="32"
-                              transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                            <rect
-                              fill="#035E56"
-                              height="32"
-                              transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                            <rect
-                              fill="#F26602"
-                              height="32"
-                              transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                          </svg>
-                        </div>
-                      </div>
+                      <img
+                        alt="maskicon"
+                        height="32"
+                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                        width="32"
+                      />
                     </div>
                   </div>
                   <div
@@ -355,45 +289,12 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                         <div
                           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                         >
-                          <div
-                            class="flex [&>div]:!rounded-none"
-                          >
-                            <div
-                              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                            >
-                              <svg
-                                height="32"
-                                width="32"
-                                x="0"
-                                y="0"
-                              >
-                                <rect
-                                  fill="#18CDF2"
-                                  height="32"
-                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#035E56"
-                                  height="32"
-                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#F26602"
-                                  height="32"
-                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                          <img
+                            alt="maskicon"
+                            height="32"
+                            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                            width="32"
+                          />
                         </div>
                         <div
                           class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -407,45 +308,12 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                     <div
                       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                     >
-                      <div
-                        class="flex [&>div]:!rounded-none"
-                      >
-                        <div
-                          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                        >
-                          <svg
-                            height="32"
-                            width="32"
-                            x="0"
-                            y="0"
-                          >
-                            <rect
-                              fill="#18CDF2"
-                              height="32"
-                              transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                            <rect
-                              fill="#035E56"
-                              height="32"
-                              transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                            <rect
-                              fill="#F26602"
-                              height="32"
-                              transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                              width="32"
-                              x="0"
-                              y="0"
-                            />
-                          </svg>
-                        </div>
-                      </div>
+                      <img
+                        alt="maskicon"
+                        height="32"
+                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                        width="32"
+                      />
                     </div>
                   </div>
                   <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
@@ -22,45 +22,12 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(250, 58, 0);"
-                >
-                  <svg
-                    height="24"
-                    width="24"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#18CDF2"
-                      height="24"
-                      transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#035E56"
-                      height="24"
-                      transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F26602"
-                      height="24"
-                      transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="24"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="24"
+              />
             </div>
             <div
               class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
@@ -242,45 +209,12 @@ exports[`SnapUIAddressInput will render a matched address name 1`] = `
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(250, 58, 0);"
-                >
-                  <svg
-                    height="24"
-                    width="24"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#18CDF2"
-                      height="24"
-                      transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#035E56"
-                      height="24"
-                      transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F26602"
-                      height="24"
-                      transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="24"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="24"
+              />
             </div>
             <div
               class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
@@ -339,45 +273,12 @@ exports[`SnapUIAddressInput will render avatar when displayAvatar is true 1`] = 
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(242, 202, 2);"
-                >
-                  <svg
-                    height="24"
-                    width="24"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#03405E"
-                      height="24"
-                      transform="translate(-5.10322745178983 -4.00545785380792) rotate(369.5 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FAA200"
-                      height="24"
-                      transform="translate(4.65401715943415 -10.42267189532552) rotate(387.5 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#016F8E"
-                      height="24"
-                      transform="translate(-16.38031686102804 -8.91841489898652) rotate(241.5 12.00000000000000 12.00000000000000)"
-                      width="24"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="24"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="24"
+              />
             </div>
             <input
               autocomplete="off"

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -32,45 +32,12 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <div
                   class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                 >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
-                    >
-                      <svg
-                        height="32"
-                        width="32"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#F2C602"
-                          height="32"
-                          transform="translate(5.02062044750432 0.81039489042363) rotate(161.5 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F5ED00"
-                          height="32"
-                          transform="translate(-9.40812135399240 -10.30504258407245) rotate(246.0 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#FB183A"
-                          height="32"
-                          transform="translate(9.19255526987956 26.91416082088715) rotate(215.5 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
+                  <img
+                    alt="maskicon"
+                    height="32"
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                    width="32"
+                  />
                 </div>
                 <div
                   class="mm-box mm-badge-wrapper__badge-container"
@@ -91,45 +58,12 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 47);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#F2C602"
-                  height="32"
-                  transform="translate(5.02062044750432 0.81039489042363) rotate(161.5 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#F5ED00"
-                  height="32"
-                  transform="translate(-9.40812135399240 -10.30504258407245) rotate(246.0 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#FB183A"
-                  height="32"
-                  transform="translate(9.19255526987956 26.91416082088715) rotate(215.5 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
       </div>
       <div
@@ -265,45 +199,12 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                 <div
                   class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                 >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="32"
-                        width="32"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="32"
-                          transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="32"
-                          transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="32"
-                          transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
+                  <img
+                    alt="maskicon"
+                    height="32"
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                    width="32"
+                  />
                 </div>
                 <div
                   class="mm-box mm-badge-wrapper__badge-container"
@@ -324,45 +225,12 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#18CDF2"
-                  height="32"
-                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#035E56"
-                  height="32"
-                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#F26602"
-                  height="32"
-                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
       </div>
       <div

--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -19,45 +19,12 @@ exports[`AccountPicker renders properly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
-              >
-                <svg
-                  height="16"
-                  width="16"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#18CDF2"
-                    height="16"
-                    transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#035E56"
-                    height="16"
-                    transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F26602"
-                    height="16"
-                    transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="16"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="16"
+            />
           </div>
           <span
             class="mm-box mm-text multichain-account-picker__label w-full mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-default"

--- a/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
+++ b/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
@@ -14,45 +14,12 @@ exports[`AddressListItem displays duplicate contact warning icon 1`] = `
         <div
           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 73, 94);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#F5D800"
-                  height="32"
-                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#1888F2"
-                  height="32"
-                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#017E8E"
-                  height="32"
-                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
         <div
           class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -135,45 +102,12 @@ exports[`AddressListItem renders the address and label without duplicate contact
         <div
           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 73, 94);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#F5D800"
-                  height="32"
-                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#1888F2"
-                  height="32"
-                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#017E8E"
-                  height="32"
-                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
         <div
           class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -237,45 +171,12 @@ exports[`AddressListItem uses a confusable when it should 1`] = `
         <div
           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 73, 94);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#F5D800"
-                  height="32"
-                  transform="translate(-2.25975164212884 9.98672785630931) rotate(238.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#1888F2"
-                  height="32"
-                  transform="translate(3.59834074343342 13.96339479555801) rotate(211.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#017E8E"
-                  height="32"
-                  transform="translate(5.50481940703773 -22.91863393981918) rotate(404.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
         <div
           class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -105,45 +105,12 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#18CDF2"
-                    height="32"
-                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#035E56"
-                    height="32"
-                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F26602"
-                    height="32"
-                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div

--- a/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
+++ b/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
@@ -12,45 +12,12 @@ exports[`Badge Status should not render the badge if showConnectedStatus is fals
       <div
         class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
       >
-        <div
-          class="flex [&>div]:!rounded-none"
-        >
-          <div
-            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-          >
-            <svg
-              height="32"
-              width="32"
-              x="0"
-              y="0"
-            >
-              <rect
-                fill="#18CDF2"
-                height="32"
-                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                width="32"
-                x="0"
-                y="0"
-              />
-              <rect
-                fill="#035E56"
-                height="32"
-                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                width="32"
-                x="0"
-                y="0"
-              />
-              <rect
-                fill="#F26602"
-                height="32"
-                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                width="32"
-                x="0"
-                y="0"
-              />
-            </svg>
-          </div>
-        </div>
+        <img
+          alt="maskicon"
+          height="32"
+          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+          width="32"
+        />
       </div>
       <div
         class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -81,45 +48,12 @@ exports[`Badge Status should render correctly 1`] = `
           <div
             class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#18CDF2"
-                    height="32"
-                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#035E56"
-                    height="32"
-                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F26602"
-                    height="32"
-                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
           <div
             class="mm-box mm-badge-wrapper__badge-container"

--- a/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
+++ b/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
@@ -148,45 +148,12 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                           <div
                             class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                           >
-                            <div
-                              class="flex [&>div]:!rounded-none"
-                            >
-                              <div
-                                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(35, 140, 225);"
-                              >
-                                <svg
-                                  height="32"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                >
-                                  <rect
-                                    fill="#FA4300"
-                                    height="32"
-                                    transform="translate(-1.71206692608472 -0.69204091301509) rotate(264.3 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#018E77"
-                                    height="32"
-                                    transform="translate(-11.34039183162060 -14.99229262588826) rotate(296.3 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#F26E02"
-                                    height="32"
-                                    transform="translate(18.20771949937685 -18.30098040188356) rotate(444.6 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                            <img
+                              alt="maskicon"
+                              height="32"
+                              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                              width="32"
+                            />
                           </div>
                           <div
                             class="mm-box mm-badge-wrapper__badge-container"
@@ -207,45 +174,12 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                   <div
                     class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(35, 140, 225);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#FA4300"
-                            height="32"
-                            transform="translate(-1.71206692608472 -0.69204091301509) rotate(264.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#018E77"
-                            height="32"
-                            transform="translate(-11.34039183162060 -14.99229262588826) rotate(296.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F26E02"
-                            height="32"
-                            transform="translate(18.20771949937685 -18.30098040188356) rotate(444.6 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                 </div>
                 <div

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -90,45 +90,12 @@ exports[`Connections Content should render correctly 1`] = `
                         <div
                           class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                         >
-                          <div
-                            class="flex [&>div]:!rounded-none"
-                          >
-                            <div
-                              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                            >
-                              <svg
-                                height="32"
-                                width="32"
-                                x="0"
-                                y="0"
-                              >
-                                <rect
-                                  fill="#18CDF2"
-                                  height="32"
-                                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#035E56"
-                                  height="32"
-                                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#F26602"
-                                  height="32"
-                                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                          <img
+                            alt="maskicon"
+                            height="32"
+                            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                            width="32"
+                          />
                         </div>
                         <div
                           class="mm-box mm-badge-wrapper__badge-container"
@@ -149,45 +116,12 @@ exports[`Connections Content should render correctly 1`] = `
                 <div
                   class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="32"
-                        width="32"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="32"
-                          transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="32"
-                          transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="32"
-                          transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                          width="32"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
+                  <img
+                    alt="maskicon"
+                    height="32"
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                    width="32"
+                  />
                 </div>
               </div>
               <div

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -69,45 +69,12 @@ exports[`SendPage render and initialization should render correctly even when a 
                   <div
                     class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 151, 242);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#2362E1"
-                            height="32"
-                            transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F94301"
-                            height="32"
-                            transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#FA7900"
-                            height="32"
-                            transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%23E5FFC3%22%20%2F%3E%3Cpath%20d%3D%22M16%2C16%20h8%20v8z%20M8%2C16%20h8%20v8%20h-8z%20M8%2C8%20h8%20v8%20h-8z%20M16%2C8%20h8%20v8%20h-8z%20%22%20fill%3D%22%233D065F%22%20%2F%3E%3C%2Fsvg%3E"
+                      width="32"
+                    />
                   </div>
                   <span
                     class="mm-box mm-text multichain-account-picker__label w-full multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"
@@ -239,45 +206,12 @@ exports[`SendPage render and initialization should render correctly even when a 
                                 <div
                                   class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                                 >
-                                  <div
-                                    class="flex [&>div]:!rounded-none"
-                                  >
-                                    <div
-                                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 151, 242);"
-                                    >
-                                      <svg
-                                        height="32"
-                                        width="32"
-                                        x="0"
-                                        y="0"
-                                      >
-                                        <rect
-                                          fill="#2362E1"
-                                          height="32"
-                                          transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
-                                          width="32"
-                                          x="0"
-                                          y="0"
-                                        />
-                                        <rect
-                                          fill="#F94301"
-                                          height="32"
-                                          transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
-                                          width="32"
-                                          x="0"
-                                          y="0"
-                                        />
-                                        <rect
-                                          fill="#FA7900"
-                                          height="32"
-                                          transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
-                                          width="32"
-                                          x="0"
-                                          y="0"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </div>
+                                  <img
+                                    alt="maskicon"
+                                    height="32"
+                                    src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%23E5FFC3%22%20%2F%3E%3Cpath%20d%3D%22M16%2C16%20h8%20v8z%20M8%2C16%20h8%20v8%20h-8z%20M8%2C8%20h8%20v8%20h-8z%20M16%2C8%20h8%20v8%20h-8z%20%22%20fill%3D%22%233D065F%22%20%2F%3E%3C%2Fsvg%3E"
+                                    width="32"
+                                  />
                                 </div>
                                 <div
                                   class="mm-box mm-badge-wrapper__badge-container"
@@ -298,45 +232,12 @@ exports[`SendPage render and initialization should render correctly even when a 
                         <div
                           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                         >
-                          <div
-                            class="flex [&>div]:!rounded-none"
-                          >
-                            <div
-                              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 151, 242);"
-                            >
-                              <svg
-                                height="32"
-                                width="32"
-                                x="0"
-                                y="0"
-                              >
-                                <rect
-                                  fill="#2362E1"
-                                  height="32"
-                                  transform="translate(3.58933018479252 -5.33431062323352) rotate(458.4 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#F94301"
-                                  height="32"
-                                  transform="translate(-15.36345928965021 7.99235163548663) rotate(268.8 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                                <rect
-                                  fill="#FA7900"
-                                  height="32"
-                                  transform="translate(-9.07625407930142 29.48001588068337) rotate(117.3 16.00000000000000 16.00000000000000)"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                />
-                              </svg>
-                            </div>
-                          </div>
+                          <img
+                            alt="maskicon"
+                            height="32"
+                            src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%23E5FFC3%22%20%2F%3E%3Cpath%20d%3D%22M16%2C16%20h8%20v8z%20M8%2C16%20h8%20v8%20h-8z%20M8%2C8%20h8%20v8%20h-8z%20M16%2C8%20h8%20v8%20h-8z%20%22%20fill%3D%22%233D065F%22%20%2F%3E%3C%2Fsvg%3E"
+                            width="32"
+                          />
                         </div>
                       </div>
                       <div

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -31,45 +31,12 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                >
-                  <svg
-                    height="32"
-                    width="32"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#18CDF2"
-                      height="32"
-                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#035E56"
-                      height="32"
-                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F26602"
-                      height="32"
-                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="32"
+              />
             </div>
             <span
               class="mm-box mm-text multichain-account-picker__label w-full multichain-send-page__account-picker__label mm-text--body-md-medium mm-text--ellipsis mm-box--padding-inline-start-1 mm-box--color-text-default"

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -39,45 +39,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#18CDF2"
-                            height="32"
-                            transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#035E56"
-                            height="32"
-                            transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F26602"
-                            height="32"
-                            transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -98,45 +65,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#18CDF2"
-                    height="32"
-                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#035E56"
-                    height="32"
-                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F26602"
-                    height="32"
-                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div
@@ -320,45 +254,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(245, 143, 0);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#018E74"
-                            height="32"
-                            transform="translate(6.31324788223360 -5.42828065250795) rotate(358.4 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#18CAF2"
-                            height="32"
-                            transform="translate(7.68561556502290 -12.13837331367715) rotate(414.8 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#C81474"
-                            height="32"
-                            transform="translate(-5.60890874850315 -25.08111129823563) rotate(322.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -379,45 +280,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(245, 143, 0);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#018E74"
-                    height="32"
-                    transform="translate(6.31324788223360 -5.42828065250795) rotate(358.4 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#18CAF2"
-                    height="32"
-                    transform="translate(7.68561556502290 -12.13837331367715) rotate(414.8 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#C81474"
-                    height="32"
-                    transform="translate(-5.60890874850315 -25.08111129823563) rotate(322.3 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div
@@ -601,45 +469,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(249, 100, 1);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#C81432"
-                            height="32"
-                            transform="translate(-0.58364599940026 -3.10395650325606) rotate(331.7 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#187AF2"
-                            height="32"
-                            transform="translate(-12.71763556831265 6.33167460903850) rotate(160.5 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#FB183E"
-                            height="32"
-                            transform="translate(28.66808622335520 -2.98423570225476) rotate(517.6 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -660,45 +495,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(249, 100, 1);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#C81432"
-                    height="32"
-                    transform="translate(-0.58364599940026 -3.10395650325606) rotate(331.7 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#187AF2"
-                    height="32"
-                    transform="translate(-12.71763556831265 6.33167460903850) rotate(160.5 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB183E"
-                    height="32"
-                    transform="translate(28.66808622335520 -2.98423570225476) rotate(517.6 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div
@@ -896,45 +698,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(242, 206, 2);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#2340E1"
-                            height="32"
-                            transform="translate(-1.94909044681660 -1.02146511188663) rotate(257.0 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#016D8E"
-                            height="32"
-                            transform="translate(12.81547793667531 3.04294704448066) rotate(77.0 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F5F500"
-                            height="32"
-                            transform="translate(13.12760557815881 -22.24733546602543) rotate(465.0 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -955,45 +724,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(242, 206, 2);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#2340E1"
-                    height="32"
-                    transform="translate(-1.94909044681660 -1.02146511188663) rotate(257.0 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#016D8E"
-                    height="32"
-                    transform="translate(12.81547793667531 3.04294704448066) rotate(77.0 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F5F500"
-                    height="32"
-                    transform="translate(13.12760557815881 -22.24733546602543) rotate(465.0 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div
@@ -1177,45 +913,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 125, 242);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#C81435"
-                            height="32"
-                            transform="translate(-2.11931973274503 -1.88565434048474) rotate(249.5 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F5E400"
-                            height="32"
-                            transform="translate(-1.51329519409837 12.00629136557892) rotate(269.5 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F96001"
-                            height="32"
-                            transform="translate(7.57809408156820 24.82791748135462) rotate(216.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -1236,45 +939,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 125, 242);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#C81435"
-                    height="32"
-                    transform="translate(-2.11931973274503 -1.88565434048474) rotate(249.5 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F5E400"
-                    height="32"
-                    transform="translate(-1.51329519409837 12.00629136557892) rotate(269.5 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F96001"
-                    height="32"
-                    transform="translate(7.57809408156820 24.82791748135462) rotate(216.3 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div
@@ -1476,45 +1146,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
                   <div
                     class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                   >
-                    <div
-                      class="flex [&>div]:!rounded-none"
-                    >
-                      <div
-                        style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 62, 0);"
-                      >
-                        <svg
-                          height="32"
-                          width="32"
-                          x="0"
-                          y="0"
-                        >
-                          <rect
-                            fill="#238FE1"
-                            height="32"
-                            transform="translate(-4.22511604300063 4.95315457589492) rotate(161.9 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#FB1891"
-                            height="32"
-                            transform="translate(-4.42582930472556 12.96227170755112) rotate(224.3 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                          <rect
-                            fill="#F90901"
-                            height="32"
-                            transform="translate(-26.83328669803749 -15.29840288989196) rotate(344.7 16.00000000000000 16.00000000000000)"
-                            width="32"
-                            x="0"
-                            y="0"
-                          />
-                        </svg>
-                      </div>
-                    </div>
+                    <img
+                      alt="maskicon"
+                      height="32"
+                      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                      width="32"
+                    />
                   </div>
                   <div
                     class="mm-box mm-badge-wrapper__badge-container"
@@ -1535,45 +1172,12 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 62, 0);"
-              >
-                <svg
-                  height="32"
-                  width="32"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#238FE1"
-                    height="32"
-                    transform="translate(-4.22511604300063 4.95315457589492) rotate(161.9 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#FB1891"
-                    height="32"
-                    transform="translate(-4.42582930472556 12.96227170755112) rotate(224.3 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F90901"
-                    height="32"
-                    transform="translate(-26.83328669803749 -15.29840288989196) rotate(344.7 16.00000000000000 16.00000000000000)"
-                    width="32"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="32"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="32"
+            />
           </div>
         </div>
         <div

--- a/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
@@ -91,45 +91,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -200,45 +167,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#FA6C00"
-                        height="32"
-                        transform="translate(0.01249901372809 -0.00638531932212) rotate(489.0 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#FB1868"
-                        height="32"
-                        transform="translate(-14.40859714033898 -8.78073616628893) rotate(387.1 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F5BC00"
-                        height="32"
-                        transform="translate(-12.05422484490241 -22.09189203281855) rotate(345.4 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -298,45 +232,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 92);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#F28A02"
-                        height="32"
-                        transform="translate(5.85679601232064 8.73763648404988) rotate(159.5 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#18ADF2"
-                        height="32"
-                        transform="translate(-10.73204448728490 -4.45155204872247) rotate(339.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#FB1873"
-                        height="32"
-                        transform="translate(16.74388510034174 -17.07926870784832) rotate(454.3 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -396,45 +297,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -505,45 +373,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(245, 184, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#C81456"
-                        height="32"
-                        transform="translate(6.08027806332155 4.08483457615849) rotate(206.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#018E8C"
-                        height="32"
-                        transform="translate(-15.50540861516881 -13.01198576121028) rotate(356.3 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#03555E"
-                        height="32"
-                        transform="translate(27.99211103277474 3.07823814627029) rotate(92.1 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -603,45 +438,12 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -804,45 +606,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -902,45 +671,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 162, 242);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#FA6C00"
-                        height="32"
-                        transform="translate(0.01249901372809 -0.00638531932212) rotate(489.0 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#FB1868"
-                        height="32"
-                        transform="translate(-14.40859714033898 -8.78073616628893) rotate(387.1 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F5BC00"
-                        height="32"
-                        transform="translate(-12.05422484490241 -22.09189203281855) rotate(345.4 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -1000,45 +736,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 92);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#F28A02"
-                        height="32"
-                        transform="translate(5.85679601232064 8.73763648404988) rotate(159.5 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#18ADF2"
-                        height="32"
-                        transform="translate(-10.73204448728490 -4.45155204872247) rotate(339.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#FB1873"
-                        height="32"
-                        transform="translate(16.74388510034174 -17.07926870784832) rotate(454.3 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -1098,45 +801,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -1196,45 +866,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(245, 184, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#C81456"
-                        height="32"
-                        transform="translate(6.08027806332155 4.08483457615849) rotate(206.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#018E8C"
-                        height="32"
-                        transform="translate(-15.50540861516881 -13.01198576121028) rotate(356.3 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#03555E"
-                        height="32"
-                        transform="translate(27.99211103277474 3.07823814627029) rotate(92.1 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div
@@ -1294,45 +931,12 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
                 class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                 style="min-width: max-content; border-radius: 8px;"
               >
-                <div
-                  class="flex [&>div]:!rounded-none"
-                >
-                  <div
-                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                  >
-                    <svg
-                      height="32"
-                      width="32"
-                      x="0"
-                      y="0"
-                    >
-                      <rect
-                        fill="#18CDF2"
-                        height="32"
-                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#035E56"
-                        height="32"
-                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                      <rect
-                        fill="#F26602"
-                        height="32"
-                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                        width="32"
-                        x="0"
-                        y="0"
-                      />
-                    </svg>
-                  </div>
-                </div>
+                <img
+                  alt="maskicon"
+                  height="32"
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                  width="32"
+                />
               </div>
             </div>
             <div

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -136,45 +136,12 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
           <div
             class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-[10px] h-10 w-10"
           >
-            <div
-              class="flex [&>div]:!rounded-none"
-            >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 40px; height: 40px; display: inline-block; background: rgb(245, 228, 0);"
-              >
-                <svg
-                  height="40"
-                  width="40"
-                  x="0"
-                  y="0"
-                >
-                  <rect
-                    fill="#F2BE02"
-                    height="40"
-                    transform="translate(6.85340641784172 -6.49420041913425) rotate(387.1 20.00000000000000 20.00000000000000)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#01778E"
-                    height="40"
-                    transform="translate(-3.25681992727619 20.88075781940391) rotate(227.4 20.00000000000000 20.00000000000000)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#C81435"
-                    height="40"
-                    transform="translate(22.46211355113039 -15.74081131487140) rotate(422.3 20.00000000000000 20.00000000000000)"
-                    width="40"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
-            </div>
+            <img
+              alt="maskicon"
+              height="40"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+              width="40"
+            />
           </div>
         </div>
         <div

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -15,45 +15,12 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#18CDF2"
-                  height="32"
-                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#035E56"
-                  height="32"
-                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#F26602"
-                  height="32"
-                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
@@ -222,45 +189,12 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
         >
-          <div
-            class="flex [&>div]:!rounded-none"
-          >
-            <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 100, 242);"
-            >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
-              >
-                <rect
-                  fill="#C81420"
-                  height="32"
-                  transform="translate(-5.50523690490468 -5.26512336373754) rotate(385.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#E9F500"
-                  height="32"
-                  transform="translate(10.67446940672640 12.42992815919339) rotate(184.5 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#FAB300"
-                  height="32"
-                  transform="translate(1.81545519923623 -26.03028190637629) rotate(431.3 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
-            </div>
-          </div>
+          <img
+            alt="maskicon"
+            height="32"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            width="32"
+          />
         </div>
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -22,45 +22,12 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                >
-                  <svg
-                    height="32"
-                    width="32"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#18CDF2"
-                      height="32"
-                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#035E56"
-                      height="32"
-                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F26602"
-                      height="32"
-                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%23EAC2FF%22%20%2F%3E%3Cpath%20d%3D%22M16%2C16%20h8%20v8%20h-8z%20M8%2C16%20h8%20v8%20h-8z%20M8%2C8%20h8%20v8z%20M24%2C16%20h-8%20v-8z%20%22%20fill%3D%22%23D075FF%22%20%2F%3E%3C%2Fsvg%3E"
+                width="32"
+              />
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
@@ -282,8 +249,11 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="32"
               />
             </div>
             <div
@@ -770,8 +740,11 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="32"
               />
             </div>
             <div
@@ -1205,45 +1178,12 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                >
-                  <svg
-                    height="32"
-                    width="32"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#18CDF2"
-                      height="32"
-                      transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#035E56"
-                      height="32"
-                      transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F26602"
-                      height="32"
-                      transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%23EAC2FF%22%20%2F%3E%3Cpath%20d%3D%22M16%2C16%20h8%20v8%20h-8z%20M8%2C16%20h8%20v8%20h-8z%20M8%2C8%20h8%20v8z%20M24%2C16%20h-8%20v-8z%20%22%20fill%3D%22%23D075FF%22%20%2F%3E%3C%2Fsvg%3E"
+                width="32"
+              />
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
@@ -1983,45 +1923,12 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 59);"
-                >
-                  <svg
-                    height="32"
-                    width="32"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#017B8E"
-                      height="32"
-                      transform="translate(0.79944606935671 -0.82160111569698) rotate(317.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F2B602"
-                      height="32"
-                      transform="translate(-7.49339603691225 11.40993542828480) rotate(134.1 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FA8E00"
-                      height="32"
-                      transform="translate(-25.71227269075480 -11.55888104326888) rotate(364.0 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%2389B0FF%22%20%2F%3E%3Cpath%20d%3D%22M24%2C16%20v8%20h-8z%20M16%2C8%20h8%20v8z%20M8%2C8%20h8%20v8%20h-8z%20M16%2C16%20v8%20h-8z%20%22%20fill%3D%22%23190066%22%20%2F%3E%3C%2Fsvg%3E"
+                width="32"
+              />
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
@@ -2457,45 +2364,12 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
-              >
-                <div
-                  style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(200, 20, 59);"
-                >
-                  <svg
-                    height="32"
-                    width="32"
-                    x="0"
-                    y="0"
-                  >
-                    <rect
-                      fill="#017B8E"
-                      height="32"
-                      transform="translate(0.79944606935671 -0.82160111569698) rotate(317.9 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#F2B602"
-                      height="32"
-                      transform="translate(-7.49339603691225 11.40993542828480) rotate(134.1 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                    <rect
-                      fill="#FA8E00"
-                      height="32"
-                      transform="translate(-25.71227269075480 -11.55888104326888) rotate(364.0 16.00000000000000 16.00000000000000)"
-                      width="32"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                </div>
-              </div>
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg%20width%3D%2232%22%20height%3D%2232%22%20viewBox%3D%220%200%2032%2032%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2232%22%20height%3D%2232%22%20fill%3D%22%2389B0FF%22%20%2F%3E%3Cpath%20d%3D%22M24%2C16%20v8%20h-8z%20M16%2C8%20h8%20v8z%20M8%2C8%20h8%20v8%20h-8z%20M16%2C16%20v8%20h-8z%20%22%20fill%3D%22%23190066%22%20%2F%3E%3C%2Fsvg%3E"
+                width="32"
+              />
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-goerli mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
@@ -3151,8 +3025,11 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="32"
               />
             </div>
             <div
@@ -3262,8 +3139,11 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
             <div
               class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
             >
-              <div
-                class="flex [&>div]:!rounded-none"
+              <img
+                alt="maskicon"
+                height="32"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                width="32"
               />
             </div>
             <div

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -125,45 +125,12 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                               <div
                                 class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                               >
-                                <div
-                                  class="flex [&>div]:!rounded-none"
-                                >
-                                  <div
-                                    style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                                  >
-                                    <svg
-                                      height="32"
-                                      width="32"
-                                      x="0"
-                                      y="0"
-                                    >
-                                      <rect
-                                        fill="#18CDF2"
-                                        height="32"
-                                        transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                        width="32"
-                                        x="0"
-                                        y="0"
-                                      />
-                                      <rect
-                                        fill="#035E56"
-                                        height="32"
-                                        transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                        width="32"
-                                        x="0"
-                                        y="0"
-                                      />
-                                      <rect
-                                        fill="#F26602"
-                                        height="32"
-                                        transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                        width="32"
-                                        x="0"
-                                        y="0"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
+                                <img
+                                  alt="maskicon"
+                                  height="32"
+                                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                                  width="32"
+                                />
                               </div>
                               <div
                                 class="mm-box mm-badge-wrapper__badge-container"
@@ -184,45 +151,12 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#18CDF2"
-                                height="32"
-                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#035E56"
-                                height="32"
-                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#F26602"
-                                height="32"
-                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -121,45 +121,12 @@ exports[`MultichainConnectPage renders correctly 1`] = `
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 94, 89);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#FB188D"
-                                height="32"
-                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#018E77"
-                                height="32"
-                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#C81471"
-                                height="32"
-                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div
@@ -363,45 +330,12 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 94, 89);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#FB188D"
-                                height="32"
-                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#018E77"
-                                height="32"
-                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#C81471"
-                                height="32"
-                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div
@@ -605,45 +539,12 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(3, 94, 89);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#FB188D"
-                                height="32"
-                                transform="translate(-1.10425413395151 -2.28627085338780) rotate(359.4 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#018E77"
-                                height="32"
-                                transform="translate(-14.91284386081665 10.85511085677637) rotate(246.0 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#C81471"
-                                height="32"
-                                transform="translate(-30.37340441878390 -6.94681861231760) rotate(324.3 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div

--- a/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
+++ b/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
@@ -133,45 +133,12 @@ exports[`ConnectPage should render correctly 1`] = `
                           <div
                             class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                           >
-                            <div
-                              class="flex [&>div]:!rounded-none"
-                            >
-                              <div
-                                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                              >
-                                <svg
-                                  height="32"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                >
-                                  <rect
-                                    fill="#18CDF2"
-                                    height="32"
-                                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#035E56"
-                                    height="32"
-                                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#F26602"
-                                    height="32"
-                                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                            <img
+                              alt="maskicon"
+                              height="32"
+                              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                              width="32"
+                            />
                           </div>
                           <div
                             class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -185,45 +152,12 @@ exports[`ConnectPage should render correctly 1`] = `
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#18CDF2"
-                                height="32"
-                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#035E56"
-                                height="32"
-                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#F26602"
-                                height="32"
-                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div
@@ -554,45 +488,12 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                           <div
                             class="shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8 flex"
                           >
-                            <div
-                              class="flex [&>div]:!rounded-none"
-                            >
-                              <div
-                                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                              >
-                                <svg
-                                  height="32"
-                                  width="32"
-                                  x="0"
-                                  y="0"
-                                >
-                                  <rect
-                                    fill="#18CDF2"
-                                    height="32"
-                                    transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#035E56"
-                                    height="32"
-                                    transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                  <rect
-                                    fill="#F26602"
-                                    height="32"
-                                    transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                    width="32"
-                                    x="0"
-                                    y="0"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
+                            <img
+                              alt="maskicon"
+                              height="32"
+                              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                              width="32"
+                            />
                           </div>
                           <div
                             class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--rectangular-bottom-right"
@@ -606,45 +507,12 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
                       >
-                        <div
-                          class="flex [&>div]:!rounded-none"
-                        >
-                          <div
-                            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
-                          >
-                            <svg
-                              height="32"
-                              width="32"
-                              x="0"
-                              y="0"
-                            >
-                              <rect
-                                fill="#18CDF2"
-                                height="32"
-                                transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#035E56"
-                                height="32"
-                                transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                              <rect
-                                fill="#F26602"
-                                height="32"
-                                transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
-                                width="32"
-                                x="0"
-                                y="0"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                        <img
+                          alt="maskicon"
+                          height="32"
+                          src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+                          width="32"
+                        />
                       </div>
                     </div>
                     <div


### PR DESCRIPTION
## **Description**

Normally, the default avatarType should have been set at the Preferences controller level. If for whatever reason the value is missing, this sets the default at the Avatar level.

This PR is 99% snapshot files.

## **Changelog**

CHANGELOG entry: set Maskicon (Polycon) as default at the avatar level

## **Related issues**

Fixes:

## **Manual testing steps**

1. Upgrade from a previous version to 13.4.0
2. Observe default account avatar


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defaults the avatar type to Maskicon when no user preference is set and updates affected UI snapshots.
> 
> - **Avatar Defaulting**
>   - Set `PreferredAvatar` fallback to `maskicon` via `getAvatarType` in `ui/components/app/preferred-avatar/preferred-avatar.tsx`.
> - **Snapshots**
>   - Update snapshots across multichain, snaps UI, confirmations, and connect flows to reflect Maskicon-based avatar rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 654d104811795430f2bbae6ad46a115013fb5832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->