### PR TITLE
feat: update formatPeriodDuration for new durations

### DIFF
--- a/shared/constants/time.ts
+++ b/shared/constants/time.ts
@@ -4,3 +4,6 @@ export const MINUTE = SECOND * 60;
 export const HOUR = MINUTE * 60;
 export const DAY = HOUR * 24;
 export const WEEK = DAY * 7;
+export const FORTNIGHT = DAY * 14;
+export const MONTH = DAY * 30;
+export const YEAR = DAY * 365;

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.tsx
@@ -23,7 +23,14 @@ import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/in
 import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
 import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
 import { ConfirmInfoRowCurrency } from '../../../../../../components/app/confirm/info/row/currency';
-import { DAY, WEEK } from '../../../../../../../shared/constants/time';
+import {
+  HOUR,
+  DAY,
+  WEEK,
+  FORTNIGHT,
+  MONTH,
+  YEAR,
+} from '../../../../../../../shared/constants/time';
 
 /**
  * Formats a period duration in seconds to a human-readable string.
@@ -35,10 +42,18 @@ import { DAY, WEEK } from '../../../../../../../shared/constants/time';
 const formatPeriodDuration = (seconds: number) => {
   // multiply by 1000 to convert to milliseconds
   switch (seconds * 1000) {
+    case HOUR:
+      return 'Hourly';
     case DAY:
       return 'Daily';
     case WEEK:
       return 'Weekly';
+    case FORTNIGHT:
+      return 'Bi-Weekly';
+    case MONTH:
+      return 'Monthly';
+    case YEAR:
+      return 'Yearly';
     default:
       return `${seconds} seconds`;
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added support for Hourly, Bi-Weekly (14 days), Monthly (30 days), and Yearly (365 days) duration periods.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36706?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for Hourly, Bi-Weekly (14 days), Monthly (30 days), and Yearly (365 days) duration periods.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="402" height="622" alt="SCR-20251009-ljwe" src="https://github.com/user-attachments/assets/1a5c11cd-dcd4-4273-b57e-a7af96f9f225" />

### **After**

<!-- [screenshots/recordings] -->
<img width="402" height="622" alt="SCR-20251009-lfoe" src="https://github.com/user-attachments/assets/13ecc8bf-270f-40a8-9bbd-571ff0fa7e99" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds time constants and updates `formatPeriodDuration` to display Hourly, Bi-Weekly, Monthly, and Yearly labels.
> 
> - **UI (Typed Sign Permission)**:
>   - Extends `formatPeriodDuration` in `ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.tsx` to map `HOUR` → "Hourly", `FORTNIGHT` → "Bi-Weekly", `MONTH` → "Monthly", `YEAR` → "Yearly" (in addition to Daily/Weekly).
>   - Updates imports to use new time constants from `shared/constants/time`.
> - **Shared Constants**:
>   - Adds `FORTNIGHT`, `MONTH`, `YEAR` to `shared/constants/time.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc528212e71b661a2398c17061188f784b7871f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->