### PR TITLE
fix(snaps): cp-13.5.0 Write a custom number input for `SnapUIInput`

### DIFF
--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEvent,
   FormEvent,
   FunctionComponent,
+  memo,
   useEffect,
   useRef,
   useState,
@@ -10,113 +11,277 @@ import classnames from 'classnames';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 import { FormTextField, FormTextFieldProps } from '../../../component-library';
 
-const DECIMAL_INPUT_REGEX = /^\d*(\.|,)?\d*$/u;
-
 export type SnapUIInputProps = {
   name: string;
   form?: string;
   label?: string | React.ReactNode;
+  min?: number;
+  max?: number;
+  step?: number;
+};
+
+/**
+ * Clamps a number between optional minimum and maximum values.
+ *
+ * @param inputValue - The number to clamp.
+ * @param minimum - The optional minimum value.
+ * @param maximum - The optional maximum value.
+ * @returns The clamped number.
+ */
+const clamp = (inputValue: number, minimum?: number, maximum?: number) => {
+  if (minimum !== undefined && inputValue < minimum) {
+    return minimum;
+  }
+
+  if (maximum !== undefined && inputValue > maximum) {
+    return maximum;
+  }
+
+  return inputValue;
 };
 
 export const SnapUIInput: FunctionComponent<
   SnapUIInputProps & FormTextFieldProps<'div'>
