### PR TITLE
ci: GitHub Actions time usage optimizations

### DIFF
--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -7,6 +7,7 @@ jobs:
   extract:
     if: ${{ github.ref_type == 'branch' && (startsWith(github.ref, 'refs/heads/Version-v') || startsWith(github.ref, 'refs/heads/release/')) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       semver: ${{ steps.out.outputs.semver }}
     steps:

--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -10,6 +10,7 @@ jobs:
   auto-update:
     name: Auto-update
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       YARN_ENABLE_HARDENED_MODE: false

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -10,6 +10,7 @@ jobs:
   build-storybook:
     name: Build storybook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.

--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-ts-migration-dashboard:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-attributions:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   check-pr-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: read
 

--- a/.github/workflows/check-release-tag.yml
+++ b/.github/workflows/check-release-tag.yml
@@ -17,6 +17,7 @@ jobs:
     # Only run on PRs targeting stable
     if: github.base_ref == 'stable'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   check-template-and-add-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event_name != 'merge_group' }} # Skip this step for merge_group events
     steps:
       - name: Checkout and setup environment

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,6 +13,7 @@ jobs:
   CLABot:
     if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   close-bug-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event.pull_request.merged == true && ( startsWith(github.event.pull_request.head.ref, 'Version-v') || startsWith(github.event.pull_request.head.ref, 'release/') )
     steps:
       - name: Checkout and setup environment

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   codespaces-update-badge:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     env:

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -5,6 +5,7 @@ on: create
 jobs:
   create-bug-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Extract version from branch name if release branch
         id: extract_version

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   cherry-pick:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -26,6 +26,7 @@ jobs:
   resolve-bases:
     # Determines if the release is hotfix or not based on semver. Then sets the appropriate base branches for the checkout and release PR.
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       checkout_base: ${{ steps.out.outputs.checkout_base }}
       release_base: ${{ steps.out.outputs.release_base }}
@@ -57,6 +58,7 @@ jobs:
   resolve-previous-ref:
     needs: resolve-bases
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       previous_ref: ${{ steps.out.outputs.previous_ref }}
     steps:

