### PR TITLE
refactor: Clean up more controller initialisation logic

### DIFF
--- a/app/scripts/controller-init/account-tracker-controller-init.ts
+++ b/app/scripts/controller-init/account-tracker-controller-init.ts
@@ -64,6 +64,11 @@ export const AccountTrackerControllerInit: ControllerInitFunction<
     },
   });
 
+  // Ensure `AccountTrackerController` updates balances after network change.
+  initMessenger.subscribe('NetworkController:networkDidChange', () => {
+    controller.updateAccounts();
+  });
+
   return {
     persistedStateKey: null,
     memStateKey: null,

--- a/app/scripts/controller-init/assets/network-enablement-controller-init.test.ts
+++ b/app/scripts/controller-init/assets/network-enablement-controller-init.test.ts
@@ -1,0 +1,98 @@
+import { Messenger } from '@metamask/base-controller';
+import { NetworkEnablementController } from '@metamask/network-enablement-controller';
+import { SolAccountType } from '@metamask/keyring-api';
+import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
+import { ControllerInitRequest } from '../types';
+import { buildControllerInitRequestMock } from '../test/utils';
+import {
+  getNetworkEnablementControllerInitMessenger,
+  getNetworkEnablementControllerMessenger,
+  NetworkEnablementControllerInitMessenger,
+  NetworkEnablementControllerMessenger,
+} from '../messengers/assets';
+import { NetworkEnablementControllerInit } from './network-enablement-controller-init';
+
+jest.mock('@metamask/network-enablement-controller');
+
+function getInitRequestMock(
+  baseMessenger = new Messenger<never, never>(),
+): jest.Mocked<
+  ControllerInitRequest<
+    NetworkEnablementControllerMessenger,
+    NetworkEnablementControllerInitMessenger
+  >
+> {
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getNetworkEnablementControllerMessenger(baseMessenger),
+    initMessenger: getNetworkEnablementControllerInitMessenger(baseMessenger),
+  };
+
+  // @ts-expect-error: Partial mock.
+  requestMock.getController.mockImplementation((controllerName) => {
+    if (controllerName === 'MultichainNetworkController') {
+      return {
+        state: {
+          multichainNetworkConfigurationsByChainId: {},
+        },
+      };
+    }
+
+    if (controllerName === 'NetworkController') {
+      return {
+        state: {
+          networkConfigurationsByChainId: {},
+        },
+      };
+    }
+
+    throw new Error(`Unexpected controller name: ${controllerName}`);
+  });
+
+  return requestMock;
+}
+
+describe('NetworkEnablementControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } =
+      NetworkEnablementControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(NetworkEnablementController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    NetworkEnablementControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(NetworkEnablementController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: {
+        enabledNetworkMap: {
+          bitcoin: {},
+          eip155: {},
+          solana: {},
+        },
+      },
+    });
+  });
+
+  it('enables the Solana network when `AccountsController:selectedAccountChange` is emitted', () => {
+    const messenger = new Messenger<
+      never,
+      AccountsControllerSelectedAccountChangeEvent
+    >();
+    const request = getInitRequestMock(messenger);
+    const { controller } = NetworkEnablementControllerInit(request);
+
+    expect(controller.enableNetworkInNamespace).not.toHaveBeenCalled();
+
+    // @ts-expect-error: Partial mock.
+    messenger.publish('AccountsController:selectedAccountChange', {
+      type: SolAccountType.DataAccount,
+    });
+
+    expect(controller.enableNetworkInNamespace).toHaveBeenCalledWith(
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      'solana',
+    );
+  });
+});

--- a/app/scripts/controller-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/controller-init/assets/network-enablement-controller-init.ts
@@ -4,7 +4,13 @@ import {
 } from '@metamask/network-enablement-controller';
 import { NetworkState } from '@metamask/network-controller';
 import { MultichainNetworkControllerState } from '@metamask/multichain-network-controller';
