### PR TITLE
refactor: Refactor more controllers/services to use modular init pattern

### DIFF
--- a/app/scripts/controller-init/account-order-controller-init.test.ts
+++ b/app/scripts/controller-init/account-order-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { AccountOrderController } from '../controllers/account-order';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAccountOrderControllerMessenger,
+  AccountOrderControllerMessenger,
+} from './messengers';
+import { AccountOrderControllerInit } from './account-order-controller-init';
+
+jest.mock('../controllers/account-order');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AccountOrderControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAccountOrderControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AccountOrderControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AccountOrderControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AccountOrderController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AccountOrderControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AccountOrderController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/scripts/controller-init/account-order-controller-init.ts
+++ b/app/scripts/controller-init/account-order-controller-init.ts
@@ -1,0 +1,26 @@
+import { AccountOrderController } from '../controllers/account-order';
+import { ControllerInitFunction } from './types';
+import { AccountOrderControllerMessenger } from './messengers';
+
+/**
+ * Initialize the accountOrder controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const AccountOrderControllerInit: ControllerInitFunction<
+  AccountOrderController,
+  AccountOrderControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AccountOrderController({
+    messenger: controllerMessenger,
+    state: persistedState.AccountOrderController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/accounts-controller-init.test.ts
+++ b/app/scripts/controller-init/accounts-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { AccountsController } from '@metamask/accounts-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAccountsControllerMessenger,
+  AccountsControllerMessenger,
+} from './messengers';
+import { AccountsControllerInit } from './accounts-controller-init';
+
+jest.mock('@metamask/accounts-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AccountsControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAccountsControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AccountsControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AccountsControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AccountsController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AccountsControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AccountsController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/scripts/controller-init/accounts-controller-init.ts
+++ b/app/scripts/controller-init/accounts-controller-init.ts
@@ -1,0 +1,27 @@
+import { AccountsController } from '@metamask/accounts-controller';
+import { ControllerInitFunction } from './types';
+import { AccountsControllerMessenger } from './messengers';
+
+/**
+ * Initialize the accounts controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const AccountsControllerInit: ControllerInitFunction<
+  AccountsController,
+  AccountsControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AccountsController({
+    messenger: controllerMessenger,
+    // @ts-expect-error: Accounts controller does not accept partial state.
+    state: persistedState.AccountsController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/alert-controller-init.test.ts
+++ b/app/scripts/controller-init/alert-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { AlertController } from '../controllers/alert-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAlertControllerMessenger,
+  AlertControllerMessenger,
+} from './messengers';
+import { AlertControllerInit } from './alert-controller-init';
+
+jest.mock('../controllers/alert-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AlertControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAlertControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AlertControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AlertControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AlertController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AlertControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AlertController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/scripts/controller-init/alert-controller-init.ts
+++ b/app/scripts/controller-init/alert-controller-init.ts
@@ -1,0 +1,26 @@
+import { AlertController } from '../controllers/alert-controller';
+import { ControllerInitFunction } from './types';
+import { AlertControllerMessenger } from './messengers';
+
+/**
+ * Initialize the alert controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const AlertControllerInit: ControllerInitFunction<
+  AlertController,
+  AlertControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AlertController({
+    state: persistedState.AlertController,
+    messenger: controllerMessenger,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/announcement-controller-init.test.ts
+++ b/app/scripts/controller-init/announcement-controller-init.test.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/base-controller';
+import { AnnouncementController } from '@metamask/announcement-controller';
+import { UI_NOTIFICATIONS } from '../../../shared/notifications';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAnnouncementControllerMessenger,
+  AnnouncementControllerMessenger,
+} from './messengers';
+import { AnnouncementControllerInit } from './announcement-controller-init';
+
+jest.mock('@metamask/announcement-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AnnouncementControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAnnouncementControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AnnouncementControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AnnouncementControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AnnouncementController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AnnouncementControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AnnouncementController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      allAnnouncements: UI_NOTIFICATIONS,
+    });
+  });
+});

--- a/app/scripts/controller-init/announcement-controller-init.ts
+++ b/app/scripts/controller-init/announcement-controller-init.ts
@@ -1,0 +1,29 @@
+import { AnnouncementController } from '@metamask/announcement-controller';
+import { UI_NOTIFICATIONS } from '../../../shared/notifications';
+import { ControllerInitFunction } from './types';
+import { AnnouncementControllerMessenger } from './messengers';
+
+/**
+ * Initialize the announcement controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const AnnouncementControllerInit: ControllerInitFunction<
+  AnnouncementController,
+  AnnouncementControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AnnouncementController({
+    messenger: controllerMessenger,
+    allAnnouncements: UI_NOTIFICATIONS,
+    // @ts-expect-error: Announcement controller does not accept partial state.
+    state: persistedState.AnnouncementController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/app-metadata-controller-init.test.ts
+++ b/app/scripts/controller-init/app-metadata-controller-init.test.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/base-controller';
+import AppMetadataController from '../controllers/app-metadata';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getAppMetadataControllerMessenger,
+  AppMetadataControllerMessenger,
+} from './messengers';
+import { AppMetadataControllerInit } from './app-metadata-controller-init';
+
+jest.mock('../controllers/app-metadata');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AppMetadataControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAppMetadataControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AppMetadataControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AppMetadataControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AppMetadataController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AppMetadataControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AppMetadataController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      currentAppVersion: process.env.METAMASK_VERSION,
+      currentMigrationVersion: expect.any(Number),
+    });
+  });
+});

--- a/app/scripts/controller-init/app-metadata-controller-init.ts
+++ b/app/scripts/controller-init/app-metadata-controller-init.ts
@@ -1,0 +1,29 @@
+import AppMetadataController from '../controllers/app-metadata';
+import { ControllerInitFunction } from './types';
+import { AppMetadataControllerMessenger } from './messengers';
+
+/**
+ * Initialize the appMetadata controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @param request.currentMigrationVersion
+ * @returns The initialized controller.
+ */
+export const AppMetadataControllerInit: ControllerInitFunction<
+  AppMetadataController,
+  AppMetadataControllerMessenger
+> = ({ controllerMessenger, persistedState, currentMigrationVersion }) => {
+  const controller = new AppMetadataController({
+    state: persistedState.AppMetadataController,
+    messenger: controllerMessenger,
+    currentAppVersion: process.env.METAMASK_VERSION,
+    currentMigrationVersion,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -83,6 +83,7 @@ import { SubscriptionService } from '../services/subscription/subscription-servi
 import { AccountOrderController } from '../controllers/account-order';
 import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
+import AppMetadataController from '../controllers/app-metadata';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -93,6 +94,7 @@ export type Controller =
   | AccountsController
   | AlertController
   | AnnouncementController
+  | AppMetadataController
   | ApprovalController
   | AppStateController
   | AuthenticationController
@@ -173,6 +175,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   AlertController['state'] &
   AccountTreeController['state'] &
   AnnouncementController['state'] &
+  AppMetadataController['state'] &
   ApprovalController['state'] &
   AppStateController['state'] &
   AuthenticationController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -67,6 +67,7 @@ import { NetworkEnablementController } from '@metamask/network-enablement-contro
 import { PermissionLogController } from '@metamask/permission-log-controller';
 import { AnnouncementController } from '@metamask/announcement-controller';
 import { PhishingController } from '@metamask/phishing-controller';
+import { LoggingController } from '@metamask/logging-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -107,6 +108,7 @@ export type Controller =
   | GatorPermissionsController
   | JsonSnapsRegistry
   | KeyringController
+  | LoggingController
   | MetaMetricsController
   | MetaMetricsDataDeletionController
   | MultichainAssetsController
@@ -185,6 +187,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   GatorPermissionsController['state'] &
   JsonSnapsRegistry['state'] &
   KeyringController['state'] &
+  LoggingController['state'] &
   MetaMetricsController['state'] &
   MetaMetricsDataDeletionController['state'] &
   MultichainAssetsController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -78,11 +78,13 @@ import AccountTrackerController from '../controllers/account-tracker-controller'
 import { AppStateController } from '../controllers/app-state-controller';
 import { SnapKeyringBuilder } from '../lib/snap-keyring/snap-keyring';
 import { SubscriptionService } from '../services/subscription/subscription-service';
+import { AccountOrderController } from '../controllers/account-order';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
  */
 export type Controller =
+  | AccountOrderController
   | AccountTrackerController
   | AnnouncementController
   | ApprovalController
@@ -157,7 +159,8 @@ export type Controller =
  * Flat state object for all controllers supporting or required by modular initialization.
  * e.g. `{ transactions: [] }`.
  */
-export type ControllerFlatState = AccountsController['state'] &
+export type ControllerFlatState = AccountOrderController['state'] &
+  AccountsController['state'] &
   AccountTreeController['state'] &
   AnnouncementController['state'] &
   ApprovalController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -66,6 +66,7 @@ import { ApprovalController } from '@metamask/approval-controller';
 import { NetworkEnablementController } from '@metamask/network-enablement-controller';
 import { PermissionLogController } from '@metamask/permission-log-controller';
 import { AnnouncementController } from '@metamask/announcement-controller';
+import { PhishingController } from '@metamask/phishing-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -122,6 +123,7 @@ export type Controller =
       CaveatSpecificationConstraint
     >
   | PermissionLogController
+  | PhishingController
   | PPOMController
   | PreferencesController
   | RateLimitController<RateLimitedApiMap>
@@ -193,6 +195,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
     CaveatSpecificationConstraint
   >['state'] &
   PermissionLogController['state'] &
+  PhishingController['state'] &
   PPOMController['state'] &
   PreferencesController['state'] &
   RatesController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -68,6 +68,7 @@ import { PermissionLogController } from '@metamask/permission-log-controller';
 import { AnnouncementController } from '@metamask/announcement-controller';
 import { PhishingController } from '@metamask/phishing-controller';
 import { LoggingController } from '@metamask/logging-controller';
+import { ErrorReportingService } from '@metamask/error-reporting-service';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -105,6 +106,7 @@ export type Controller =
   | DelegationController
   | DeFiPositionsController
   | EnsController
+  | ErrorReportingService
   | ExecutionService
   | GasFeeController
   | GatorPermissionsController

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -65,6 +65,7 @@ import { BridgeStatusController } from '@metamask/bridge-status-controller';
 import { ApprovalController } from '@metamask/approval-controller';
 import { NetworkEnablementController } from '@metamask/network-enablement-controller';
 import { PermissionLogController } from '@metamask/permission-log-controller';
+import { AnnouncementController } from '@metamask/announcement-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -83,6 +84,7 @@ import { SubscriptionService } from '../services/subscription/subscription-servi
  */
 export type Controller =
   | AccountTrackerController
+  | AnnouncementController
   | ApprovalController
   | AppStateController
   | AuthenticationController
@@ -157,6 +159,7 @@ export type Controller =
  */
 export type ControllerFlatState = AccountsController['state'] &
   AccountTreeController['state'] &
+  AnnouncementController['state'] &
   ApprovalController['state'] &
   AppStateController['state'] &
   AuthenticationController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -86,6 +86,7 @@ import { AccountOrderController } from '../controllers/account-order';
 export type Controller =
   | AccountOrderController
   | AccountTrackerController
+  | AccountsController
   | AnnouncementController
   | ApprovalController
   | AppStateController

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -81,6 +81,7 @@ import { SnapKeyringBuilder } from '../lib/snap-keyring/snap-keyring';
 import { SubscriptionService } from '../services/subscription/subscription-service';
 import { AccountOrderController } from '../controllers/account-order';
 import { AlertController } from '../controllers/alert-controller';
+import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -107,6 +108,7 @@ export type Controller =
   | JsonSnapsRegistry
   | KeyringController
   | MetaMetricsController
+  | MetaMetricsDataDeletionController
   | MultichainAssetsController
   | MultichainAssetsRatesController
   | MultichainBalancesController
@@ -184,6 +186,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   JsonSnapsRegistry['state'] &
   KeyringController['state'] &
   MetaMetricsController['state'] &
+  MetaMetricsDataDeletionController['state'] &
   MultichainAssetsController['state'] &
   MultichainAssetsRatesController['state'] &
   MultichainBalancesController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -80,6 +80,7 @@ import { AppStateController } from '../controllers/app-state-controller';
 import { SnapKeyringBuilder } from '../lib/snap-keyring/snap-keyring';
 import { SubscriptionService } from '../services/subscription/subscription-service';
 import { AccountOrderController } from '../controllers/account-order';
+import { AlertController } from '../controllers/alert-controller';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -88,6 +89,7 @@ export type Controller =
   | AccountOrderController
   | AccountTrackerController
   | AccountsController
+  | AlertController
   | AnnouncementController
   | ApprovalController
   | AppStateController
@@ -164,6 +166,7 @@ export type Controller =
  */
 export type ControllerFlatState = AccountOrderController['state'] &
   AccountsController['state'] &
+  AlertController['state'] &
   AccountTreeController['state'] &
   AnnouncementController['state'] &
   ApprovalController['state'] &

--- a/app/scripts/controller-init/error-reporting-service-init.test.ts
+++ b/app/scripts/controller-init/error-reporting-service-init.test.ts
@@ -36,7 +36,6 @@ describe('ErrorReportingServiceInit', () => {
     const controllerMock = jest.mocked(ErrorReportingService);
     expect(controllerMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
-      state: undefined,
       captureException: expect.any(Function),
     });
   });

--- a/app/scripts/controller-init/error-reporting-service-init.test.ts
+++ b/app/scripts/controller-init/error-reporting-service-init.test.ts
@@ -1,0 +1,43 @@
+import { Messenger } from '@metamask/base-controller';
+import { ErrorReportingService } from '@metamask/error-reporting-service';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getErrorReportingServiceMessenger,
+  ErrorReportingServiceMessenger,
+} from './messengers';
+import { ErrorReportingServiceInit } from './error-reporting-service-init';
+
+jest.mock('@metamask/error-reporting-service');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<ErrorReportingServiceMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getErrorReportingServiceMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('ErrorReportingServiceInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = ErrorReportingServiceInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(ErrorReportingService);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    ErrorReportingServiceInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(ErrorReportingService);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      captureException: expect.any(Function),
+    });
+  });
+});

