### PR TITLE
chore: update `CODEOWNERS.md` with `@metamask/wallet-integrations` team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,7 +150,7 @@ test/e2e/mock-e2e-allowlist.js            @MetaMask/qa
 test/e2e/mock-e2e.js                      @MetaMask/qa
 
 # Wallet Integrations
-app/scripts/lib/rpc-method-middleware
+app/scripts/lib/rpc-method-middleware                                 @MetaMask/wallet-integrations
 shared/lib/caip25-caveat-merger.ts                                    @MetaMask/wallet-integrations
 test/e2e/page-objects/benchmark                                       @MetaMask/wallet-integrations
 test/e2e/playwright/benchmark                                         @MetaMask/wallet-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,6 +149,23 @@ test/e2e/helpers.js                       @MetaMask/qa
 test/e2e/mock-e2e-allowlist.js            @MetaMask/qa
 test/e2e/mock-e2e.js                      @MetaMask/qa
 
-# Wallet API Platform - Page Load Benchmark
-test/e2e/page-objects/benchmark           @MetaMask/wallet-api-platform-engineers
-test/e2e/playwright/benchmark             @MetaMask/wallet-api-platform-engineers
+# Wallet Integrations
+app/scripts/lib/rpc-method-middleware
+shared/lib/caip25-caveat-merger.ts                                    @MetaMask/wallet-integrations
+test/e2e/page-objects/benchmark                                       @MetaMask/wallet-integrations
+test/e2e/playwright/benchmark                                         @MetaMask/wallet-integrations
+test/e2e/flask/multichain                                             @MetaMask/wallet-integrations
+# TODO CONSOLIDATE THE MIDDLEWARE BELOW INTO THE RPC-METHOD-MIDDLEWARE FOLDER
+app/scripts/lib/createRPCMethodTrackingMiddleware.js                  @MetaMask/wallet-integrations
+app/scripts/lib/createMetamaskMiddleware.js                           @MetaMask/wallet-integrations
+app/scripts/lib/createOnboardingMiddleware.js                         @MetaMask/wallet-integrations
+app/scripts/lib/createMetaRPCHandler.js                               @MetaMask/wallet-integrations
+app/scripts/lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware.ts @MetaMask/wallet-integrations
+app/scripts/lib/createUnsupportedMethodMiddleware.ts                  @MetaMask/wallet-integrations
+app/scripts/lib/createHyperliquidReferralMiddleware.ts                @MetaMask/wallet-integrations
+app/scripts/lib/metaRPCClientFactory.ts                               @MetaMask/wallet-integrations
+app/scripts/lib/middleware/                                           @MetaMask/wallet-integrations
+app/scripts/lib/stream-utils.js                                       @MetaMask/wallet-integrations
+app/scripts/lib/createOriginThrottlingMiddleware.ts                   @MetaMask/wallet-integrations
+app/scripts/lib/createMainFrameOriginMiddleware.ts                    @MetaMask/wallet-integrations
+app/scripts/lib/createTracingMiddleware.ts                            @MetaMask/wallet-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,18 +154,16 @@ app/scripts/lib/rpc-method-middleware                                 @MetaMask/
 shared/lib/caip25-caveat-merger.ts                                    @MetaMask/wallet-integrations
 test/e2e/page-objects/benchmark                                       @MetaMask/wallet-integrations
 test/e2e/playwright/benchmark                                         @MetaMask/wallet-integrations
-test/e2e/flask/multichain                                             @MetaMask/wallet-integrations
+test/e2e/flask/multichain-api                                         @MetaMask/wallet-integrations
 # TODO CONSOLIDATE THE MIDDLEWARE BELOW INTO THE RPC-METHOD-MIDDLEWARE FOLDER
 app/scripts/lib/createRPCMethodTrackingMiddleware.js                  @MetaMask/wallet-integrations
 app/scripts/lib/createMetamaskMiddleware.js                           @MetaMask/wallet-integrations
 app/scripts/lib/createOnboardingMiddleware.js                         @MetaMask/wallet-integrations
 app/scripts/lib/createMetaRPCHandler.js                               @MetaMask/wallet-integrations
 app/scripts/lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware.ts @MetaMask/wallet-integrations
-app/scripts/lib/createUnsupportedMethodMiddleware.ts                  @MetaMask/wallet-integrations
 app/scripts/lib/createHyperliquidReferralMiddleware.ts                @MetaMask/wallet-integrations
 app/scripts/lib/metaRPCClientFactory.ts                               @MetaMask/wallet-integrations
 app/scripts/lib/middleware/                                           @MetaMask/wallet-integrations
-app/scripts/lib/stream-utils.js                                       @MetaMask/wallet-integrations
 app/scripts/lib/createOriginThrottlingMiddleware.ts                   @MetaMask/wallet-integrations
 app/scripts/lib/createMainFrameOriginMiddleware.ts                    @MetaMask/wallet-integrations
 app/scripts/lib/createTracingMiddleware.ts                            @MetaMask/wallet-integrations


### PR DESCRIPTION
There are a ton of files/folders here that have been owned by Wallet Integrations Team (formerly Wallet API Platform team) where we have not been pinged for reviews because of missing CODEOWNER entries. This is my fault. Its time to correct it.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CODEOWNERS to add `@MetaMask/wallet-integrations` ownership across middleware/libs and E2E benchmarks/tests, replacing prior `wallet-api-platform` entries.
> 
> - **CODEOWNERS updates**:
>   - **Add `@MetaMask/wallet-integrations` ownership** for:
>     - `app/scripts/lib/rpc-method-middleware`
>     - `shared/lib/caip25-caveat-merger.ts`
>     - `test/e2e/page-objects/benchmark`
>     - `test/e2e/playwright/benchmark`
>     - `test/e2e/flask/multichain-api`
>     - `app/scripts/lib/middleware/`
>     - `app/scripts/lib/createRPCMethodTrackingMiddleware.js`
>     - `app/scripts/lib/createMetamaskMiddleware.js`
>     - `app/scripts/lib/createOnboardingMiddleware.js`
>     - `app/scripts/lib/createMetaRPCHandler.js`
>     - `app/scripts/lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware.ts`
>     - `app/scripts/lib/createHyperliquidReferralMiddleware.ts`
>     - `app/scripts/lib/metaRPCClientFactory.ts`
>     - `app/scripts/lib/createOriginThrottlingMiddleware.ts`
>     - `app/scripts/lib/createMainFrameOriginMiddleware.ts`
>     - `app/scripts/lib/createTracingMiddleware.ts`
>   - **Replace** `@MetaMask/wallet-api-platform-engineers` ownership of benchmark paths with `@MetaMask/wallet-integrations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b255573e121c1b43f7ce708b3019cf4d4fbcc587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->