### PR TITLE
fix: show Solana destination assets when swapping cp-13.5.0

### DIFF
--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -113,6 +113,7 @@ type FilterPredicate = (
  * - all other tokens
  *
  * @param chainId - the selected src/dest chainId
+ * @param selectedToken - the selected token to show at the top of the token list
  * @param tokenToExclude - a token to exclude from the token list, usually the token being swapped from
  * @param tokenToExclude.symbol
  * @param tokenToExclude.address
@@ -121,6 +122,7 @@ type FilterPredicate = (
  */
 export const useTokensWithFiltering = (
   chainId?: ChainId | Hex | CaipChainId,
+  selectedToken?: BridgeToken,
   tokenToExclude?: null | Pick<BridgeToken, 'symbol' | 'address' | 'chainId'>,
   accountAddress?: string,
 ) => {
@@ -255,6 +257,25 @@ export const useTokensWithFiltering = (
           return;
         }
 
+        // Yield selected token first if it's defined
+        if (selectedToken) {
+          const token = buildTokenData(
+            chainId,
+            tokenList[selectedToken.address] ?? {
+              symbol: selectedToken.symbol,
+              address: selectedToken.address,
+              decimals: selectedToken.decimals,
+              iconUrl: selectedToken.image,
+              name: selectedToken.symbol,
+              occurrences: selectedToken.occurrences ?? 1,
+              aggregators: selectedToken.aggregators ?? [],
+            },
+          );
+          if (token) {
+            yield token;
+          }
+        }
+
         // Yield multichain tokens with balances and are not blocked
         for (const token of multichainTokensWithBalance) {
           if (
@@ -353,6 +374,7 @@ export const useTokensWithFiltering = (
       chainId,
       tokenList,
       tokenToExclude,
+      selectedToken,
     ],
   );
   return {

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -274,6 +274,7 @@ const PrepareBridgePage = ({
     isLoading: isToTokensLoading,
   } = useTokensWithFiltering(
     toChain?.chainId ?? fromChain?.chainId,
+    toToken,
     fromChain?.chainId === toChain?.chainId && fromToken && fromChain
       ? (() => {
           // Determine the address format based on chain type
@@ -661,7 +662,9 @@ const PrepareBridgePage = ({
 
                 setRotateSwitchTokens(!rotateSwitchTokens);
 
-                if (!isSwap) {
+                if (isSwap) {
+                  dispatch(setFromToken(toToken));
+                } else {
                   // Handle account switching for Solana
                   dispatch(
                     setFromChain({
@@ -705,13 +708,7 @@ const PrepareBridgePage = ({
               },
               header: t('yourNetworks'),
             }}
-            customTokenListGenerator={
-              toChain &&
-              fromChain &&
-              isCrossChain(fromChain.chainId, toChain.chainId)
-                ? toTokenListGenerator
-                : undefined
-            }
+            customTokenListGenerator={toTokenListGenerator}
             amountInFiat={
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -20,7 +20,6 @@ import {
   isNativeAddress,
   UnifiedSwapBridgeEventName,
   type BridgeController,
-  isCrossChain,
 } from '@metamask/bridge-controller';
 import { Hex, parseCaipChainId } from '@metamask/utils';
 import {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:** The Solana tokens are not visible in the dest asset list unless the active account has a balance

**Solution:** Always use the custom token list for the dest asset picker because the AssetPicker component does not fetch Solana tokens

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36830?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: `fix: use custom token list generator when solana is selected as the destination swap network`

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36828, https://github.com/MetaMask/metamask-extension/issues/36772

## **Manual testing steps**

1. Load Swap page
2. Select SOL as src
3. Open dest token picker
4. Verify that all tokens are visible (not just the ones with balances)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="419" height="611" alt="Screenshot 2025-10-13 at 4 24 02 PM" src="https://github.com/user-attachments/assets/7be596af-1e09-4e11-941c-9bd6b5e56b0e" />


### **After**

<img width="411" height="611" alt="Screenshot 2025-10-13 at 4 16 18 PM" src="https://github.com/user-attachments/assets/cb3559c3-950e-4d65-b825-71e2102f9402" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always use the custom destination token list (showing Solana assets), prioritize the currently selected token at the top, and adjust switch behavior during swaps.
> 
> - **Bridge Hooks**:
>   - `useTokensWithFiltering`:
>     - Adds `selectedToken` param and yields it first if present.
>     - Builds fallback token data when missing from `tokenList`; updates memo deps.
> - **Prepare Bridge Page** (`ui/pages/bridge/prepare/prepare-bridge-page.tsx`):
>   - Always pass `toToken` to `useTokensWithFiltering` and always set `customTokenListGenerator` to `toTokenListGenerator` (removes `isCrossChain` gating) to ensure destination tokens (e.g., Solana) are shown.
>   - Switch handler: when `isSwap`, `setFromToken(toToken)`; else keep account/chain switch logic.
>   - Removes `isCrossChain` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76714d53fd90bdb3a757ba284baa54ac57476a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->