-import { BtcScope, SolAccountType, SolScope } from '@metamask/keyring-api';
+import {
+  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
+  BtcScope,
+  ///: END:ONLY_INCLUDE_IF
+  SolAccountType,
+  SolScope,
+} from '@metamask/keyring-api';
 import { KnownCaipNamespace } from '@metamask/utils';
 import {
   NetworkEnablementControllerMessenger,
@@ -168,7 +174,7 @@ export const NetworkEnablementControllerInit: ControllerInitFunction<
           scopes: [BtcScope.Mainnet],
         },
       );
-      ///: END:ONLY_INCLUDE_IF(bitcoin)
+      ///: END:ONLY_INCLUDE_IF
 
       const allEnabledNetworks = Object.values(
         controller.state.enabledNetworkMap,
@@ -188,7 +194,7 @@ export const NetworkEnablementControllerInit: ControllerInitFunction<
         if (chainId === BtcScope.Mainnet && btcAccounts.length === 0) {
           shouldEnableMainnetNetworks = true;
         }
-        ///: END:ONLY_INCLUDE_IF(bitcoin)
+        ///: END:ONLY_INCLUDE_IF
 
         if (shouldEnableMainnetNetworks) {
           controller.enableNetwork('0x1');

--- a/app/scripts/controller-init/messengers/account-tracker-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/account-tracker-controller-messenger.ts
@@ -2,6 +2,7 @@ import { Messenger } from '@metamask/base-controller';
 import {
   NetworkControllerGetSelectedNetworkClientAction,
   NetworkControllerGetStateAction,
+  NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
@@ -48,6 +49,8 @@ type AllowedInitializationActions =
   | RemoteFeatureFlagControllerGetStateAction
   | PreferencesControllerGetStateAction;
 
+type AllowedInitializationEvents = NetworkControllerNetworkDidChangeEvent;
+
 export type AccountTrackerControllerInitMessenger = ReturnType<
   typeof getAccountTrackerControllerInitMessenger
 >;
@@ -60,7 +63,10 @@ export type AccountTrackerControllerInitMessenger = ReturnType<
  * messenger.
  */
 export function getAccountTrackerControllerInitMessenger(
-  messenger: Messenger<AllowedInitializationActions, never>,
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
 ) {
   return messenger.getRestricted({
     name: 'AccountTrackerControllerInit',
@@ -70,6 +76,6 @@ export function getAccountTrackerControllerInitMessenger(
       'RemoteFeatureFlagController:getState',
       'PreferencesController:getState',
     ],
-    allowedEvents: [],
+    allowedEvents: ['NetworkController:networkDidChange'],
   });
 }

--- a/app/scripts/controller-init/messengers/assets/index.ts
+++ b/app/scripts/controller-init/messengers/assets/index.ts
@@ -31,5 +31,11 @@ export type {
 export { getNetworkOrderControllerMessenger } from './network-order-controller-messenger';
 export type { NetworkOrderControllerMessenger } from './network-order-controller-messenger';
 
-export { getNetworkEnablementControllerMessenger } from './network-enablement-controller-messenger';
-export type { NetworkEnablementControllerMessenger } from './network-enablement-controller-messenger';
+export {
+  getNetworkEnablementControllerMessenger,
+  getNetworkEnablementControllerInitMessenger,
+} from './network-enablement-controller-messenger';
+export type {
+  NetworkEnablementControllerMessenger,
+  NetworkEnablementControllerInitMessenger,
+} from './network-enablement-controller-messenger';

--- a/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.test.ts
@@ -1,0 +1,27 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getNetworkEnablementControllerMessenger,
+  getNetworkEnablementControllerInitMessenger,
+} from './network-enablement-controller-messenger';
+
+describe('getNetworkEnablementControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const networkEnablementControllerMessenger =
+      getNetworkEnablementControllerMessenger(messenger);
+    expect(networkEnablementControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});
+
+describe('getNetworkEnablementControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const networkEnablementControllerInitMessenger =
+      getNetworkEnablementControllerInitMessenger(messenger);
+    expect(networkEnablementControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.ts
@@ -7,6 +7,7 @@ import {
   NetworkControllerNetworkAddedEvent,
 } from '@metamask/network-controller';
 import { TransactionControllerTransactionSubmittedEvent } from '@metamask/transaction-controller';
+import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
 
 type Actions =
   | NetworkControllerGetStateAction
@@ -37,5 +38,28 @@ export function getNetworkEnablementControllerMessenger(
       'NetworkController:stateChange',
       'TransactionController:transactionSubmitted',
     ],
+  });
+}
+
+type AllowedInitializationEvents = AccountsControllerSelectedAccountChangeEvent;
+
+export type NetworkEnablementControllerInitMessenger = ReturnType<
+  typeof getNetworkEnablementControllerInitMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed initialization events of the
+ * network enablement controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getNetworkEnablementControllerInitMessenger(
+  messenger: Messenger<never, AllowedInitializationEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'NetworkEnablementControllerInit',
+    allowedActions: [],
+    allowedEvents: ['AccountsController:selectedAccountChange'],
   });
 }

