### PR TITLE
unzipper.d.ts

### DIFF
--- a/types/unzipper.d.ts
+++ b/types/unzipper.d.ts
@@ -1,17 +1,38 @@
-import 'unzipper';
+import type { Readable } from 'stream';
 
 declare module 'unzipper' {
-  type Source = {
-    stream: (offset: number, length: number) => NodeJS.ReadableStream;
-    size: () => Promise<number>;
-  };
-  type Options = {
+  /**
+   * Represents a source from which ZIP data can be streamed.
+   */
+  export interface Source {
+    stream(offset: number, length: number): Readable;
+    size(): Promise<number>;
+  }
+
+  /**
+   * Optional configuration for reading ZIP files.
+   */
+  export interface Options {
     tailSize?: number;
-  };
-  namespace Open {
-    function custom(
-      source: Source,
-      options?: Options,
-    ): Promise<CentralDirectory>;
+  }
+
+  /**
+   * Represents the central directory structure of the ZIP file.
+   * This is part of unzipper’s internal API.
+   */
+  export interface CentralDirectory {
+    files: unknown[];
+    comment: string;
+  }
+
+  export namespace Open {
+    /**
+     * Opens a ZIP file from a custom source.
+     *
+     * @param source - A custom data source providing stream and size methods.
+     * @param options - Optional configuration for reading ZIP files.
+     * @returns A promise resolving to a CentralDirectory instance.
+     */
+    function custom(source: Source, options?: Options): Promise<CentralDirectory>;
   }
 }


### PR DESCRIPTION
Replaced NodeJS.ReadableStream with Readable from 'stream' The correct modern type for streams in Node.js is Readable (imported from the 'stream' module). NodeJS.ReadableStream is an outdated global type and doesn’t provide full IntelliSense or modern compatibility

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36740?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `NodeJS.ReadableStream` with `stream.Readable`, converts internal types to exported interfaces, adds `CentralDirectory`, and documents `Open.custom` in `types/unzipper.d.ts`.
> 
> - **Type definition modernization** in `types/unzipper.d.ts`:
>   - Replace `NodeJS.ReadableStream` with `Readable` from `stream` in `Source.stream`.
>   - Convert `Source` and `Options` from type aliases to exported interfaces.
>   - Add and export `CentralDirectory` interface (`files`, `comment`).
>   - Update `Open.custom` signature to return `Promise<CentralDirectory>`.
>   - Add concise JSDoc comments for `Source`, `Options`, `CentralDirectory`, and `Open.custom`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f6012902f7e2f28d51a26e6e340acd8513168cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->