### PR TITLE
fix: fix conversion rate display when testnet is selected from dapp

### DIFF
--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -13,6 +13,7 @@ import {
   getCurrencyRates,
   getUseCurrencyRateCheck,
   useSafeChainsListValidationSelector,
+  getEnabledNetworksByNamespace,
 } from '../../../../selectors';
 import {
   getMultichainCurrentChainId,
@@ -186,6 +187,11 @@ describe('Token Cell', () => {
     }
     if (selector === useSafeChainsListValidationSelector) {
       return true;
+    }
+    if (selector === getEnabledNetworksByNamespace) {
+      return {
+        '0x1': true,
+      };
     }
     return undefined;
   });


### PR DESCRIPTION
## **Description**

This PR fixes an issue when the user selects a non testnet network from the network selector, then connects to a testnet on a dapp which resulted in showing "No conversion rate available" on the token list.

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing the token list to show "No conversion rate available" once the user connects to testnet from a dapp.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36659

## **Manual testing steps**

1. Go to Tokens tab
2. Choose any popular network.
3. Notice that fiat values are being displayed correctly for all tokens
4. Go to settings
5. Make sure you have the setting "Show conversions on testnetworks" OFF
6. Go to test-dapp
7. Click on network picker and choose a testnet (exp Sepolia)
8. Re-open MM and you should now still see the fiat values displayed correctly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/85f39661-948f-45cd-b1d1-498ad545cd31

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/989737de-fdd5-4f9f-9773-f9f8fa18253a


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts fiat visibility in token list to detect testnets via enabled networks, avoiding missing conversion rates when a dapp selects a testnet.
> 
> - **Assets / Hooks**:
>   - Update `useTokenDisplayInfo` to determine testnet via `getEnabledNetworksByNamespace` and `TEST_CHAINS` instead of `getIsTestnet`.
>   - Recompute `isMainnet` and `shouldShowFiat` using the new `isTestnetSelected` check, preserving fiat display when a dapp connects to a testnet (respecting `showFiatInTestnets`).
> - **Tests**:
>   - Update `ui/components/app/assets/token-cell/token-cell.test.tsx` to mock `getEnabledNetworksByNamespace`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 996cf38a25735c890adb7b67acb09c3a4064a2fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->