--- a/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/assets/network-enablement-controller-messenger.ts
@@ -8,6 +8,10 @@ import {
 } from '@metamask/network-controller';
 import { TransactionControllerTransactionSubmittedEvent } from '@metamask/transaction-controller';
 import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
+import {
+  AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
+  AccountTreeControllerSelectedAccountGroupChangeEvent,
+} from '@metamask/account-tree-controller';
 
 type Actions =
   | NetworkControllerGetStateAction
@@ -41,7 +45,12 @@ export function getNetworkEnablementControllerMessenger(
   });
 }
 
-type AllowedInitializationEvents = AccountsControllerSelectedAccountChangeEvent;
+type AllowedInitializationActions =
+  AccountTreeControllerGetAccountsFromSelectedAccountGroupAction;
+
+type AllowedInitializationEvents =
+  | AccountsControllerSelectedAccountChangeEvent
+  | AccountTreeControllerSelectedAccountGroupChangeEvent;
 
 export type NetworkEnablementControllerInitMessenger = ReturnType<
   typeof getNetworkEnablementControllerInitMessenger
@@ -55,11 +64,19 @@ export type NetworkEnablementControllerInitMessenger = ReturnType<
  * messenger.
  */
 export function getNetworkEnablementControllerInitMessenger(
-  messenger: Messenger<never, AllowedInitializationEvents>,
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
 ) {
   return messenger.getRestricted({
     name: 'NetworkEnablementControllerInit',
-    allowedActions: [],
-    allowedEvents: ['AccountsController:selectedAccountChange'],
+    allowedActions: [
+      'AccountTreeController:getAccountsFromSelectedAccountGroup',
+    ],
+    allowedEvents: [
+      'AccountsController:selectedAccountChange',
+      'AccountTreeController:selectedAccountGroupChange',
+    ],
   });
 }

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -50,6 +50,7 @@ import {
 } from './assets';
 import {
   getNotificationServicesControllerMessenger,
+  getNotificationServicesPushControllerInitMessenger,
   getNotificationServicesPushControllerMessenger,
 } from './notifications';
 import { getDeFiPositionsControllerMessenger } from './defi-positions';
