### PR TITLE
feat: Implement BTC labels in send flow

### DIFF
--- a/ui/pages/confirmations/components/UI/account-type-label/account-type-label.test.tsx
+++ b/ui/pages/confirmations/components/UI/account-type-label/account-type-label.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AccountTypeLabel } from './account-type-label';
+
+describe('AccountTypeLabel', () => {
+  it('should return null when label is undefined', () => {
+    const { container } = render(<AccountTypeLabel label={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render Tag component when label is provided', () => {
+    const { container, getByText } = render(
+      <AccountTypeLabel label="Native SegWit" />,
+    );
+
+    expect(container.firstChild).not.toBeNull();
+    expect(getByText('Native SegWit')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/UI/account-type-label/account-type-label.tsx
+++ b/ui/pages/confirmations/components/UI/account-type-label/account-type-label.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Text, TextVariant, TextColor } from '@metamask/design-system-react';
+
+import { Tag } from '../../../../../components/component-library';
+
+export const AccountTypeLabel = ({ label }: { label?: string }) => {
+  if (!label) {
+    return null;
+  }
+
+  return <Tag label={label} />;
+};

--- a/ui/pages/confirmations/components/UI/account-type-label/account-type-label.tsx
+++ b/ui/pages/confirmations/components/UI/account-type-label/account-type-label.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Text, TextVariant, TextColor } from '@metamask/design-system-react';
 
 import { Tag } from '../../../../../components/component-library';
 

--- a/ui/pages/confirmations/components/UI/account-type-label/index.ts
+++ b/ui/pages/confirmations/components/UI/account-type-label/index.ts
@@ -1,0 +1,1 @@
+export { AccountTypeLabel } from './account-type-label';

--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
+import { BtcAccountType } from '@metamask/keyring-api';
 import createMockStore from 'redux-mock-store';
 
 import { renderWithProvider } from '../../../../../../test/jest';
@@ -183,5 +184,15 @@ describe('NFTAsset', () => {
 
     const image = getByAltText('Test NFT');
     expect(image).toHaveAttribute('src', 'https://example.com/collection.png');
+  });
+
+  it('renders account type label when account type is provided', () => {
+    const assetWithAccountType = {
+      ...mockTokenAsset,
+      accountType: BtcAccountType.P2wpkh,
+    };
+    const { getByText } = render(<Asset asset={assetWithAccountType} />);
+
+    expect(getByText('Native SegWit')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { KeyringAccountType } from '@metamask/keyring-api';
 import {
   AvatarToken,
   AvatarNetwork,
@@ -22,7 +23,9 @@ import {
   NFT_STANDARDS,
 } from '../../../types/send';
 import { useNftImageUrl } from '../../../hooks/useNftImageUrl';
+import { accountTypeLabel } from '../../../constants/network';
 import { useFormatters } from '../../../../../hooks/useFormatters';
+import { AccountTypeLabel } from '../account-type-label';
 
 type AssetProps = {
   asset: AssetType;
@@ -119,6 +122,8 @@ const TokenAsset = ({ asset, onClick, isSelected }: AssetProps) => {
   const { formatCurrencyWithMinThreshold, formatTokenQuantity } =
     useFormatters();
 
+  const typeLabel = accountTypeLabel[asset.accountType as KeyringAccountType];
+
   return (
     <Box
       alignItems={AlignItems.center}
@@ -161,9 +166,20 @@ const TokenAsset = ({ asset, onClick, isSelected }: AssetProps) => {
         flexDirection={FlexDirection.Column}
         style={{ flex: 1, overflow: 'hidden' }}
       >
-        <Text variant={TextVariant.bodyMdMedium} color={TextColor.textDefault}>
-          {name}
-        </Text>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Row}
+          alignItems={AlignItems.center}
+        >
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.textDefault}
+            marginRight={1}
+          >
+            {name}
+          </Text>
+          <AccountTypeLabel label={typeLabel} />
+        </Box>
         <Text
           variant={TextVariant.bodySmMedium}
           color={TextColor.textAlternative}

--- a/ui/pages/confirmations/components/UI/recipient/recipient.test.tsx
+++ b/ui/pages/confirmations/components/UI/recipient/recipient.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BtcAccountType } from '@metamask/keyring-api';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../../store/store';
@@ -137,5 +138,20 @@ describe('Recipient', () => {
     );
 
     expect(getByText('0x12345...45678')).toBeInTheDocument();
+  });
+
+  it('renders account type label when account type is provided', () => {
+    const { getByText } = render(
+      <Recipient
+        isAccount={true}
+        recipient={{
+          ...mockAccountRecipient,
+          accountType: BtcAccountType.P2wpkh,
+        }}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(getByText('Native SegWit')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/UI/recipient/recipient.tsx
+++ b/ui/pages/confirmations/components/UI/recipient/recipient.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { AvatarAccountSize } from '@metamask/design-system-react';
+import { KeyringAccountType } from '@metamask/keyring-api';
+
 import { PreferredAvatar } from '../../../../../components/app/preferred-avatar';
 import { Box, Text } from '../../../../../components/component-library';
 import {
@@ -12,6 +14,8 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { type Recipient as RecipientType } from '../../../hooks/send/useRecipients';
 import { shortenAddress } from '../../../../../helpers/utils/util';
+import { accountTypeLabel } from '../../../constants/network';
+import { AccountTypeLabel } from '../account-type-label';
 
 export const Recipient = ({
   isAccount,
@@ -28,6 +32,8 @@ export const Recipient = ({
   const recipientName = isAccount
     ? recipient.accountGroupName
     : recipient.contactName;
+  const typeLabel =
+    accountTypeLabel[recipient.accountType as KeyringAccountType];
 
   return (
     <Box
@@ -54,12 +60,20 @@ export const Recipient = ({
       />
       <Box>
         <Text variant={TextVariant.bodyMdMedium}>{recipientName}</Text>
-        <Text
-          variant={TextVariant.bodySmMedium}
-          color={TextColor.textAlternative}
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Row}
+          alignItems={AlignItems.center}
         >
-          {shortenAddress(address)}
-        </Text>
+          <Text
+            variant={TextVariant.bodySmMedium}
+            color={TextColor.textAlternative}
+            marginRight={2}
+          >
+            {shortenAddress(address)}
+          </Text>
+          <AccountTypeLabel label={typeLabel} />
+        </Box>
       </Box>
     </Box>
   );

--- a/ui/pages/confirmations/constants/network.ts
+++ b/ui/pages/confirmations/constants/network.ts
@@ -1,0 +1,10 @@
+import { BtcAccountType, KeyringAccountType } from '@metamask/keyring-api';
+
+// This map is used to display the account type label next to the token / account name
+// Add more account type here to support labels in case we need them for other networks
+export const accountTypeLabel: Partial<Record<KeyringAccountType, string>> = {
+  [BtcAccountType.P2pkh]: 'Legacy',
+  [BtcAccountType.P2sh]: 'Nested SegWit',
+  [BtcAccountType.P2wpkh]: 'Native SegWit',
+  [BtcAccountType.P2tr]: 'Taproot',
+};

--- a/ui/pages/confirmations/hooks/send/useAccountRecipients.test.ts
+++ b/ui/pages/confirmations/hooks/send/useAccountRecipients.test.ts
@@ -1,3 +1,6 @@
+import { BtcAccountType } from '@metamask/keyring-api';
+
+import { cloneDeep } from 'lodash';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers';
 import mockState from '../../../../../test/data/mock-state.json';
 import { ConsolidatedWallets } from '../../../../selectors/multichain-accounts/account-tree.types';
@@ -141,6 +144,20 @@ describe('useAccountRecipients', () => {
       isSolanaSendType: false,
       isBitcoinSendType: true,
     } as unknown as ReturnType<typeof useSendType>);
+    const accountsWithAccountType = cloneDeep(mockWalletsWithAccounts);
+    (
+      accountsWithAccountType.wallet1.groups.group1.accounts[0] as {
+        address: string;
+        type: BtcAccountType;
+      }
+    ).type = BtcAccountType.P2wpkh;
+    (
+      accountsWithAccountType.wallet1.groups.group1.accounts[1] as {
+        address: string;
+        type: BtcAccountType;
+      }
+    ).type = BtcAccountType.P2sh;
+    mockGetWalletsWithAccounts.mockReturnValue(accountsWithAccountType);
     mockIsEVMAccountForSend.mockReturnValue(false);
     mockIsSolanaAccountForSend.mockReturnValue(false);
     mockIsBitcoinAccountForSend.mockReturnValue(true);
@@ -153,11 +170,13 @@ describe('useAccountRecipients', () => {
     expect(result.current).toEqual([
       {
         accountGroupName: 'Account Group 1',
+        accountType: BtcAccountType.P2wpkh,
         address: '0x1234567890abcdef1234567890abcdef12345678',
         walletName: 'MetaMask Wallet',
       },
       {
         accountGroupName: 'Account Group 1',
+        accountType: BtcAccountType.P2sh,
         address: '0xabcdef1234567890abcdef1234567890abcdef12',
         walletName: 'MetaMask Wallet',
       },

--- a/ui/pages/confirmations/hooks/send/useAccountRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useAccountRecipients.ts
@@ -39,6 +39,7 @@ export const useAccountRecipients = (): Recipient[] => {
           if (shouldInclude) {
             recipients.push({
               accountGroupName,
+              accountType: account.type,
               address: account.address,
               walletName,
             });

--- a/ui/pages/confirmations/hooks/send/useRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipients.ts
@@ -1,8 +1,10 @@
+import { KeyringAccountType } from '@metamask/keyring-api';
 import { useContactRecipients } from './useContactRecipients';
 import { useAccountRecipients } from './useAccountRecipients';
 
 export type Recipient = {
   accountGroupName?: string;
+  accountType?: KeyringAccountType;
   address: string;
   contactName?: string;
   isContact?: boolean;

--- a/ui/pages/confirmations/types/send.ts
+++ b/ui/pages/confirmations/types/send.ts
@@ -1,3 +1,4 @@
+import { KeyringAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
 
 export enum AssetStandard {
@@ -12,6 +13,7 @@ export const NFT_STANDARDS = [AssetStandard.ERC721, AssetStandard.ERC1155];
 export type Asset = {
   accountAddress?: string;
   accountId?: string;
+  accountType?: KeyringAccountType;
   address?: string;
   assetId?: string;
   balance?: string | number | undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add BTC labels to the send flow asset and accounts.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36761?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5965

## **Manual testing steps**

1. Have btc in your account
2. Click send from wallet view
3. See BTC asset have type - select it
4. Click recipient selection modal
5. See BTC type next to recipient address

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="413" height="611" alt="Screenshot 2025-10-10 at 13 13 23" src="https://github.com/user-attachments/assets/7eadfaf6-e743-4cbf-bffa-3714fb499e33" />

<img width="417" height="624" alt="Screenshot 2025-10-10 at 13 13 33" src="https://github.com/user-attachments/assets/80b5d9b6-c645-488b-b64e-812498d3dda9" />


### **After**

<img width="416" height="623" alt="Screenshot 2025-10-10 at 13 08 29" src="https://github.com/user-attachments/assets/6120ba35-9926-47f3-8c4f-5e7a5e227c1a" />

<img width="414" height="620" alt="Screenshot 2025-10-10 at 13 08 36" src="https://github.com/user-attachments/assets/eb2d586c-ea4b-4454-af8a-850579a97fbd" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Bitcoin account type labels (Legacy, Nested SegWit, Native SegWit, Taproot) to asset and recipient UI, with supporting types, hooks, and tests.
> 
> - **UI**:
>   - **Account type labels**: Display BTC account type next to token name in `UI/asset/asset.tsx` and next to address in `UI/recipient/recipient.tsx` via `AccountTypeLabel`.
>   - **New component**: `UI/account-type-label/account-type-label.tsx` with tests.
> - **Constants**:
>   - `constants/network.ts`: `accountTypeLabel` map for `KeyringAccountType` (BTC variants).
> - **Types/Data**:
>   - `types/send.ts`: `Asset` now includes `accountType`.
>   - `hooks/send/useRecipients.ts`: `Recipient` now includes `accountType`.
>   - `hooks/send/useAccountRecipients.ts`: passes through `account.type` to recipients.
> - **Tests**:
>   - Add/expand tests in `asset.test.tsx`, `recipient.test.tsx`, `useAccountRecipients.test.ts` for label rendering and BTC account types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d09e2de398345e5ec1a890c7a83fafa243d94618. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->