### PR TITLE
feat: Add account watch and snap account options to multichain

### DIFF
--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.test.tsx
@@ -7,6 +7,10 @@ import {
   CONNECT_HARDWARE_ROUTE,
   IMPORT_SRP_ROUTE,
 } from '../../../helpers/constants/routes';
+import {
+  getIsAddSnapAccountEnabled,
+  getIsWatchEthereumAccountEnabled,
+} from '../../../selectors';
 import { AddWalletModal } from './add-wallet-modal';
 
 const mockHistoryPush = jest.fn();
@@ -119,5 +123,49 @@ describe('AddWalletModal', () => {
     renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
 
     expect(screen.getByText('manageInstitutionalWallets')).toBeInTheDocument();
+  });
+
+  it('renders the add snap account option when addSnapAccountEnabled is true', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      return selector === getIsAddSnapAccountEnabled;
+    });
+
+    // Mock platform.openTab
+    // @ts-expect-error mocking platform
+    global.platform = {
+      ...global.platform,
+      openTab: jest.fn(),
+    };
+
+    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
+
+    const snapAccountOption = screen.getByTestId(
+      'add-wallet-modal-snap-account',
+    );
+
+    expect(snapAccountOption).toBeInTheDocument();
+    expect(screen.getByText('settingAddSnapAccount')).toBeInTheDocument();
+
+    fireEvent.click(snapAccountOption);
+
+    expect(global.platform.openTab).toHaveBeenCalled();
+  });
+
+  it('renders the watch Ethereum account option when isAddWatchEthereumAccountEnabled is true', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      return selector === getIsWatchEthereumAccountEnabled;
+    });
+
+    const mockTrackEvent = jest.fn();
+    jest.spyOn(React, 'useContext').mockImplementation(() => mockTrackEvent);
+
+    renderWithProvider(<AddWalletModal isOpen={true} onClose={mockOnClose} />);
+
+    const watchAccountOption = screen.getByTestId(
+      'add-wallet-modal-watch-ethereum-account',
+    );
+
+    expect(watchAccountOption).toBeInTheDocument();
+    expect(screen.getByText('addEthereumWatchOnlyAccount')).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -1,4 +1,9 @@
-import React, { useCallback, useContext } from 'react';
+import React, {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  useCallback,
+  useContext,
+  ///: END:ONLY_INCLUDE_IF
+} from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Box,
@@ -37,11 +42,14 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   getIsAddSnapAccountEnabled,
   getIsWatchEthereumAccountEnabled,
+  ///: END:ONLY_INCLUDE_IF
   getManageInstitutionalWallets,
 } from '../../../selectors';
 import { INSTITUTIONAL_WALLET_SNAP_ID } from '../../../../shared/lib/accounts';
+///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
@@ -53,6 +61,7 @@ import {
   ACCOUNT_WATCHER_SNAP_ID,
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/snap-keyring/account-watcher-snap';
+///: END:ONLY_INCLUDE_IF
 
 export type AddWalletModalProps = Omit<
   ModalProps,
@@ -79,11 +88,13 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
   const institutionalWalletsEnabled = useSelector(
     getManageInstitutionalWallets,
   );
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const trackEvent = useContext(MetaMetricsContext);
   const addSnapAccountEnabled = useSelector(getIsAddSnapAccountEnabled);
   const isAddWatchEthereumAccountEnabled = useSelector(
     getIsWatchEthereumAccountEnabled,
   );
+  ///: END:ONLY_INCLUDE_IF
 
   const walletOptions: WalletOption[] = [
     {
@@ -133,7 +144,8 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
     }
   };
 
-  const handleSnapAccountLinkClick = () => {
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  const handleSnapAccountLinkClick = useCallback(() => {
     trackEvent({
       category: MetaMetricsEventCategory.Navigation,
       event: MetaMetricsEventName.AccountAddSelected,
@@ -150,8 +162,10 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
     global.platform.openTab({
       url: process.env.ACCOUNT_SNAPS_DIRECTORY_URL as string,
     });
-  };
+  }, [trackEvent]);
+  ///: END:ONLY_INCLUDE_IF
 
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const handleAddWatchAccount = useCallback(async () => {
     await trackEvent({
       category: MetaMetricsEventCategory.Navigation,
@@ -175,6 +189,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
     onClose();
     history.push(`/snaps/view/${encodeURIComponent(ACCOUNT_WATCHER_SNAP_ID)}`);
   }, [trackEvent, onClose, history]);
+  ///: END:ONLY_INCLUDE_IF
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} {...props}>
@@ -223,78 +238,86 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
               <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
             </Box>
           ))}
-          {addSnapAccountEnabled && (
-            <Box
-              key="snap-account"
-              onClick={() => handleSnapAccountLinkClick()}
-              onKeyDown={(e: React.KeyboardEvent) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleSnapAccountLinkClick();
-                }
-              }}
-              alignItems={BoxAlignItems.Center}
-              padding={4}
-              gap={3}
-              backgroundColor={BoxBackgroundColor.BackgroundDefault}
-              flexDirection={BoxFlexDirection.Row}
-              borderColor={BoxBorderColor.BorderMuted}
-              className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
-              tabIndex={0}
-              data-testid={`add-wallet-modal-snap-account`}
-            >
-              <Icon
-                name={IconName.Snaps}
-                size={IconSize.Md}
-                color={IconColor.IconAlternative}
-              />
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-                className="flex-1"
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+            addSnapAccountEnabled && (
+              <Box
+                key="snap-account"
+                onClick={() => handleSnapAccountLinkClick()}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleSnapAccountLinkClick();
+                  }
+                }}
+                alignItems={BoxAlignItems.Center}
+                padding={4}
+                gap={3}
+                backgroundColor={BoxBackgroundColor.BackgroundDefault}
+                flexDirection={BoxFlexDirection.Row}
+                borderColor={BoxBorderColor.BorderMuted}
+                className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
+                tabIndex={0}
+                data-testid={`add-wallet-modal-snap-account`}
               >