@@ -531,7 +532,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   NotificationServicesPushController: {
     getMessenger: getNotificationServicesPushControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getNotificationServicesPushControllerInitMessenger,
   },
   OAuthService: {
     getMessenger: getOAuthServiceMessenger,

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -46,6 +46,7 @@ import {
   getTokenRatesControllerInitMessenger,
   getTokenRatesControllerMessenger,
   getAssetsContractControllerInitMessenger,
+  getNetworkEnablementControllerInitMessenger,
 } from './assets';
 import {
   getNotificationServicesControllerMessenger,
@@ -694,6 +695,6 @@ export const CONTROLLER_MESSENGERS = {
   },
   NetworkEnablementController: {
     getMessenger: getNetworkEnablementControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getNetworkEnablementControllerInitMessenger,
   },
 } as const;

--- a/app/scripts/controller-init/messengers/network-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/network-controller-messenger.ts
@@ -1,9 +1,13 @@
-import { Messenger } from '@metamask/base-controller';
+import {
+  ControllerStateChangeEvent,
+  Messenger,
+} from '@metamask/base-controller';
 import type { ErrorReportingServiceCaptureExceptionAction } from '@metamask/error-reporting-service';
 import {
   NetworkControllerRpcEndpointDegradedEvent,
   NetworkControllerRpcEndpointUnavailableEvent,
 } from '@metamask/network-controller';
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import {
   MetaMetricsControllerGetMetaMetricsIdAction,
   MetaMetricsControllerTrackEventAction,
@@ -37,7 +41,11 @@ type AllowedInitializationActions =
 
 type AllowedInitializationEvents =
   | NetworkControllerRpcEndpointUnavailableEvent
-  | NetworkControllerRpcEndpointDegradedEvent;
+  | NetworkControllerRpcEndpointDegradedEvent
+  | ControllerStateChangeEvent<
+      'RemoteFeatureFlagController',
+      RemoteFeatureFlagControllerState
+    >;
 
 export type NetworkControllerInitMessenger = ReturnType<
   typeof getNetworkControllerInitMessenger
@@ -65,6 +73,7 @@ export function getNetworkControllerInitMessenger(
     allowedEvents: [
       'NetworkController:rpcEndpointUnavailable',
       'NetworkController:rpcEndpointDegraded',
+      'RemoteFeatureFlagController:stateChange',
     ],
   });
 }

