### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/confirmation-refactoring/confirmation-page-structure/README.md
+++ b/docs/confirmation-refactoring/confirmation-page-structure/README.md
@@ -52,7 +52,7 @@ Other confirmation components listed above map to different types of transaction
 4. ### Edit gas popovers:
 
    There are 2 different versions popovers for gas editing:
-   - Legacy gas popover - [component](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/app/edit-gas-popover)
+   - Legacy gas popover - [component](https://github.com/MetaMask/metamask-extension/tree/main/ui/pages/confirmations/components/edit-gas-popover)
    - EIP-1559 V2 gas popover - [component1](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/app/edit-gas-fee-popover), [component2](https://github.com/MetaMask/metamask-extension/tree/main/ui/components/app/advanced-gas-fee-popover).
      Context [transaction-modal-context](https://github.com/MetaMask/metamask-extension/blob/main/ui/contexts/transaction-modal.js) is used to show hide EIP-1559 gas popovers.
 


### PR DESCRIPTION
https://github.com/MetaMask/metamask-extension/tree/main/ui/components/app/edit-gas-popover - old
https://github.com/MetaMask/metamask-extension/tree/main/ui/pages/confirmations/components/edit-gas-popover - actual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the legacy gas popover link in the confirmation pages refactoring doc to the correct `ui/pages/confirmations/components/edit-gas-popover` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c449f86d3ffc2dfd1ebed3164cad7902909352b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->