### PR TITLE
fix(action): require changelog entry even if the PR description doesn't match template

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -183,6 +183,22 @@ async function main(): Promise<void> {
     }
 
   } else if (labelable.type === LabelableType.PullRequest) {
+    // Check changelog entry for all PRs (regardless of template match)
+    const hasNoChangelogLabel = labelable.labels?.some(
+      (label) => label.name === "no-changelog"
+    );
+
+    // Require changelog entry
+    if (hasNoChangelogLabel) {
+      console.log(`PR ${labelable.number} has "no-changelog" label. Skipping changelog entry check.`);
+    } else if (!hasChangelogEntry(labelable.body)) {
+      const errorMessage = `PR is missing a valid "CHANGELOG entry:" line.`;
+      console.log(errorMessage);
+
+      core.setFailed(errorMessage);
+      process.exit(1);
+    }
+
     if (templateType === TemplateType.PullRequest) {
       console.log("PR matches 'pull-request-template.md' template.");
       await removeLabelFromLabelableIfPresent(
@@ -190,22 +206,6 @@ async function main(): Promise<void> {
         labelable,
         invalidPullRequestTemplateLabel,
       );
-
-      // Skip changelog check if PR has "no-changelog" label
-      const hasNoChangelogLabel = labelable.labels?.some(
-        (label) => label.name === "no-changelog"
-      );
-
-      // Require changelog entry
-      if (hasNoChangelogLabel) {
-        console.log(`PR ${labelable.number} has "no-changelog" label. Skipping changelog entry check.`);
-      } else if (!hasChangelogEntry(labelable.body)) {
-        const errorMessage = `PR is missing a valid "CHANGELOG entry:" line.`;
-        console.log(errorMessage);
-
-        core.setFailed(errorMessage);
-        process.exit(1);
-      }
     } else {
       const errorMessage = `PR body does not match template ('pull-request-template.md').\n\nMake sure PR's body includes all section titles.\n\nSections titles are listed here: https://github.com/MetaMask/metamask-extension/blob/main/.github/scripts/shared/template.ts#L40-L47`;
       console.log(errorMessage);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

At the moment, PRs which don't match the PR template bypass the changelog entry check, while we'd like to make it mandatory on every PR.
This PR fixes it.

[Same PR for Mobile](https://github.com/MetaMask/metamask-mobile/pull/21021)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36745?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a changelog entry check for all PRs (skipping only when labeled `no-changelog`), not just those matching the PR template.
> 
> - **GitHub Action (`.github/scripts/check-template-and-add-labels.ts`)**:
>   - Enforce `CHANGELOG entry:` check for all PRs, independent of template match; skip only if labeled `no-changelog`.
>   - Remove redundant changelog check from the PR-template branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 320aebc85b25c29ad41e53c2e74cdd384e022ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->