### PR TITLE
fix: Tighten publishHook logic and move it to the confirmations domain cp-13.5.0

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -1,5 +1,6 @@
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
+import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import {
   type PublishBatchHookRequest,
   type PublishBatchHookTransaction,
@@ -10,16 +11,17 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { trace } from '../../../../shared/lib/trace';
 import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import { getShieldGatewayConfig } from '../../../../shared/modules/shield';
 import { TransactionMetricsRequest } from '../../../../shared/types/metametrics';
 import {
+  getSmartTransactionCommonParams,
   SmartTransactionHookMessenger,
-  publishBatchHook,
-  publishHook,
+  submitBatchSmartTransactionHook,
+  submitSmartTransactionHook,
 } from '../../lib/smart-transaction/smart-transactions';
+import { Delegation7702PublishHook } from '../../lib/transaction/hooks/delegation-7702-publish';
 import { EnforceSimulationHook } from '../../lib/transaction/hooks/enforce-simulation-hook';
 import {
   handlePostTransactionBalanceUpdate,
@@ -31,6 +33,8 @@ import {
   handleTransactionRejected,
   handleTransactionSubmitted,
 } from '../../lib/transaction/metrics';
+import { isSendBundleSupported } from '../../lib/transaction/sentinel-api';
+import { getTransactionById } from '../../lib/transaction/util';
 import { ControllerFlatState } from '../controller-list';
 import { TransactionControllerInitMessenger } from '../messengers/transaction-controller-messenger';
 import {
@@ -343,4 +347,113 @@ function addTransactionControllerListeners(
 
 function getUIState(flatState: ControllerFlatState) {
   return { metamask: flatState };
+}
+
+export async function publishHook({
+  flatState,
+  initMessenger,
+  signedTx,
+  smartTransactionsController,
+  transactionController,
+  transactionMeta,
+}: {
+  flatState: ControllerFlatState;
+  initMessenger: TransactionControllerInitMessenger;
+  signedTx: string;
+  smartTransactionsController: SmartTransactionsController;
+  transactionController: TransactionController;
+  transactionMeta: TransactionMeta;
+}) {
+  const { isSmartTransaction, featureFlags, isHardwareWalletAccount } =
+    getSmartTransactionCommonParams(flatState, transactionMeta.chainId);
+  const sendBundleSupport = await isSendBundleSupported(
+    transactionMeta.chainId,
+  );
+
+  if (!isSmartTransaction || !sendBundleSupport) {
+    const hook = new Delegation7702PublishHook({
+      isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(
+        transactionController,
+      ),
+      messenger: initMessenger,
+    }).getHook();
+
+    const result = await hook(transactionMeta, signedTx);
+    if (result?.transactionHash) {
+      return result;
+    }
+    // else, fall back to regular regular transaction submission
+  }
+
+  if (
+    isSmartTransaction &&
+    (sendBundleSupport || transactionMeta.selectedGasFeeToken === undefined)
+  ) {
+    const result = await submitSmartTransactionHook({
+      transactionMeta,
+      signedTransactionInHex: signedTx as Hex,
+      transactionController,
+      smartTransactionsController,
+      controllerMessenger: initMessenger,
+      isSmartTransaction,
+      isHardwareWallet: isHardwareWalletAccount,
+      // @ts-expect-error Smart transaction selector return type does not match FeatureFlags type from hook
+      featureFlags,
+    });
+
+    if (result?.transactionHash) {
+      return result;
+    }
+    // else, fall back to regular regular transaction submission
+  }
+
+  // Default: fall back to regular transaction submission
+  return { transactionHash: undefined };
+}
+
+export function publishBatchHook({
+  transactionController,
+  smartTransactionsController,
+  hookControllerMessenger,
+  flatState,
+  transactions,
+}: {
+  transactionController: TransactionController;
+  smartTransactionsController: SmartTransactionsController;
+  hookControllerMessenger: SmartTransactionHookMessenger;
+  flatState: ControllerFlatState;
+  transactions: PublishBatchHookTransaction[];
+}) {
+  // Get transactionMeta based on the last transaction ID
+  const lastTransaction = transactions[transactions.length - 1];
+  const transactionMeta = getTransactionById(
+    lastTransaction.id ?? '',
+    transactionController,
+  );
+
+  // If we couldn't find the transaction, we should handle that gracefully
+  if (!transactionMeta) {
+    throw new Error(
+      `publishBatchSmartTransactionHook: Could not find transaction with id ${lastTransaction.id}`,
+    );
+  }
+
+  const { isSmartTransaction, featureFlags, isHardwareWalletAccount } =
+    getSmartTransactionCommonParams(flatState, transactionMeta.chainId);
+
+  if (!isSmartTransaction) {
+    return undefined;
+  }
+
+  return submitBatchSmartTransactionHook({
+    transactions,
+    transactionController,
+    smartTransactionsController,
+    controllerMessenger: hookControllerMessenger,
+    isSmartTransaction,
+    isHardwareWallet: isHardwareWalletAccount,
+    // @ts-expect-error Smart transaction selector return type does not match FeatureFlags type from hook
+    featureFlags,
+    transactionMeta,
+  });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR moves publishHook and publishBatchHook to the transaction controller init file so they are under confirmations codeowners going forward.

Apart from that, it makes 2 important fixes to the logic that has [recently changed](https://github.com/MetaMask/metamask-extension/pull/35296). I'll highlight them here to simplify the review.

First, enable the execution to proceed when it enters and leaves the 7702 hook, so that a transaction can still be submitted through the transaction controller in those cases:

```
-    return await hook(transactionMeta, signedTx);
+    const result = await hook(transactionMeta, signedTx);
+
+    if (result.transactionHash) {
+      return result;
+    }
``` 

Second, make it so in transactions on networks without send bundle support still make it to the smart transactions hook if there are no selected gas fee tokens. 

```
   if (
     isSmartTransaction &&
-     (sendBundleSupport || transactionMeta.selectedGasFeeToken !== undefined)
+     (sendBundleSupport || transactionMeta.selectedGasFeeToken === undefined)
   ) {
     const result = await submitSmartTransactionHook({
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36843?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: "null"

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6027

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
