### PR TITLE
test: fix flaky test `Speed Up and Cancel Transaction Tests Speed up transaction Successfully speeds up a pending transaction`

### DIFF
--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -46,7 +46,10 @@ class ActivityListPage {
     tag: 'button',
   };
 
-  private readonly speedupButton = '[data-testid="speedup-button"]';
+  private readonly speedupButton = {
+    tag: 'button',
+    text: 'Speed Up',
+  };
 
   private readonly confirmTransactionReplacementButton = {
     text: 'Submit',

--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -48,7 +48,7 @@ class ActivityListPage {
 
   private readonly speedupButton = {
     tag: 'button',
-    text: 'Speed Up',
+    text: 'Speed up',
   };
 
   private readonly confirmTransactionReplacementButton = {

--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -46,10 +46,9 @@ class ActivityListPage {
     tag: 'button',
   };
 
-  private readonly speedupButton = {
-    tag: 'button',
-    text: 'Speed up',
-  };
+  private readonly speedupInlineButton = '[data-testid="speed-up-button"]';
+
+  private readonly speedupModalButton = '[data-testid="speedup-button"]';
 
   private readonly confirmTransactionReplacementButton = {
     text: 'Submit',
@@ -189,6 +188,10 @@ class ActivityListPage {
 
   async checkNoTxInActivity(): Promise<void> {
     await this.driver.assertElementNotPresent(this.completedTransactions);
+  }
+
+  async checkSpeedUpInlineButtonIsPresent(): Promise<void> {
+    await this.driver.waitForSelector(this.speedupInlineButton);
   }
 
   /**
@@ -393,7 +396,7 @@ class ActivityListPage {
   }
 
   async clickSpeedUpTransaction() {
-    await this.driver.clickElement(this.speedupButton);
+    await this.driver.clickElement(this.speedupModalButton);
   }
 
   async clickConfirmTransactionReplacement() {

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -57,6 +57,8 @@ describe('Speed Up and Cancel Transaction Tests', function () {
           const activityListPage = new ActivityListPage(driver);
           await activityListPage.checkCompletedTxNumberDisplayedInActivity(1);
 
+          await activityListPage.checkSpeedUpInlineButtonIsPresent();
+          await activityListPage.clickTransactionListItem();
           await activityListPage.clickSpeedUpTransaction();
           await activityListPage.clickConfirmTransactionReplacement();
           await driver.delay(3000); // Delay needed to ensure the transaction is updated before mining

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -57,7 +57,6 @@ describe('Speed Up and Cancel Transaction Tests', function () {
           const activityListPage = new ActivityListPage(driver);
           await activityListPage.checkCompletedTxNumberDisplayedInActivity(1);
 
-          await activityListPage.clickTransactionListItem();
           await activityListPage.clickSpeedUpTransaction();
           await activityListPage.clickConfirmTransactionReplacement();
           await driver.delay(3000); // Delay needed to ensure the transaction is updated before mining


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test is flaky because the following happens:
1. We confirm a transaction
2. We go to the activity list, while this transaction is pending
3. We click on the pending transaction, to open the transaction details modal
4. We then click Speed up
5. And we confirm the modal

The problem is that in step 3, when we click on the pending tx, if that tx updates after we click, the component is re-rendered and the tx details modal is closed. Then we cannot find the speed up id button (the one from the modal, not the one from the tx item - note they have 2 different ids: `speedup-button` and `speed-up-button`.

To fix this, instead of trying to open the tx details and then speed up, we wait until the speed up button appears in the component (so no more re-renders happen) and click on it.

Example of failure: https://github.com/MetaMask/metamask-extension/actions/runs/18270673628/job/52012969962

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/e3d6329c-8e56-4a58-b4d9-20c7a6f56714" />

<img width="1818" height="1180" alt="image" src="https://github.com/user-attachments/assets/62f34cfe-359c-47c6-93da-647d2d62e1dd" />



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36601?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
7. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes flakiness in the speed-up transaction test by waiting for the inline speed-up button and using distinct selectors for inline vs modal actions.
> 
> - **E2E Tests**:
>   - In `test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts`, wait for inline `speed-up` availability via `checkSpeedUpInlineButtonIsPresent()` before opening item and confirming speed-up.
> - **Page Objects**:
>   - In `test/e2e/page-objects/pages/home/activity-list.ts`:
>     - Split speed-up selectors: add `speedupInlineButton` (`[data-testid="speed-up-button"]`) and `speedupModalButton` (`[data-testid="speedup-button"]`).
>     - Add `checkSpeedUpInlineButtonIsPresent()` helper.
>     - Update `clickSpeedUpTransaction()` to use `speedupModalButton`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d103a04c816f80320f6ac8233b6974f696cd7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->