--- a/app/scripts/controller-init/messengers/notifications/index.ts
+++ b/app/scripts/controller-init/messengers/notifications/index.ts
@@ -5,4 +5,6 @@ export {
 export {
   getNotificationServicesPushControllerMessenger,
   type NotificationServicesPushControllerMessenger,
+  getNotificationServicesPushControllerInitMessenger,
+  type NotificationServicesPushControllerInitMessenger,
 } from './notification-services-push-controller-messenger';

--- a/app/scripts/controller-init/messengers/notifications/notification-services-push-controller-messenger.test.ts
+++ b/app/scripts/controller-init/messengers/notifications/notification-services-push-controller-messenger.test.ts
@@ -1,11 +1,26 @@
 import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
-import { getNotificationServicesPushControllerMessenger } from './notification-services-push-controller-messenger';
+import {
+  getNotificationServicesPushControllerMessenger,
+  getNotificationServicesPushControllerInitMessenger,
+} from './notification-services-push-controller-messenger';
 
-describe('getAuthenticationControllerMessenger', () => {
+describe('getNotificationServicesPushControllerMessenger', () => {
   it('returns a restricted messenger', () => {
     const messenger = new Messenger<never, never>();
     const authenticationControllerMessenger =
       getNotificationServicesPushControllerMessenger(messenger);
+
+    expect(authenticationControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});
+
+describe('getNotificationServicesPushControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const authenticationControllerMessenger =
+      getNotificationServicesPushControllerInitMessenger(messenger);
 
     expect(authenticationControllerMessenger).toBeInstanceOf(
       RestrictedMessenger,

--- a/app/scripts/controller-init/messengers/notifications/notification-services-push-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/notifications/notification-services-push-controller-messenger.ts
@@ -1,18 +1,64 @@
 import { Messenger } from '@metamask/base-controller';
-import {
-  type NotificationServicesPushControllerMessenger,
-  type AllowedActions,
-  type AllowedEvents,
+import type {
+  AllowedActions,
+  AllowedEvents,
+  NotificationServicesPushControllerOnNewNotificationEvent,
+  NotificationServicesPushControllerPushNotificationClickedEvent,
 } from '@metamask/notification-services-controller/push-services';
+import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller';
 
-export { type NotificationServicesPushControllerMessenger } from '@metamask/notification-services-controller/push-services';
+export type NotificationServicesPushControllerMessenger = ReturnType<
+  typeof getNotificationServicesPushControllerMessenger
+>;
 
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * notification services push controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ * @returns The restricted messenger.
+ */
 export function getNotificationServicesPushControllerMessenger(
   messenger: Messenger<AllowedActions, AllowedEvents>,
-): NotificationServicesPushControllerMessenger {
+) {
   return messenger.getRestricted({
     name: 'NotificationServicesPushController',
     allowedActions: ['AuthenticationController:getBearerToken'],
     allowedEvents: [],
+  });
+}
+
+type AllowedInitializationActions = MetaMetricsControllerTrackEventAction;
+
+type AllowedInitializationEvents =
+  | NotificationServicesPushControllerOnNewNotificationEvent
+  | NotificationServicesPushControllerPushNotificationClickedEvent;
+
+export type NotificationServicesPushControllerInitMessenger = ReturnType<
+  typeof getNotificationServicesPushControllerInitMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed initialization actions of the
+ * notification services push controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ * @returns The restricted messenger.
+ */
+export function getNotificationServicesPushControllerInitMessenger(
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  return messenger.getRestricted({
+    name: 'NotificationServicesPushControllerInit',
+    allowedActions: ['MetaMetricsController:trackEvent'],
+    allowedEvents: [
+      'NotificationServicesPushController:onNewNotifications',
+      'NotificationServicesPushController:pushNotificationClicked',
+    ],
   });
 }

--- a/app/scripts/controller-init/network-controller-init.ts
+++ b/app/scripts/controller-init/network-controller-init.ts
@@ -235,6 +235,20 @@ export const NetworkControllerInit: ControllerInitFunction<
     },
   );
 
+  initMessenger.subscribe(
+    'RemoteFeatureFlagController:stateChange',
+    (isRpcFailoverEnabled) => {
+      if (isRpcFailoverEnabled) {
+        console.log('Enabling RPC failover.');
+        controller.enableRpcFailover();
+      } else {
+        console.log('Disabling RPC failover.');
+        controller.disableRpcFailover();
+      }
+    },
+    (state) => state.remoteFeatureFlags.walletFrameworkRpcFailoverEnabled,
+  );
+
   controller.initializeProvider();
 
   return {

--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.test.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.test.ts
@@ -6,7 +6,9 @@ import { Messenger } from '@metamask/base-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ControllerInitRequest } from '../types';
 import {
+  getNotificationServicesPushControllerInitMessenger,
   getNotificationServicesPushControllerMessenger,
+  NotificationServicesPushControllerInitMessenger,
   type NotificationServicesPushControllerMessenger,
 } from '../messengers/notifications';
 import { NotificationServicesPushControllerInit } from './notification-services-push-controller-init';
@@ -14,7 +16,10 @@ import { NotificationServicesPushControllerInit } from './notification-services-
 jest.mock('@metamask/notification-services-controller/push-services');
 
 function buildInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<NotificationServicesPushControllerMessenger>
+  ControllerInitRequest<
+    NotificationServicesPushControllerMessenger,
+    NotificationServicesPushControllerInitMessenger
+  >
 > {
   const baseControllerMessenger = new Messenger();
 
@@ -23,7 +28,9 @@ function buildInitRequestMock(): jest.Mocked<
     controllerMessenger: getNotificationServicesPushControllerMessenger(
       baseControllerMessenger,
     ),
-    initMessenger: undefined,
+    initMessenger: getNotificationServicesPushControllerInitMessenger(
+      baseControllerMessenger,
+    ),
   };
 }
 

--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
@@ -64,9 +64,9 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
   initMessenger.subscribe(
     'NotificationServicesPushController:onNewNotifications',
     (notification) => {
-      const chainId =
-        hasProperty(notification, 'chain_id') &&
-        (notification.chain_id as number);
+      const chainId = hasProperty(notification, 'chain_id')
+        ? (notification.chain_id as number)
+        : null;
 
       initMessenger.call('MetaMetricsController:trackEvent', {
         category: MetaMetricsEventCategory.PushNotifications,
@@ -85,9 +85,9 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
   initMessenger.subscribe(
     'NotificationServicesPushController:pushNotificationClicked',
     (notification) => {
-      const chainId =
-        hasProperty(notification, 'chain_id') &&
-        (notification.chain_id as number);
+      const chainId = hasProperty(notification, 'chain_id')
+        ? (notification.chain_id as number)
+        : null;
 
       initMessenger.call('MetaMetricsController:trackEvent', {
         category: MetaMetricsEventCategory.PushNotifications,

--- a/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/controller-init/notifications/notification-services-push-controller-init.ts
@@ -7,18 +7,27 @@ import {
   deleteRegToken,
   createSubscribeToPushNotifications,
 } from '@metamask/notification-services-controller/push-services/web';
+import { hasProperty } from '@metamask/utils';
 import { ControllerInitFunction } from '../types';
-import { type NotificationServicesPushControllerMessenger } from '../messengers/notifications';
+import type {
+  NotificationServicesPushControllerMessenger,
+  NotificationServicesPushControllerInitMessenger,
+} from '../messengers/notifications';
 import { isManifestV3 } from '../../../../shared/modules/mv3.utils';
 import {
   onPushNotificationClicked,
   onPushNotificationReceived,
 } from '../../controllers/push-notifications';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 
 export const NotificationServicesPushControllerInit: ControllerInitFunction<
   NotificationServicesPushController,
-  NotificationServicesPushControllerMessenger
-> = ({ controllerMessenger, persistedState }) => {
+  NotificationServicesPushControllerMessenger,
+  NotificationServicesPushControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, persistedState }) => {
   const controller = new NotificationServicesPushController({
     messenger: controllerMessenger,
     state: {
@@ -51,6 +60,48 @@ export const NotificationServicesPushControllerInit: ControllerInitFunction<
       },
     },
   });
+
+  initMessenger.subscribe(
+    'NotificationServicesPushController:onNewNotifications',
+    (notification) => {
+      const chainId =
+        hasProperty(notification, 'chain_id') &&
+        (notification.chain_id as number);
+
+      initMessenger.call('MetaMetricsController:trackEvent', {
+        category: MetaMetricsEventCategory.PushNotifications,
+        event: MetaMetricsEventName.PushNotificationReceived,
+        properties: {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          notification_id: notification.id,
+          notification_type: notification.type,
+          chain_id: chainId,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+      });
+    },
+  );
+
+  initMessenger.subscribe(
+    'NotificationServicesPushController:pushNotificationClicked',
+    (notification) => {
+      const chainId =
+        hasProperty(notification, 'chain_id') &&
+        (notification.chain_id as number);
+
+      initMessenger.call('MetaMetricsController:trackEvent', {
+        category: MetaMetricsEventCategory.PushNotifications,
+        event: MetaMetricsEventName.PushNotificationClicked,
+        properties: {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          notification_id: notification.id,
+          notification_type: notification.type,
+          chain_id: chainId,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+      });
+    },
+  );
 
   return {
     controller,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -72,7 +72,6 @@ import {
   add0x,
   hexToBytes,
   bytesToHex,
-  KnownCaipNamespace,
 } from '@metamask/utils';
 import { normalize } from '@metamask/eth-sig-util';
 
@@ -741,19 +740,6 @@ export default class MetamaskController extends EventEmitter {
       'KeyringController:stateChange',
       (state) => {
         this._onKeyringControllerUpdate(state);
-      },
-    );
-
-    // TODO: Remove this after BIP-44 rollout
-    this.controllerMessenger.subscribe(
-      'AccountsController:selectedAccountChange',
-      (account) => {
-        if (account.type === SolAccountType.DataAccount) {
-          this.networkEnablementController.enableNetworkInNamespace(
-            SolScope.Mainnet,
-            KnownCaipNamespace.Solana,
-          );
-        }
       },
     );
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -512,14 +512,6 @@ export default class MetamaskController extends EventEmitter {
       }
     });
 
-    // ensure AccountTrackerController updates balances after network change
-    this.controllerMessenger.subscribe(
-      'NetworkController:networkDidChange',
-      () => {
-        this.accountTrackerController.updateAccounts();
-      },
-    );
-
     /** @type {import('./controller-init/utils').InitFunctions} */
     const controllerInitFunctions = {
       ApprovalController: ApprovalControllerInit,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -729,28 +729,6 @@ export default class MetamaskController extends EventEmitter {
       this.metaMetricsController.handleMetaMaskStateUpdate(update);
     });
 
-    this.controllerMessenger.subscribe(
-      'RemoteFeatureFlagController:stateChange',
-      (isRpcFailoverEnabled) => {
-        if (isRpcFailoverEnabled) {
-          console.log(
-            'isRpcFailoverEnabled = ',
-            isRpcFailoverEnabled,
-            ', enabling RPC failover',
-          );
-          this.networkController.enableRpcFailover();
-        } else {
-          console.log(
-            'isRpcFailoverEnabled = ',
-            isRpcFailoverEnabled,
-            ', disabling RPC failover',
-          );
-          this.networkController.disableRpcFailover();
-        }
-      },
-      (state) => state.remoteFeatureFlags.walletFrameworkRpcFailoverEnabled,
-    );
-
     this.controllerMessenger.subscribe('KeyringController:unlock', () =>
       this._onUnlock(),
     );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -794,49 +794,6 @@ export default class MetamaskController extends EventEmitter {
     );
 
     this.controllerMessenger.subscribe(
-      'AccountTreeController:selectedAccountGroupChange',
-      () => {
-        const solAccounts =
-          this.accountTreeController.getAccountsFromSelectedAccountGroup({
-            scopes: [SolScope.Mainnet],
-          });
-
-        // eslint-disable-next-line no-unused-vars
-        let btcAccounts = [];
-        ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-        btcAccounts =
-          this.accountTreeController.getAccountsFromSelectedAccountGroup({
-            scopes: [BtcScope.Mainnet],
-          });
-        ///: END:ONLY_INCLUDE_IF(bitcoin)
-
-        const allEnabledNetworks = Object.values(
-          this.networkEnablementController.state.enabledNetworkMap,
-        ).reduce((acc, curr) => {
-          return { ...acc, ...curr };
-        }, {});
-
-        if (Object.keys(allEnabledNetworks).length === 1) {
-          const chainId = Object.keys(allEnabledNetworks)[0];
-
-          let shouldEnableMainetNetworks = false;
-          if (chainId === SolScope.Mainnet && solAccounts.length === 0) {
-            shouldEnableMainetNetworks = true;
-          }
-          ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-          if (chainId === BtcScope.Mainnet && btcAccounts.length === 0) {
-            shouldEnableMainetNetworks = true;
-          }
-          ///: END:ONLY_INCLUDE_IF(bitcoin)
-
-          if (shouldEnableMainetNetworks) {
-            this.networkEnablementController.enableNetwork('0x1');
-          }
-        }
-      },
-    );
-
-    this.controllerMessenger.subscribe(
       `OnboardingController:stateChange`,
       previousValueComparator(async (prevState, currState) => {
         const { completedOnboarding: prevCompletedOnboarding } = prevState;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -794,36 +794,6 @@ export default class MetamaskController extends EventEmitter {
     );
 
     this.controllerMessenger.subscribe(
-      'NotificationServicesPushController:onNewNotifications',
-      (notification) => {
-        this.metaMetricsController.trackEvent({
-          category: MetaMetricsEventCategory.PushNotifications,
-          event: MetaMetricsEventName.PushNotificationReceived,
-          properties: {
-            notification_id: notification.id,
-            notification_type: notification.type,
-            chain_id: notification?.chain_id,
-          },
-        });
-      },
-    );
-
-    this.controllerMessenger.subscribe(
-      'NotificationServicesPushController:pushNotificationClicked',
-      (notification) => {
-        this.metaMetricsController.trackEvent({
-          category: MetaMetricsEventCategory.PushNotifications,
-          event: MetaMetricsEventName.PushNotificationClicked,
-          properties: {
-            notification_id: notification.id,
-            notification_type: notification.type,
-            chain_id: notification?.chain_id,
-          },
-        });
-      },
-    );
-
-    this.controllerMessenger.subscribe(
       'AccountTreeController:selectedAccountGroupChange',
       () => {
         const solAccounts =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This moves logic for controller initialisation to the initialisation files where possible, i.e., in cases where the logic is isolated to the controller itself and does not rely on methods in the MetaMask controller. The following cases are moved to the corresponding init file:

- The network enablement controller is listening for `AccountsController:selectedAccountChange` and `AccountTreeController:selectedAccountGroupChange` to determine whether certain networks need to be enabled. The whole controller init wasn't tested, so I added some basic tests for it as well.
- The notification services push controller is listening to some of its own events and tracks events based on those.`NetworkController:networkDidChange` and updates the accounts when it's emitted.
- The network controller listens to `RemoteFeatureFlagController:stateChange` to determine whether to enable RPC failover or not.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36665?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts various controller event subscriptions from MetaMaskController into their respective init modules, adds/init-restricts messengers to support these events/actions, and updates tests accordingly.
> 
> - **Controller Inits**:
>   - `AccountTrackerControllerInit`: subscribes to `NetworkController:networkDidChange` to call `controller.updateAccounts()`.
>   - `NetworkEnablementControllerInit`: handles
>     - `AccountsController:selectedAccountChange` → enable Solana mainnet namespace.
>     - `AccountTreeController:selectedAccountGroupChange` → enable `0x1` when only Solana/Bitcoin mainnet is enabled and no corresponding accounts exist.
>   - `NetworkControllerInit`: subscribes to `RemoteFeatureFlagController:stateChange` (selector: `walletFrameworkRpcFailoverEnabled`) to enable/disable RPC failover.
>   - `NotificationServicesPushControllerInit`: tracks push events by subscribing to
>     - `NotificationServicesPushController:onNewNotifications` and
>     - `NotificationServicesPushController:pushNotificationClicked` → `MetaMetricsController:trackEvent`.
> - **Messengers**:
>   - Add/init-restrict messengers to allow required actions/events:
>     - `AccountTrackerControllerInitMessenger` now allows `NetworkController:networkDidChange`.
>     - `NetworkEnablementControllerInitMessenger` allows account tree actions and selected-account/group events.
>     - `NotificationServicesPushControllerInitMessenger` allows push events and `MetaMetricsController:trackEvent`.
>     - `NetworkControllerInitMessenger` allows `RemoteFeatureFlagController:stateChange`.
>   - Export new init messengers in `messengers/*/index.ts` and wire them in `CONTROLLER_MESSENGERS`.
> - **MetaMask Controller Cleanup**:
>   - Remove in-controller subscriptions for the above behaviors; logic now resides in respective init modules; drop unused imports.
> - **Tests**:
>   - Add/init tests for `network-enablement-controller-init`, related messengers, `notification-services-push-controller` init messenger, and update `network-controller-init` to cover RPC failover toggling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bf8697af1032e48725e1a3a8f5c7a4c3351d9ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->