### PR TITLE
refactor: Refactor remaining confirmation-related controllers to use modular init pattern

### DIFF
--- a/app/scripts/controller-init/confirmations/address-book-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/address-book-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { AddressBookController } from '@metamask/address-book-controller';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getAddressBookControllerMessenger,
+  AddressBookControllerMessenger,
+} from '../messengers';
+import { AddressBookControllerInit } from './address-book-controller-init';
+
+jest.mock('@metamask/address-book-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AddressBookControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getAddressBookControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AddressBookControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = AddressBookControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AddressBookController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    AddressBookControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AddressBookController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/address-book-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/address-book-controller-init.ts
@@ -1,0 +1,25 @@
+import { AddressBookController } from '@metamask/address-book-controller';
+import { ControllerInitFunction } from '../types';
+import { AddressBookControllerMessenger } from '../messengers';
+
+/**
+ * Initialize the address book controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the extension.
+ * @returns The initialized controller.
+ */
+export const AddressBookControllerInit: ControllerInitFunction<
+  AddressBookController,
+  AddressBookControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AddressBookController({
+    messenger: controllerMessenger,
+    state: persistedState.AddressBookController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/approval-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/approval-controller-init.test.ts
@@ -1,0 +1,43 @@
+import { Messenger } from '@metamask/base-controller';
+import { ApprovalController } from '@metamask/approval-controller';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getApprovalControllerMessenger,
+  ApprovalControllerMessenger,
+} from '../messengers';
+import { ApprovalControllerInit } from './approval-controller-init';
+
+jest.mock('@metamask/approval-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<ApprovalControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getApprovalControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('ApprovalControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = ApprovalControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(ApprovalController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    ApprovalControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(ApprovalController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      showApprovalRequest: expect.any(Function),
+      typesExcludedFromRateLimiting: expect.any(Array),
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/approval-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/approval-controller-init.ts
@@ -1,0 +1,41 @@
+import { ApprovalController } from '@metamask/approval-controller';
+import { ApprovalType } from '@metamask/controller-utils';
+import { ControllerInitFunction } from '../types';
+import { ApprovalControllerMessenger } from '../messengers';
+import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
+
+/**
+ * Initialize the approval controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.showUserConfirmation
+ * @returns The initialized controller.
+ */
+export const ApprovalControllerInit: ControllerInitFunction<
+  ApprovalController,
+  ApprovalControllerMessenger
+> = ({ controllerMessenger, showUserConfirmation }) => {
+  const controller = new ApprovalController({
+    messenger: controllerMessenger,
+    showApprovalRequest: showUserConfirmation,
+    typesExcludedFromRateLimiting: [
+      ApprovalType.PersonalSign,
+      ApprovalType.EthSignTypedData,
+      ApprovalType.Transaction,
+      ApprovalType.WatchAsset,
+      ApprovalType.EthGetEncryptionPublicKey,
+      ApprovalType.EthDecrypt,
+
+      // Exclude Smart TX Status Page from rate limiting to allow sequential
+      // transactions.
+      SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+    ],
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/decrypt-message-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/decrypt-message-controller-init.test.ts
@@ -1,0 +1,55 @@
+import { Messenger } from '@metamask/base-controller';
+import DecryptMessageController from '../../controllers/decrypt-message';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getDecryptMessageControllerMessenger,
+  DecryptMessageControllerMessenger,
+  getDecryptMessageControllerInitMessenger,
+} from '../messengers';
+import { DecryptMessageControllerInitMessenger } from '../messengers/decrypt-message-controller-messenger';
+import { DecryptMessageControllerInit } from './decrypt-message-controller-init';
+
+jest.mock('../../controllers/decrypt-message');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    DecryptMessageControllerMessenger,
+    DecryptMessageControllerInitMessenger
+  >
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getDecryptMessageControllerMessenger(baseMessenger),
+    initMessenger: getDecryptMessageControllerInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('DecryptMessageControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = DecryptMessageControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(DecryptMessageController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    const manager = {};
+    const request = getInitRequestMock();
+
+    // @ts-expect-error: Partial mock.
+    request.getController.mockReturnValue(manager);
+
+    DecryptMessageControllerInit(request);
+
+    const controllerMock = jest.mocked(DecryptMessageController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      getState: expect.any(Function),
+      metricsEvent: expect.any(Function),
+      manager,
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/decrypt-message-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/decrypt-message-controller-init.ts
@@ -1,0 +1,38 @@
+import DecryptMessageController from '../../controllers/decrypt-message';
+import { ControllerInitFunction } from '../types';
+import { DecryptMessageControllerMessenger } from '../messengers';
+import { DecryptMessageControllerInitMessenger } from '../messengers/decrypt-message-controller-messenger';
+
+/**
+ * Initialize the decryptMessage controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.initMessenger - The messenger to use for initialization.
+ * @param request.getController - Function to get other initialized controllers.
+ * @param request.getUIState - Function to get the UI state.
+ * @returns The initialized controller.
+ */
+export const DecryptMessageControllerInit: ControllerInitFunction<
+  DecryptMessageController,
+  DecryptMessageControllerMessenger,
+  DecryptMessageControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, getController, getUIState }) => {
+  const manager = getController('DecryptMessageManager');
+
+  const controller = new DecryptMessageController({
+    messenger: controllerMessenger,
+    manager,
+    getState: getUIState,
+    metricsEvent: initMessenger.call.bind(
+      initMessenger,
+      'MetaMetricsController:trackEvent',
+    ),
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/decrypt-message-manager-init.test.ts
+++ b/app/scripts/controller-init/confirmations/decrypt-message-manager-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { DecryptMessageManager } from '@metamask/message-manager';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getDecryptMessageManagerMessenger,
+  DecryptMessageManagerMessenger,
+} from '../messengers';
+import { DecryptMessageManagerInit } from './decrypt-message-manager-init';
+
+jest.mock('@metamask/message-manager');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<DecryptMessageManagerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getDecryptMessageManagerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('DecryptMessageManagerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = DecryptMessageManagerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(DecryptMessageManager);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    DecryptMessageManagerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(DecryptMessageManager);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      additionalFinishStatuses: ['decrypted'],
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/decrypt-message-manager-init.ts
+++ b/app/scripts/controller-init/confirmations/decrypt-message-manager-init.ts
@@ -1,0 +1,26 @@
+import { DecryptMessageManager } from '@metamask/message-manager';
+import { ControllerInitFunction } from '../types';
+import { DecryptMessageManagerMessenger } from '../messengers';
+
+/**
+ * Initialize the decrypt message manager.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const DecryptMessageManagerInit: ControllerInitFunction<
+  DecryptMessageManager,
+  DecryptMessageManagerMessenger
+> = ({ controllerMessenger }) => {
+  const controller = new DecryptMessageManager({
+    additionalFinishStatuses: ['decrypted'],
+    messenger: controllerMessenger,
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/encryption-public-key-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/encryption-public-key-controller-init.test.ts
@@ -1,0 +1,59 @@
+import { Messenger } from '@metamask/base-controller';
+import EncryptionPublicKeyController from '../../controllers/encryption-public-key';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getEncryptionPublicKeyControllerMessenger,
+  EncryptionPublicKeyControllerMessenger,
+  getEncryptionPublicKeyControllerInitMessenger,
+  EncryptionPublicKeyControllerInitMessenger,
+} from '../messengers';
+import { EncryptionPublicKeyControllerInit } from './encryption-public-key-controller-init';
+
+jest.mock('../../controllers/encryption-public-key');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    EncryptionPublicKeyControllerMessenger,
+    EncryptionPublicKeyControllerInitMessenger
+  >
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger:
+      getEncryptionPublicKeyControllerMessenger(baseMessenger),
+    initMessenger: getEncryptionPublicKeyControllerInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('EncryptionPublicKeyControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } =
+      EncryptionPublicKeyControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(EncryptionPublicKeyController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    const manager = {};
+    const request = getInitRequestMock();
+
+    // @ts-expect-error: Partial mock.
+    request.getController.mockReturnValue(manager);
+
+    EncryptionPublicKeyControllerInit(request);
+
+    const controllerMock = jest.mocked(EncryptionPublicKeyController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      getAccountKeyringType: expect.any(Function),
+      getEncryptionPublicKey: expect.any(Function),
+      getState: expect.any(Function),
+      metricsEvent: expect.any(Function),
+      manager,
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/encryption-public-key-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/encryption-public-key-controller-init.ts
@@ -1,0 +1,50 @@
+import EncryptionPublicKeyController from '../../controllers/encryption-public-key';
+import { ControllerInitFunction } from '../types';
+import {
+  EncryptionPublicKeyControllerMessenger,
+  EncryptionPublicKeyControllerInitMessenger,
+} from '../messengers';
+
+/**
+ * Initialize the encryption public key controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.initMessenger - The messenger to use for initialization.
+ * @param request.getController - Function to get other initialized controllers.
+ * @param request.getUIState - Function to get the UI state.
+ * @returns The initialized controller.
+ */
+export const EncryptionPublicKeyControllerInit: ControllerInitFunction<
+  EncryptionPublicKeyController,
+  EncryptionPublicKeyControllerMessenger,
+  EncryptionPublicKeyControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, getController, getUIState }) => {
+  const manager = getController('EncryptionPublicKeyManager');
+  const keyringController = getController('KeyringController');
+
+  const controller = new EncryptionPublicKeyController({
+    messenger: controllerMessenger,
+    manager,
+    getState: getUIState,
+    getAccountKeyringType: (account) => {
+      return keyringController.getAccountKeyringType(account);
+    },
+    getEncryptionPublicKey: (address) => {
+      return initMessenger.call(
+        'KeyringController:getEncryptionPublicKey',
+        address,
+      );
+    },
+    metricsEvent: initMessenger.call.bind(
+      initMessenger,
+      'MetaMetricsController:trackEvent',
+    ),
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/encryption-public-key-message-manager-init.test.ts
+++ b/app/scripts/controller-init/confirmations/encryption-public-key-message-manager-init.test.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { EncryptionPublicKeyManager } from '@metamask/message-manager';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getEncryptionPublicKeyManagerMessenger,
+  EncryptionPublicKeyManagerMessenger,
+} from '../messengers';
+import { EncryptionPublicKeyManagerInit } from './encryption-public-key-message-manager-init';
+
+jest.mock('@metamask/message-manager');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<EncryptionPublicKeyManagerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getEncryptionPublicKeyManagerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('EncryptionPublicKeyManagerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = EncryptionPublicKeyManagerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(EncryptionPublicKeyManager);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    EncryptionPublicKeyManagerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(EncryptionPublicKeyManager);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      additionalFinishStatuses: ['received'],
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/encryption-public-key-message-manager-init.ts
+++ b/app/scripts/controller-init/confirmations/encryption-public-key-message-manager-init.ts
@@ -1,0 +1,26 @@
+import { EncryptionPublicKeyManager } from '@metamask/message-manager';
+import { ControllerInitFunction } from '../types';
+import { EncryptionPublicKeyManagerMessenger } from '../messengers';
+
+/**
+ * Initialize the encryption public key message manager.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const EncryptionPublicKeyManagerInit: ControllerInitFunction<
+  EncryptionPublicKeyManager,
+  EncryptionPublicKeyManagerMessenger
+> = ({ controllerMessenger }) => {
+  const controller = new EncryptionPublicKeyManager({
+    additionalFinishStatuses: ['received'],
+    messenger: controllerMessenger,
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/signature-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/signature-controller-init.test.ts
@@ -1,0 +1,55 @@
+import { Messenger } from '@metamask/base-controller';
+import { SignatureController } from '@metamask/signature-controller';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getSignatureControllerInitMessenger,
+  getSignatureControllerMessenger,
+  SignatureControllerInitMessenger,
+  SignatureControllerMessenger,
+} from '../messengers';
+import { SignatureControllerInit } from './signature-controller-init';
+
+jest.mock('@metamask/signature-controller', () => ({
+  SignatureController: jest.fn().mockImplementation(() => ({
+    hub: {
+      on: jest.fn(),
+    },
+  })),
+}));
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    SignatureControllerMessenger,
+    SignatureControllerInitMessenger
+  >
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getSignatureControllerMessenger(baseMessenger),
+    initMessenger: getSignatureControllerInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('SignatureControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = SignatureControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(Object);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    SignatureControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(SignatureController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      decodingApiUrl: process.env.DECODING_API_URL,
+      isDecodeSignatureRequestEnabled: expect.any(Function),
+      trace: expect.any(Function),
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/signature-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/signature-controller-init.ts
@@ -1,0 +1,51 @@
+import { SignatureController } from '@metamask/signature-controller';
+import { ControllerInitFunction } from '../types';
+import {
+  SignatureControllerInitMessenger,
+  SignatureControllerMessenger,
+} from '../messengers';
+import { trace } from '../../../../shared/lib/trace';
+import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
+
+/**
+ * Initialize the signature controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.initMessenger
+ * @returns The initialized controller.
+ */
+export const SignatureControllerInit: ControllerInitFunction<
+  SignatureController,
+  SignatureControllerMessenger,
+  SignatureControllerInitMessenger
+> = ({ controllerMessenger, initMessenger }) => {
+  const controller = new SignatureController({
+    messenger: controllerMessenger,
+    decodingApiUrl: process.env.DECODING_API_URL,
+    isDecodeSignatureRequestEnabled: () => {
+      const state = initMessenger.call('PreferencesController:getState');
+      return state.useTransactionSimulations;
+    },
+
+    // @ts-expect-error: Types of `TraceRequest` are not the same.
+    trace,
+  });
+
+  controller.hub.on('cancelWithReason', ({ metadata: message, reason }) => {
+    initMessenger.call('MetaMetricsController:trackEvent', {
+      event: reason,
+      category: MetaMetricsEventCategory.Transactions,
+      properties: {
+        action: 'Sign Request',
+        type: message.type,
+      },
+    });
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/base-controller';
+import { UserOperationController } from '@metamask/user-operation-controller';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getUserOperationControllerMessenger,
+  UserOperationControllerMessenger,
+} from '../messengers';
+import { UserOperationControllerInit } from './user-operation-controller-init';
+
+jest.mock('@metamask/user-operation-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<UserOperationControllerMessenger>
+> {
+  const baseMessenger = new Messenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getUserOperationControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('UserOperationControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = UserOperationControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(UserOperationController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    UserOperationControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(UserOperationController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      entrypoint: process.env.EIP_4337_ENTRYPOINT,
+      getGasFeeEstimates: expect.any(Function),
+    });
+  });
+});

--- a/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
@@ -21,6 +21,16 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
 
+  // @ts-expect-error: Partial mock.
+  requestMock.getController.mockImplementation((name: string) => {
+    if (name === 'GasFeeController') {
+      return {
+        fetchGasFeeEstimates: jest.fn(),
+      };
+    }
+    return undefined;
+  });
+
   return requestMock;
 }
 

--- a/app/scripts/controller-init/confirmations/user-operation-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/user-operation-controller-init.ts
@@ -15,15 +15,15 @@ export const UserOperationControllerInit: ControllerInitFunction<
   UserOperationController,
   UserOperationControllerMessenger
 > = ({ controllerMessenger, persistedState, getController }) => {
+  const gasFeeController = getController('GasFeeController');
+
   const controller = new UserOperationController({
     messenger: controllerMessenger,
     state: persistedState.UserOperationController,
     // @ts-expect-error: `UserOperationController` does not accept `undefined`.
     entrypoint: process.env.EIP_4337_ENTRYPOINT,
-    getGasFeeEstimates: (...args) => {
-      const gasFeeController = getController('GasFeeController');
-      return gasFeeController.fetchGasFeeEstimates(...args);
-    },
+    getGasFeeEstimates: (...args) =>
+      gasFeeController.fetchGasFeeEstimates(...args),
   });
 
   return {

--- a/app/scripts/controller-init/confirmations/user-operation-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/user-operation-controller-init.ts
@@ -1,0 +1,32 @@
+import { UserOperationController } from '@metamask/user-operation-controller';
+import { ControllerInitFunction } from '../types';
+import { UserOperationControllerMessenger } from '../messengers';
+
+/**
+ * Initialize the user operation controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state.
+ * @param request.getController - Function to get other controllers.
+ * @returns The initialized controller.
+ */
+export const UserOperationControllerInit: ControllerInitFunction<
+  UserOperationController,
+  UserOperationControllerMessenger
+> = ({ controllerMessenger, persistedState, getController }) => {
+  const controller = new UserOperationController({
+    messenger: controllerMessenger,
+    state: persistedState.UserOperationController,
+    // @ts-expect-error: `UserOperationController` does not accept `undefined`.
+    entrypoint: process.env.EIP_4337_ENTRYPOINT,
+    getGasFeeEstimates: (...args) => {
+      const gasFeeController = getController('GasFeeController');
+      return gasFeeController.fetchGasFeeEstimates(...args);
+    },
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -74,6 +74,7 @@ import {
   DecryptMessageManager,
   EncryptionPublicKeyManager,
 } from '@metamask/message-manager';
+import { SignatureController } from '@metamask/signature-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -154,6 +155,7 @@ export type Controller =
   | SeedlessOnboardingController<EncryptionKey>
   | SelectedNetworkController
   | ShieldController
+  | SignatureController
   | SmartTransactionsController
   | SnapController
   | SnapInterfaceController
@@ -230,6 +232,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   SeedlessOnboardingController<EncryptionKey>['state'] &
   SelectedNetworkController['state'] &
   ShieldController['state'] &
+  SignatureController['state'] &
   SmartTransactionsController['state'] &
   SnapController['state'] &
   SnapInsightsController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -70,6 +70,7 @@ import { PhishingController } from '@metamask/phishing-controller';
 import { LoggingController } from '@metamask/logging-controller';
 import { ErrorReportingService } from '@metamask/error-reporting-service';
 import { AddressBookController } from '@metamask/address-book-controller';
+import { DecryptMessageManager } from '@metamask/message-manager';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -86,6 +87,7 @@ import { AccountOrderController } from '../controllers/account-order';
 import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import AppMetadataController from '../controllers/app-metadata';
+import DecryptMessageController from '../controllers/decrypt-message';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -105,6 +107,8 @@ export type Controller =
   | BridgeStatusController
   | CronjobController
   | CurrencyRateController
+  | DecryptMessageController
+  | DecryptMessageManager
   | DelegationController
   | DeFiPositionsController
   | EnsController

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -70,7 +70,10 @@ import { PhishingController } from '@metamask/phishing-controller';
 import { LoggingController } from '@metamask/logging-controller';
 import { ErrorReportingService } from '@metamask/error-reporting-service';
 import { AddressBookController } from '@metamask/address-book-controller';
-import { DecryptMessageManager } from '@metamask/message-manager';
+import {
+  DecryptMessageManager,
+  EncryptionPublicKeyManager,
+} from '@metamask/message-manager';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -88,6 +91,7 @@ import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import AppMetadataController from '../controllers/app-metadata';
 import DecryptMessageController from '../controllers/decrypt-message';
+import EncryptionPublicKeyController from '../controllers/encryption-public-key';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -111,6 +115,8 @@ export type Controller =
   | DecryptMessageManager
   | DelegationController
   | DeFiPositionsController
+  | EncryptionPublicKeyController
+  | EncryptionPublicKeyManager
   | EnsController
   | ErrorReportingService
   | ExecutionService

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -69,6 +69,7 @@ import { AnnouncementController } from '@metamask/announcement-controller';
 import { PhishingController } from '@metamask/phishing-controller';
 import { LoggingController } from '@metamask/logging-controller';
 import { ErrorReportingService } from '@metamask/error-reporting-service';
+import { AddressBookController } from '@metamask/address-book-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -93,6 +94,7 @@ export type Controller =
   | AccountOrderController
   | AccountTrackerController
   | AccountsController
+  | AddressBookController
   | AlertController
   | AnnouncementController
   | AppMetadataController
@@ -176,6 +178,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   AccountsController['state'] &
   AlertController['state'] &
   AccountTreeController['state'] &
+  AddressBookController['state'] &
   AnnouncementController['state'] &
   AppMetadataController['state'] &
   ApprovalController['state'] &

--- a/app/scripts/controller-init/controller-list.ts
+++ b/app/scripts/controller-init/controller-list.ts
@@ -75,6 +75,7 @@ import {
   EncryptionPublicKeyManager,
 } from '@metamask/message-manager';
 import { SignatureController } from '@metamask/signature-controller';
+import { UserOperationController } from '@metamask/user-operation-controller';
 import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import SwapsController from '../controllers/swaps';
@@ -172,6 +173,7 @@ export type Controller =
   | TokensController
   | TransactionController
   | InstitutionalSnapController
+  | UserOperationController
   | UserStorageController
   | TokenRatesController
   | NftController
@@ -244,6 +246,7 @@ export type ControllerFlatState = AccountOrderController['state'] &
   TokenListController['state'] &
   TokensController['state'] &
   TransactionController['state'] &
+  UserOperationController['state'] &
   UserStorageController['state'] &
   TokenRatesController['state'] &
   NftController['state'] &

--- a/app/scripts/controller-init/messengers/address-book-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/address-book-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
+
+describe('getAddressBookControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const addressBookControllerMessenger =
+      getAddressBookControllerMessenger(messenger);
+
+    expect(addressBookControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/address-book-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/address-book-controller-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type AddressBookControllerMessenger = ReturnType<
+  typeof getAddressBookControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * address book controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getAddressBookControllerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'AddressBookController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/approval-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/approval-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getApprovalControllerMessenger } from './approval-controller-messenger';
+
+describe('getApprovalControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const approvalControllerMessenger =
+      getApprovalControllerMessenger(messenger);
+
+    expect(approvalControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/approval-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/approval-controller-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type ApprovalControllerMessenger = ReturnType<
+  typeof getApprovalControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * approval controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getApprovalControllerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'ApprovalController',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/decrypt-message-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/decrypt-message-controller-messenger.test.ts
@@ -1,0 +1,29 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getDecryptMessageControllerInitMessenger,
+  getDecryptMessageControllerMessenger,
+} from './decrypt-message-controller-messenger';
+
+describe('getDecryptMessageControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const decryptMessageControllerMessenger =
+      getDecryptMessageControllerMessenger(messenger);
+
+    expect(decryptMessageControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});
+
+describe('getDecryptMessageControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const decryptMessageControllerInitMessenger =
+      getDecryptMessageControllerInitMessenger(messenger);
+
+    expect(decryptMessageControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/decrypt-message-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/decrypt-message-controller-messenger.ts
@@ -1,0 +1,58 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/decrypt-message';
+import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
+
+export type DecryptMessageControllerMessenger = ReturnType<
+  typeof getDecryptMessageControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * decrypt message controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getDecryptMessageControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'DecryptMessageController',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'ApprovalController:acceptRequest',
+      'ApprovalController:rejectRequest',
+      'KeyringController:decryptMessage',
+    ],
+    allowedEvents: [
+      'DecryptMessageManager:stateChange',
+      'DecryptMessageManager:unapprovedMessage',
+    ],
+  });
+}
+
+type AllowedInitializationActions = MetaMetricsControllerTrackEventAction;
+
+export type DecryptMessageControllerInitMessenger = ReturnType<
+  typeof getDecryptMessageControllerInitMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events needed to
+ * initialize the decrypt message controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getDecryptMessageControllerInitMessenger(
+  messenger: Messenger<AllowedInitializationActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'DecryptMessageControllerInit',
+    allowedActions: ['MetaMetricsController:trackEvent'],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/decrypt-message-manager-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/decrypt-message-manager-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
+
+describe('getDecryptMessageManagerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const decryptMessageManagerMessenger =
+      getDecryptMessageManagerMessenger(messenger);
+
+    expect(decryptMessageManagerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/scripts/controller-init/messengers/decrypt-message-manager-messenger.ts
+++ b/app/scripts/controller-init/messengers/decrypt-message-manager-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type DecryptMessageManagerMessenger = ReturnType<
+  typeof getDecryptMessageManagerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * decrypt message manager.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getDecryptMessageManagerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'DecryptMessageManager',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/encryption-public-key-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/encryption-public-key-controller-messenger.test.ts
@@ -1,0 +1,29 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getEncryptionPublicKeyControllerInitMessenger,
+  getEncryptionPublicKeyControllerMessenger,
+} from './encryption-public-key-controller-messenger';
+
+describe('getEncryptionPublicKeyControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const encryptionPublicKeyControllerMessenger =
+      getEncryptionPublicKeyControllerMessenger(messenger);
+
+    expect(encryptionPublicKeyControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});
+
+describe('getEncryptionPublicKeyControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const encryptionPublicKeyControllerInitMessenger =
+      getEncryptionPublicKeyControllerInitMessenger(messenger);
+
+    expect(encryptionPublicKeyControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/encryption-public-key-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/encryption-public-key-controller-messenger.ts
@@ -1,0 +1,63 @@
+import { Messenger } from '@metamask/base-controller';
+import { KeyringControllerGetEncryptionPublicKeyAction } from '@metamask/keyring-controller';
+import {
+  AllowedActions,
+  AllowedEvents,
+} from '../../controllers/encryption-public-key';
+import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
+
+export type EncryptionPublicKeyControllerMessenger = ReturnType<
+  typeof getEncryptionPublicKeyControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * encryption public key controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getEncryptionPublicKeyControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'EncryptionPublicKeyController',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'ApprovalController:acceptRequest',
+      'ApprovalController:rejectRequest',
+    ],
+    allowedEvents: [
+      'EncryptionPublicKeyManager:stateChange',
+      'EncryptionPublicKeyManager:unapprovedMessage',
+    ],
+  });
+}
+
+type AllowedInitializationActions =
+  | KeyringControllerGetEncryptionPublicKeyAction
+  | MetaMetricsControllerTrackEventAction;
+
+export type EncryptionPublicKeyControllerInitMessenger = ReturnType<
+  typeof getEncryptionPublicKeyControllerInitMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events needed to
+ * initialize the encryption public key controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getEncryptionPublicKeyControllerInitMessenger(
+  messenger: Messenger<AllowedInitializationActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'EncryptionPublicKeyControllerInit',
+    allowedActions: [
+      'KeyringController:getEncryptionPublicKey',
+      'MetaMetricsController:trackEvent',
+    ],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/encryption-public-key-manager-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/encryption-public-key-manager-messenger.test.ts
@@ -1,0 +1,14 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
+
+describe('getEncryptionPublicKeyManagerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const encryptionPublicKeyManagerMessenger =
+      getEncryptionPublicKeyManagerMessenger(messenger);
+
+    expect(encryptionPublicKeyManagerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/encryption-public-key-manager-messenger.ts
+++ b/app/scripts/controller-init/messengers/encryption-public-key-manager-messenger.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/base-controller';
+
+export type EncryptionPublicKeyManagerMessenger = ReturnType<
+  typeof getEncryptionPublicKeyManagerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * encryption public key manager.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getEncryptionPublicKeyManagerMessenger(
+  messenger: Messenger<never, never>,
+) {
+  return messenger.getRestricted({
+    name: 'EncryptionPublicKeyManager',
+
+    // This controller does not call any actions or subscribe to any events.
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -165,6 +165,11 @@ import { getAppMetadataControllerMessenger } from './app-metadata-controller-mes
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 import { getApprovalControllerMessenger } from './approval-controller-messenger';
 import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
+import { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
+import {
+  getDecryptMessageControllerInitMessenger,
+  getDecryptMessageControllerMessenger,
+} from './decrypt-message-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -208,6 +213,13 @@ export {
   getCurrencyRateControllerMessenger,
   getCurrencyRateControllerInitMessenger,
 } from './currency-rate-controller-messenger';
+export type { DecryptMessageControllerMessenger } from './decrypt-message-controller-messenger';
+export {
+  getDecryptMessageControllerMessenger,
+  getDecryptMessageControllerInitMessenger,
+} from './decrypt-message-controller-messenger';
+export type { DecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
+export { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
 export type {
   EnsControllerMessenger,
   EnsControllerInitMessenger,
@@ -383,6 +395,14 @@ export const CONTROLLER_MESSENGERS = {
   CurrencyRateController: {
     getMessenger: getCurrencyRateControllerMessenger,
     getInitMessenger: getCurrencyRateControllerInitMessenger,
+  },
+  DecryptMessageController: {
+    getMessenger: getDecryptMessageControllerMessenger,
+    getInitMessenger: getDecryptMessageControllerInitMessenger,
+  },
+  DecryptMessageManager: {
+    getMessenger: getDecryptMessageManagerMessenger,
+    getInitMessenger: noop,
   },
   DeFiPositionsController: {
     getMessenger: getDeFiPositionsControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -163,6 +163,7 @@ import { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-dat
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
+import { getApprovalControllerMessenger } from './approval-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -184,6 +185,8 @@ export type { AppMetadataControllerMessenger } from './app-metadata-controller-m
 export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
+export type { ApprovalControllerMessenger } from './approval-controller-messenger';
+export { getApprovalControllerMessenger } from './approval-controller-messenger';
 export type {
   BridgeControllerMessenger,
   BridgeControllerInitMessenger,
@@ -344,6 +347,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   AppMetadataController: {
     getMessenger: getAppMetadataControllerMessenger,
+    getInitMessenger: noop,
+  },
+  ApprovalController: {
+    getMessenger: getApprovalControllerMessenger,
     getInitMessenger: noop,
   },
   AppStateController: {

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -175,6 +175,10 @@ import {
   getEncryptionPublicKeyControllerMessenger,
 } from './encryption-public-key-controller-messenger';
 import { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
+import {
+  getSignatureControllerInitMessenger,
+  getSignatureControllerMessenger,
+} from './signature-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -311,6 +315,14 @@ export {
 } from './remote-feature-flag-controller-messenger';
 export type { SelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
 export { getSelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
+export type {
+  SignatureControllerMessenger,
+  SignatureControllerInitMessenger,
+} from './signature-controller-messenger';
+export {
+  getSignatureControllerMessenger,
+  getSignatureControllerInitMessenger,
+} from './signature-controller-messenger';
 export type { SubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 export { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 export type {
@@ -560,6 +572,10 @@ export const CONTROLLER_MESSENGERS = {
   ShieldController: {
     getMessenger: getShieldControllerMessenger,
     getInitMessenger: getShieldControllerInitMessenger,
+  },
+  SignatureController: {
+    getMessenger: getSignatureControllerMessenger,
+    getInitMessenger: getSignatureControllerInitMessenger,
   },
   SnapsNameProvider: {
     getMessenger: getSnapsNameProviderMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -179,6 +179,7 @@ import {
   getSignatureControllerInitMessenger,
   getSignatureControllerMessenger,
 } from './signature-controller-messenger';
+import { getUserOperationControllerMessenger } from './user-operation-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -365,6 +366,8 @@ export {
   getTokensControllerMessenger,
   getTokensControllerInitMessenger,
 } from './tokens-controller-messenger';
+export type { UserOperationControllerMessenger } from './user-operation-controller-messenger';
+export { getUserOperationControllerMessenger } from './user-operation-controller-messenger';
 
 export const CONTROLLER_MESSENGERS = {
   AccountOrderController: {
@@ -644,6 +647,10 @@ export const CONTROLLER_MESSENGERS = {
   TransactionController: {
     getMessenger: getTransactionControllerMessenger,
     getInitMessenger: getTransactionControllerInitMessenger,
+  },
+  UserOperationController: {
+    getMessenger: getUserOperationControllerMessenger,
+    getInitMessenger: noop,
   },
   UserStorageController: {
     getMessenger: getUserStorageControllerMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -164,6 +164,7 @@ import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 import { getApprovalControllerMessenger } from './approval-controller-messenger';
+import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -177,6 +178,8 @@ export {
 } from './account-tracker-controller-messenger';
 export type { AccountsControllerMessenger } from './accounts-controller-messenger';
 export { getAccountsControllerMessenger } from './accounts-controller-messenger';
+export type { AddressBookControllerMessenger } from './address-book-controller-messenger';
+export { getAddressBookControllerMessenger } from './address-book-controller-messenger';
 export type { AlertControllerMessenger } from './alert-controller-messenger';
 export { getAlertControllerMessenger } from './alert-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
@@ -335,6 +338,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   AccountsController: {
     getMessenger: getAccountsControllerMessenger,
+    getInitMessenger: noop,
+  },
+  AddressBookController: {
+    getMessenger: getAddressBookControllerMessenger,
     getInitMessenger: noop,
   },
   AlertController: {

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -170,6 +170,11 @@ import {
   getDecryptMessageControllerInitMessenger,
   getDecryptMessageControllerMessenger,
 } from './decrypt-message-controller-messenger';
+import {
+  getEncryptionPublicKeyControllerInitMessenger,
+  getEncryptionPublicKeyControllerMessenger,
+} from './encryption-public-key-controller-messenger';
+import { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -220,6 +225,16 @@ export {
 } from './decrypt-message-controller-messenger';
 export type { DecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
 export { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
+export type {
+  EncryptionPublicKeyControllerMessenger,
+  EncryptionPublicKeyControllerInitMessenger,
+} from './encryption-public-key-controller-messenger';
+export {
+  getEncryptionPublicKeyControllerMessenger,
+  getEncryptionPublicKeyControllerInitMessenger,
+} from './encryption-public-key-controller-messenger';
+export type { EncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
+export { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
 export type {
   EnsControllerMessenger,
   EnsControllerInitMessenger,
@@ -411,6 +426,14 @@ export const CONTROLLER_MESSENGERS = {
   DelegationController: {
     getMessenger: getDelegationControllerMessenger,
     getInitMessenger: getDelegationControllerInitMessenger,
+  },
+  EncryptionPublicKeyController: {
+    getMessenger: getEncryptionPublicKeyControllerMessenger,
+    getInitMessenger: getEncryptionPublicKeyControllerInitMessenger,
+  },
+  EncryptionPublicKeyManager: {
+    getMessenger: getEncryptionPublicKeyManagerMessenger,
+    getInitMessenger: noop,
   },
   EnsController: {
     getMessenger: getEnsControllerMessenger,

--- a/app/scripts/controller-init/messengers/signature-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/signature-controller-messenger.test.ts
@@ -1,0 +1,27 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getSignatureControllerMessenger,
+  getSignatureControllerInitMessenger,
+} from './signature-controller-messenger';
+
+describe('getSignatureControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const signatureControllerMessenger =
+      getSignatureControllerMessenger(messenger);
+
+    expect(signatureControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getSignatureControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const signatureControllerInitMessenger =
+      getSignatureControllerInitMessenger(messenger);
+
+    expect(signatureControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/signature-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/signature-controller-messenger.ts
@@ -1,0 +1,81 @@
+import { Messenger } from '@metamask/base-controller';
+import type { AccountsControllerGetStateAction } from '@metamask/accounts-controller';
+import type { AddApprovalRequest } from '@metamask/approval-controller';
+import type { AddLog } from '@metamask/logging-controller';
+import type { GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction } from '@metamask/gator-permissions-controller';
+import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
+import type {
+  KeyringControllerSignMessageAction,
+  KeyringControllerSignPersonalMessageAction,
+  KeyringControllerSignTypedMessageAction,
+} from '@metamask/keyring-controller';
+import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
+import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
+
+type AllowedActions =
+  | AccountsControllerGetStateAction
+  | AddApprovalRequest
+  | AddLog
+  | GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction
+  | NetworkControllerGetNetworkClientByIdAction
+  | KeyringControllerSignMessageAction
+  | KeyringControllerSignPersonalMessageAction
+  | KeyringControllerSignTypedMessageAction;
+
+export type SignatureControllerMessenger = ReturnType<
+  typeof getSignatureControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * signature controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getSignatureControllerMessenger(
+  messenger: Messenger<AllowedActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'SignatureController',
+    allowedActions: [
+      'AccountsController:getState',
+      'ApprovalController:addRequest',
+      'KeyringController:signMessage',
+      'KeyringController:signPersonalMessage',
+      'KeyringController:signTypedMessage',
+      'LoggingController:add',
+      'NetworkController:getNetworkClientById',
+      'GatorPermissionsController:decodePermissionFromPermissionContextForOrigin',
+    ],
+    allowedEvents: [],
+  });
+}
+
+type AllowedInitializationActions =
+  | MetaMetricsControllerTrackEventAction
+  | PreferencesControllerGetStateAction;
+
+export type SignatureControllerInitMessenger = ReturnType<
+  typeof getSignatureControllerInitMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events needed to
+ * initialize the signature controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getSignatureControllerInitMessenger(
+  messenger: Messenger<AllowedInitializationActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'SignatureControllerInit',
+    allowedActions: [
+      'MetaMetricsController:trackEvent',
+      'PreferencesController:getState',
+    ],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/messengers/user-operation-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/user-operation-controller-messenger.test.ts
@@ -1,0 +1,14 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getUserOperationControllerMessenger } from './user-operation-controller-messenger';
+
+describe('getUserOperationControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const userOperationControllerMessenger =
+      getUserOperationControllerMessenger(messenger);
+
+    expect(userOperationControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/user-operation-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/user-operation-controller-messenger.ts
@@ -1,0 +1,42 @@
+import { Messenger } from '@metamask/base-controller';
+import { AddApprovalRequest } from '@metamask/approval-controller';
+import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
+import {
+  KeyringControllerPatchUserOperationAction,
+  KeyringControllerPrepareUserOperationAction,
+  KeyringControllerSignUserOperationAction,
+} from '@metamask/keyring-controller';
+
+type AllowedActions =
+  | AddApprovalRequest
+  | KeyringControllerPatchUserOperationAction
+  | KeyringControllerPrepareUserOperationAction
+  | KeyringControllerSignUserOperationAction
+  | NetworkControllerGetNetworkClientByIdAction;
+
+export type UserOperationControllerMessenger = ReturnType<
+  typeof getUserOperationControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * user operation controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getUserOperationControllerMessenger(
+  messenger: Messenger<AllowedActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'UserOperationController',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'NetworkController:getNetworkClientById',
+      'KeyringController:prepareUserOperation',
+      'KeyringController:patchUserOperation',
+      'KeyringController:signUserOperation',
+    ],
+    allowedEvents: [],
+  });
+}

--- a/app/scripts/controller-init/smart-transactions/smart-transactions-controller-init.test.ts
+++ b/app/scripts/controller-init/smart-transactions/smart-transactions-controller-init.test.ts
@@ -134,58 +134,56 @@ describe('SmartTransactionsController Init', () => {
           },
         },
       },
-      getStateUI: jest.fn().mockReturnValue({
-        metamask: {
-          internalAccounts: {
-            selectedAccount: 'account-id',
-            accounts: {
-              'account-id': {
-                id: 'account-id',
-                address: '0x123',
-                metadata: {
-                  name: 'Test Account',
-                },
+      getUIState: jest.fn().mockReturnValue({
+        internalAccounts: {
+          selectedAccount: 'account-id',
+          accounts: {
+            'account-id': {
+              id: 'account-id',
+              address: '0x123',
+              metadata: {
+                name: 'Test Account',
               },
             },
           },
-          preferences: {
-            smartTransactionsOptInStatus: true,
+        },
+        preferences: {
+          smartTransactionsOptInStatus: true,
+        },
+        selectedNetworkClientId: 'mainnet',
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/abc',
+              },
+            ],
           },
-          selectedNetworkClientId: 'mainnet',
-          networkConfigurationsByChainId: {
-            '0x1': {
-              chainId: '0x1',
-              rpcEndpoints: [
-                {
-                  networkClientId: 'mainnet',
-                  url: 'https://mainnet.infura.io/v3/abc',
-                },
-              ],
+        },
+        featureFlags: {
+          smartTransactions: {
+            mobileActive: false,
+            extensionActive: true,
+            extensionReturnTxHashAsap: false,
+          },
+        },
+        swapsState: {
+          swapsFeatureFlags: {
+            ethereum: {
+              extensionActive: true,
+              mobileActive: false,
+              smartTransactions: {
+                expectedDeadline: 45,
+                maxDeadline: 150,
+                extensionReturnTxHashAsap: false,
+              },
             },
-          },
-          featureFlags: {
             smartTransactions: {
               mobileActive: false,
               extensionActive: true,
               extensionReturnTxHashAsap: false,
-            },
-          },
-          swapsState: {
-            swapsFeatureFlags: {
-              ethereum: {
-                extensionActive: true,
-                mobileActive: false,
-                smartTransactions: {
-                  expectedDeadline: 45,
-                  maxDeadline: 150,
-                  extensionReturnTxHashAsap: false,
-                },
-              },
-              smartTransactions: {
-                mobileActive: false,
-                extensionActive: true,
-                extensionReturnTxHashAsap: false,
-              },
             },
           },
         },
@@ -392,7 +390,7 @@ describe('SmartTransactionsController Init', () => {
 
       const result = getFeatureFlags();
 
-      expect(fullRequest.getStateUI).toHaveBeenCalled();
+      expect(fullRequest.getUIState).toHaveBeenCalled();
       expect(result).toHaveProperty('smartTransactions');
       expect(result.smartTransactions).toHaveProperty('extensionActive');
       expect(result.smartTransactions).toHaveProperty('mobileActive');
@@ -407,23 +405,21 @@ describe('SmartTransactionsController Init', () => {
       // To test the null case, we need to make getStateUI return a state
       // that would cause getFeatureFlagsByChainId to return null
       const { fullRequest } = buildInitRequest({
-        getStateUI: jest.fn().mockReturnValue({
-          metamask: {
-            preferences: {},
-            selectedNetworkClientId: 'mainnet',
-            networkConfigurationsByChainId: {
-              '0x1': {
-                chainId: '0x1',
-                rpcEndpoints: [
-                  {
-                    networkClientId: 'mainnet',
-                    url: 'https://mainnet.infura.io/v3/abc',
-                  },
-                ],
-              },
+        getUIState: jest.fn().mockReturnValue({
+          preferences: {},
+          selectedNetworkClientId: 'mainnet',
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1',
+              rpcEndpoints: [
+                {
+                  networkClientId: 'mainnet',
+                  url: 'https://mainnet.infura.io/v3/abc',
+                },
+              ],
             },
-            // No swapsState to test null case
           },
+          // No swapsState to test null case
         }),
       });
 
@@ -461,34 +457,32 @@ describe('SmartTransactionsController Init', () => {
     it('uses selected account address for metrics', async () => {
       const selectedAddress = '0xselected';
       const { fullRequest } = buildInitRequest({
-        getStateUI: jest.fn().mockReturnValue({
-          metamask: {
-            internalAccounts: {
-              selectedAccount: 'selected-account-id',
-              accounts: {
-                'selected-account-id': {
-                  id: 'selected-account-id',
-                  address: selectedAddress,
-                  metadata: {
-                    name: 'Selected Account',
-                  },
+        getUIState: jest.fn().mockReturnValue({
+          internalAccounts: {
+            selectedAccount: 'selected-account-id',
+            accounts: {
+              'selected-account-id': {
+                id: 'selected-account-id',
+                address: selectedAddress,
+                metadata: {
+                  name: 'Selected Account',
                 },
               },
             },
-            preferences: {
-              smartTransactionsOptInStatus: true,
-            },
-            swapsState: {
-              swapsFeatureFlags: {
-                ethereum: {
-                  extensionActive: true,
-                  mobileActive: false,
-                },
-                smartTransactions: {
-                  mobileActive: false,
-                  extensionActive: true,
-                  extensionReturnTxHashAsap: false,
-                },
+          },
+          preferences: {
+            smartTransactionsOptInStatus: true,
+          },
+          swapsState: {
+            swapsFeatureFlags: {
+              ethereum: {
+                extensionActive: true,
+                mobileActive: false,
+              },
+              smartTransactions: {
+                mobileActive: false,
+                extensionActive: true,
+                extensionReturnTxHashAsap: false,
               },
             },
           },

--- a/app/scripts/controller-init/smart-transactions/smart-transactions-controller-init.ts
+++ b/app/scripts/controller-init/smart-transactions/smart-transactions-controller-init.ts
@@ -13,13 +13,15 @@ import {
   SmartTransactionsControllerInitMessenger,
   SmartTransactionsControllerMessenger,
 } from '../messengers/smart-transactions-controller-messenger';
-import { ControllerFlatState } from '../controller-list';
+// This import is only used for the type.
+// eslint-disable-next-line import/no-restricted-paths
+import type { MetaMaskReduxState } from '../../../../ui/store/store';
 
 type SmartTransactionsControllerInitRequest = ControllerInitRequest<
   SmartTransactionsControllerMessenger,
   SmartTransactionsControllerInitMessenger
 > & {
-  getStateUI: () => { metamask: ControllerFlatState };
+  getUIState: () => MetaMaskReduxState['metamask'];
   getGlobalNetworkClientId: () => string;
   getAccountType: (address: string) => Promise<string>;
   getDeviceModel: (address: string) => Promise<string>;
@@ -37,7 +39,7 @@ export const SmartTransactionsControllerInit: ControllerInitFunction<
     initMessenger,
     getController,
     persistedState,
-    getStateUI,
+    getUIState,
     getGlobalNetworkClientId,
     getAccountType,
     getDeviceModel,
@@ -74,17 +76,14 @@ export const SmartTransactionsControllerInit: ControllerInitFunction<
     updateTransaction: (...args) =>
       transactionController.updateTransaction(...args),
     getFeatureFlags: () => {
-      const state = getStateUI();
+      const state = { metamask: getUIState() };
       return getFeatureFlagsByChainId(
         state as unknown as ProviderConfigState & FeatureFlagsMetaMaskState,
       ) as unknown as FeatureFlags;
     },
     getMetaMetricsProps: async () => {
-      const { metamask } = getStateUI();
-      const { internalAccounts } = metamask as Pick<
-        ControllerFlatState,
-        'internalAccounts'
-      >;
+      const metamask = getUIState();
+      const { internalAccounts } = metamask;
       const selectedAccountId = internalAccounts?.selectedAccount;
       const selectedAccount = selectedAccountId
         ? internalAccounts?.accounts?.[selectedAccountId]

--- a/app/scripts/controller-init/test/utils.ts
+++ b/app/scripts/controller-init/test/utils.ts
@@ -33,6 +33,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
     setupUntrustedCommunicationEip1193: jest.fn(),
     setLocked: jest.fn(),
     showNotification: jest.fn(),
+    showUserConfirmation: jest.fn(),
     preinstalledSnaps: [],
   };
 }

--- a/app/scripts/controller-init/test/utils.ts
+++ b/app/scripts/controller-init/test/utils.ts
@@ -26,6 +26,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
     getPermittedAccounts: jest.fn(),
     getProvider: jest.fn(),
     getTransactionMetricsRequest: jest.fn(),
+    getUIState: jest.fn(),
     updateAccountBalanceForTransactionNetwork: jest.fn(),
     offscreenPromise: Promise.resolve(),
     persistedState: {},

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -215,6 +215,11 @@ export type ControllerInitRequest<
   ) => Promise<void>;
 
   /**
+   * Show the confirmation UI to the user.
+   */
+  showUserConfirmation: () => void | Promise<void>;
+
+  /**
    * A list of preinstalled Snaps loaded from disk during boot.
    */
   preinstalledSnaps: PreinstalledSnap[];

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -17,6 +17,9 @@ import { MessageSender } from '../../../types/global';
 import type { CronjobControllerStorageManager } from '../lib/CronjobControllerStorageManager';
 import { HardwareTransportBridgeClass } from '../lib/hardware-keyring-builder-factory';
 import ExtensionPlatform from '../platforms/extension';
+// This import is only used for the type.
+// eslint-disable-next-line import/no-restricted-paths
+import type { MetaMaskReduxState } from '../../../ui/store/store';
 import { Controller, ControllerFlatState } from './controller-list';
 
 /** The supported controller names. */
@@ -130,6 +133,11 @@ export type ControllerInitRequest<
    * Includes data and callbacks required to generate metrics.
    */
   getTransactionMetricsRequest(): TransactionMetricsRequest;
+
+  /**
+   * Get the MetaMask state of the client available to the UI.
+   */
+  getUIState(): MetaMaskReduxState['metamask'];
 
   /**
    * Overrides for the keyrings.

--- a/app/scripts/controllers/decrypt-message.test.ts
+++ b/app/scripts/controllers/decrypt-message.test.ts
@@ -125,7 +125,9 @@ describe('DecryptMessageController', () => {
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       metricsEvent: metricsEventMock as any,
-      managerMessenger: managerMessengerMock,
+      manager: new DecryptMessageManager({
+        messenger: managerMessengerMock,
+      }),
     } as DecryptMessageControllerOptions);
   });
 

--- a/app/scripts/controllers/encryption-public-key.test.ts
+++ b/app/scripts/controllers/encryption-public-key.test.ts
@@ -116,7 +116,9 @@ describe('EncryptionPublicKeyController', () => {
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       metricsEvent: metricsEventMock as any,
-      managerMessenger: managerMessengerMock,
+      manager: new EncryptionPublicKeyManager({
+        messenger: managerMessengerMock,
+      }),
     } as EncryptionPublicKeyControllerOptions);
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -23,7 +23,6 @@ import LatticeKeyring from 'eth-lattice-keyring';
 import { rawChainData } from 'eth-chainlist';
 import { QrKeyring } from '@metamask/eth-qr-keyring';
 import { nanoid } from 'nanoid';
-import { AddressBookController } from '@metamask/address-book-controller';
 import { ApprovalRequestNotFoundError } from '@metamask/approval-controller';
 import { Messenger } from '@metamask/base-controller';
 import {
@@ -392,6 +391,7 @@ import { LoggingControllerInit } from './controller-init/logging-controller-init
 import { AppMetadataControllerInit } from './controller-init/app-metadata-controller-init';
 import { ErrorReportingServiceInit } from './controller-init/error-reporting-service-init';
 import { ApprovalControllerInit } from './controller-init/confirmations/approval-controller-init';
+import { AddressBookControllerInit } from './controller-init/confirmations/address-book-controller-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -508,18 +508,6 @@ export default class MetamaskController extends EventEmitter {
       } else {
         this.stopNetworkRequests();
       }
-    });
-
-    const addressBookControllerMessenger =
-      this.controllerMessenger.getRestricted({
-        name: 'AddressBookController',
-        allowedActions: [],
-        allowedEvents: [],
-      });
-
-    this.addressBookController = new AddressBookController({
-      messenger: addressBookControllerMessenger,
-      state: initState.AddressBookController,
     });
 
     this.decryptMessageController = new DecryptMessageController({
@@ -656,6 +644,7 @@ export default class MetamaskController extends EventEmitter {
       SnapKeyringBuilder: SnapKeyringBuilderInit,
       KeyringController: KeyringControllerInit,
       AccountsController: AccountsControllerInit,
+      AddressBookController: AddressBookControllerInit,
       AlertController: AlertControllerInit,
       PermissionController: PermissionControllerInit,
       PermissionLogController: PermissionLogControllerInit,
@@ -751,6 +740,7 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController = controllersByName.PreferencesController;
     this.keyringController = controllersByName.KeyringController;
     this.accountsController = controllersByName.AccountsController;
+    this.addressBookController = controllersByName.AddressBookController;
     this.alertController = controllersByName.AlertController;
     this.permissionController = controllersByName.PermissionController;
     this.permissionLogController = controllersByName.PermissionLogController;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -245,7 +245,6 @@ import {
   getPlatform,
 } from './lib/util';
 import createMetamaskMiddleware from './lib/createMetamaskMiddleware';
-import EncryptionPublicKeyController from './controllers/encryption-public-key';
 import {
   createHyperliquidReferralMiddleware,
   HyperliquidPermissionTriggerType,
@@ -393,6 +392,8 @@ import { ApprovalControllerInit } from './controller-init/confirmations/approval
 import { AddressBookControllerInit } from './controller-init/confirmations/address-book-controller-init';
 import { DecryptMessageManagerInit } from './controller-init/confirmations/decrypt-message-manager-init';
 import { DecryptMessageControllerInit } from './controller-init/confirmations/decrypt-message-controller-init';
+import { EncryptionPublicKeyControllerInit } from './controller-init/confirmations/encryption-public-key-controller-init';
+import { EncryptionPublicKeyManagerInit } from './controller-init/confirmations/encryption-public-key-message-manager-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -511,36 +512,6 @@ export default class MetamaskController extends EventEmitter {
       }
     });
 
-    this.encryptionPublicKeyController = new EncryptionPublicKeyController({
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'EncryptionPublicKeyController',
-        allowedActions: [
-          `ApprovalController:addRequest`,
-          `ApprovalController:acceptRequest`,
-          `ApprovalController:rejectRequest`,
-        ],
-        allowedEvents: [
-          'EncryptionPublicKeyManager:stateChange',
-          'EncryptionPublicKeyManager:unapprovedMessage',
-        ],
-      }),
-      managerMessenger: this.controllerMessenger.getRestricted({
-        name: 'EncryptionPublicKeyManager',
-      }),
-      getEncryptionPublicKey: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'KeyringController:getEncryptionPublicKey',
-      ),
-      getAccountKeyringType: (...args) => {
-        return this.keyringController.getAccountKeyringType(...args);
-      },
-      getState: this.getState.bind(this),
-      metricsEvent: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'MetaMetricsController:trackEvent',
-      ),
-    });
-
     this.signatureController = new SignatureController({
       messenger: this.controllerMessenger.getRestricted({
         name: 'SignatureController',
@@ -625,6 +596,8 @@ export default class MetamaskController extends EventEmitter {
       AlertController: AlertControllerInit,
       DecryptMessageManager: DecryptMessageManagerInit,
       DecryptMessageController: DecryptMessageControllerInit,
+      EncryptionPublicKeyManager: EncryptionPublicKeyManagerInit,
+      EncryptionPublicKeyController: EncryptionPublicKeyControllerInit,
       PermissionController: PermissionControllerInit,
       PermissionLogController: PermissionLogControllerInit,
       SubjectMetadataController: SubjectMetadataControllerInit,
@@ -722,6 +695,8 @@ export default class MetamaskController extends EventEmitter {
     this.addressBookController = controllersByName.AddressBookController;
     this.alertController = controllersByName.AlertController;
     this.decryptMessageController = controllersByName.DecryptMessageController;
+    this.encryptionPublicKeyController =
+      controllersByName.EncryptionPublicKeyController;
     this.permissionController = controllersByName.PermissionController;
     this.permissionLogController = controllersByName.PermissionLogController;
     this.subjectMetadataController =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the remaining confirmations-related controllers to use the modular init pattern.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36658?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: #29526.
Fixes: #29573.
Fixes: #29579.
Fixes: #29580.
Fixes: #29581.
Fixes: #29588.

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates remaining confirmation-related controllers to modular init with restricted messengers, updates SmartTransactions to use getUIState, adjusts decrypt/encryption controllers to accept managers, and rewires MetaMaskController and tests accordingly.
> 
> - **Controller Initialization (modularization)**:
>   - Add/init `AddressBookController`, `ApprovalController`, `DecryptMessageManager`, `DecryptMessageController`, `EncryptionPublicKeyManager`, `EncryptionPublicKeyController`, `SignatureController`, `UserOperationController` under `app/scripts/controller-init/confirmations/*`.
>   - Register new restricted messengers and exports; extend `CONTROLLER_MESSENGERS` and include controllers/state in `controller-list`.
>   - Update `MetaMaskController` to use modular init (remove direct instantiation), pass `showUserConfirmation`/`getUIState`, and rewire related event handlers.
> - **Controllers**:
>   - Change `DecryptMessageController` and `EncryptionPublicKeyController` to accept `manager` (not `managerMessenger`) and subscribe to explicit `*Manager` events; minor type updates.
>   - Smart Transactions: switch init to `getUIState` (MetaMaskReduxState), adjust feature flag selection, and keep API passthroughs.
> - **Messengers/Types**:
>   - Add restricted messengers for the new controllers/managers; expose init messengers for metrics/keyring where needed.
>   - Extend `ControllerInitRequest` with `getUIState` and `showUserConfirmation`.
> - **Tests**:
>   - Add init/messenger tests for new controllers/managers; update existing tests to new constructor signatures and `getUIState` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0dbef4cb5ca09fa71a9a54b8dea7e4327d48352. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->