### PR TITLE
feat: Transaction shield coverage footer

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -1713,6 +1713,7 @@ const state = {
     networkConnectionBanner: {
       status: 'unknown',
     },
+    coverageResults: {},
   },
   appState: {
     isAccountMenuOpen: false,

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5665,6 +5665,30 @@
   "shieldConfirmMembership": {
     "message": "Confirm membership"
   },
+  "shieldCoverageAlertMessageChainNotSupported": {
+    "message": "This chain is not supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageLearnHowCoverageWorks": {
+    "message": "Learn how coverage works"
+  },
+  "shieldCoverageAlertMessagePotentialRisks": {
+    "message": "This transaction has potential risks, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageSignatureNotSupported": {
+    "message": "This signature isn't supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageTitle": {
+    "message": "This transaction isn't covered"
+  },
+  "shieldCoverageAlertMessageTxTypeNotSupported": {
+    "message": "This transaction type is not supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageUnknown": {
+    "message": "This request can't be verified, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCovered": {
+    "message": "Covered"
+  },
   "shieldEntryModalAssetCoverage": {
     "message": "$10,000 asset coverage per transaction"
   },
@@ -5689,6 +5713,12 @@
   },
   "shieldEstimatedChangesMonthlyTooltip": {
     "message": "Authorize up to $$1 for the full year. You'll be billed $$2 each month, not the full amount now."
+  },
+  "shieldFooterAgreement": {
+    "message": "By continuing, I agree to Transaction Shield $1."
+  },
+  "shieldNotCovered": {
+    "message": "Not covered"
   },
   "shieldPlanAnnual": {
     "message": "Annual"
@@ -5750,6 +5780,9 @@
   },
   "shieldPlanTitle": {
     "message": "Choose your plan"
+  },
+  "shieldStartNowCTA": {
+    "message": "Start now"
   },
   "shieldTx": {
     "message": "Transaction Shield"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5665,6 +5665,30 @@
   "shieldConfirmMembership": {
     "message": "Confirm membership"
   },
+  "shieldCoverageAlertMessageChainNotSupported": {
+    "message": "This chain is not supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageLearnHowCoverageWorks": {
+    "message": "Learn how coverage works"
+  },
+  "shieldCoverageAlertMessagePotentialRisks": {
+    "message": "This transaction has potential risks, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageSignatureNotSupported": {
+    "message": "This signature isn't supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageTitle": {
+    "message": "This transaction isn't covered"
+  },
+  "shieldCoverageAlertMessageTxTypeNotSupported": {
+    "message": "This transaction type is not supported, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCoverageAlertMessageUnknown": {
+    "message": "This request can't be verified, so it isn't protected by Transaction Shield. $1."
+  },
+  "shieldCovered": {
+    "message": "Covered"
+  },
   "shieldEntryModalAssetCoverage": {
     "message": "$10,000 asset coverage per transaction"
   },
@@ -5689,6 +5713,12 @@
   },
   "shieldEstimatedChangesMonthlyTooltip": {
     "message": "Authorize up to $$1 for the full year. You'll be billed $$2 each month, not the full amount now."
+  },
+  "shieldFooterAgreement": {
+    "message": "By continuing, I agree to Transaction Shield $1."
+  },
+  "shieldNotCovered": {
+    "message": "Not covered"
   },
   "shieldPlanAnnual": {
     "message": "Annual"
@@ -5750,6 +5780,9 @@
   },
   "shieldPlanTitle": {
     "message": "Choose your plan"
+  },
+  "shieldStartNowCTA": {
+    "message": "Start now"
   },
   "shieldTx": {
     "message": "Transaction Shield"

--- a/app/scripts/controller-init/shield/shield-controller-init.ts
+++ b/app/scripts/controller-init/shield/shield-controller-init.ts
@@ -26,7 +26,12 @@ export const ShieldControllerInit: ControllerInitFunction<
     state: persistedState.ShieldController,
     backend: new ShieldRemoteBackend({
       getAccessToken,
-      fetch,
+      fetch: (input, init) => {
+        // From https://github.com/MetaMask/metamask-extension/pull/35588/
+        // Without wrapping fetch, the requests are not sent as expected. More
+        // investigation is needed.
+        return fetch(input, init);
+      },
       baseUrl,
     }),
   });

--- a/builds.yml
+++ b/builds.yml
@@ -408,7 +408,7 @@ env:
   # URL of Shield gateway
   - SHIELD_GATEWAY_URL: 'https://shield-gateway.dev-api.cx.metamask.io'
   # URL of Shield rule engine
-  - SHIELD_RULE_ENGINE_URL: 'https://shield-rule-engine.dev-api.cx.metamask.io'
+  - SHIELD_RULE_ENGINE_URL: 'https://ruleset-engine.dev-api.cx.metamask.io'
 
   # Snaps
   # This should only be used for local testing, and should not be enabled in any

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "@metamask/scure-bip39": "^2.0.3",
     "@metamask/seedless-onboarding-controller": "^4.0.0",
     "@metamask/selected-network-controller": "^24.0.0",
-    "@metamask/shield-controller": "^0.1.1",
+    "@metamask/shield-controller": "^0.1.2",
     "@metamask/signature-controller": "^34.0.0",
     "@metamask/smart-transactions-controller": "^18.1.0",
     "@metamask/snaps-controllers": "^15.0.1",

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -2346,7 +2346,8 @@
     "isUpdatingGatorPermissions": false,
     "networkConnectionBanner": {
       "status": "unknown"
-    }
+    },
+    "coverageResults": {}
   },
   "ramps": {
     "buyableChains": [

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -315,6 +315,7 @@
     "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": 0.0017123,
     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": 1.8e-9
   },
+  "coverageResults": {},
   "currencyRates": {
     "ETH": {
       "conversionRate": 556.12
@@ -1131,6 +1132,7 @@
       "subjectType": "snap"
     }
   },
+  "subscriptions": [],
   "swapsState": {
     "quotes": {},
     "quotesPollingLimitEnabled": false,

--- a/ui/components/app/alert-system/inline-alert/__snapshots__/inline-alert.test.tsx.snap
+++ b/ui/components/app/alert-system/inline-alert/__snapshots__/inline-alert.test.tsx.snap
@@ -8,10 +8,20 @@ exports[`Inline Alert renders alert with danger severity 1`] = `
     <div
       class="mm-box inline-alert inline-alert__danger mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--rounded-sm"
       data-testid="inline-alert"
+      style="cursor: pointer;"
     >
       <span
         class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/danger.svg');"
+      />
+      <p
+        class="mm-box mm-text mm-text--body-sm mm-box--color-inherit"
+      >
+        [alert]
+      </p>
+      <span
+        class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-inherit"
+        style="mask-image: url('./images/icons/arrow-right.svg');"
       />
     </div>
   </div>
@@ -26,10 +36,20 @@ exports[`Inline Alert renders alert with informative severity 1`] = `
     <div
       class="mm-box inline-alert inline-alert__info mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--rounded-sm"
       data-testid="inline-alert"
+      style="cursor: pointer;"
     >
       <span
         class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/info.svg');"
+      />
+      <p
+        class="mm-box mm-text mm-text--body-sm mm-box--color-inherit"
+      >
+        [alert]
+      </p>
+      <span
+        class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-inherit"
+        style="mask-image: url('./images/icons/arrow-right.svg');"
       />
     </div>
   </div>
@@ -44,10 +64,20 @@ exports[`Inline Alert renders alert with warning severity 1`] = `
     <div
       class="mm-box inline-alert inline-alert__warning mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--rounded-sm"
       data-testid="inline-alert"
+      style="cursor: pointer;"
     >
       <span
         class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/info.svg');"
+      />
+      <p
+        class="mm-box mm-text mm-text--body-sm mm-box--color-inherit"
+      >
+        [alert]
+      </p>
+      <span
+        class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-inherit"
+        style="mask-image: url('./images/icons/arrow-right.svg');"
       />
     </div>
   </div>

--- a/ui/components/app/alert-system/inline-alert/index.scss
+++ b/ui/components/app/alert-system/inline-alert/index.scss
@@ -1,6 +1,5 @@
 .inline-alert {
   padding: 2px;
-  cursor: pointer;
 
   &__danger {
     color: var(--color-error-default);
@@ -8,9 +7,15 @@
 
   &__info {
     color: var(--color-info-default);
+    background-color: var(--color-info-muted);
   }
 
   &__warning {
     color: var(--color-warning-default);
+  }
+
+  &__success {
+    color: var(--color-success-default);
+    background-color: var(--color-success-muted);
   }
 }

--- a/ui/components/app/alert-system/inline-alert/inline-alert.tsx
+++ b/ui/components/app/alert-system/inline-alert/inline-alert.tsx
@@ -1,12 +1,21 @@
-import React from 'react';
 import classnames from 'classnames';
-import { Box, Icon, IconName, IconSize } from '../../../component-library';
+import React from 'react';
 import {
   AlignItems,
   BorderRadius,
   Display,
   Severity,
+  TextColor,
+  TextVariant,
 } from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../component-library';
 
 export type InlineAlertProps = {
   /** The onClick handler for the inline alerts */
@@ -15,6 +24,10 @@ export type InlineAlertProps = {
   severity?: Severity;
   /** Additional styles to apply to the inline alert */
   style?: React.CSSProperties;
+  /** The text to override the default text */
+  textOverride?: string;
+  /** Whether to show the arrow icon */
+  showArrow?: boolean;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -23,7 +36,11 @@ export default function InlineAlert({
   onClick,
   severity = Severity.Info,
   style,
+  textOverride,
+  showArrow = true,
 }: InlineAlertProps) {
+  const t = useI18nContext();
+
   return (
     <Box display={Display.Flex}>
       <Box
@@ -37,14 +54,22 @@ export default function InlineAlert({
           'inline-alert__info': severity === Severity.Info,
           'inline-alert__warning': severity === Severity.Warning,
           'inline-alert__danger': severity === Severity.Danger,
+          'inline-alert__success': severity === Severity.Success,
         })}
-        style={style}
+        style={{
+          cursor: onClick ? 'pointer' : 'default',
+          ...style,
+        }}
         onClick={onClick}
       >
         <Icon
           name={severity === Severity.Danger ? IconName.Danger : IconName.Info}
           size={IconSize.Sm}
         />
+        <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
+          {textOverride ?? t('alert')}
+        </Text>
+        {showArrow && <Icon name={IconName.ArrowRight} size={IconSize.Xs} />}
       </Box>
     </Box>
   );

--- a/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
+++ b/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
 import {
+  JustifyContent,
   Severity,
   TextColor,
 } from '../../../../../../helpers/constants/design-system';
-import InlineAlert from '../../../../alert-system/inline-alert/inline-alert';
 import useAlerts from '../../../../../../hooks/useAlerts';
+import { Box } from '../../../../../component-library';
+import { useAlertMetrics } from '../../../../alert-system/contexts/alertMetricsContext';
+import InlineAlert from '../../../../alert-system/inline-alert/inline-alert';
+import { MultipleAlertModal } from '../../../../alert-system/multiple-alert-modal';
 import {
   ConfirmInfoRow,
   ConfirmInfoRowProps,
   ConfirmInfoRowVariant,
 } from '../row';
-import { Box } from '../../../../../component-library';
-import { MultipleAlertModal } from '../../../../alert-system/multiple-alert-modal';
-import { useAlertMetrics } from '../../../../alert-system/contexts/alertMetricsContext';
 
 export type ConfirmInfoAlertRowProps = ConfirmInfoRowProps & {
   alertKey: string;
@@ -50,6 +51,10 @@ export const ConfirmInfoAlertRow = ({
   const hasFieldAlert = fieldAlerts.length > 0;
   const selectedAlertSeverity = fieldAlerts[0]?.severity;
   const selectedAlertKey = fieldAlerts[0]?.key;
+  const selectedAlertShowArrow = fieldAlerts[0]?.showArrow;
+  const selectedAlertInlineAlertText = fieldAlerts[0]?.inlineAlertText;
+  const selectedAlertIsOpenModalOnClick =
+    fieldAlerts[0]?.isOpenModalOnClick ?? true;
 
   const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false);
 
@@ -62,12 +67,19 @@ export const ConfirmInfoAlertRow = ({
     trackInlineAlertClicked(selectedAlertKey);
   };
 
+  const onClickHandler =
+    hasFieldAlert && selectedAlertIsOpenModalOnClick
+      ? handleInlineAlertClick
+      : undefined;
   const confirmInfoRowProps = {
     ...rowProperties,
     style: { background: 'transparent', ...rowProperties.style },
     color: getAlertTextColors(variant ?? selectedAlertSeverity),
     variant,
-    onClick: hasFieldAlert ? handleInlineAlertClick : undefined,
+    onClick: onClickHandler,
+    labelChildrenStyleOverride: rowProperties.labelChildren
+      ? { justifyContent: JustifyContent.center }
+      : {},
   };
 
   if (isShownWithAlertsOnly && !hasFieldAlert) {
@@ -76,9 +88,30 @@ export const ConfirmInfoAlertRow = ({
 
   const inlineAlert = hasFieldAlert ? (
     <Box marginLeft={1}>
-      <InlineAlert severity={selectedAlertSeverity} />
+      <InlineAlert
+        severity={selectedAlertSeverity}
+        showArrow={selectedAlertShowArrow}
+        textOverride={selectedAlertInlineAlertText}
+        onClick={onClickHandler}
+      />
     </Box>
   ) : null;
+
+  let confirmInfoRow: React.ReactNode;
+  if (confirmInfoRowProps.labelChildren) {
+    confirmInfoRow = (
+      <ConfirmInfoRow
+        {...rowProperties}
+        labelChildren={rowProperties.labelChildren}
+      >
+        {inlineAlert}
+      </ConfirmInfoRow>
+    );
+  } else {
+    confirmInfoRow = (
+      <ConfirmInfoRow {...confirmInfoRowProps} labelChildren={inlineAlert} />
+    );
+  }
 
   return (
     <>
@@ -92,7 +125,7 @@ export const ConfirmInfoAlertRow = ({
           skipAlertNavigation={true}
         />
       )}
-      <ConfirmInfoRow {...confirmInfoRowProps} labelChildren={inlineAlert} />
+      {confirmInfoRow}
     </>
   );
 };

--- a/ui/components/app/confirm/info/row/constants.ts
+++ b/ui/components/app/confirm/info/row/constants.ts
@@ -2,15 +2,16 @@ export const TEST_ADDRESS = '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1';
 
 export enum RowAlertKey {
   AccountTypeUpgrade = 'accountTypeUpgrade',
-  EstimatedFee = 'estimatedFee',
-  SigningInWith = 'signingInWith',
-  RequestFrom = 'requestFrom',
-  Network = 'network',
-  Resimulation = 'resimulation',
-  Speed = 'speed',
-  InteractingWith = 'interactingWith',
   EstimatedChangesStatic = 'estimatedChangesStatic',
+  EstimatedFee = 'estimatedFee',
   IncomingTokens = 'incomingTokens',
+  InteractingWith = 'interactingWith',
+  Network = 'network',
+  RequestFrom = 'requestFrom',
+  Resimulation = 'resimulation',
+  ShieldFooterCoverageIndicator = 'shieldFooterCoverageIndicator',
+  SigningInWith = 'signingInWith',
+  Speed = 'speed',
 }
 
 export enum AlertActionKey {

--- a/ui/components/app/confirm/info/row/row.tsx
+++ b/ui/components/app/confirm/info/row/row.tsx
@@ -47,6 +47,7 @@ export type ConfirmInfoRowProps = {
   tooltipIcon?: IconName;
   tooltipIconColor?: IconColor;
   variant?: ConfirmInfoRowVariant;
+  labelChildrenStyleOverride?: React.CSSProperties;
 };
 
 const BACKGROUND_COLORS = {
@@ -92,6 +93,7 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
   tooltipIcon,
   tooltipIconColor,
   onClick,
+  labelChildrenStyleOverride,
 }) => {
   const [expanded, setExpanded] = useState(!collapsed);
 
@@ -156,7 +158,11 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
           onClick={onClick}
           className={onClick && 'hoverable'}
         >
-          <Box display={Display.Flex} alignItems={AlignItems.center}>
+          <Box
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            style={labelChildrenStyleOverride}
+          >
             <Text variant={TextVariant.bodyMdMedium} color={TextColor.inherit}>
               {label}
             </Text>

--- a/ui/components/multichain/pages/page/components/footer/footer.tsx
+++ b/ui/components/multichain/pages/page/components/footer/footer.tsx
@@ -19,6 +19,10 @@ interface FooterProps extends StyleUtilityProps {
    * Additional CSS class provided to the footer
    */
   className?: string;
+  /**
+   * Additional CSS style provided to the footer
+   */
+  style?: React.CSSProperties;
 }
 
 export const Footer = ({ children, className = '', ...props }: FooterProps) => {

--- a/ui/ducks/confirm-alerts/confirm-alerts.ts
+++ b/ui/ducks/confirm-alerts/confirm-alerts.ts
@@ -2,7 +2,11 @@ import { ReactNode } from 'react';
 import { SecurityProvider } from '../../../shared/constants/security-provider';
 import { Severity } from '../../helpers/constants/design-system';
 
-export type AlertSeverity = Severity.Danger | Severity.Warning | Severity.Info;
+export type AlertSeverity =
+  | Severity.Danger
+  | Severity.Info
+  | Severity.Success
+  | Severity.Warning;
 
 /**
  * A confirmable alert to be displayed in the UI.
@@ -24,15 +28,25 @@ export type Alert = {
   field?: string;
 
   /**
-   * The unique key of the alert.
+   * Optional text to override the default on the inline alert.
    */
-  key: string;
+  inlineAlertText?: string;
 
   /**
    * Whether the alert is a blocker and un-acknowledgeable, preventing the user
    * from proceeding and relying on actions to proceed. The default is `false`.
    */
   isBlocking?: boolean;
+
+  /**
+   * Whether the modal is opened when the inline alert is clicked.
+   */
+  isOpenModalOnClick?: boolean;
+
+  /**
+   * The unique key of the alert.
+   */
+  key: string;
 
   /**
    * The security provider associated with the alert.
@@ -45,14 +59,19 @@ export type Alert = {
   reason?: string;
 
   /**
+   * URL to report issue.
+   */
+  reportUrl?: string;
+
+  /**
    * The severity of the alert.
    */
   severity: AlertSeverity;
 
   /**
-   * URL to report issue.
+   * Whether to show the arrow icon on the inline alert.
    */
-  reportUrl?: string;
+  showArrow?: boolean;
 } & MessageOrContent;
 
 type MessageOrContent =

--- a/ui/hooks/useAlerts.ts
+++ b/ui/hooks/useAlerts.ts
@@ -47,7 +47,7 @@ const useAlerts = (ownerId: string) => {
     (alertKey: string, isConfirmed: boolean) => {
       dispatch(setAlertConfirmedAction(ownerId, alertKey, isConfirmed));
     },
-    [dispatch, setAlertConfirmedAction, ownerId],
+    [dispatch, ownerId],
   );
 
   const isAlertConfirmed = useCallback(
@@ -97,6 +97,7 @@ function sortAlertsBySeverity(alerts: Alert[]): Alert[] {
     [Severity.Danger]: 3,
     [Severity.Warning]: 2,
     [Severity.Info]: 1,
+    [Severity.Success]: 0,
   };
 
   return alerts.sort(

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
@@ -24,12 +27,15 @@ import { doesAddressRequireLedgerHidConnection } from '../../../../../selectors'
 import { resolvePendingApproval } from '../../../../../store/actions';
 import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessLoading } from '../../../hooks/gas/useIsGaslessLoading';
+import { useEnableShieldCoverageChecks } from '../../../hooks/transactions/useEnableShieldCoverageChecks';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useOriginThrottling } from '../../../hooks/useOriginThrottling';
 import { isSignatureTransactionType } from '../../../utils';
 import { getConfirmationSender } from '../utils';
 import OriginThrottleModal from './origin-throttle-modal';
+import ShieldFooterAgreement from './shield-footer-agreement';
+import ShieldFooterCoverageIndicator from './shield-footer-coverage-indicator/shield-footer-coverage-indicator';
 
 export type OnCancelHandler = ({
   location,
@@ -80,6 +86,8 @@ const ConfirmButton = ({
   onCancel: OnCancelHandler;
 }) => {
   const t = useI18nContext();
+
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const [confirmModalVisible, setConfirmModalVisible] =
     useState<boolean>(false);
@@ -142,16 +150,43 @@ const ConfirmButton = ({
           onClick={onSubmit}
           size={ButtonSize.Lg}
         >
-          {t('confirm')}
+          {currentConfirmation?.type ===
+          TransactionType.shieldSubscriptionApprove
+            ? t('shieldStartNowCTA')
+            : t('confirm')}
         </Button>
       )}
     </>
   );
 };
 
+const CancelButton = ({
+  handleFooterCancel,
+}: {
+  handleFooterCancel: () => void;
+}) => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  if (currentConfirmation?.type === TransactionType.shieldSubscriptionApprove) {
+    return null;
+  }
+
+  return (
+    <Button
+      block
+      data-testid="confirm-footer-cancel-button"
+      onClick={handleFooterCancel}
+      size={ButtonSize.Lg}
+      variant={ButtonVariant.Secondary}
+    >
+      {t('cancel')}
+    </Button>
+  );
+};
+
 const Footer = () => {
   const dispatch = useDispatch();
-  const t = useI18nContext();
   const { onTransactionConfirm } = useTransactionConfirm();
 
   const { currentConfirmation, isScrollToBottomCompleted } =
@@ -210,33 +245,39 @@ const Footer = () => {
     onCancel({ location: MetaMetricsEventLocation.Confirmation });
   }, [onCancel, shouldThrottleOrigin]);
 
+  const isShowShieldFooterCoverageIndicator = useEnableShieldCoverageChecks();
+
   return (
-    <PageFooter
-      className="confirm-footer_page-footer"
-      flexDirection={FlexDirection.Column}
-    >
-      <OriginThrottleModal
-        isOpen={showOriginThrottleModal}
-        onConfirmationCancel={onCancel}
-      />
-      <Box display={Display.Flex} flexDirection={FlexDirection.Row} gap={4}>
-        <Button
-          block
-          data-testid="confirm-footer-cancel-button"
-          onClick={handleFooterCancel}
-          size={ButtonSize.Lg}
-          variant={ButtonVariant.Secondary}
-        >
-          {t('cancel')}
-        </Button>
-        <ConfirmButton
-          alertOwnerId={currentConfirmation?.id}
-          onSubmit={() => onSubmit()}
-          disabled={isConfirmDisabled}
-          onCancel={onCancel}
+    <>
+      <ShieldFooterCoverageIndicator />
+      <PageFooter
+        className="confirm-footer_page-footer"
+        flexDirection={FlexDirection.Column}
+        // box shadow to match the original var(--shadow-size-md) on the footer,
+        // but only applied to the bottom of the box, so it doesn't overlap with
+        // the shield footer coverage indicator
+        style={
+          isShowShieldFooterCoverageIndicator
+            ? { boxShadow: '0 4px 16px -8px var(--color-shadow-default)' }
+            : undefined
+        }
+      >
+        <OriginThrottleModal
+          isOpen={showOriginThrottleModal}
+          onConfirmationCancel={onCancel}
         />
-      </Box>
-    </PageFooter>
+        <Box display={Display.Flex} flexDirection={FlexDirection.Row} gap={4}>
+          <CancelButton handleFooterCancel={handleFooterCancel} />
+          <ConfirmButton
+            alertOwnerId={currentConfirmation?.id}
+            onSubmit={onSubmit}
+            disabled={isConfirmDisabled}
+            onCancel={onCancel}
+          />
+        </Box>
+        <ShieldFooterAgreement />
+      </PageFooter>
+    </>
   );
 };
 

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { TransactionType } from '@metamask/transaction-controller';
+
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { tEn } from '../../../../../../test/lib/i18n-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import ShieldFooterAgreement from './shield-footer-agreement';
+
+describe('ShieldFooterAgreement', () => {
+  it('renders terms of use link for shield subscription approve', () => {
+    const transaction = {
+      ...genUnapprovedContractInteractionConfirmation(),
+      type: TransactionType.shieldSubscriptionApprove,
+    };
+
+    const state = getMockConfirmStateForTransaction(transaction);
+    const store = configureMockStore([])(state);
+
+    const { getByText } = renderWithConfirmContextProvider(
+      <ShieldFooterAgreement />,
+      store,
+    );
+
+    expect(getByText(tEn('snapsTermsOfUse') as string)).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
@@ -1,0 +1,51 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import React from 'react';
+import {
+  Box,
+  ButtonLink,
+  ButtonLinkSize,
+  Text,
+} from '../../../../../components/component-library';
+import {
+  Display,
+  FlexDirection,
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../context/confirm';
+
+// TODO: change to the correct URL
+const SHIELD_TERMS_OF_USE_URL = 'https://consensys.io/terms-of-use';
+
+const ShieldFooterAgreement = () => {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const t = useI18nContext();
+
+  if (currentConfirmation?.type !== TransactionType.shieldSubscriptionApprove) {
+    return null;
+  }
+
+  return (
+    <Box display={Display.Flex} flexDirection={FlexDirection.Row} gap={4}>
+      <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
+        {t('shieldFooterAgreement', [
+          <ButtonLink
+            href={SHIELD_TERMS_OF_USE_URL}
+            color={TextColor.textAlternative}
+            size={ButtonLinkSize.Inherit}
+            externalLink
+            key="shield-footer-agreement-button"
+          >
+            {t('snapsTermsOfUse')}
+          </ButtonLink>,
+        ])}
+      </Text>
+    </Box>
+  );
+};
+
+export default ShieldFooterAgreement;

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+
+import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
+import { tEn } from '../../../../../../../test/lib/i18n-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../../test/data/confirmations/contract-interaction';
+import ShieldFooterCoverageIndicator from './shield-footer-coverage-indicator';
+
+jest.mock(
+  '../../../../hooks/transactions/useEnableShieldCoverageChecks',
+  () => ({
+    useEnableShieldCoverageChecks: jest.fn(() => true),
+  }),
+);
+
+jest.mock(
+  '../../../../../../components/app/alert-system/contexts/alertMetricsContext',
+  () => ({
+    useAlertMetrics: jest.fn(() => ({
+      trackInlineAlertClicked: jest.fn(),
+      trackAlertRender: jest.fn(),
+      trackAlertActionClicked: jest.fn(),
+    })),
+  }),
+);
+
+describe('ShieldFooterCoverageIndicator', () => {
+  it('renders transaction shield label when coverage indicator is enabled', () => {
+    const transaction = genUnapprovedContractInteractionConfirmation();
+    const state = getMockConfirmStateForTransaction(transaction);
+    const store = configureMockStore([])(state);
+
+    const { getByText } = renderWithConfirmContextProvider(
+      <ShieldFooterCoverageIndicator />,
+      store,
+    );
+
+    expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
@@ -1,0 +1,51 @@
+import { SignatureRequest } from '@metamask/signature-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import React from 'react';
+import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
+import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
+import { Box, Text } from '../../../../../../components/component-library';
+import {
+  AlignItems,
+  TextColor,
+  TextVariant,
+} from '../../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../../context/confirm';
+import { useEnableShieldCoverageChecks } from '../../../../hooks/transactions/useEnableShieldCoverageChecks';
+
+const ShieldFooterCoverageIndicator = () => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<
+    TransactionMeta | SignatureRequest
+  >();
+  const isShowShieldFooterCoverageIndicator = useEnableShieldCoverageChecks();
+
+  if (!isShowShieldFooterCoverageIndicator) {
+    return null;
+  }
+
+  return (
+    <Box
+      paddingLeft={4}
+      paddingRight={4}
+      // box shadow to match the original var(--shadow-size-md) on the footer,
+      // but only applied to the top of the box, so it doesn't overlap with
+      // the existing
+      style={{ boxShadow: '0 -4px 16px -8px var(--color-shadow-default)' }}
+    >
+      <ConfirmInfoAlertRow
+        alertKey={RowAlertKey.ShieldFooterCoverageIndicator}
+        ownerId={currentConfirmation.id}
+        label=""
+        labelChildren={
+          <Text variant={TextVariant.bodyMdMedium} color={TextColor.inherit}>
+            {t('transactionShield')}
+          </Text>
+        }
+        style={{ marginBottom: 0, alignItems: AlignItems.center }}
+      />
+    </Box>
+  );
+};
+
+export default ShieldFooterCoverageIndicator;

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.test.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.test.js
@@ -63,6 +63,15 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('react-router-dom-v5-compat', () => {
+  const original = jest.requireActual('react-router-dom-v5-compat');
+  return {
+    ...original,
+    useNavigate: () => jest.fn(),
+    useSearchParams: () => [new URLSearchParams(''), jest.fn()],
+  };
+});
+
 jest.mock('../../confirm-decrypt-message', () => {
   return {
     __esModule: true,

--- a/ui/pages/confirmations/confirm/confirm.test.tsx
+++ b/ui/pages/confirmations/confirm/confirm.test.tsx
@@ -34,6 +34,23 @@ jest.mock('../hooks/gas/useIsGaslessLoading', () => ({
   },
 }));
 
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  const actual = jest.requireActual('react-router-dom-v5-compat');
+  return {
+    ...actual,
+    useNavigate: () => mockUseNavigate,
+    useSearchParams: () => [new URLSearchParams(''), jest.fn()],
+    useLocation: () => ({
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'test',
+    }),
+  };
+});
+
 const middleware = [thunk];
 const mockedAssetDetails = jest.mocked(useAssetDetails);
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ButtonLink, Text } from '../../../../../components/component-library';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+
+const SHIELD_LEARN_HOW_COVERAGE_WORKS_URL =
+  'https://metamask.io/transaction-shield';
+
+export const ShieldCoverageAlertMessage = (modalBodyStr: string) => {
+  const t = useI18nContext();
+
+  return (
+    <Text
+      variant={TextVariant.bodyMd}
+      color={TextColor.textDefault}
+      data-testid="alert-modal__selected-alert"
+    >
+      {t(modalBodyStr, [
+        <ButtonLink
+          href={SHIELD_LEARN_HOW_COVERAGE_WORKS_URL}
+          key="link"
+          target="_blank"
+          rel="noreferrer noopener"
+          color={TextColor.primaryDefault}
+        >
+          {t('shieldCoverageAlertMessageLearnHowCoverageWorks')}
+        </ButtonLink>,
+      ])}
+    </Text>
+  );
+};

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
@@ -1,0 +1,109 @@
+import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockApproveConfirmState } from '../../../../../test/data/confirmations/helper';
+import { tEn } from '../../../../../test/lib/i18n-helpers';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../../helpers/constants/design-system';
+import { useShieldCoverageAlert } from './useShieldCoverageAlert';
+
+jest.mock('../transactions/useEnableShieldCoverageChecks', () => ({
+  useEnableShieldCoverageChecks: jest.fn(() => true),
+}));
+
+describe('useShieldCoverageAlert', () => {
+  const { useEnableShieldCoverageChecks } = jest.requireMock(
+    '../transactions/useEnableShieldCoverageChecks',
+  ) as { useEnableShieldCoverageChecks: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnableShieldCoverageChecks.mockReturnValue(true);
+  });
+
+  const getStateWithCoverage = (
+    status: string,
+    reasonCode = 'E104',
+  ): Record<string, unknown> => {
+    const baseState = getMockApproveConfirmState();
+    const { metamask } = baseState as unknown as {
+      metamask: { transactions: { id: number }[] };
+    };
+    const txId = metamask.transactions[0].id;
+    return {
+      ...baseState,
+      metamask: {
+        ...metamask,
+        coverageResults: {
+          [txId]: {
+            results: [
+              {
+                status,
+                reasonCode,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+  };
+
+  it('returns empty array when shield coverage checks are disabled', () => {
+    useEnableShieldCoverageChecks.mockReturnValue(false);
+
+    const baseState = getMockApproveConfirmState();
+    const { metamask } = baseState as unknown as {
+      metamask: { transactions: { id: number }[] };
+    };
+    const txId = metamask.transactions[0].id;
+    const state = {
+      ...baseState,
+      metamask: {
+        ...metamask,
+        coverageResults: {
+          [txId]: { results: [] },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns success alert when status is covered', () => {
+    const state = getStateWithCoverage('covered', 'E104');
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.key).toBe('shieldCoverageAlert');
+    expect(alert.field).toBe(RowAlertKey.ShieldFooterCoverageIndicator);
+    expect(alert.severity).toBe(Severity.Success);
+    expect(alert.inlineAlertText).toBe(tEn('shieldCovered'));
+    expect(alert.isOpenModalOnClick).toBe(false);
+    expect(alert.showArrow).toBe(false);
+    expect(alert.reason).toBe(tEn('shieldCoverageAlertMessageTitle'));
+    expect(alert.content).toBeTruthy();
+  });
+
+  it('returns info alert when status is not covered', () => {
+    const state = getStateWithCoverage('not_covered', 'E102');
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.severity).toBe(Severity.Info);
+    expect(alert.inlineAlertText).toBe(tEn('shieldNotCovered'));
+    expect(alert.isOpenModalOnClick).toBe(true);
+  });
+});

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -1,0 +1,166 @@
+import { SignatureRequest } from '@metamask/signature-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { RowAlertKey } from '../../../../components/app/confirm/info/row/constants';
+import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  getCoverageStatus,
+  ShieldState,
+} from '../../../../selectors/shield/coverage';
+import { useConfirmContext } from '../../context/confirm';
+import { useEnableShieldCoverageChecks } from '../transactions/useEnableShieldCoverageChecks';
+import { ShieldCoverageAlertMessage } from './transactions/ShieldCoverageAlertMessage';
+
+const getModalBodyStr = (reasonCode: string | undefined) => {
+  // grouping codes with a fallthrough pattern is not allowed by the linter
+  let modalBodyStr: string;
+  switch (reasonCode) {
+    // Local setup
+    case 'E104':
+      modalBodyStr = 'shieldCoverageAlertMessageTxTypeNotSupported';
+      break;
+    // Sender type not supported
+    case 'E200':
+      modalBodyStr = 'shieldCoverageAlertMessageTxTypeNotSupported';
+      break;
+    // Receiver type not supported
+    case 'E300':
+      modalBodyStr = 'shieldCoverageAlertMessageTxTypeNotSupported';
+      break;
+    // Transaction type not supported
+    case 'E400':
+      modalBodyStr = 'shieldCoverageAlertMessageTxTypeNotSupported';
+      break;
+    // Transaction to not supported
+    case 'E401':
+      modalBodyStr = 'shieldCoverageAlertMessageTxTypeNotSupported';
+      break;
+    // Malicious domain
+    case 'E101':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Risky domain
+    case 'E102':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Scan origin error
+    case 'E103':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Receiver contract malicious
+    case 'E301':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Receiver contract risky
+    case 'E302':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Method params contract malicious
+    case 'E500':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Method params contract unknown
+    case 'E501':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Malicious token contract
+    case 'E600':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Risky token contract
+    case 'E601':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Invalid blockaid result
+    case 'E001':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Invalid sentinel result
+    case 'E002':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Malicious blockaid result
+    case 'E003':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Unknown blockaid result
+    case 'E004':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Malicious sentinel result
+    case 'E005':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Invalid coverage result
+    case 'E006':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Unknown error
+    case 'E007':
+      modalBodyStr = 'shieldCoverageAlertMessagePotentialRisks';
+      break;
+    // Unsupported chain id
+    case 'E008':
+      modalBodyStr = 'shieldCoverageAlertMessageChainNotSupported';
+      break;
+    // Signature method not supported
+    case 'E700':
+      modalBodyStr = 'shieldCoverageAlertMessageSignatureNotSupported';
+      break;
+    // Signature decoding failed
+    case 'E701':
+      modalBodyStr = 'shieldCoverageAlertMessageSignatureNotSupported';
+      break;
+    // SIWE domain not matching
+    case 'E702':
+      modalBodyStr = 'shieldCoverageAlertMessageSignatureNotSupported';
+      break;
+    // SIWE account mismatch
+    case 'E703':
+      modalBodyStr = 'shieldCoverageAlertMessageSignatureNotSupported';
+      break;
+    default:
+      modalBodyStr = 'shieldCoverageAlertMessageUnknown';
+  }
+
+  return modalBodyStr;
+};
+
+export function useShieldCoverageAlert(): Alert[] {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<
+    TransactionMeta | SignatureRequest
+  >();
+  const { reasonCode, status } = useSelector((state) =>
+    getCoverageStatus(state as ShieldState, currentConfirmation?.id),
+  );
+  const modalBodyStr = getModalBodyStr(reasonCode);
+
+  const isEnableShieldCoverageChecks = useEnableShieldCoverageChecks();
+  const showAlert = isEnableShieldCoverageChecks;
+
+  return useMemo<Alert[]>((): Alert[] => {
+    if (!showAlert) {
+      return [];
+    }
+
+    return [
+      {
+        key: 'shieldCoverageAlert',
+        reason: t('shieldCoverageAlertMessageTitle'),
+        field: RowAlertKey.ShieldFooterCoverageIndicator,
+        severity: status === 'covered' ? Severity.Success : Severity.Info,
+        content: ShieldCoverageAlertMessage(modalBodyStr),
+        isBlocking: false,
+        inlineAlertText: t(
+          status === 'covered' ? 'shieldCovered' : 'shieldNotCovered',
+        ),
+        showArrow: false,
+        isOpenModalOnClick: status !== 'covered',
+      },
+    ];
+  }, [status, modalBodyStr, showAlert, t]);
+}

--- a/ui/pages/confirmations/hooks/transactions/useEnableShieldCoverageChecks.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useEnableShieldCoverageChecks.test.ts
@@ -1,0 +1,80 @@
+import { PRODUCT_TYPES } from '@metamask/subscription-controller';
+import { renderHookWithProvider } from '../../../../../test/lib/render-helpers';
+import { useEnableShieldCoverageChecks } from './useEnableShieldCoverageChecks';
+
+jest.mock('../../../../hooks/subscription/useSubscription', () => ({
+  useUserSubscriptions: jest.fn(() => ({
+    subscriptions: [],
+    loading: false,
+    error: null,
+  })),
+}));
+
+describe('useEnableShieldCoverageChecks', () => {
+  const { useUserSubscriptions } = jest.requireMock(
+    '../../../../hooks/subscription/useSubscription',
+  ) as { useUserSubscriptions: jest.Mock };
+
+  const originalEnv = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    useUserSubscriptions.mockReturnValue({
+      subscriptions: [],
+      loading: false,
+      error: null,
+    });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns true when user has a SHIELD subscription', () => {
+    useUserSubscriptions.mockReturnValue({
+      subscriptions: [
+        {
+          products: [{ name: PRODUCT_TYPES.SHIELD }],
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useEnableShieldCoverageChecks(),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when user has no SHIELD subscription and env flag is not true', () => {
+    process.env.METAMASK_SHIELD_ENABLED = 'false';
+    useUserSubscriptions.mockReturnValue({
+      subscriptions: [],
+      loading: false,
+      error: null,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useEnableShieldCoverageChecks(),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when env flag is true (even without subscription)', () => {
+    process.env.METAMASK_SHIELD_ENABLED = 'true';
+    useUserSubscriptions.mockReturnValue({
+      subscriptions: [],
+      loading: false,
+      error: null,
+    });
+
+    const { result } = renderHookWithProvider(() =>
+      useEnableShieldCoverageChecks(),
+    );
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/ui/pages/confirmations/hooks/transactions/useEnableShieldCoverageChecks.ts
+++ b/ui/pages/confirmations/hooks/transactions/useEnableShieldCoverageChecks.ts
@@ -1,0 +1,28 @@
+import { PRODUCT_TYPES } from '@metamask/subscription-controller';
+import { useUserSubscriptions } from '../../../../hooks/subscription/useSubscription';
+
+export const useEnableShieldCoverageChecks = () => {
+  const {
+    subscriptions,
+    loading: subscriptionsLoading,
+    error: subscriptionsError,
+  } = useUserSubscriptions();
+
+  const hasUserSubscribedToShield =
+    !subscriptionsLoading &&
+    !subscriptionsError &&
+    subscriptions.some((subscription) =>
+      subscription.products.some(
+        (product) => product.name === PRODUCT_TYPES.SHIELD,
+      ),
+    );
+
+  return (
+    hasUserSubscribedToShield ||
+    // TODO: Delete this condition before releasing to prod. When we release the
+    // feature to users, this environment variable will be set to 'true' on
+    // `builds.yml`. We should remove this condition before that happens, so
+    // that coverage is only shown to users that have subscribed to shield.
+    String(process.env.METAMASK_SHIELD_ENABLED) === 'true'
+  );
+};

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -21,6 +21,7 @@ import { useSelectedAccountAlerts } from './alerts/useSelectedAccountAlerts';
 import { useAddressTrustSignalAlerts } from './alerts/useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './alerts/useOriginTrustSignalAlerts';
 import { useTokenTrustSignalAlerts } from './alerts/useTokenTrustSignalAlerts';
+import { useShieldCoverageAlert } from './alerts/useShieldCoverageAlert';
 
 function useSignatureAlerts(): Alert[] {
   const accountMismatchAlerts = useAccountMismatchAlerts();
@@ -44,6 +45,7 @@ function useTransactionAlerts(): Alert[] {
   const nonContractAddressAlerts = useNonContractAddressAlerts();
   const pendingTransactionAlerts = usePendingTransactionAlerts();
   const resimulationAlert = useResimulationAlert();
+  const shieldCoverageAlert = useShieldCoverageAlert();
   const signingOrSubmittingAlerts = useSigningOrSubmittingAlerts();
   const tokenTrustSignalAlerts = useTokenTrustSignalAlerts();
 
@@ -60,6 +62,7 @@ function useTransactionAlerts(): Alert[] {
       ...nonContractAddressAlerts,
       ...pendingTransactionAlerts,
       ...resimulationAlert,
+      ...shieldCoverageAlert,
       ...signingOrSubmittingAlerts,
       ...tokenTrustSignalAlerts,
     ],
@@ -75,6 +78,7 @@ function useTransactionAlerts(): Alert[] {
       nonContractAddressAlerts,
       pendingTransactionAlerts,
       resimulationAlert,
+      shieldCoverageAlert,
       signingOrSubmittingAlerts,
       tokenTrustSignalAlerts,
     ],

--- a/ui/selectors/shield/coverage.test.ts
+++ b/ui/selectors/shield/coverage.test.ts
@@ -1,0 +1,54 @@
+import type { CoverageStatus } from '@metamask/shield-controller';
+import { getCoverageStatus, ShieldState } from './coverage';
+
+describe('shield coverage selectors', () => {
+  const confirmationId = 'abc123';
+
+  it('returns undefineds when there are no coverage results', () => {
+    const state = {
+      metamask: {
+        coverageResults: {},
+      },
+    } as unknown as ShieldState;
+
+    const result = getCoverageStatus(state, confirmationId);
+    expect(result).toEqual({ status: undefined, reasonCode: undefined });
+  });
+
+  it('returns undefineds when results array is empty', () => {
+    const state = {
+      metamask: {
+        coverageResults: {
+          [confirmationId]: { results: [] },
+        },
+      },
+    } as unknown as ShieldState;
+
+    const result = getCoverageStatus(state, confirmationId);
+    expect(result).toEqual({ status: undefined, reasonCode: undefined });
+  });
+
+  it('returns status and reasonCode from the first result', () => {
+    const status: CoverageStatus = 'covered';
+    const reasonCode = 'ok';
+    const state = {
+      metamask: {
+        coverageResults: {
+          [confirmationId]: {
+            results: [
+              {
+                status,
+                reasonCode,
+              },
+              { status: 'other', reasonCode: 'ignored' },
+            ],
+          },
+        },
+      },
+    } as unknown as ShieldState;
+
+    const result = getCoverageStatus(state, confirmationId);
+    expect(result.status).toBe(status);
+    expect(result.reasonCode).toBe(reasonCode);
+  });
+});

--- a/ui/selectors/shield/coverage.ts
+++ b/ui/selectors/shield/coverage.ts
@@ -1,0 +1,26 @@
+import {
+  ShieldControllerState,
+  type CoverageStatus,
+} from '@metamask/shield-controller';
+
+export type ShieldState = {
+  metamask: ShieldControllerState;
+};
+
+export function getCoverageStatus(
+  state: ShieldState,
+  confirmationId: string,
+): { status: CoverageStatus | undefined; reasonCode: string | undefined } {
+  const coverageResults = state.metamask.coverageResults[confirmationId];
+  if (!coverageResults || coverageResults.results.length === 0) {
+    return { status: undefined, reasonCode: undefined };
+  }
+
+  const result = coverageResults.results[0];
+
+  return {
+    status: result.status,
+    // @ts-expect-error TODO: upgrade types on shield-controller
+    reasonCode: result.reasonCode,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7609,15 +7609,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/shield-controller@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@metamask/shield-controller@npm:0.1.1"
+"@metamask/shield-controller@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@metamask/shield-controller@npm:0.1.2"
   dependencies:
     "@metamask/base-controller": "npm:^8.2.0"
     "@metamask/utils": "npm:^11.4.2"
   peerDependencies:
     "@metamask/transaction-controller": ^60.0.0
-  checksum: 10/10d628a0c127c6ed4ba51865ca094be091441c091eb958f02a8e43d78a9915eeaec368a95a13f7733adb951f470457dce9175cd7102bf13e81bc879f777e2c6c
+  checksum: 10/2c99909c89e23f0da65987b077fdc078aa6bcf4297c35eaaac59297fb8b34388feff07f39207141432dff90d4566721f14e100e5f9383c131d0f55dd8e13359d
   languageName: node
   linkType: hard
 
@@ -31928,7 +31928,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.0.3"
     "@metamask/seedless-onboarding-controller": "npm:^4.0.0"
     "@metamask/selected-network-controller": "npm:^24.0.0"
-    "@metamask/shield-controller": "npm:^0.1.1"
+    "@metamask/shield-controller": "npm:^0.1.2"
     "@metamask/signature-controller": "npm:^34.0.0"
     "@metamask/smart-transactions-controller": "npm:^18.1.0"
     "@metamask/snap-simple-keyring-site": "npm:^2.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36677?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**
 
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5963

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="413" height="615" alt="Screenshot 2025-10-08 at 13 46 41" src="https://github.com/user-attachments/assets/8da35f99-fc04-4a01-8c17-68cb1bd26a1b" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Transaction Shield coverage indicator/footer and alerts to confirmations, with supporting hooks, i18n, selectors, config, and UI tweaks.
> 
> - **Confirmations UI**:
>   - Add `ShieldFooterCoverageIndicator` below footer and `ShieldFooterAgreement`; tailor confirm/cancel buttons for `shieldSubscriptionApprove`.
>   - Enhance `InlineAlert` (text/arrow support, success variant, background colors) and adjust `ConfirmInfoAlertRow`/`ConfirmInfoRow` for click/label layout.
> - **Alerts & Logic**:
>   - New `useEnableShieldCoverageChecks` (subscription/env gated) and `useShieldCoverageAlert` integrated into `useConfirmationAlerts`.
>   - Add `ShieldCoverageAlertMessage` and i18n strings (`shieldCovered`, `shieldNotCovered`, coverage messages).
> - **State/Selectors**:
>   - Add `coverageResults` to `metamask` state (storybook/mock/integration) and new selector `selectors/shield/coverage#getCoverageStatus`.
> - **Config/Deps**:
>   - Bump `@metamask/shield-controller` to `^0.1.2`; update `SHIELD_RULE_ENGINE_URL` to `https://ruleset-engine.dev-api.cx.metamask.io` and wrap backend `fetch`.
> - **Styling/Tests**:
>   - Update inline alert styles; add comprehensive tests for new components/hooks/selectors and router mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f65c08c7373f819e76423c61540d734d610364e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->