### PR TITLE
fix: preferences controller merging cp-13.4.1

### DIFF
--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -113,6 +113,29 @@ const setupController = ({
 };
 
 describe('preferences controller', () => {
+  describe('initialization and merging', () => {
+    it('defaults avatarType to maskicon', () => {
+      const { controller } = setupController({});
+      expect(controller.state.preferences.avatarType).toBe('maskicon');
+    });
+
+    it('preserves existing avatarType', () => {
+      const { controller } = setupController({});
+      const defaultPreferences = controller.state.preferences;
+
+      const { controller: mergedController } = setupController({
+        state: {
+          preferences: {
+            ...defaultPreferences,
+            avatarType: 'jazzicon',
+          },
+        },
+      });
+
+      expect(mergedController.state.preferences.avatarType).toBe('jazzicon');
+    });
+  });
+
   describe('useBlockie', () => {
     it('defaults useBlockie to false', () => {
       const { controller } = setupController({});

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -535,14 +535,22 @@ export class PreferencesController extends BaseController<
    * @param options.state - The initial controller state
    */
   constructor({ messenger, state }: PreferencesControllerOptions) {
+    const defaultState = getDefaultPreferencesControllerState();
+
+    const mergedState = {
+      ...defaultState,
+      ...state,
+      preferences: {
+        ...defaultState.preferences,
+        ...state?.preferences,
+      },
+    };
+
     super({
       messenger,
       metadata: controllerMetadata,
       name: controllerName,
-      state: {
-        ...getDefaultPreferencesControllerState(),
-        ...state,
-      },
+      state: mergedState,
     });
 
     this.messagingSystem.subscribe(

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -256,10 +256,15 @@
     "lostIdentities": "object",
     "forgottenPassword": false,
     "preferences": {
+      "dismissSmartAccountSuggestionEnabled": "boolean",
+      "featureNotificationsEnabled": "boolean",
       "hideZeroBalanceTokens": false,
+      "petnamesEnabled": "boolean",
+      "privacyMode": "boolean",
       "showExtensionInFullSizeView": false,
       "showFiatInTestnets": false,
       "showTestNetworks": false,
+      "skipDeepLinkInterstitial": "boolean",
       "smartTransactionsOptInStatus": true,
       "showNativeTokenAsMainBalance": true,
       "showMultiRpcModal": "boolean",
@@ -267,7 +272,8 @@
       "shouldShowAggregatedBalancePopover": "boolean",
       "tokenNetworkFilter": { "0x539": "boolean" },
       "smartTransactionsMigrationApplied": "boolean",
-      "smartAccountOptIn": "boolean"
+      "smartAccountOptIn": "boolean",
+      "useNativeCurrencyAsPrimaryCurrency": "boolean"
     },
     "ipfsGateway": "string",
     "isIpfsGatewayEnabled": "boolean",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -93,10 +93,15 @@
     "featureFlags": {},
     "currentLocale": "en",
     "preferences": {
+      "dismissSmartAccountSuggestionEnabled": "boolean",
+      "featureNotificationsEnabled": "boolean",
       "hideZeroBalanceTokens": false,
+      "petnamesEnabled": "boolean",
+      "privacyMode": "boolean",
       "showExtensionInFullSizeView": false,
       "showFiatInTestnets": false,
       "showTestNetworks": false,
+      "skipDeepLinkInterstitial": "boolean",
       "smartTransactionsOptInStatus": true,
       "showNativeTokenAsMainBalance": true,
       "showMultiRpcModal": "boolean",
@@ -104,7 +109,8 @@
       "shouldShowAggregatedBalancePopover": "boolean",
       "tokenNetworkFilter": { "0x539": "boolean" },
       "smartTransactionsMigrationApplied": "boolean",
-      "smartAccountOptIn": "boolean"
+      "smartAccountOptIn": "boolean",
+      "useNativeCurrencyAsPrimaryCurrency": "boolean"
     },
     "firstTimeFlowType": "import",
     "completedOnboarding": true,


### PR DESCRIPTION
## **Description**

The original shallow merge in the PreferencesController constructor:

```js
state: {
  ...getDefaultPreferencesControllerState(),
  ...state,
},
```

Would completely replace the defaults for state.preferences with the persisted one, preventing any new properties like `avatarType` from being added

## **Changelog**

CHANGELOG entry: fix issue where Preferences is not preserved during updates

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load 13.3
2. Update to 13.4
3. Should see new avatarType

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deep-merges default state (including `preferences`) in `PreferencesController` to preserve new keys like `avatarType`, with new tests and updated state snapshot schemas.
> 
> - **Controller**:
>   - Deep-merge defaults in `PreferencesController` constructor, including nested `preferences`, to avoid overwriting new fields (e.g., `preferences.avatarType`).
> - **Tests**:
>   - Add unit tests validating default `preferences.avatarType` (`maskicon`) and preservation when provided (`jazzicon`).
> - **E2E/State Snapshots**:
>   - Extend snapshot schemas to include new `preferences` fields: `dismissSmartAccountSuggestionEnabled`, `featureNotificationsEnabled`, `petnamesEnabled`, `privacyMode`, `skipDeepLinkInterstitial`, `useNativeCurrencyAsPrimaryCurrency`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5a69683061f31caf353769ffa3ec5e8615a80c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->