### PR TITLE
fix: shield coverage text style

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -147,17 +147,29 @@ export function useShieldCoverageAlert(): Alert[] {
       return [];
     }
 
+    let severity = Severity.Info;
+    let inlineAlertText = t('shieldNotCovered');
+    switch (status) {
+      case 'covered':
+        severity = Severity.Success;
+        inlineAlertText = t('shieldCovered');
+        break;
+      case 'malicious':
+        severity = Severity.Danger;
+        break;
+      default:
+        break;
+    }
+
     return [
       {
         key: 'shieldCoverageAlert',
         reason: t('shieldCoverageAlertMessageTitle'),
         field: RowAlertKey.ShieldFooterCoverageIndicator,
-        severity: status === 'covered' ? Severity.Success : Severity.Info,
+        severity,
         content: ShieldCoverageAlertMessage(modalBodyStr),
         isBlocking: false,
-        inlineAlertText: t(
-          status === 'covered' ? 'shieldCovered' : 'shieldNotCovered',
-        ),
+        inlineAlertText,
         showArrow: false,
         isOpenModalOnClick: status !== 'covered',
       },

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -158,7 +158,6 @@ export function useShieldCoverageAlert(): Alert[] {
         severity = Severity.Danger;
         break;
       default:
-        break;
     }
 
     return [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Correct shield transaction coverage text style for malicious case

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36810?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: correct transaction shield coverage text style

## **Related issues**

Fixes:

## **Manual testing steps**

1. Subscribe to shield
2. Test a malcious transaction
3. Transaction confirm screen should show `not covered` in red alert

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust shield coverage alert to show Danger severity for malicious status and set inline text per status.
> 
> - **UI — Confirmations Alerts**:
>   - Update `ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts`:
>     - Use a `switch` on `status` to set `severity` to `Success` (covered), `Danger` (malicious), or `Info` (default).
>     - Derive `inlineAlertText` separately: `shieldCovered` for covered, `shieldNotCovered` otherwise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e3b728c00593e90d2b8f47c3d622132ee89e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->