-                {t('settingAddSnapAccount')}
-              </Text>
-              <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
-            </Box>
-          )}
-          {isAddWatchEthereumAccountEnabled && (
-            <Box
-              key="watch-ethereum-account"
-              onClick={() => handleAddWatchAccount()}
-              onKeyDown={(e: React.KeyboardEvent) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleAddWatchAccount();
-                }
-              }}
-              alignItems={BoxAlignItems.Center}
-              padding={4}
-              gap={3}
-              backgroundColor={BoxBackgroundColor.BackgroundDefault}
-              flexDirection={BoxFlexDirection.Row}
-              borderColor={BoxBorderColor.BorderMuted}
-              className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
-              tabIndex={0}
-              data-testid={`add-wallet-modal-watch-ethereum-account`}
-            >
-              <Icon
-                name={IconName.Eye}
-                size={IconSize.Md}
-                color={IconColor.IconAlternative}
-              />
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-                className="flex-1"
+                <Icon
+                  name={IconName.Snaps}
+                  size={IconSize.Md}
+                  color={IconColor.IconAlternative}
+                />
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                  className="flex-1"
+                >
+                  {t('settingAddSnapAccount')}
+                </Text>
+                <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
+              </Box>
+            )
+            ///: END:ONLY_INCLUDE_IF
+          }
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+            isAddWatchEthereumAccountEnabled && (
+              <Box
+                key="watch-ethereum-account"
+                onClick={() => handleAddWatchAccount()}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleAddWatchAccount();
+                  }
+                }}
+                alignItems={BoxAlignItems.Center}
+                padding={4}
+                gap={3}
+                backgroundColor={BoxBackgroundColor.BackgroundDefault}
+                flexDirection={BoxFlexDirection.Row}
+                borderColor={BoxBorderColor.BorderMuted}
+                className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
+                tabIndex={0}
+                data-testid={`add-wallet-modal-watch-ethereum-account`}
               >
-                {t('addEthereumWatchOnlyAccount')}
-              </Text>
-              <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
-            </Box>
-          )}
+                <Icon
+                  name={IconName.Eye}
+                  size={IconSize.Md}
+                  color={IconColor.IconAlternative}
+                />
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                  className="flex-1"
+                >
+                  {t('addEthereumWatchOnlyAccount')}
+                </Text>
+                <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
+              </Box>
+            )
+            ///: END:ONLY_INCLUDE_IF
+          }
         </ModalBody>
       </ModalContent>
     </Modal>


### PR DESCRIPTION
## **Description**
This PR adds account watcher snap option and link to snaps using snap accounts to the multichain account list add wallet modal.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36717?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added snap accounts link and account watcher option to multichain account list

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1133

## **Manual testing steps**
1. Build Flask extension.
2. Go to settings and enable account watcher and snap accounts.
3. Go to multichain account list.
4. Click "Add wallet" button in footer.
5. Make sure that there are following options: "Add account Snap", "Watch an Ethereum account (Beta)".
6. Click on both options and inspect behavior.

## **Screenshots/Recordings**
### **Before**
<img width="402" height="602" alt="Screenshot 2025-10-09 at 12 03 30" src="https://github.com/user-attachments/assets/82a4adb7-0213-4513-b2b5-4deacaa9a40a" />

### **After**
Flask version:

<img width="402" height="602" alt="Screenshot 2025-10-09 at 11 47 29" src="https://github.com/user-attachments/assets/08e1721c-bbdd-44c1-967e-ee36c3f8410b" />

Flask version:

https://github.com/user-attachments/assets/20dd3cf0-8816-4286-8197-2722de5d7a50


#### Non-flask version
<img width="402" height="602" alt="Screenshot 2025-10-09 at 15 31 29" src="https://github.com/user-attachments/assets/1a1871a6-cc62-46aa-8480-98b85a7c1d99" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Flask-gated options in the Add Wallet modal to open Snap accounts directory and to add a watch-only Ethereum account, with navigation and metrics tracking.
> 
> - **UI (Flask-only)**:
>   - Add `snap-account` option in `ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx` that opens `process.env.ACCOUNT_SNAPS_DIRECTORY_URL` via `global.platform.openTab`.
>   - Add `watch-ethereum-account` option that navigates to `/snaps/view/${encodeURIComponent(ACCOUNT_WATCHER_SNAP_ID)}`.
>   - Gate options by selectors `getIsAddSnapAccountEnabled` and `getIsWatchEthereumAccountEnabled`; include `data-testid` hooks.
> - **Analytics**:
>   - Track selections via `MetaMetricsContext` with `MetaMetricsEventName.AccountAddSelected` and related properties.
> - **Tests**:
>   - Extend `add-wallet-modal.test.tsx` to assert visibility of new options when selectors return true; verify click behavior (`global.platform.openTab` called, elements present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2322cc0278799ac97452bdb0c4e364ceef8e4ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->