### PR TITLE
fix: flaky test ` Multichain API Call `wallet_createSession` With requested EVM scope...` issue with fill

### DIFF
--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -22,7 +22,7 @@ import {
   type FixtureCallbackArgs,
 } from '../testHelpers';
 
-describe('Multichain API TEST', function () {
+describe('Multichain API', function () {
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks', function () {
     it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
       await withFixtures(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -22,7 +22,7 @@ import {
   type FixtureCallbackArgs,
 } from '../testHelpers';
 
-describe('Multichain API', function () {
+describe('Multichain API TEST', function () {
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks', function () {
     it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
       await withFixtures(

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -103,7 +103,7 @@ class TestDappMultichain {
   }
 
   async fillExtensionIdInput(extensionId: string) {
-    await this.driver.fill(this.extensionIdInput, extensionId, 3);
+    await this.driver.fill(this.extensionIdInput, extensionId, { retries: 3 });
   }
 
   /**

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -103,7 +103,7 @@ class TestDappMultichain {
   }
 
   async fillExtensionIdInput(extensionId: string) {
-    await this.driver.fill(this.extensionIdInput, extensionId);
+    await this.driver.fill(this.extensionIdInput, extensionId, 3);
   }
 
   /**

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -1,7 +1,7 @@
 import { Browser } from 'selenium-webdriver';
 import { NormalizedScopeObject } from '@metamask/chain-agnostic-permission';
 import { Json } from '@metamask/utils';
-import { largeDelayMs, WINDOW_TITLES } from '../../helpers';
+import { largeDelayMs, veryLargeDelayMs, WINDOW_TITLES } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import { replaceColon } from '../../flask/multichain-api/testHelpers';
 
@@ -134,7 +134,7 @@ class TestDappMultichain {
         : extensionId,
     );
     await this.clickConnectExternallyConnectableButton();
-    await this.driver.delay(largeDelayMs);
+    await this.driver.delay(veryLargeDelayMs);
   }
 
   /**

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -283,16 +283,17 @@ class Driver {
    * This method is particularly useful for automating interactions with text fields,
    * such as username or password inputs, search boxes, or any editable text areas.
    *
-   * @param {string | object} rawLocator - element locator
-   * @param {string} input - The value to fill the element with.
-   * @param {number} retries - Number of retries, defaults to 0.
+   * @param {string | object} rawLocator - Element locator
+   * @param {string} input - The value to fill the element with
+   * @param {object} [options] - Optional configuration
+   * @param {number} [options.retries] - Number of attempts, Defaults to 0
    * @returns {Promise<WebElement>} Promise resolving to the filled element
    * @example <caption>Example to fill address in the send transaction screen</caption>
    *          await driver.fill(
    *                'input[data-testid="ens-input"]',
    *                '0xc427D562164062a23a5cFf596A4a3208e72Acd28');
    */
-  async fill(rawLocator, input, retries = 0) {
+  async fill(rawLocator, input, { retries = 0 } = {}) {
     const element = await this.findElement(rawLocator);
 
     // No verification/retry path (default behavior)

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -285,7 +285,7 @@ class Driver {
    *
    * @param {string | object} rawLocator - element locator
    * @param {string} input - The value to fill the element with.
-  * @param {number} [retries=0] - Number of retries; 0 performs no verification.
+   * @param {number} retries - Number of retries, defaults to 0.
    * @returns {Promise<WebElement>} Promise resolving to the filled element
    * @example <caption>Example to fill address in the send transaction screen</caption>
    *          await driver.fill(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The fill method is flaky as in this spec we can see how the extension id was sent twice, making the spec fail as the dapp fails with `Error connecting: TypeError: Error in invocation of runtime.connect(optional string extensionId, optional object connectInfo): Invalid extension id: 'hebhblbkkdabgoldnojllkipeoacjiochebhblbkkdabgoldn` 

<img width="3128" height="1468" alt="image" src="https://github.com/user-attachments/assets/1d6f941a-54b0-4df9-9376-f836b33b0174" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36818?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a retry/verification option to `driver.fill` and uses it in the multichain dapp page, plus increases the connect delay to reduce flakiness.
> 
> - **E2E Driver** (`test/e2e/webdriver/driver.js`):
>   - Enhance `fill(rawLocator, input, { retries })` to support optional retries with value verification via `getAttribute('value')` and `waitUntil`; throws if not set after attempts. Updates JSDoc accordingly.
> - **Multichain Test Dapp Page** (`test/e2e/page-objects/pages/test-dapp-multichain.ts`):
>   - Use `driver.fill(..., { retries: 3 })` for `extensionId` input.
>   - Increase post-connect wait from `largeDelayMs` to `veryLargeDelayMs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1022e62bf5d10a8b0c330e3169224735e9bdb962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->