### PR TITLE
fix: Adjust Sentry release name for proper semantic versioning

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -5,9 +5,9 @@ import browser from 'webextension-polyfill';
 import { sentryLogger as log } from '../../../shared/lib/sentry';
 import { isManifestV3 } from '../../../shared/modules/mv3.utils';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
+import { getSentryRelease } from '../../../shared/lib/sentry-release';
 import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 import { filterEvents } from './sentry-filter-events';
-import { getSentryRelease } from '../../../shared/lib/sentry-release';
 
 let installType = 'unknown';
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -7,6 +7,7 @@ import { isManifestV3 } from '../../../shared/modules/mv3.utils';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
 import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 import { filterEvents } from './sentry-filter-events';
+import { getSentryRelease } from '../../../shared/lib/sentry-release';
 
 let installType = 'unknown';
 
@@ -571,12 +572,4 @@ function getEventType(event) {
   }
 
   return 'Event';
-}
-
-export function getSentryRelease(environment, version) {
-  const packageName =
-    environment === 'production'
-      ? 'metamask-extension'
-      : `metamask-extension-${environment}`;
-  return `${packageName}@${version}`;
 }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -577,6 +577,6 @@ export function getSentryRelease(environment, version) {
   const packageName =
     environment === 'production'
       ? 'metamask-extension'
-      : 'metamask-extension-test';
+      : `metamask-extension-${environment}`;
   return `${packageName}@${version}`;
 }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -17,7 +17,10 @@ const internalLog = createModuleLogger(log, 'internal');
 const METAMASK_BUILD_TYPE = process.env.METAMASK_BUILD_TYPE;
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG;
 const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT;
-const RELEASE = process.env.METAMASK_VERSION;
+const RELEASE = getSentryRelease(
+  METAMASK_ENVIRONMENT,
+  process.env.METAMASK_VERSION,
+);
 const SENTRY_DSN = process.env.SENTRY_DSN;
 const SENTRY_DSN_DEV = process.env.SENTRY_DSN_DEV;
 /* eslint-enable prefer-destructuring */
@@ -568,4 +571,12 @@ function getEventType(event) {
   }
 
   return 'Event';
+}
+
+export function getSentryRelease(environment, version) {
+  const packageName =
+    environment === 'production'
+      ? 'metamask-extension'
+      : 'metamask-extension-test';
+  return `${packageName}@${version}`;
 }

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 
-const { getSentryRelease } = require('../app/scripts/lib/setupSentry');
+const { getSentryRelease } = require('../shared/lib/sentry-release');
 const { runCommand, runInShell } = require('./lib/run-command');
 const { getVersion } = require('./lib/get-version');
 const { loadBuildTypesConfig } = require('./lib/build-type');

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -74,14 +74,15 @@ async function start() {
   } else {
     // create sentry release
     console.log(`creating Sentry release for "${version}"...`);
-    await runCommand('sentry-cli', ['releases', 'new', version]);
+    const release = `metamask-extension@${version}`;
+    await runCommand('sentry-cli', ['releases', 'new', release]);
     console.log(
       `removing any existing files from Sentry release "${version}"...`,
     );
     await runCommand('sentry-cli', [
       'releases',
       'files',
-      version,
+      release,
       'delete',
       '--all',
     ]);
@@ -97,7 +98,7 @@ async function start() {
   // upload sentry source and sourcemaps
   await runInShell('./development/sentry-upload-artifacts.sh', [
     '--release',
-    version,
+    release,
     ...additionalUploadArgs,
   ]);
 }

--- a/shared/lib/sentry-release.js
+++ b/shared/lib/sentry-release.js
@@ -1,9 +1,8 @@
 /**
- *
- *
- * @param {string} environment
- * @param {string} version
- * @returns
+ * Get the Sentry release string from the current build environment and version.
+ * @param {string} environment - The build environment, preferably `METAMASK_ENVIRONMENT`.
+ * @param {string} version - The SemVer version string.
+ * @returns A combined string that fits the Sentry release name conventions.
  */
 export function getSentryRelease(environment, version) {
   const packageName =

--- a/shared/lib/sentry-release.js
+++ b/shared/lib/sentry-release.js
@@ -1,0 +1,14 @@
+/**
+ *
+ *
+ * @param {string} environment
+ * @param {string} version
+ * @returns
+ */
+export function getSentryRelease(environment, version) {
+  const packageName =
+    environment === 'production'
+      ? 'metamask-extension'
+      : `metamask-extension-${environment}`;
+  return `${packageName}@${version}`;
+}

--- a/shared/lib/sentry-release.js
+++ b/shared/lib/sentry-release.js
@@ -1,5 +1,6 @@
 /**
  * Get the Sentry release string from the current build environment and version.
+ *
  * @param {string} environment - The build environment, preferably `METAMASK_ENVIRONMENT`.
  * @param {string} version - The SemVer version string.
  * @returns A combined string that fits the Sentry release name conventions.

--- a/shared/lib/sentry-release.js
+++ b/shared/lib/sentry-release.js
@@ -9,6 +9,6 @@ export function getSentryRelease(environment, version) {
   const packageName =
     environment === 'production'
       ? 'metamask-extension'
-      : `metamask-extension-${environment}`;
+      : `metamask-extension-test`;
   return `${packageName}@${version}`;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use `metamask-extension@version` as the name for the Sentry release. This lets Sentry use semantic versioning for comparing release versions.

https://sentry.zendesk.com/hc/en-us/articles/39401527753499-Why-are-my-releases-not-marked-as-semver-semantic-versioning

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36816?quickstart=1)

I have verified locally that this creates releases that Sentry consider valid SemVer and still uploads source maps correctly:
<img width="393" height="301" alt="Screenshot 2025-10-14 at 13 35 54" src="https://github.com/user-attachments/assets/dec02d45-5053-4580-9784-8ddf583376a0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts package-based Sentry release names via a shared helper and updates setup and publish scripts to use the computed release instead of raw version.
> 
> - **Sentry release naming**:
>   - Add `shared/lib/sentry-release.js` with `getSentryRelease(environment, version)` returning `metamask-extension[@version]` or `metamask-extension-test[@version]`.
>   - Update `app/scripts/lib/setupSentry.js` to compute `release` via `getSentryRelease(...)` instead of using `METAMASK_VERSION` directly.
>   - Update `development/sentry-publish.js`:
>     - Compute `release` from version and use it for release creation, file cleanup, and artifact upload (`--release`).
>     - Replace version-centric checks with `checkIfReleaseExists` and associated messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48d4b22fe0625f1b2562d59a699c147b3eab69de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->