### PR TITLE
fix: cp-13.5.0 prevent wrongly format balance from being passed

### DIFF
--- a/ui/pages/asset/components/token-asset.tsx
+++ b/ui/pages/asset/components/token-asset.tsx
@@ -34,7 +34,7 @@ import AssetOptions from './asset-options';
 import AssetPage from './asset-page';
 
 const TokenAsset = ({ token, chainId }: { token: Token; chainId: Hex }) => {
-  const { address, symbol, isERC721, image } = token;
+  const { address, symbol, decimals, isERC721, image } = token;
 
   const tokenList = useSelector(getTokenList);
   const allNetworks: {
@@ -88,7 +88,16 @@ const TokenAsset = ({ token, chainId }: { token: Token; chainId: Hex }) => {
   const {
     tokensWithBalances,
   }: { tokensWithBalances: { string: string; balance: string }[] } =
-    useTokenTracker({ tokens: [token], address: undefined });
+    useTokenTracker({
+      tokens: [
+        {
+          address,
+          symbol,
+          decimals,
+        },
+      ],
+      address: undefined,
+    });
 
   const balance = tokensWithBalances?.[0];
   const fiat = useTokenFiatAmount(address, balance?.string, symbol, {}, false);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Prevents passing an incorrectly balance field to eth-token-tracker.

EVM assets from the basic selector do not have a `balance` field, but solana assets do, and it's a stringified decimal.

When that value is passed down to the `eth-token-tracker` library, which has no types (footgun), it throws when trying to convert that value, so we've changed the code to avoid passing it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36612?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug in which an error appeared when opening solana tokens

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36603

## **Manual testing steps**

1. Go to the home wallet page with an account that has Solana tokens (not native assets)
2. Open asset details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="969" height="594" alt="image" src="https://github.com/user-attachments/assets/39c67484-6fdc-450b-b8f5-7162f5489388" />


### **After**

<!-- [screenshots/recordings] -->
<img width="687" height="945" alt="image" src="https://github.com/user-attachments/assets/383b3221-027b-4473-8a32-c6a25c737065" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
