### PR TITLE
fix: change notification feature flag to use rollout variants

### DIFF
--- a/ui/selectors/metamask-notifications/metamask-notifications.test.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.test.ts
@@ -31,7 +31,9 @@ describe('Metamask Notifications Selectors', () => {
       isUpdatingMetamaskNotificationsAccount: [],
       isCheckingAccountsPresence: false,
       remoteFeatureFlags: {
-        assetsEnableNotificationsByDefault: false,
+        assetsEnableNotificationsByDefaultV2: {
+          value: false,
+        },
       },
     },
   });

--- a/ui/selectors/metamask-notifications/metamask-notifications.ts
+++ b/ui/selectors/metamask-notifications/metamask-notifications.ts
@@ -53,8 +53,14 @@ const getMetamask = (state: NotificationAppState) => ({
 export function getIsNotificationEnabledByDefaultFeatureFlag(
   state: NotificationAppState,
 ) {
-  const { assetsEnableNotificationsByDefault } = getRemoteFeatureFlags(state);
-  return Boolean(assetsEnableNotificationsByDefault);
+  const { assetsEnableNotificationsByDefaultV2 } = getRemoteFeatureFlags(state);
+  const result =
+    assetsEnableNotificationsByDefaultV2 &&
+    typeof assetsEnableNotificationsByDefaultV2 === 'object' &&
+    'value' in assetsEnableNotificationsByDefaultV2 &&
+    Boolean(assetsEnableNotificationsByDefaultV2.value);
+
+  return Boolean(result);
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Allows us to control the feature flag rollout.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36724?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update notifications enabled by default feature flag to control rollout

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1258

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the notifications default-enable flag to the V2 rollout variant with a value field and updates selector logic and tests.
> 
> - **Selectors**:
>   - Update `getIsNotificationEnabledByDefaultFeatureFlag` to use `remoteFeatureFlags.assetsEnableNotificationsByDefaultV2.value` with safe guards.
> - **Tests**:
>   - Adjust mock `remoteFeatureFlags` in `ui/selectors/metamask-notifications/metamask-notifications.test.ts` to use `assetsEnableNotificationsByDefaultV2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed923d78311db7f6c28e9992f4835f6210cf693b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->