### PR TITLE
test: Fix e2e tests failure with bip44 stage2 enabled

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -317,23 +317,6 @@ async function withFixtures(options, testSuite) {
     webSocketServer.start();
     await setupSolanaWebsocketMocks(solanaWebSocketSpecificMocks);
 
-    // The feature flag wrapper chooses state 2 by default
-    // but we want most tests to be able to run with state 0 (bip-44 disabled)
-    // So the default argument is 0
-    // and doing nothing here means we get state 2
-
-    if (forceBip44Version === 0) {
-      console.log('Applying multichain accounts feature flag disabled mock');
-      await mockMultichainAccountsFeatureFlagDisabled(mockServer);
-    } else if (forceBip44Version === 1) {
-      console.log(
-        'Applying multichain accounts state 1 feature state 1 enabled mock',
-      );
-      await mockMultichainAccountsFeatureFlagStateOne(mockServer);
-    } else {
-      console.log('BIP-44 state 2 enabled');
-    }
-
     // Decide between the regular setupMocking and the passThrough version
     const mockingSetupFunction = useMockingPassThrough
       ? setupMockingPassThrough

--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -40,6 +40,7 @@ export const loginWithBalanceValidation = async (
   value?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
+  return
   const homePage = new HomePage(driver);
 
   // Verify the expected balance on the homepage

--- a/test/e2e/page-objects/flows/login.flow.ts
+++ b/test/e2e/page-objects/flows/login.flow.ts
@@ -40,7 +40,6 @@ export const loginWithBalanceValidation = async (
   value?: string,
 ) => {
   await loginWithoutBalanceValidation(driver, password);
-  return
   const homePage = new HomePage(driver);
 
   // Verify the expected balance on the homepage

--- a/test/e2e/tests/account/account-details.spec.ts
+++ b/test/e2e/tests/account/account-details.spec.ts
@@ -12,7 +12,13 @@ describe('Show account details', function () {
   it('should show the correct private key from account menu', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilder()
+          .withEnabledNetworks({
+              eip155: {
+                '0x1': true,
+              },
+            })
+          .build(),
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36703?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes BIP-44/multichain accounts feature-flag mocking from test helpers so e2e runs with the default stage 2 state.
> 
> - **Tests**:
>   - Remove logic in `test/e2e/helpers.js` that applied `mockMultichainAccountsFeatureFlagDisabled`/`mockMultichainAccountsFeatureFlagStateOne` based on `forceBip44Version`, allowing default BIP-44 stage 2 behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0320c818a5275a89968f820040be0e3f979cbcaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->