### PR TITLE
fix: error message displayed while sending tokens to a contract address

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7139,6 +7139,9 @@
   "tokenContractAddress": {
     "message": "Token contract address"
   },
+  "tokenContractError": {
+    "message": "This address is a token contract address. If you send tokens to this address, you will lose them."
+  },
   "tokenDecimal": {
     "message": "Token decimal"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7139,6 +7139,9 @@
   "tokenContractAddress": {
     "message": "Token contract address"
   },
+  "tokenContractError": {
+    "message": "This address is a token contract address. If you send tokens to this address, you will lose them."
+  },
   "tokenDecimal": {
     "message": "Token decimal"
   },

--- a/ui/pages/confirmations/utils/sendValidations.test.ts
+++ b/ui/pages/confirmations/utils/sendValidations.test.ts
@@ -138,7 +138,7 @@ describe('SendValidations', () => {
           '0x1',
         ),
       ).toEqual({
-        error: 'invalidAddress',
+        error: 'tokenContractError',
       });
 
       expect(mockGetTokenStandardAndDetailsByChain).toHaveBeenCalledWith(

--- a/ui/pages/confirmations/utils/sendValidations.ts
+++ b/ui/pages/confirmations/utils/sendValidations.ts
@@ -77,7 +77,7 @@ export const validateEvmHexAddress = async (
     );
     if (tokenDetails?.standard) {
       return {
-        error: 'invalidAddress',
+        error: 'tokenContractError',
       };
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix in error message displayed while sending tokens to a contract address

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36462

## **Manual testing steps**

1. Send token to a contract address
2. Check the error displayed

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return `tokenContractError` for token contract recipients, add i18n strings, and update tests accordingly.
> 
> - **Validations**:
>   - Update `validateEvmHexAddress` in `ui/pages/confirmations/utils/sendValidations.ts` to return `tokenContractError` when the recipient is a token contract (based on `getTokenStandardAndDetailsByChain`).
>   - Adjust unit test in `ui/pages/confirmations/utils/sendValidations.test.ts` to expect `tokenContractError`.
> - **i18n**:
>   - Add `tokenContractError` message to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json` with a clear warning about sending tokens to token contract addresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c2fdc5e7c3c02035da4b0b4aeb810074afe9f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->