--- a/.github/workflows/crowdin-action.yml
+++ b/.github/workflows/crowdin-action.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -65,6 +65,7 @@ jobs:
       - test-e2e-firefox-webpack
       - test-e2e-firefox-flask
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ !cancelled() }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   fitness-functions:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event_name != 'merge_group' }} # Skip this step for merge_group events
     steps:
       - name: Checkout and setup environment

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   identify-codeowners:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/locales-only.yml
+++ b/.github/workflows/locales-only.yml
@@ -12,6 +12,7 @@ jobs:
     # For the `pull_request` event, the branch is `github.head_ref``.
     if: ${{ github.head_ref == 'l10n_crowdin_action' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ permissions:
 jobs:
   prep-deps:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -71,6 +72,7 @@ jobs:
     needs:
       - prep-deps
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -203,6 +205,7 @@ jobs:
     needs:
       - build-dist-browserify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       EXTENSION_BUNDLESIZE_STATS_TOKEN: ${{ secrets.EXTENSION_BUNDLESIZE_STATS_TOKEN }}
       SELENIUM_BROWSER: chrome
@@ -298,6 +301,7 @@ jobs:
       - prep-deps
       - build-dist-browserify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -327,6 +331,7 @@ jobs:
       - prep-deps
       - build-dist-browserify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       GOOGLE_PROD_CLIENT_ID: 00000000000
@@ -402,6 +407,7 @@ jobs:
   all-jobs-completed:
     name: All jobs completed
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - lint-workflows
       - test-lint
@@ -435,6 +441,7 @@ jobs:
     name: All jobs pass
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - all-jobs-completed
       - needs-e2e

--- a/.github/workflows/needs-e2e.yml
+++ b/.github/workflows/needs-e2e.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   needs-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       needs-e2e: ${{ steps.determine.outputs.NEEDS_E2E }}
     env:
@@ -74,6 +75,7 @@ jobs:
     needs:
       - needs-e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/page-load-benchmark-pr.yml
+++ b/.github/workflows/page-load-benchmark-pr.yml
@@ -18,6 +18,7 @@ jobs:
   page-load-benchmark-pr:
     name: Run Page Load Benchmarks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       OWNER: ${{ github.repository_owner }}
       REPOSITORY: ${{ github.event.repository.name }}

--- a/.github/workflows/page-load-benchmark-upload.yml
+++ b/.github/workflows/page-load-benchmark-upload.yml
@@ -10,6 +10,7 @@ jobs:
   page-load-benchmark-upload:
     name: Upload Page Load Benchmarks Data
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,7 @@ jobs:
   publish-prerelease:
     name: Publish prerelease
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
       OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # Publishing tokens
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release-pr-approval.yml
+++ b/.github/workflows/release-pr-approval.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Require Release Team approval
         uses: op5dev/require-team-approval@dfd7b8b9a88bf82a955c103f7e19642b0411aecd

--- a/.github/workflows/remove-labels-after-pr-closed.yml
+++ b/.github/workflows/remove-labels-after-pr-closed.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -10,8 +10,8 @@ env:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-
-    timeout-minutes: 3022.04
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -10,7 +10,8 @@ env:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-
+    timeout-minutes: 3022.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -28,6 +28,7 @@ jobs:
   run-build:
     name: ${{ inputs.build-name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # Build parameter
       ENABLE_MV3: ${{ inputs.enable-mv3 }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -45,6 +45,7 @@ jobs:
   run-e2e:
     name: ${{ inputs.test-suite-name }}${{ inputs.matrix-total > 1 && format(' ({0})', inputs.matrix-index) || '' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ghcr.io/metamask/metamask-extension-e2e-image:v1.0.0
       credentials:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,7 @@ jobs:
   test-unit:
     name: Unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
@@ -39,6 +40,7 @@ jobs:
   test-webpack:
     name: Webpack tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -61,6 +63,7 @@ jobs:
   test-integration:
     name: Integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -83,6 +86,7 @@ jobs:
   report-coverage:
     name: Report coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - test-unit
       - test-webpack

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && contains(fromJSON('["push", "pull_request"]'), github.event.workflow_run.event) && !github.event.workflow_run.repository.fork }}
     name: SonarCloud
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -12,6 +12,7 @@ jobs:
   get-next-version:
     name: Get next version vX.Y.Z
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       next-version: ${{ env.NEXT_SEMVER_VERSION }}
     steps:

--- a/.github/workflows/tag-release-branch.yml
+++ b/.github/workflows/tag-release-branch.yml
@@ -21,6 +21,7 @@ jobs:
   tag-release-branch:
     name: Tag Release Branch HEAD
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Restrict to users with write access (release team members)
     if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     outputs:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -7,6 +7,7 @@ jobs:
   test-lint:
     name: Test lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -7,6 +7,7 @@ jobs:
   test-storybook:
     name: Test storybook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -9,6 +9,7 @@ jobs:
     name: Determine whether this issue comment was on a pull request from a fork
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-attributions') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
@@ -23,6 +24,7 @@ jobs:
   react-to-comment:
     name: React to the comment
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: is-fork-pull-request
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
@@ -45,6 +47,7 @@ jobs:
   prepare:
     name: Prepare dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: is-fork-pull-request
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
@@ -71,6 +74,7 @@ jobs:
   update-attributions:
     name: Update Attributions
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
       - is-fork-pull-request
@@ -101,6 +105,7 @@ jobs:
   commit-updated-attributions:
     name: Commit the updated Attributions
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
       - is-fork-pull-request
@@ -158,6 +163,7 @@ jobs:
   check-status:
     name: Check whether the attributions update succeeded
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - commit-updated-attributions
       - is-fork-pull-request
@@ -174,6 +180,7 @@ jobs:
     name: Comment about the attributions update failure
     if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - is-fork-pull-request
       - check-status

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -15,6 +15,7 @@ jobs:
     if: ${{ needs.run-tests.outputs.current-coverage > needs.run-tests.outputs.stored-coverage }}
     name: Update coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - run-tests
     env:

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: created
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
+
 jobs:
   is-fork-pull-request:
     name: Determine whether this issue comment was on a pull request from a fork

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -13,6 +13,7 @@ jobs:
     name: Determine whether this issue comment was on a pull request from a fork
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-policies') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
@@ -28,6 +29,7 @@ jobs:
   react-to-comment:
     name: React to the comment
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: is-fork-pull-request
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
@@ -50,6 +52,7 @@ jobs:
   prepare:
     name: Prepare dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: is-fork-pull-request
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
@@ -79,6 +82,7 @@ jobs:
   update-lavamoat-build-policy:
     name: Update LavaMoat build policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
     steps:
@@ -115,6 +119,7 @@ jobs:
         build-type: [main, beta, experimental, flask]
     name: Update LavaMoat ${{ matrix.build-type }} application policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
       - update-lavamoat-build-policy
@@ -162,6 +167,7 @@ jobs:
   update-lavamoat-webpack-policy:
     name: Update LavaMoat webpack policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
     steps:
@@ -198,6 +204,7 @@ jobs:
   commit-updated-policies:
     name: Commit the updated LavaMoat policies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prepare
       - is-fork-pull-request
@@ -325,6 +332,7 @@ jobs:
   check-status:
     name: Check whether the policy update succeeded
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - commit-updated-policies
     outputs:
@@ -338,6 +346,7 @@ jobs:
     name: Comment about the policy update failure
     if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - is-fork-pull-request
       - check-status

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -5,8 +5,8 @@ on:
     types: created
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ !contains(github.ref_name, 'release/')}}
 
 jobs:
   is-fork-pull-request:

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   pr-title-linter:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # this is a hash for amannn/action-semantic-pull-request@v5.4.0
       - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f

--- a/.github/workflows/validate-lavamoat-policies.yml
+++ b/.github/workflows/validate-lavamoat-policies.yml
@@ -7,6 +7,7 @@ jobs:
   validate-lavamoat-policy-build:
     name: Validate LavaMoat build policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -36,6 +37,7 @@ jobs:
   validate-lavamoat-policy-webapp:
     name: Validate LavaMoat webapp policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         build-type: [main, beta, experimental, flask]
@@ -68,6 +70,7 @@ jobs:
   validate-lavamoat-policy-webpack:
     name: Validate LavaMoat webpack policy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- [Add `concurrency` field to `update-lavamoat-policies`.](https://github.com/MetaMask/metamask-extension/pull/36629/commits/a20025f96b0ef139a6efc53b99d7c24aea27fc44)
  - Saves approx. 20 minutes of billable time (=runtime of `update-lavamoat-policies`) for each `@metamaskbot update-policies` comment.
  - Cancels CI run when the comment is posted, instead of waiting for the `update-lavamoat-policies` workflow to complete. 
  - Excluded release branches, where even an incomplete CI run might provide useful info.

- Set `timeout-minutes` for all jobs to 30 (instead of default of 360).
  - Example of 6-hour run: https://github.com/MetaMask/metamask-extension/actions/runs/18155641151/job/51675026463?pr=33539

> All jobs should set [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes).
> ...
> By default, GitHub Actions kills workflows after 6 hours if they have not finished by then. Many workflows don't need nearly as much time to finish, but sometimes unexpected errors occur or a job hangs until the workflow run is killed 6 hours after starting it. Therefore it's recommended to specify a shorter timeout.
> ...
> This has the following advantages:
> 
> PRs won't be pending CI for half the day, issues can be caught early or workflow runs can be restarted. The number of overall parallel builds is limited, hanging jobs will not cause issues for other PRs if they are cancelled early.
>
> -- [`ghalint`](https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/012.md#job_timeout_minutes_is_required)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36629?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets 30-minute timeouts across CI jobs and adds concurrency control to the LavaMoat policies update workflow.
> 
> - **CI/CD workflows**:
>   - **Global job timeouts**: Set `timeout-minutes: 30` for jobs across many workflows in `.github/workflows/*` (tests, builds, e2e reports, benchmarks, release/publish, maintenance tasks).
>   - **LavaMoat policies workflow**: Add `concurrency` to `update-lavamoat-policies.yml` with group `${{ github.workflow }}-${{ github.ref_name }}` and `cancel-in-progress` disabled for `release/*` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc0884839878669be0b2610e760189b478f9017f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->