-> = ({ name, form, label, disabled, type, textFieldProps, ...props }) => {
-  const { handleInputChange, getValue, focusedInput, setCurrentFocusedInput } =
-    useSnapInterfaceContext();
+> = memo(
+  ({
+    name,
+    form,
+    step = 1,
+    min,
+    max,
+    label,
+    disabled,
+    type,
+    textFieldProps,
+    ...props
+  }) => {
+    const {
+      handleInputChange,
+      getValue,
+      focusedInput,
+      setCurrentFocusedInput,
+    } = useSnapInterfaceContext();
 
-  const inputRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLDivElement>(null);
 
-  const initialValue = getValue(name, form) as string;
+    const initialValue = getValue(name, form) as string;
 
-  const [value, setValue] = useState(initialValue ?? '');
+    const [value, setValue] = useState(initialValue ?? '');
 
-  useEffect(() => {
-    if (initialValue !== undefined && initialValue !== null) {
-      setValue(initialValue);
-    }
-  }, [initialValue]);
+    useEffect(() => {
+      if (initialValue !== undefined && initialValue !== null) {
+        setValue(initialValue);
+      }
+    }, [initialValue]);
 
-  /*
-   * Focus input if the last focused input was this input
-   * This avoids losing the focus when the UI is re-rendered
-   */
-  useEffect(() => {
-    if (inputRef.current && name === focusedInput) {
-      (inputRef.current.querySelector('input') as HTMLInputElement).focus();
-    }
-  }, [inputRef]);
+    /*
+     * Focus input if the last focused input was this input
+     * This avoids losing the focus when the UI is re-rendered
+     */
+    useEffect(() => {
+      if (inputRef.current && name === focusedInput) {
+        (inputRef.current.querySelector('input') as HTMLInputElement).focus();
+      }
+    }, [inputRef]);
 
-  /**
-   * Get the input value, replacing commas with dots for number inputs.
-   *
-   * @param text - The current text input value.
-   * @returns The processed input value.
-   */
-  const getInputValue = (text: string) => {
-    if (type === 'number') {
-      // Mimic browser behaviour where commas are replaced.
-      return text.replace(/,/gu, '.');
-    }
+    /**
+     * Get the input value, replacing commas with dots for number inputs.
+     *
+     * @param text - The current text input value.
+     * @returns The processed input value.
+     */
+    const getInputValue = (text: string) => {
+      if (type === 'number') {
+        // Mimic browser behaviour where commas are replaced.
+        return text.replace(/,/gu, '.');
+      }
 
-    return text;
-  };
+      return text;
+    };
 
-  /**
-   * Handle input change event.
-   * The value is processed to replace commas with dots for number inputs.
-   *
-   * @param event - The change event object.
-   */
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const textValue = getInputValue(event.target.value);
+    /**
+     * Apply the change to the input value in the UI and in the interface state.
+     * The value is processed to replace commas with dots for number inputs.
+     *
+     * @param text - The new text input value.
+     */
+    const applyChange = (text: string) => {
+      const textValue = getInputValue(text);
 
-    setValue(textValue);
-    handleInputChange(name, textValue ?? null, form);
-  };
+      setValue(textValue);
+      handleInputChange(name, textValue ?? null, form);
+    };
 
-  /**
-   * Handle before input event to restrict invalid characters for number inputs.
-   * This is necessary because Firefox does not support type="number".
-   *
-   * @param event - The form event object.
-   */
-  const handleBeforeInput = (event: FormEvent<HTMLInputElement>) => {
-    const inputValue = (event.nativeEvent as InputEvent).data;
+    /**
+     * Handle input change event.
+     *
+     * @param event - The change event object.
+     */
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) =>
+      applyChange(event.target.value);
 
-    if (
-      type === 'number' &&
-      inputValue &&
-      !DECIMAL_INPUT_REGEX.test(inputValue)
-    ) {
-      event.preventDefault();
-    }
-  };
+    /**
+     * Check if a character is allowed in number inputs.
+     *
+     * @param character - The character to check.
+     * @param currentValue - The current input value.
+     * @param selectionStart - The current cursor position.
+     * @returns Whether the character is allowed.
+     */
+    const isAllowedCharacter = (
+      character: string,
+      currentValue: string,
+      selectionStart: number | null,
+    ) => {
+      if (/\d/u.test(character)) {
+        return true;
+      }
 
-  const handleFocus = () => setCurrentFocusedInput(name);
-  const handleBlur = () => setCurrentFocusedInput(null);
+      if (character === '.' || character === ',') {
+        // allow only one decimal separator
+        return !currentValue.includes('.') && !currentValue.includes(',');
+      }
 
-  return (
-    <FormTextField
-      ref={inputRef}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      className={classnames('snap-ui-renderer__input', {
-        'snap-ui-renderer__field': label !== undefined,
-      })}
-      id={name}
-      value={value}
-      textFieldProps={{
-        ...textFieldProps,
-        inputProps: {
-          onBeforeInput: handleBeforeInput,
-          ...textFieldProps?.inputProps,
-        },
-      }}
-      onChange={handleChange}
-      label={label}
-      labelProps={{ marginBottom: 0 }}
-      disabled={disabled}
-      {...props}
-    />
-  );
-};
+      if (character === '-') {
+        // only allow minus at position 0
+        return (
+          (selectionStart === 0 || selectionStart === null) &&
+          !currentValue.includes('-')
+        );
+      }
+      return false;
+    };
+
+    /**
+     * Handle before input event to restrict invalid characters for number inputs.
+     * This is necessary because Firefox does not support type="number".
+     *
+     * @param event - The form event object.
+     */
+    const handleBeforeInput = (event: FormEvent<HTMLInputElement>) => {
+      const inputEvent = event.nativeEvent as InputEvent;
+      const character = inputEvent.data;
+
+      if (!character) {
+        return;
+      }
+
+      const target = event.target as HTMLInputElement;
+      const { value: eventValue, selectionStart } = target;
+
+      // helper reused from above
+      if (!isAllowedCharacter(character, eventValue, selectionStart)) {
+        event.preventDefault();
+      }
+    };
+
+    /**
+     * Handle incrementing or decrementing the number input value.
+     *
+     * @param direction - Direction to increment (1) or decrement (-1).
+     * @param multiplier - Multiplier for the step (e.g., 10 when Shift is held).
+     */
+    const handleIncrement = (direction: 1 | -1, multiplier = 1) => {
+      const base = Number(value) ?? 0;
+      const delta = step * multiplier * direction;
+      const next = clamp(Number(base + delta), min, max).toString();
+
+      applyChange(next);
+
+      inputRef.current?.querySelector('input')?.focus();
+    };
+
+    /**
+     * Handle key down events for number inputs to support arrow key increment/decrement.
+     *
+     * @param event - The keyboard event object.
+     */
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const multiplier = event.shiftKey ? 10 : 1;
+
+      switch (event.key) {
+        case 'ArrowUp': {
+          event.preventDefault();
+          handleIncrement(1, multiplier);
+          break;
+        }
+
+        case 'ArrowDown': {
+          event.preventDefault();
+          handleIncrement(-1, multiplier);
+          break;
+        }
+
+        default:
+          break;
+      }
+    };
+
+    /**
+     * Handle mouse wheel events for number inputs to support increment/decrement.
+     *
+     * @param event - The wheel event object.
+     */
+    const handleWheel = (event: React.WheelEvent<HTMLInputElement>) => {
+      // If wheel on input, increment/decrement
+      if (document.activeElement === inputRef.current?.querySelector('input')) {
+        event.preventDefault();
+
+        const direction = event.deltaY < 0 ? 1 : -1;
+        const multiplier = event.shiftKey ? 10 : 1;
+
+        handleIncrement(direction, multiplier);
+      }
+    };
+
+    const handleFocus = () => setCurrentFocusedInput(name);
+    const handleBlur = () => setCurrentFocusedInput(null);
+
+    return type === 'number' ? (
+      <FormTextField
+        ref={inputRef}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        className={classnames('snap-ui-renderer__input', {
+          'snap-ui-renderer__field': label !== undefined,
+        })}
+        id={name}
+        value={value}
+        textFieldProps={{
+          inputProps: {
+            onBeforeInput: handleBeforeInput,
+          },
+        }}
+        onChange={handleChange}
+        label={label}
+        labelProps={{ marginBottom: 0 }}
+        disabled={disabled}
+        onKeyDown={handleKeyDown}
+        onWheel={handleWheel}
+        {...props}
+      />
+    ) : (
+      <FormTextField
+        ref={inputRef}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        className={classnames('snap-ui-renderer__input', {
+          'snap-ui-renderer__field': label !== undefined,
+        })}
+        id={name}
+        value={value}
+        textFieldProps={{
+          ...textFieldProps,
+          inputProps: {
+            ...textFieldProps?.inputProps,
+          },
+        }}
+        onChange={handleChange}
+        label={label}
+        labelProps={{ marginBottom: 0 }}
+        disabled={disabled}
+        {...props}
+      />
+    );
+  },
+);

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -21,7 +21,7 @@ export type SnapUIInputProps = {
 };
 
 /**
- * Clamps a number between optional minimum and maximum values.
+ * Clamp a number between optional minimum and maximum values.
  *
  * @param inputValue - The number to clamp.
  * @param minimum - The optional minimum value.

--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -19,13 +19,11 @@ export const constructInputProps = (props: InputElement['props']) => {
 
       return {
         type,
+        step,
+        min,
+        max,
         textFieldProps: {
-          type,
-          inputProps: {
-            step: step?.toString(),
-            min: min?.toString(),
-            max: max?.toString(),
-          },
+          type: 'text',
         },
       };
     }


### PR DESCRIPTION
## **Description**

This PR writes a custom implementation for number inputs based on a text input to fix the firefox handling of number inputs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36842?quickstart=1)

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: #35941 

## **Manual testing steps**

1. Go test-snaps
2. use the send flow example snap

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/5cca28e0-6fdd-4ccd-82d3-3ebfebef4959

### **After**


https://github.com/user-attachments/assets/90703760-3dc2-4726-a261-4fd7e3f13098

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces native number input with a custom text-based implementation that supports min/max/step, input filtering, and arrow/wheel increments.
> 
> - **SnapUIInput**:
>   - Implement custom number input: render as text, normalize commas, restrict characters (`.` `,` `-`), and clamp using `min`/`max` with `step` (Shift x10).
>   - Add arrow up/down and mouse wheel increment/decrement; keep focus on interaction.
>   - Expose new props: `min`, `max`, `step`; factor `applyChange`; add `memo`.
> - **Renderer (`snap-ui-renderer/components/input.ts`)**:
>   - For `type: 'number'`, pass `min`/`max`/`step` to `SnapUIInput` and set `textFieldProps.type` to `text` (no longer using `inputProps` for these).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e79c88180358ebce27f8ae69f454548cca894050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->