### PR TITLE
fix: cp-13.5.0 Send functionality related fixes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3696,6 +3696,9 @@
   "nameProvider_token": {
     "message": "MetaMask"
   },
+  "nameResolutionFailedError": {
+    "message": "No address resolution found for this name."
+  },
   "nameSetPlaceholder": {
     "message": "Choose a nickname...",
     "description": "Placeholder text for name input field in name component modal."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3696,6 +3696,9 @@
   "nameProvider_token": {
     "message": "MetaMask"
   },
+  "nameResolutionFailedError": {
+    "message": "No address resolution found for this name."
+  },
   "nameSetPlaceholder": {
     "message": "Choose a nickname...",
     "description": "Placeholder text for name input field in name component modal."

--- a/ui/pages/confirmations/components/send/amount/amount.test.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.test.tsx
@@ -62,7 +62,8 @@ describe('Amount', () => {
     } as unknown as SendContext.SendContextType);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -86,7 +87,8 @@ describe('Amount', () => {
     } as unknown as SendContext.SendContextType);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -110,7 +112,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -121,6 +124,7 @@ describe('Amount', () => {
     expect(getByText('$ 20.00')).toBeInTheDocument();
     fireEvent.click(getByTestId('toggle-fiat-mode'));
     expect(getByRole('textbox')).toHaveValue('20');
+    expect(getByText('USD')).toBeInTheDocument();
     fireEvent.change(getByRole('textbox'), { target: { value: 100 } });
     expect(getByText('0 NEU')).toBeInTheDocument();
   });
@@ -136,7 +140,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -172,7 +177,8 @@ describe('Amount', () => {
     } as unknown as SendContext.SendContextType);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -191,7 +197,8 @@ describe('Amount', () => {
     } as unknown as SendContext.SendContextType);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -252,7 +259,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -272,7 +280,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: false,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -292,7 +301,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: false,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -315,7 +325,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',
@@ -336,7 +347,8 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof BalanceFunctions.useBalance>);
     jest.spyOn(CurrencyConversions, 'useCurrencyConversions').mockReturnValue({
       conversionSupportedForAsset: true,
-      fiatCurrencySymbol: 'USD',
+      fiatCurrencySymbol: '$',
+      fiatCurrencyName: 'usd',
       getFiatValue: () => '20',
       getFiatDisplayValue: () => '$ 20.00',
       getNativeValue: () => '20',

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -45,6 +45,7 @@ export const Amount = ({
   const [fiatMode, setFiatMode] = useState(false);
   const {
     conversionSupportedForAsset,
+    fiatCurrencyName,
     getFiatValue,
     getFiatDisplayValue,
     getNativeValue,
@@ -154,7 +155,9 @@ export const Amount = ({
         value={amount}
         endAccessory={
           <Box display={Display.Flex}>
-            <Text>{asset?.symbol}</Text>
+            <Text>
+              {fiatMode ? fiatCurrencyName?.toUpperCase() : asset?.symbol}
+            </Text>
             {conversionSupportedForAsset && (
               <ButtonIcon
                 ariaLabel="toggle fiat mode"

--- a/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
+++ b/ui/pages/confirmations/hooks/send/useCurrencyConversions.ts
@@ -132,6 +132,7 @@ export const useCurrencyConversions = () => {
       asset?.standard !== ERC1155 &&
       asset?.standard !== ERC721,
     fiatCurrencySymbol: getCurrencySymbol(currentCurrency),
+    fiatCurrencyName: currentCurrency,
     getFiatValue,
     getFiatDisplayValue,
     getNativeValue,

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.test.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.test.ts
@@ -58,6 +58,32 @@ describe('useMaxAmount', () => {
     expect(result.getMaxAmount()).toEqual('999.999570668411440000');
   });
 
+  it('not throw error if gas fee estimates is not available', () => {
+    jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+      asset: EVM_NATIVE_ASSET,
+      chainId: '0x5',
+      from: MOCK_ADDRESS_1,
+    } as unknown as SendContext.SendContextType);
+    useBalanceMock.mockReturnValue({
+      balance: '10.00',
+      decimals: 18,
+      rawBalanceNumeric: new Numeric('1000000000000000000000', 10),
+    });
+    const result = renderHook({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        gasFeeEstimatesByChainId: {
+          '0x5': {
+            gasFeeEstimates: {},
+          },
+        },
+      },
+    });
+
+    expect(result.getMaxAmount()).toEqual('1000');
+  });
+
   it('return 0 if balance of native asset is less than gas needed', () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: EVM_NATIVE_ASSET,

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.ts
@@ -28,9 +28,8 @@ export const getEstimatedTotalGas = (
   if (!gasFeeEstimates) {
     return new Numeric('0', 10);
   }
-  const {
-    medium: { suggestedMaxFeePerGas },
-  } = gasFeeEstimates;
+  const { medium: { suggestedMaxFeePerGas } = { suggestedMaxFeePerGas: 0 } } =
+    gasFeeEstimates;
   const totalGas = new Numeric(
     suggestedMaxFeePerGas * NATIVE_TRANSFER_GAS_LIMIT,
     10,

--- a/ui/pages/confirmations/hooks/send/useNameValidation.ts
+++ b/ui/pages/confirmations/hooks/send/useNameValidation.ts
@@ -18,7 +18,7 @@ export const useNameValidation = () => {
 
         if (resolutions.length === 0) {
           return {
-            error: 'ensUnknownError',
+            error: 'nameResolutionFailedError',
           };
         }
 
@@ -33,7 +33,7 @@ export const useNameValidation = () => {
       }
 
       return {
-        error: 'ensUnknownError',
+        error: 'nameResolutionFailedError',
       };
     },
     [fetchResolutions],

--- a/ui/pages/confirmations/hooks/send/useRecipientValidation.test.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipientValidation.test.ts
@@ -210,7 +210,7 @@ describe('useRecipientValidation', () => {
     jest.spyOn(NameValidation, 'useNameValidation').mockReturnValue({
       validateName: () =>
         Promise.resolve({
-          error: 'ensUnknownError',
+          error: 'nameResolutionFailedError',
         }),
     });
 
@@ -244,7 +244,7 @@ describe('useRecipientValidation', () => {
     jest.spyOn(NameValidation, 'useNameValidation').mockReturnValue({
       validateName: () =>
         Promise.resolve({
-          error: 'ensUnknownError',
+          error: 'nameResolutionFailedError',
         }),
     });
 

--- a/ui/pages/confirmations/hooks/send/useRecipients.test.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipients.test.ts
@@ -46,8 +46,49 @@ describe('useRecipients', () => {
     const { result } = renderHookWithProvider(() => useRecipients(), mockState);
 
     expect(result.current).toEqual([
-      ...mockContactRecipients,
       ...mockAccountRecipients,
+      ...mockContactRecipients,
+    ]);
+  });
+
+  it('it returns unique recipients', () => {
+    const mockAccountRecipients: Recipient[] = [
+      {
+        address: '0x5678901234',
+        walletName: 'Wallet 1',
+        accountGroupName: 'Account 1',
+      },
+      {
+        address: '0xfedcba5678',
+        walletName: 'Wallet 2',
+        accountGroupName: 'Account 2',
+      },
+    ];
+
+    const mockContactRecipients: Recipient[] = [
+      { address: '0x1234567890', contactName: 'Contact 1' },
+      { address: '0xabcdef1234', contactName: 'Contact 2' },
+      {
+        address: '0x1234567890',
+        walletName: 'Wallet 11',
+        accountGroupName: 'Account 11',
+      },
+      {
+        address: '0x5678901234',
+        walletName: 'Wallet 12',
+        accountGroupName: 'Account 12',
+      },
+    ];
+
+    mockUseContactRecipients.mockReturnValue(mockContactRecipients);
+    mockUseAccountRecipients.mockReturnValue(mockAccountRecipients);
+
+    const { result } = renderHookWithProvider(() => useRecipients(), mockState);
+
+    expect(result.current).toEqual([
+      ...mockAccountRecipients,
+      mockContactRecipients[0],
+      mockContactRecipients[1],
     ]);
   });
 

--- a/ui/pages/confirmations/hooks/send/useRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useRecipients.ts
@@ -10,8 +10,20 @@ export type Recipient = {
 };
 
 export const useRecipients = (): Recipient[] => {
-  const contactRecipients = useContactRecipients();
   const accountRecipients = useAccountRecipients();
+  const contactRecipients = useContactRecipients();
 
-  return [...contactRecipients, ...accountRecipients];
+  const recipients = [...accountRecipients];
+
+  contactRecipients.forEach((recipient) => {
+    if (
+      !recipients.some(
+        (r) => r.address.toLowerCase() === recipient.address.toLowerCase(),
+      )
+    ) {
+      recipients.push(recipient);
+    }
+  });
+
+  return recipients;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Multiple small new send implementation related fixes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36787
Fixes: https://github.com/MetaMask/metamask-extension/issues/36789
Fixes: https://github.com/MetaMask/metamask-extension/issues/36757

## **Manual testing steps**

1. Trigger send flow
2. Check the new amount recipient page

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines send flow by showing fiat currency code in Amount, exposing fiatCurrencyName, safely handling missing gas estimates for max amount, standardizing name-resolution error, and returning unique recipients (with tests and i18n updates).
> 
> - **Send Flow**:
>   - **Amount input (`ui/.../amount.tsx`)**: Show fiat currency code when in fiat mode; uses `fiatCurrencyName` from `useCurrencyConversions`.
>   - **Currency conversions (`useCurrencyConversions.ts`)**: Expose `fiatCurrencyName` in hook return.
>   - **Max amount (`useMaxAmount.ts`)**: Gracefully handle missing `gasFeeEstimates` (default to `0`) in `getEstimatedTotalGas`.
>   - **Name resolution (`useNameValidation.ts`)**: Use `error: \`nameResolutionFailedError\`` for failed lookups.
>   - **Recipients (`useRecipients.ts`)**: Return accounts first and de-duplicate contacts by address.
> - **i18n**:
>   - Add `nameResolutionFailedError` string to `app/_locales/en/messages.json` and `en_GB/messages.json`.
> - **Tests**:
>   - Update Amount tests to use `fiatCurrencySymbol: '$'` and assert `USD`; add coverage for fiat toggle behavior.
>   - Add test ensuring max amount does not throw when gas estimates are unavailable.
>   - Update recipient tests for de-duplication and ordering.
>   - Update recipient validation tests for new name resolution error key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b1e9aee251dddd9e57cf0d222e736554cc410f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->