### PR TITLE
fix: Remove flask code fences for the snap accounts link

### DIFF
--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -1,9 +1,4 @@
-import React, {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-  useCallback,
-  useContext,
-  ///: END:ONLY_INCLUDE_IF
-} from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Box,
@@ -42,20 +37,20 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   getIsAddSnapAccountEnabled,
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   getIsWatchEthereumAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
   getManageInstitutionalWallets,
 } from '../../../selectors';
 import { INSTITUTIONAL_WALLET_SNAP_ID } from '../../../../shared/lib/accounts';
-///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import {
   ACCOUNT_WATCHER_NAME,
   ACCOUNT_WATCHER_SNAP_ID,
@@ -88,9 +83,9 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
   const institutionalWalletsEnabled = useSelector(
     getManageInstitutionalWallets,
   );
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const trackEvent = useContext(MetaMetricsContext);
   const addSnapAccountEnabled = useSelector(getIsAddSnapAccountEnabled);
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const isAddWatchEthereumAccountEnabled = useSelector(
     getIsWatchEthereumAccountEnabled,
   );
@@ -144,7 +139,6 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
     }
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const handleSnapAccountLinkClick = useCallback(() => {
     trackEvent({
       category: MetaMetricsEventCategory.Navigation,
@@ -163,7 +157,6 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
       url: process.env.ACCOUNT_SNAPS_DIRECTORY_URL as string,
     });
   }, [trackEvent]);
-  ///: END:ONLY_INCLUDE_IF
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   const handleAddWatchAccount = useCallback(async () => {
@@ -238,46 +231,42 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
               <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
             </Box>
           ))}
-          {
-            ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
-            addSnapAccountEnabled && (
-              <Box
-                key="snap-account"
-                onClick={() => handleSnapAccountLinkClick()}
-                onKeyDown={(e: React.KeyboardEvent) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleSnapAccountLinkClick();
-                  }
-                }}
-                alignItems={BoxAlignItems.Center}
-                padding={4}
-                gap={3}
-                backgroundColor={BoxBackgroundColor.BackgroundDefault}
-                flexDirection={BoxFlexDirection.Row}
-                borderColor={BoxBorderColor.BorderMuted}
-                className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
-                tabIndex={0}
-                data-testid={`add-wallet-modal-snap-account`}
+          {addSnapAccountEnabled && (
+            <Box
+              key="snap-account"
+              onClick={() => handleSnapAccountLinkClick()}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleSnapAccountLinkClick();
+                }
+              }}
+              alignItems={BoxAlignItems.Center}
+              padding={4}
+              gap={3}
+              backgroundColor={BoxBackgroundColor.BackgroundDefault}
+              flexDirection={BoxFlexDirection.Row}
+              borderColor={BoxBorderColor.BorderMuted}
+              className="hover:bg-background-default-hover cursor-pointer transition-all duration-200 w-full text-left outline-none focus:outline-none focus:shadow-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-default)]"
+              tabIndex={0}
+              data-testid={`add-wallet-modal-snap-account`}
+            >
+              <Icon
+                name={IconName.Snaps}
+                size={IconSize.Md}
+                color={IconColor.IconAlternative}
+              />
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+                className="flex-1"
               >
-                <Icon
-                  name={IconName.Snaps}
-                  size={IconSize.Md}
-                  color={IconColor.IconAlternative}
-                />
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
-                  className="flex-1"
-                >
-                  {t('settingAddSnapAccount')}
-                </Text>
-                <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
-              </Box>
-            )
-            ///: END:ONLY_INCLUDE_IF
-          }
+                {t('settingAddSnapAccount')}
+              </Text>
+              <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
+            </Box>
+          )}
           {
             ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
             isAddWatchEthereumAccountEnabled && (


### PR DESCRIPTION
## **Description**
This PR removes flask code fences for Snap accounts link located in "Add wallet" modal. This way we enable the Snap accounts link to the main production version of extension.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36770?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add changes to enable Snap accounts link to stable

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Open extension
2. Go to account list
3. Click on the "Add wallet" button located in footer.
4. Make sure that modal opens and option called "Add account Snap" is visible.
5. Make sure that option link to the proper web page.

## **Screenshots/Recordings**
### **Before**
Stable (`main`):
<img width="403" height="601" alt="Screenshot 2025-10-10 at 14 48 36" src="https://github.com/user-attachments/assets/a5a7c7c5-0669-4ed3-96ae-1fa4e2dd22c6" />

Flask:
<img width="403" height="601" alt="Screenshot 2025-10-10 at 14 51 58" src="https://github.com/user-attachments/assets/0bd9647e-de8f-475f-b033-982514987841" />

### **After**
Stable (`main`):
<img width="403" height="601" alt="Screenshot 2025-10-10 at 14 33 11" src="https://github.com/user-attachments/assets/c2c15963-5979-4f1a-b98f-b1165ea0ad84" />

Flask:
<img width="403" height="601" alt="Screenshot 2025-10-10 at 14 42 53" src="https://github.com/user-attachments/assets/650a681b-43bf-4664-be6a-98c023ee3ec1" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Flask-only guards to show the Snap accounts link in Add Wallet modal in stable, while keeping the watch-only Ethereum account behind Flask.
> 
> - **UI (Add Wallet Modal `ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx`)**:
>   - Exposes Snap accounts link to all builds by removing `build-flask` fences around `useCallback`/`useContext`, `getIsAddSnapAccountEnabled`, event tracking, and the Snap link UI block (still feature-flagged by `addSnapAccountEnabled`).
>   - Keeps the Watch Ethereum Account option and related selector/handlers behind `build-flask` fences.
>   - Minor JSX cleanup and import consolidation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62affb80d66246fc7b75e002cf4d9dbecfd327c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->