### PR TITLE
fix: Properly resolve ENS content hashes

### DIFF
--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -41,8 +41,7 @@ export default async function resolveEnsToIpfsContentId({ provider, name }) {
   const isLegacyResolver =
     await resolverContract.supportsInterface('0xd8389dc5');
   if (isEIP1577Compliant) {
-    const contentLookupResult = await resolverContract.contenthash(hash);
-    const rawContentHash = contentLookupResult[0];
+    const rawContentHash = await resolverContract.contenthash(hash);
     let decodedContentHash = contentHash.decode(rawContentHash);
     const type = contentHash.getCodec(rawContentHash);
 
@@ -55,8 +54,7 @@ export default async function resolveEnsToIpfsContentId({ provider, name }) {
   }
   if (isLegacyResolver) {
     // lookup content id
-    const contentLookupResult = await resolverContract.content(hash);
-    const content = contentLookupResult[0];
+    const content = await resolverContract.content(hash);
     if (hexValueIsEmpty(content)) {
       throw new Error(
         `EnsIpfsResolver - no content ID found for name "${name}"`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a bug that was introduced when replacing `ethjs` with `ethers`. Since this file doesn't have any type information it was missed that the return type had changed, this effectively broke the ENS IPFS content hash resolver feature.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36812?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug that caused ENS content hashes not to resolve properly

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/33500

## **Manual testing steps**

1. Make sure MetaMask Extension is running and the network is set to Ethereum mainnet
2. Type https://vitalik.eth/ into browser address bar and hit enter
3. Wait for the domain to resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch to using direct return values from resolver `contenthash` and `content` calls instead of indexing into array results, fixing ENS IPFS resolution.
> 
> - **ENS-IPFS Resolver (`app/scripts/lib/ens-ipfs/resolver.js`)**:
>   - Read `resolverContract.contenthash(hash)` and `resolverContract.content(hash)` return values directly (remove `[0]` indexing) to match ethers return types.
>   - Preserves decoding and codec handling; error handling unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d3af91b08eac27b77abdb74c3047d36ecb1631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->