--- a/app/scripts/controller-init/error-reporting-service-init.ts
+++ b/app/scripts/controller-init/error-reporting-service-init.ts
@@ -1,0 +1,27 @@
+import { ErrorReportingService } from '@metamask/error-reporting-service';
+import { captureException } from '../../../shared/lib/sentry';
+import { ControllerInitFunction } from './types';
+import { ErrorReportingServiceMessenger } from './messengers';
+
+/**
+ * Initialize the error reporting service.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the service.
+ * @returns The initialized controller.
+ */
+export const ErrorReportingServiceInit: ControllerInitFunction<
+  ErrorReportingService,
+  ErrorReportingServiceMessenger
+> = ({ controllerMessenger }) => {
+  const controller = new ErrorReportingService({
+    messenger: controllerMessenger,
+    captureException,
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/logging-controller-init.test.ts
+++ b/app/scripts/controller-init/logging-controller-init.test.ts
@@ -1,0 +1,50 @@
+import { Messenger } from '@metamask/base-controller';
+import { LoggingController } from '@metamask/logging-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getLoggingControllerMessenger,
+  LoggingControllerMessenger,
+} from './messengers';
+import { LoggingControllerInit } from './logging-controller-init';
+
+jest.mock('@metamask/logging-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<LoggingControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getLoggingControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+    extension: {
+      runtime: {
+        onInstalled: {
+          addListener: jest.fn(),
+        },
+      },
+    },
+  };
+
+  // @ts-expect-error: Partial mock.
+  return requestMock;
+}
+
+describe('LoggingControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = LoggingControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(LoggingController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    LoggingControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(LoggingController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/scripts/controller-init/logging-controller-init.ts
+++ b/app/scripts/controller-init/logging-controller-init.ts
@@ -1,0 +1,41 @@
+import { LoggingController, LogType } from '@metamask/logging-controller';
+import { LOG_EVENT } from '../../../shared/constants/logs';
+import { ControllerInitFunction } from './types';
+import { LoggingControllerMessenger } from './messengers';
+
+/**
+ * Initialize the logging controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @param request.extension
+ * @returns The initialized controller.
+ */
+export const LoggingControllerInit: ControllerInitFunction<
+  LoggingController,
+  LoggingControllerMessenger
+> = ({ controllerMessenger, persistedState, extension }) => {
+  const controller = new LoggingController({
+    messenger: controllerMessenger,
+    state: persistedState.LoggingController,
+  });
+
+  extension.runtime.onInstalled.addListener((details) => {
+    if (details.reason === 'update') {
+      controller.add({
+        type: LogType.GenericLog,
+        data: {
+          event: LOG_EVENT.VERSION_UPDATE,
+          previousVersion: details.previousVersion,
+          version: process.env.METAMASK_VERSION,
+        },
+      });
+    }
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/messengers/account-order-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/account-order-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
+
+describe('getAccountOrderControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const accountOrderControllerMessenger =
+      getAccountOrderControllerMessenger(messenger);
+
+    expect(accountOrderControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/account-order-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/account-order-controller-messenger.ts
@@ -1,8 +1,4 @@
 import { Messenger } from '@metamask/base-controller';
-import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/account-tracker-controller';
 
 export type AccountOrderControllerMessenger = ReturnType<
   typeof getAccountOrderControllerMessenger
@@ -16,7 +12,7 @@ export type AccountOrderControllerMessenger = ReturnType<
  * messenger.
  */
 export function getAccountOrderControllerMessenger(
-  messenger: Messenger<AllowedActions, AllowedEvents>,
+  messenger: Messenger<never, never>,
 ) {
   return messenger.getRestricted({
     name: 'AccountOrderController',

--- a/app/scripts/controller-init/messengers/account-order-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/account-order-controller-messenger.ts
@@ -1,0 +1,28 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/account-tracker-controller';
+
+export type AccountOrderControllerMessenger = ReturnType<
+  typeof getAccountOrderControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * account order controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAccountOrderControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'AccountOrderController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/accounts-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/accounts-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAccountsControllerMessenger } from './accounts-controller-messenger';
+
+describe('getAccountsControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const accountsControllerMessenger =
+      getAccountsControllerMessenger(messenger);
+
+    expect(accountsControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/accounts-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/accounts-controller-messenger.ts
@@ -1,0 +1,33 @@
+import { Messenger } from '@metamask/base-controller';
+import { AllowedActions, AllowedEvents } from '@metamask/accounts-controller';
+
+export type AccountsControllerMessenger = ReturnType<
+  typeof getAccountsControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * accounts controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAccountsControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'AccountsController',
+    allowedActions: [
+      'KeyringController:getState',
+      'KeyringController:getKeyringsByType',
+    ],
+    allowedEvents: [
+      'SnapController:stateChange',
+      'KeyringController:stateChange',
+      'SnapKeyring:accountAssetListUpdated',
+      'SnapKeyring:accountBalancesUpdated',
+      'SnapKeyring:accountTransactionsUpdated',
+      'MultichainNetworkController:networkDidChange',
+    ],
+  });
+}

--- a/app/scripts/controller-init/messengers/alert-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/alert-controller-messenger.test.ts
@@ -1,0 +1,11 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAlertControllerMessenger } from './alert-controller-messenger';
+
+describe('getAlertControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const alertControllerMessenger = getAlertControllerMessenger(messenger);
+
+    expect(alertControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/alert-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/alert-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/alert-controller';
+
+export type AlertControllerMessenger = ReturnType<
+  typeof getAlertControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * alert controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAlertControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'AlertController',
+    allowedActions: ['AccountsController:getSelectedAccount'],
+    allowedEvents: ['AccountsController:selectedAccountChange'],
+  });
+}

--- a/app/scripts/controller-init/messengers/announcement-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/announcement-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
+
+describe('getAnnouncementControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const announcementControllerMessenger =
+      getAnnouncementControllerMessenger(messenger);
+
+    expect(announcementControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/announcement-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/announcement-controller-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type AnnouncementControllerMessenger = ReturnType<
+  typeof getAnnouncementControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * announcement controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAnnouncementControllerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'AnnouncementController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/app-metadata-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/app-metadata-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
+
+describe('getAppMetadataControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const appMetadataControllerMessenger =
+      getAppMetadataControllerMessenger(messenger);
+
+    expect(appMetadataControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/app-metadata-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/app-metadata-controller-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type AppMetadataControllerMessenger = ReturnType<
+  typeof getAppMetadataControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * app metadata controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAppMetadataControllerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'AppMetadataController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/error-reporting-service-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/error-reporting-service-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
+
+describe('getErrorReportingServiceMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const errorReportingServiceMessenger =
+      getErrorReportingServiceMessenger(messenger);
+
+    expect(errorReportingServiceMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/error-reporting-service-messenger.ts
+++ b/app/scripts/controller-init/messengers/error-reporting-service-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type ErrorReportingServiceMessenger = ReturnType<
+  typeof getErrorReportingServiceMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * error reporting service.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getErrorReportingServiceMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'ErrorReportingService',
+
+    // This service does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -161,6 +161,7 @@ import { getPhishingControllerMessenger } from './phishing-controller-messenger'
 import { getAlertControllerMessenger } from './alert-controller-messenger';
 import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
+import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -178,6 +179,8 @@ export type { AlertControllerMessenger } from './alert-controller-messenger';
 export { getAlertControllerMessenger } from './alert-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
+export type { AppMetadataControllerMessenger } from './app-metadata-controller-messenger';
+export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
 export type {
@@ -334,6 +337,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   AnnouncementController: {
     getMessenger: getAnnouncementControllerMessenger,
+    getInitMessenger: noop,
+  },
+  AppMetadataController: {
+    getMessenger: getAppMetadataControllerMessenger,
     getInitMessenger: noop,
   },
   AppStateController: {

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -159,6 +159,7 @@ import { getAccountOrderControllerMessenger } from './account-order-controller-m
 import { getAccountsControllerMessenger } from './accounts-controller-messenger';
 import { getPhishingControllerMessenger } from './phishing-controller-messenger';
 import { getAlertControllerMessenger } from './alert-controller-messenger';
+import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -222,6 +223,8 @@ export {
 } from './keyring-controller-messenger';
 export type { MetaMetricsControllerMessenger } from './metametrics-controller-messenger';
 export { getMetaMetricsControllerMessenger } from './metametrics-controller-messenger';
+export type { MetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
+export { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 export type {
   NetworkControllerMessenger,
   NetworkControllerInitMessenger,
@@ -388,6 +391,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   MetaMetricsController: {
     getMessenger: getMetaMetricsControllerMessenger,
+    getInitMessenger: noop,
+  },
+  MetaMetricsDataDeletionController: {
+    getMessenger: getMetaMetricsDataDeletionControllerMessenger,
     getInitMessenger: noop,
   },
   MultichainAssetsController: {

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -155,7 +155,10 @@ import {
 } from './network-controller-messenger';
 import { getSubscriptionServiceMessenger } from './subscription/subscription-service-messenger';
 import { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
+import { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 
+export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
+export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type {
   AccountTrackerControllerMessenger,
   AccountTrackerControllerInitMessenger,
@@ -298,6 +301,10 @@ export {
 } from './tokens-controller-messenger';
 
 export const CONTROLLER_MESSENGERS = {
+  AccountOrderController: {
+    getMessenger: getAccountOrderControllerMessenger,
+    getInitMessenger: noop,
+  },
   AccountTrackerController: {
     getMessenger: getAccountTrackerControllerMessenger,
     getInitMessenger: getAccountTrackerControllerInitMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -158,6 +158,7 @@ import { getAnnouncementControllerMessenger } from './announcement-controller-me
 import { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 import { getAccountsControllerMessenger } from './accounts-controller-messenger';
 import { getPhishingControllerMessenger } from './phishing-controller-messenger';
+import { getAlertControllerMessenger } from './alert-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -171,6 +172,8 @@ export {
 } from './account-tracker-controller-messenger';
 export type { AccountsControllerMessenger } from './accounts-controller-messenger';
 export { getAccountsControllerMessenger } from './accounts-controller-messenger';
+export type { AlertControllerMessenger } from './alert-controller-messenger';
+export { getAlertControllerMessenger } from './alert-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
@@ -317,6 +320,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   AccountsController: {
     getMessenger: getAccountsControllerMessenger,
+    getInitMessenger: noop,
+  },
+  AlertController: {
+    getMessenger: getAlertControllerMessenger,
     getInitMessenger: noop,
   },
   AnnouncementController: {

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -156,6 +156,7 @@ import {
 import { getSubscriptionServiceMessenger } from './subscription/subscription-service-messenger';
 import { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 import { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
+import { getAccountsControllerMessenger } from './accounts-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -167,6 +168,8 @@ export {
   getAccountTrackerControllerMessenger,
   getAccountTrackerControllerInitMessenger,
 } from './account-tracker-controller-messenger';
+export type { AccountsControllerMessenger } from './accounts-controller-messenger';
+export { getAccountsControllerMessenger } from './accounts-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
@@ -308,6 +311,10 @@ export const CONTROLLER_MESSENGERS = {
   AccountTrackerController: {
     getMessenger: getAccountTrackerControllerMessenger,
     getInitMessenger: getAccountTrackerControllerInitMessenger,
+  },
+  AccountsController: {
+    getMessenger: getAccountsControllerMessenger,
+    getInitMessenger: noop,
   },
   AnnouncementController: {
     getMessenger: getAnnouncementControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -160,6 +160,7 @@ import { getAccountsControllerMessenger } from './accounts-controller-messenger'
 import { getPhishingControllerMessenger } from './phishing-controller-messenger';
 import { getAlertControllerMessenger } from './alert-controller-messenger';
 import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
+import { getLoggingControllerMessenger } from './logging-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -221,6 +222,8 @@ export {
   getKeyringControllerMessenger,
   getKeyringControllerInitMessenger,
 } from './keyring-controller-messenger';
+export type { LoggingControllerMessenger } from './logging-controller-messenger';
+export { getLoggingControllerMessenger } from './logging-controller-messenger';
 export type { MetaMetricsControllerMessenger } from './metametrics-controller-messenger';
 export { getMetaMetricsControllerMessenger } from './metametrics-controller-messenger';
 export type { MetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
@@ -388,6 +391,10 @@ export const CONTROLLER_MESSENGERS = {
   KeyringController: {
     getMessenger: getKeyringControllerMessenger,
     getInitMessenger: getKeyringControllerInitMessenger,
+  },
+  LoggingController: {
+    getMessenger: getLoggingControllerMessenger,
+    getInitMessenger: noop,
   },
   MetaMetricsController: {
     getMessenger: getMetaMetricsControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -154,6 +154,7 @@ import {
   getNetworkControllerMessenger,
 } from './network-controller-messenger';
 import { getSubscriptionServiceMessenger } from './subscription/subscription-service-messenger';
+import { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 
 export type {
   AccountTrackerControllerMessenger,
@@ -163,6 +164,8 @@ export {
   getAccountTrackerControllerMessenger,
   getAccountTrackerControllerInitMessenger,
 } from './account-tracker-controller-messenger';
+export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
+export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
 export type {
@@ -298,6 +301,10 @@ export const CONTROLLER_MESSENGERS = {
   AccountTrackerController: {
     getMessenger: getAccountTrackerControllerMessenger,
     getInitMessenger: getAccountTrackerControllerInitMessenger,
+  },
+  AnnouncementController: {
+    getMessenger: getAnnouncementControllerMessenger,
+    getInitMessenger: noop,
   },
   AppStateController: {
     getMessenger: getAppStateControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -162,6 +162,7 @@ import { getAlertControllerMessenger } from './alert-controller-messenger';
 import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
+import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -209,6 +210,8 @@ export {
   getEnsControllerMessenger,
   getEnsControllerInitMessenger,
 } from './ens-controller-messenger';
+export type { ErrorReportingServiceMessenger } from './error-reporting-service-messenger';
+export { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 export type {
   GasFeeControllerMessenger,
   GasFeeControllerInitMessenger,
@@ -378,6 +381,10 @@ export const CONTROLLER_MESSENGERS = {
   EnsController: {
     getMessenger: getEnsControllerMessenger,
     getInitMessenger: getEnsControllerInitMessenger,
+  },
+  ErrorReportingService: {
+    getMessenger: getErrorReportingServiceMessenger,
+    getInitMessenger: noop,
   },
   ExecutionService: {
     getMessenger: getExecutionServiceMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -157,6 +157,7 @@ import { getSubscriptionServiceMessenger } from './subscription/subscription-ser
 import { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 import { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 import { getAccountsControllerMessenger } from './accounts-controller-messenger';
+import { getPhishingControllerMessenger } from './phishing-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -250,6 +251,8 @@ export {
 } from './permission-controller-messenger';
 export type { PermissionLogControllerMessenger } from './permission-log-controller-messenger';
 export { getPermissionLogControllerMessenger } from './permission-log-controller-messenger';
+export type { PhishingControllerMessenger } from './phishing-controller-messenger';
+export { getPhishingControllerMessenger } from './phishing-controller-messenger';
 export type {
   RemoteFeatureFlagControllerMessenger,
   RemoteFeatureFlagControllerInitMessenger,
@@ -436,6 +439,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   PermissionLogController: {
     getMessenger: getPermissionLogControllerMessenger,
+    getInitMessenger: noop,
+  },
+  PhishingController: {
+    getMessenger: getPhishingControllerMessenger,
     getInitMessenger: noop,
   },
   RateLimitController: {

--- a/app/scripts/controller-init/messengers/logging-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/logging-controller-messenger.test.ts
@@ -1,0 +1,11 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getLoggingControllerMessenger } from './logging-controller-messenger';
+
+describe('getLoggingControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const loggingControllerMessenger = getLoggingControllerMessenger(messenger);
+
+    expect(loggingControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/logging-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/logging-controller-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type LoggingControllerMessenger = ReturnType<
+  typeof getLoggingControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * logging controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getLoggingControllerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'LoggingController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/metametrics-data-deletion-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/metametrics-data-deletion-controller-messenger.test.ts
@@ -1,0 +1,14 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
+
+describe('getMetaMetricsDataDeletionControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const metaMetricsDataDeletionControllerMessenger =
+      getMetaMetricsDataDeletionControllerMessenger(messenger);
+
+    expect(metaMetricsDataDeletionControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/metametrics-data-deletion-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/metametrics-data-deletion-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/metametrics-data-deletion/metametrics-data-deletion';
+
+export type MetaMetricsDataDeletionControllerMessenger = ReturnType<
+  typeof getMetaMetricsDataDeletionControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * MetaMetrics data deletion controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getMetaMetricsDataDeletionControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'MetaMetricsDataDeletionController',
+    allowedActions: ['MetaMetricsController:getState'],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/phishing-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/phishing-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getPhishingControllerMessenger } from './phishing-controller-messenger';
+
+describe('getPhishingControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const phishingControllerMessenger =
+      getPhishingControllerMessenger(messenger);
+
+    expect(phishingControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/phishing-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/phishing-controller-messenger.ts
@@ -1,0 +1,23 @@
+import { Messenger } from '@metamask/base-controller';
+import { AllowedEvents } from '@metamask/phishing-controller';
+
+export type PhishingControllerMessenger = ReturnType<
+  typeof getPhishingControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * phishing controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getPhishingControllerMessenger(
+  messenger: Messenger<never, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'PhishingController',
+    allowedActions: [],
+    allowedEvents: ['TransactionController:stateChange'],
+  });
+}

--- a/app/scripts/controller-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/controller-init/metametrics-data-deletion-controller-init.test.ts
@@ -1,0 +1,46 @@
+import { Messenger } from '@metamask/base-controller';
+import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
+import { DataDeletionService } from '../services/data-deletion-service';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getMetaMetricsDataDeletionControllerMessenger,
+  MetaMetricsDataDeletionControllerMessenger,
+} from './messengers';
+import { MetaMetricsDataDeletionControllerInit } from './metametrics-data-deletion-controller-init';
+
+jest.mock('../controllers/metametrics-data-deletion/metametrics-data-deletion');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<MetaMetricsDataDeletionControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger:
+      getMetaMetricsDataDeletionControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('MetaMetricsDataDeletionControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } =
+      MetaMetricsDataDeletionControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(MetaMetricsDataDeletionController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    MetaMetricsDataDeletionControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(MetaMetricsDataDeletionController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      dataDeletionService: expect.any(DataDeletionService),
+    });
+  });
+});

--- a/app/scripts/controller-init/metametrics-data-deletion-controller-init.ts
+++ b/app/scripts/controller-init/metametrics-data-deletion-controller-init.ts
@@ -1,0 +1,29 @@
+import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
+import { DataDeletionService } from '../services/data-deletion-service';
+import { ControllerInitFunction } from './types';
+import { MetaMetricsDataDeletionControllerMessenger } from './messengers';
+
+/**
+ * Initialize the MetaMetrics data deletion controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const MetaMetricsDataDeletionControllerInit: ControllerInitFunction<
+  MetaMetricsDataDeletionController,
+  MetaMetricsDataDeletionControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const dataDeletionService = new DataDeletionService();
+  const controller = new MetaMetricsDataDeletionController({
+    messenger: controllerMessenger,
+    state: persistedState.MetaMetricsDataDeletionController,
+    dataDeletionService,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/phishing-controller-init.test.ts
+++ b/app/scripts/controller-init/phishing-controller-init.test.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/base-controller';
+import { PhishingController } from '@metamask/phishing-controller';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  getPhishingControllerMessenger,
+  PhishingControllerMessenger,
+} from './messengers';
+import { PhishingControllerInit } from './phishing-controller-init';
+
+jest.mock('@metamask/phishing-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<PhishingControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getPhishingControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('PhishingControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = PhishingControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(PhishingController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    PhishingControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(PhishingController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      hotlistRefreshInterval: 5_000,
+      stalelistRefreshInterval: 30_000,
+    });
+  });
+});

--- a/app/scripts/controller-init/phishing-controller-init.ts
+++ b/app/scripts/controller-init/phishing-controller-init.ts
@@ -1,0 +1,33 @@
+import { PhishingController } from '@metamask/phishing-controller';
+import { Duration, inMilliseconds } from '@metamask/utils';
+import { ControllerInitFunction } from './types';
+import { PhishingControllerMessenger } from './messengers';
+
+/**
+ * Initialize the phishing controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state to use for the
+ * controller.
+ * @returns The initialized controller.
+ */
+export const PhishingControllerInit: ControllerInitFunction<
+  PhishingController,
+  PhishingControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new PhishingController({
+    messenger: controllerMessenger,
+    state: persistedState.PhishingController,
+    hotlistRefreshInterval: process.env.IN_TEST
+      ? inMilliseconds(5, Duration.Second)
+      : undefined,
+    stalelistRefreshInterval: process.env.IN_TEST
+      ? inMilliseconds(30, Duration.Second)
+      : undefined,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/test/utils.ts
+++ b/app/scripts/controller-init/test/utils.ts
@@ -16,6 +16,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
   >
 > {
   return {
+    currentMigrationVersion: 0,
     // @ts-expect-error: Partial mock.
     extension: {},
     platform: new ExtensionPlatform(),

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -75,6 +75,11 @@ export type ControllerInitRequest<
   controllerMessenger: ControllerMessengerType;
 
   /**
+   * The current version of the extension, used for migrations.
+   */
+  currentMigrationVersion: number;
+
+  /**
    * An instance of an encryptor to use for encrypting and decrypting
    * sensitive data.
    */

--- a/app/scripts/controllers/account-order.ts
+++ b/app/scripts/controllers/account-order.ts
@@ -88,7 +88,7 @@ export class AccountOrderController extends BaseController<
     state,
   }: {
     messenger: AccountOrderControllerMessenger;
-    state?: AccountOrderControllerState;
+    state?: Partial<AccountOrderControllerState>;
   }) {
     // Call the constructor of BaseControllerV2
     super({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -127,7 +127,6 @@ import {
   BridgeStatusAction,
 } from '@metamask/bridge-status-controller';
 
-import { ErrorReportingService } from '@metamask/error-reporting-service';
 import {
   SeedlessOnboardingControllerErrorMessage,
   SecretType,
@@ -400,6 +399,7 @@ import { AlertControllerInit } from './controller-init/alert-controller-init';
 import { MetaMetricsDataDeletionControllerInit } from './controller-init/metametrics-data-deletion-controller-init';
 import { LoggingControllerInit } from './controller-init/logging-controller-init';
 import { AppMetadataControllerInit } from './controller-init/app-metadata-controller-init';
+import { ErrorReportingServiceInit } from './controller-init/error-reporting-service-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -510,20 +510,6 @@ export default class MetamaskController extends EventEmitter {
         // Exclude Smart TX Status Page from rate limiting to allow sequential transactions
         SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
       ],
-    });
-
-    const errorReportingServiceMessenger =
-      this.controllerMessenger.getRestricted({
-        name: 'ErrorReportingService',
-        allowedActions: [],
-        allowedEvents: [],
-      });
-    // Initializing the ErrorReportingService populates the
-    // ErrorReportingServiceMessenger.
-    // eslint-disable-next-line no-new
-    new ErrorReportingService({
-      messenger: errorReportingServiceMessenger,
-      captureException,
     });
 
     this.multichainSubscriptionManager = new MultichainSubscriptionManager({
@@ -690,6 +676,7 @@ export default class MetamaskController extends EventEmitter {
     /** @type {import('./controller-init/utils').InitFunctions} */
     const controllerInitFunctions = {
       LoggingController: LoggingControllerInit,
+      ErrorReportingService: ErrorReportingServiceInit,
       AppMetadataController: AppMetadataControllerInit,
       PreferencesController: PreferencesControllerInit,
       SnapKeyringBuilder: SnapKeyringBuilderInit,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -258,7 +258,6 @@ import {
 } from './lib/util';
 import createMetamaskMiddleware from './lib/createMetamaskMiddleware';
 import EncryptionPublicKeyController from './controllers/encryption-public-key';
-import AppMetadataController from './controllers/app-metadata';
 import {
   createHyperliquidReferralMiddleware,
   HyperliquidPermissionTriggerType,
@@ -400,6 +399,7 @@ import { PhishingControllerInit } from './controller-init/phishing-controller-in
 import { AlertControllerInit } from './controller-init/alert-controller-init';
 import { MetaMetricsDataDeletionControllerInit } from './controller-init/metametrics-data-deletion-controller-init';
 import { LoggingControllerInit } from './controller-init/logging-controller-init';
+import { AppMetadataControllerInit } from './controller-init/app-metadata-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -493,17 +493,6 @@ export default class MetamaskController extends EventEmitter {
           this.platform.openExtensionInBrowser();
         }
       }
-    });
-
-    this.appMetadataController = new AppMetadataController({
-      state: initState.AppMetadataController,
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'AppMetadataController',
-        allowedActions: [],
-        allowedEvents: [],
-      }),
-      currentMigrationVersion: this.currentMigrationVersion,
-      currentAppVersion: version,
     });
 
     this.approvalController = new ApprovalController({
@@ -701,6 +690,7 @@ export default class MetamaskController extends EventEmitter {
     /** @type {import('./controller-init/utils').InitFunctions} */
     const controllerInitFunctions = {
       LoggingController: LoggingControllerInit,
+      AppMetadataController: AppMetadataControllerInit,
       PreferencesController: PreferencesControllerInit,
       SnapKeyringBuilder: SnapKeyringBuilderInit,
       KeyringController: KeyringControllerInit,
@@ -796,6 +786,7 @@ export default class MetamaskController extends EventEmitter {
 
     // Backwards compatibility for existing references
     this.loggingController = controllersByName.LoggingController;
+    this.appMetadataController = controllersByName.AppMetadataController;
     this.preferencesController = controllersByName.PreferencesController;
     this.keyringController = controllersByName.KeyringController;
     this.accountsController = controllersByName.AccountsController;
@@ -8730,6 +8721,7 @@ export default class MetamaskController extends EventEmitter {
 
   #initControllers({ existingControllers, initFunctions, initState }) {
     const initRequest = {
+      currentMigrationVersion: this.opts.currentMigrationVersion,
       encryptor: this.opts.encryptor,
       extension: this.extension,
       platform: this.platform,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -247,7 +247,6 @@ import {
 import createOriginMiddleware from './lib/createOriginMiddleware';
 import createMainFrameOriginMiddleware from './lib/createMainFrameOriginMiddleware';
 import createTabIdMiddleware from './lib/createTabIdMiddleware';
-import { AccountOrderController } from './controllers/account-order';
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware';
 import { isStreamWritable, setupMultiplex } from './lib/stream-utils';
 import { ReferralStatus } from './controllers/preferences-controller';
@@ -402,6 +401,7 @@ import { SnapKeyringBuilderInit } from './controller-init/accounts/snap-keyring-
 import { PermissionLogControllerInit } from './controller-init/permission-log-controller-init';
 import { NetworkControllerInit } from './controller-init/network-controller-init';
 import { AnnouncementControllerInit } from './controller-init/announcement-controller-init';
+import { AccountOrderControllerInit } from './controller-init/account-order-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -616,14 +616,6 @@ export default class MetamaskController extends EventEmitter {
       state: initState.PhishingController,
       hotlistRefreshInterval: process.env.IN_TEST ? 5 * SECOND : undefined,
       stalelistRefreshInterval: process.env.IN_TEST ? 30 * SECOND : undefined,
-    });
-
-    const accountOrderMessenger = this.controllerMessenger.getRestricted({
-      name: 'AccountOrderController',
-    });
-    this.accountOrderController = new AccountOrderController({
-      messenger: accountOrderMessenger,
-      state: initState.AccountOrderController,
     });
 
     // start and stop polling for balances based on activeControllerConnections
@@ -889,6 +881,7 @@ export default class MetamaskController extends EventEmitter {
       NameController: NameControllerInit,
       NetworkEnablementController: NetworkEnablementControllerInit,
       AnnouncementController: AnnouncementControllerInit,
+      AccountOrderController: AccountOrderControllerInit,
     };
 
     const {
@@ -983,6 +976,7 @@ export default class MetamaskController extends EventEmitter {
     this.ensController = controllersByName.EnsController;
     this.nameController = controllersByName.NameController;
     this.announcementController = controllersByName.AnnouncementController;
+    this.accountOrderController = controllersByName.AccountOrderController;
 
     this.backup = new Backup({
       preferencesController: this.preferencesController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -248,7 +248,6 @@ import createTabIdMiddleware from './lib/createTabIdMiddleware';
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware';
 import { isStreamWritable, setupMultiplex } from './lib/stream-utils';
 import { ReferralStatus } from './controllers/preferences-controller';
-import { AlertController } from './controllers/alert-controller';
 import Backup from './lib/backup';
 import DecryptMessageController from './controllers/decrypt-message';
 import createMetaRPCHandler from './lib/createMetaRPCHandler';
@@ -402,6 +401,7 @@ import { AnnouncementControllerInit } from './controller-init/announcement-contr
 import { AccountOrderControllerInit } from './controller-init/account-order-controller-init';
 import { AccountsControllerInit } from './controller-init/accounts-controller-init';
 import { PhishingControllerInit } from './controller-init/phishing-controller-init';
+import { AlertControllerInit } from './controller-init/alert-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -606,15 +606,6 @@ export default class MetamaskController extends EventEmitter {
       state: initState.AddressBookController,
     });
 
-    this.alertController = new AlertController({
-      state: initState.AlertController,
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'AlertController',
-        allowedEvents: ['AccountsController:selectedAccountChange'],
-        allowedActions: ['AccountsController:getSelectedAccount'],
-      }),
-    });
-
     this.decryptMessageController = new DecryptMessageController({
       getState: this.getState.bind(this),
       messenger: this.controllerMessenger.getRestricted({
@@ -747,6 +738,7 @@ export default class MetamaskController extends EventEmitter {
       SnapKeyringBuilder: SnapKeyringBuilderInit,
       KeyringController: KeyringControllerInit,
       AccountsController: AccountsControllerInit,
+      AlertController: AlertControllerInit,
       PermissionController: PermissionControllerInit,
       PermissionLogController: PermissionLogControllerInit,
       SubjectMetadataController: SubjectMetadataControllerInit,
@@ -838,6 +830,7 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController = controllersByName.PreferencesController;
     this.keyringController = controllersByName.KeyringController;
     this.accountsController = controllersByName.AccountsController;
+    this.alertController = controllersByName.AlertController;
     this.permissionController = controllersByName.PermissionController;
     this.permissionLogController = controllersByName.PermissionLogController;
     this.subjectMetadataController =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -30,7 +30,6 @@ import {
 } from '@metamask/approval-controller';
 import { Messenger } from '@metamask/base-controller';
 import { PhishingController } from '@metamask/phishing-controller';
-import { AnnouncementController } from '@metamask/announcement-controller';
 import {
   MethodNames,
   PermissionDoesNotExistError,
@@ -157,7 +156,6 @@ import {
 } from '../../shared/constants/hardware-wallets';
 import { KeyringType } from '../../shared/constants/keyring';
 import { RestrictedMethods } from '../../shared/constants/permissions';
-import { UI_NOTIFICATIONS } from '../../shared/notifications';
 import { MILLISECOND, MINUTE, SECOND } from '../../shared/constants/time';
 import {
   HYPERLIQUID_APPROVAL_TYPE,
@@ -403,6 +401,7 @@ import { KeyringControllerInit } from './controller-init/keyring-controller-init
 import { SnapKeyringBuilderInit } from './controller-init/accounts/snap-keyring-builder-init';
 import { PermissionLogControllerInit } from './controller-init/permission-log-controller-init';
 import { NetworkControllerInit } from './controller-init/network-controller-init';
+import { AnnouncementControllerInit } from './controller-init/announcement-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -617,16 +616,6 @@ export default class MetamaskController extends EventEmitter {
       state: initState.PhishingController,
       hotlistRefreshInterval: process.env.IN_TEST ? 5 * SECOND : undefined,
       stalelistRefreshInterval: process.env.IN_TEST ? 30 * SECOND : undefined,
-    });
-
-    const announcementMessenger = this.controllerMessenger.getRestricted({
-      name: 'AnnouncementController',
-    });
-
-    this.announcementController = new AnnouncementController({
-      messenger: announcementMessenger,
-      allAnnouncements: UI_NOTIFICATIONS,
-      state: initState.AnnouncementController,
     });
 
     const accountOrderMessenger = this.controllerMessenger.getRestricted({
@@ -899,6 +888,7 @@ export default class MetamaskController extends EventEmitter {
       EnsController: EnsControllerInit,
       NameController: NameControllerInit,
       NetworkEnablementController: NetworkEnablementControllerInit,
+      AnnouncementController: AnnouncementControllerInit,
     };
 
     const {
@@ -992,6 +982,7 @@ export default class MetamaskController extends EventEmitter {
       controllersByName.GatorPermissionsController;
     this.ensController = controllersByName.EnsController;
     this.nameController = controllersByName.NameController;
+    this.announcementController = controllersByName.AnnouncementController;
 
     this.backup = new Backup({
       preferencesController: this.preferencesController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -278,8 +278,6 @@ import {
   getPermittedAccountsForScopesByOrigin,
   getOriginsWithSessionProperty,
 } from './controllers/permissions';
-import { MetaMetricsDataDeletionController } from './controllers/metametrics-data-deletion/metametrics-data-deletion';
-import { DataDeletionService } from './services/data-deletion-service';
 import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { getAccountsBySnapId } from './lib/snap-keyring';
@@ -402,6 +400,7 @@ import { AccountOrderControllerInit } from './controller-init/account-order-cont
 import { AccountsControllerInit } from './controller-init/accounts-controller-init';
 import { PhishingControllerInit } from './controller-init/phishing-controller-init';
 import { AlertControllerInit } from './controller-init/alert-controller-init';
+import { MetaMetricsDataDeletionControllerInit } from './controller-init/metametrics-data-deletion-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -570,20 +569,6 @@ export default class MetamaskController extends EventEmitter {
     this.multichainMiddlewareManager = new MultichainMiddlewareManager();
     this.deprecatedNetworkVersions = {};
 
-    const dataDeletionService = new DataDeletionService();
-    const metaMetricsDataDeletionMessenger =
-      this.controllerMessenger.getRestricted({
-        name: 'MetaMetricsDataDeletionController',
-        allowedActions: ['MetaMetricsController:getState'],
-        allowedEvents: [],
-      });
-    this.metaMetricsDataDeletionController =
-      new MetaMetricsDataDeletionController({
-        dataDeletionService,
-        messenger: metaMetricsDataDeletionMessenger,
-        state: initState.metaMetricsDataDeletionController,
-      });
-
     // start and stop polling for balances based on activeControllerConnections
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
       const { completedOnboarding } = this.onboardingController.state;
@@ -745,6 +730,7 @@ export default class MetamaskController extends EventEmitter {
       AppStateController: AppStateControllerInit,
       NetworkController: NetworkControllerInit,
       MetaMetricsController: MetaMetricsControllerInit,
+      MetaMetricsDataDeletionController: MetaMetricsDataDeletionControllerInit,
       RemoteFeatureFlagController: RemoteFeatureFlagControllerInit,
       GasFeeController: GasFeeControllerInit,
       ExecutionService: ExecutionServiceInit,
@@ -838,6 +824,8 @@ export default class MetamaskController extends EventEmitter {
     this.appStateController = controllersByName.AppStateController;
     this.networkController = controllersByName.NetworkController;
     this.metaMetricsController = controllersByName.MetaMetricsController;
+    this.metaMetricsDataDeletionController =
+      controllersByName.MetaMetricsDataDeletionController;
     this.remoteFeatureFlagController =
       controllersByName.RemoteFeatureFlagController;
     this.gasFeeController = controllersByName.GasFeeController;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -29,7 +29,6 @@ import {
   ApprovalRequestNotFoundError,
 } from '@metamask/approval-controller';
 import { Messenger } from '@metamask/base-controller';
-import { PhishingController } from '@metamask/phishing-controller';
 import {
   MethodNames,
   PermissionDoesNotExistError,
@@ -402,6 +401,7 @@ import { NetworkControllerInit } from './controller-init/network-controller-init
 import { AnnouncementControllerInit } from './controller-init/announcement-controller-init';
 import { AccountOrderControllerInit } from './controller-init/account-order-controller-init';
 import { AccountsControllerInit } from './controller-init/accounts-controller-init';
+import { PhishingControllerInit } from './controller-init/phishing-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -583,18 +583,6 @@ export default class MetamaskController extends EventEmitter {
         messenger: metaMetricsDataDeletionMessenger,
         state: initState.metaMetricsDataDeletionController,
       });
-
-    const phishingControllerMessenger = this.controllerMessenger.getRestricted({
-      name: 'PhishingController',
-      allowedEvents: ['TransactionController:stateChange'],
-    });
-
-    this.phishingController = new PhishingController({
-      messenger: phishingControllerMessenger,
-      state: initState.PhishingController,
-      hotlistRefreshInterval: process.env.IN_TEST ? 5 * SECOND : undefined,
-      stalelistRefreshInterval: process.env.IN_TEST ? 30 * SECOND : undefined,
-    });
 
     // start and stop polling for balances based on activeControllerConnections
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
@@ -778,6 +766,7 @@ export default class MetamaskController extends EventEmitter {
       SnapInterfaceController: SnapInterfaceControllerInit,
       WebSocketService: WebSocketServiceInit,
       PPOMController: PPOMControllerInit,
+      PhishingController: PhishingControllerInit,
       OnboardingController: OnboardingControllerInit,
       AccountTrackerController: AccountTrackerControllerInit,
       TransactionController: TransactionControllerInit,
@@ -868,6 +857,7 @@ export default class MetamaskController extends EventEmitter {
     this.snapInterfaceController = controllersByName.SnapInterfaceController;
     this.snapsRegistry = controllersByName.SnapsRegistry;
     this.ppomController = controllersByName.PPOMController;
+    this.phishingController = controllersByName.PhishingController;
     this.onboardingController = controllersByName.OnboardingController;
     this.accountTrackerController = controllersByName.AccountTrackerController;
     this.txController = controllersByName.TransactionController;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -39,7 +39,6 @@ import {
   METAMASK_DOMAIN,
   createSelectedNetworkMiddleware,
 } from '@metamask/selected-network-controller';
-import { LoggingController, LogType } from '@metamask/logging-controller';
 
 import {
   createPreinstalledSnapsMiddleware,
@@ -168,7 +167,6 @@ import {
   MetaMetricsEventName,
   MetaMetricsRequestedThrough,
 } from '../../shared/constants/metametrics';
-import { LOG_EVENT } from '../../shared/constants/logs';
 
 import {
   getStorageItem,
@@ -401,6 +399,7 @@ import { AccountsControllerInit } from './controller-init/accounts-controller-in
 import { PhishingControllerInit } from './controller-init/phishing-controller-init';
 import { AlertControllerInit } from './controller-init/alert-controller-init';
 import { MetaMetricsDataDeletionControllerInit } from './controller-init/metametrics-data-deletion-controller-init';
+import { LoggingControllerInit } from './controller-init/logging-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -469,16 +468,6 @@ export default class MetamaskController extends EventEmitter {
     this.initializeChainlist();
 
     this.controllerMessenger = new Messenger();
-
-    this.loggingController = new LoggingController({
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'LoggingController',
-        allowedActions: [],
-        allowedEvents: [],
-      }),
-      state: initState.LoggingController,
-    });
-
     this.currentMigrationVersion = opts.currentMigrationVersion;
 
     // observable state store
@@ -503,14 +492,6 @@ export default class MetamaskController extends EventEmitter {
         if (version === '8.1.0') {
           this.platform.openExtensionInBrowser();
         }
-        this.loggingController.add({
-          type: LogType.GenericLog,
-          data: {
-            event: LOG_EVENT.VERSION_UPDATE,
-            previousVersion: details.previousVersion,
-            version,
-          },
-        });
       }
     });
 
@@ -654,7 +635,7 @@ export default class MetamaskController extends EventEmitter {
           'KeyringController:signMessage',
           'KeyringController:signPersonalMessage',
           'KeyringController:signTypedMessage',
-          `${this.loggingController.name}:add`,
+          'LoggingController:add',
           `NetworkController:getNetworkClientById`,
           `GatorPermissionsController:decodePermissionFromPermissionContextForOrigin`,
         ],
@@ -719,6 +700,7 @@ export default class MetamaskController extends EventEmitter {
 
     /** @type {import('./controller-init/utils').InitFunctions} */
     const controllerInitFunctions = {
+      LoggingController: LoggingControllerInit,
       PreferencesController: PreferencesControllerInit,
       SnapKeyringBuilder: SnapKeyringBuilderInit,
       KeyringController: KeyringControllerInit,
@@ -813,6 +795,7 @@ export default class MetamaskController extends EventEmitter {
     this.controllersByName = controllersByName;
 
     // Backwards compatibility for existing references
+    this.loggingController = controllersByName.LoggingController;
     this.preferencesController = controllersByName.PreferencesController;
     this.keyringController = controllersByName.KeyringController;
     this.accountsController = controllersByName.AccountsController;

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@metamask/eip-5792-middleware": "^1.1.0",
     "@metamask/ens-controller": "^17.0.1",
     "@metamask/ens-resolver-snap": "^0.1.4",
-    "@metamask/error-reporting-service": "^2.0.0",
+    "@metamask/error-reporting-service": "^2.2.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^18.0.0",
     "@metamask/eth-ledger-bridge-keyring": "11.1.2",

--- a/shared/notifications/index.ts
+++ b/shared/notifications/index.ts
@@ -1,17 +1,9 @@
+import { AnnouncementMap } from '@metamask/announcement-controller';
+
 type NotificationImage = {
   src: string;
   width?: string;
   height?: string;
-};
-
-type UINotification = {
-  id: number;
-  date: string | null;
-  image?: NotificationImage;
-};
-
-type UINotifications = {
-  [key: number]: UINotification;
 };
 
 export type TranslationFunction = (key: string) => string;
@@ -52,4 +44,4 @@ export type TranslatedUINotifications = {
 };
 
 // If in the future we need to add a new notification, we can do it here
-export const UI_NOTIFICATIONS: UINotifications = {};
+export const UI_NOTIFICATIONS: AnnouncementMap = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5951,12 +5951,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/error-reporting-service@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/error-reporting-service@npm:2.0.0"
+"@metamask/error-reporting-service@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@metamask/error-reporting-service@npm:2.2.0"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.1"
-  checksum: 10/639206e3d3fcf136243503073692b97cac194dc6f2003e62db58315b82393be8d6426d22b0e0c97c7f2903ffa3c11ef4600565576bcb58ea6ff72fce74e18d59
+    "@metamask/base-controller": "npm:^8.4.0"
+  checksum: 10/f2cd8845247c753c3f37b6af9ea47960340b4120e69e5c6fda88ec2daf953ec3ab96a8a767b6a382a1537a221b0dbccadfe443d72935a8bbc9250f4389834a51
   languageName: node
   linkType: hard
 
@@ -32167,7 +32167,7 @@ __metadata:
     "@metamask/eip-5792-middleware": "npm:^1.1.0"
     "@metamask/ens-controller": "npm:^17.0.1"
     "@metamask/ens-resolver-snap": "npm:^0.1.4"
-    "@metamask/error-reporting-service": "npm:^2.0.0"
+    "@metamask/error-reporting-service": "npm:^2.2.0"
     "@metamask/eslint-config": "npm:^9.0.0"
     "@metamask/eslint-config-jest": "npm:^9.0.0"
     "@metamask/eslint-config-mocha": "npm:^9.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors several more controllers and services to modular init. We may want to consider splitting up this PR into smaller PRs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36593?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: #29523.
Fixes: #29524.
Fixes: #29538.
Fixes: #29544.
Fixes: #29545.
Fixes: #29547.
Fixes: #29574.
Fixes: #29529.

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates many controllers/services to modular initialization with new restricted messengers, rewires MetaMaskController to use them, and bumps error-reporting-service.
> 
> - **Controller Init modernization**:
>   - Add modular init for `AccountsController`, `AccountOrderController`, `AlertController`, `AnnouncementController`, `AppMetadataController`, `LoggingController`, `PhishingController`, `MetaMetricsDataDeletionController`, and `ErrorReportingService`.
>   - Create restricted messengers and unit tests for each; register in `CONTROLLER_MESSENGERS`.
>   - Extend `ControllerInitRequest` with `currentMigrationVersion`; allow `AccountOrderController` to accept partial state.
>   - Update `controller-list.ts` to include new controllers in `Controller` union and `ControllerFlatState`.
>   - Align notifications typing for announcements and export `UI_NOTIFICATIONS` accordingly.
>   - Bump `@metamask/error-reporting-service` to `^2.2.0`.
> - **MetaMaskController wiring**:
>   - Replace inline instantiation of affected controllers/services with their init functions; map instances from `controllersByName`.
>   - Move version-update logging to `LoggingControllerInit`; adjust onInstalled listener and messenger action names (e.g., `AccountsController:getState`, `LoggingController:add`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5abb1b541c4c81c6428ee0a8bd03fa1c638cd2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->