### PR TITLE
fix: cp-13.5.0 filter activity tab correctly

### DIFF
--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -20,7 +20,6 @@ import {
   getCurrentNetwork,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
-  getEnabledNetworksByNamespace,
   getSelectedMultichainNetworkChainId,
   getEnabledNetworks,
 } from '../../../selectors';
@@ -39,6 +38,7 @@ import { SWAPS_CHAINID_CONTRACT_ADDRESS_MAP } from '../../../../shared/constants
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import {
   getIsEvmMultichainNetworkSelected,
+  getAllEnabledNetworksForAllNamespaces,
   ///: BEGIN:ONLY_INCLUDE_IF(multichain)
   getSelectedMultichainNetworkConfiguration,
   ///: END:ONLY_INCLUDE_IF
@@ -452,25 +452,22 @@ export default function UnifiedTransactionList({
 
   const isEvmNetwork = useSelector(getIsEvmMultichainNetworkSelected);
 
-  const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
+  const enabledNetworksForAllNamespaces = useSelector(
+    getAllEnabledNetworksForAllNamespaces,
+  );
   const currentMultichainChainId = useSelector(
     getSelectedMultichainNetworkChainId,
   );
 
   const enabledNetworksFilteredCompletedTransactions = useMemo(() => {
-    if (!enabledNetworksByNamespace || !currentMultichainChainId) {
+    if (!currentMultichainChainId) {
       return unfilteredCompletedTransactionsAllChains;
     }
 
     // If no networks are enabled for this namespace, return empty array
-    if (Object.keys(enabledNetworksByNamespace).length === 0) {
+    if (enabledNetworksForAllNamespaces.length === 0) {
       return [];
     }
-
-    // Get the list of enabled chain IDs for this namespace
-    const enabledChainIds = Object.keys(enabledNetworksByNamespace).filter(
-      (enabledChainId) => enabledNetworksByNamespace[enabledChainId],
-    );
 
     const transactionsToFilter = unfilteredCompletedTransactionsAllChains;
 
@@ -478,17 +475,24 @@ export default function UnifiedTransactionList({
     const filteredTransactions = transactionsToFilter.filter(
       (transactionGroup) => {
         const transactionChainId = transactionGroup.initialTransaction?.chainId;
-        const isIncluded = enabledChainIds.includes(transactionChainId);
+        const isIncluded =
+          enabledNetworksForAllNamespaces.includes(transactionChainId);
         return isIncluded;
       },
     );
 
     return filteredTransactions;
   }, [
-    enabledNetworksByNamespace,
+    enabledNetworksForAllNamespaces,
     currentMultichainChainId,
     unfilteredCompletedTransactionsAllChains,
   ]);
+
+  const enabledNonEvmChainIds = useMemo(() => {
+    return nonEvmChainIds.filter((chainId) =>
+      enabledNetworksForAllNamespaces.includes(chainId),
+    );
+  }, [nonEvmChainIds, enabledNetworksForAllNamespaces]);
 
   const unifiedActivityItems = useMemo(() => {
     return buildUnifiedActivityItems(
@@ -499,7 +503,7 @@ export default function UnifiedTransactionList({
         hideTokenTransactions,
         tokenAddress,
         evmChainIds,
-        nonEvmChainIds,
+        nonEvmChainIds: enabledNonEvmChainIds,
       },
     );
   }, [
@@ -509,6 +513,7 @@ export default function UnifiedTransactionList({
     hideTokenTransactions,
     tokenAddress,
     evmChainIds,
+    enabledNonEvmChainIds,
   ]);
   const groupedUnifiedActivityItems =
     groupAnyTransactionsByDate(unifiedActivityItems);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Filters non-evm activity correctly.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36773?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug in which any network selected showed Solana activity

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36660

## **Manual testing steps**

1. Use an SRP with Solana and evm activity
2. Go to Activity tab and select any network other than Solana
3. Solana should not be visible

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="703" height="881" alt="image" src="https://github.com/user-attachments/assets/1690ff28-5965-4636-ac23-74922f77de55" />


### **After**

<!-- [screenshots/recordings] -->
<img width="717" height="824" alt="image" src="https://github.com/user-attachments/assets/550a82ae-1fd1-42fb-8ee2-174552c01d2c" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update activity filtering to use a unified enabled networks list and limit non‑EVM activity to enabled chains.
> 
> - **Activity Filtering**
>   - Replace `getEnabledNetworksByNamespace` with `getAllEnabledNetworksForAllNamespaces` and use a flat list of enabled chain IDs across namespaces.
>   - Filter completed EVM transactions by `enabledNetworksForAllNamespaces` (returns all if no `currentMultichainChainId`, empty if none enabled).
>   - Compute `enabledNonEvmChainIds` by intersecting `nonEvmChainIds` with enabled networks; pass to `buildUnifiedActivityItems` to restrict non‑EVM activity.
> - **Imports/Selectors**
>   - Add `getAllEnabledNetworksForAllNamespaces` import; remove usage of `getEnabledNetworksByNamespace`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ef734f54fca30575abdde3f57f8e9264b5e147c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->