### PR TITLE
fix: flaky test `Account syncing - Unsupported Account types does not sync...`

### DIFF
--- a/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
@@ -3,15 +3,17 @@ import {
   USER_STORAGE_GROUPS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_KEY,
 } from '@metamask/account-tree-controller';
-import { withFixtures, unlockWallet } from '../../../helpers';
+import { withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixture-builder';
 import { mockIdentityServices } from '../mocks';
 import {
   UserStorageMockttpController,
   UserStorageMockttpControllerEvents,
 } from '../../../helpers/identity/user-storage/userStorageMockttpController';
-import HeaderNavbar from '../../../page-objects/pages/header-navbar';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 import AccountListPage from '../../../page-objects/pages/account-list-page';
+import HeaderNavbar from '../../../page-objects/pages/header-navbar';
+import HomePage from '../../../page-objects/pages/home/homepage';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
 import { arrangeTestUtils } from './helpers';
 
@@ -55,7 +57,12 @@ describe('Account syncing - Unsupported Account types', function () {
         testSpecificMock: sharedMockSetup,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        // Balance is 0 because aggregated balance has changed and doesn't display dev networks
+        // The method should be udpdated to use the new selector and we can then remove checkExpectedTokenBalanceIsDisplayed
+        await loginWithBalanceValidation(driver, undefined, undefined, '0');
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedTokenBalanceIsDisplayed('25', 'ETH');
 
         const header = new HeaderNavbar(driver);
         await header.checkPageIsLoaded();
@@ -123,7 +130,12 @@ describe('Account syncing - Unsupported Account types', function () {
         testSpecificMock: sharedMockSetup,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        // Balance is 0 because aggregated balance has changed and doesn't display dev networks
+        // The method should be udpdated to use the new selector and we can then remove checkExpectedTokenBalanceIsDisplayed
+        await loginWithBalanceValidation(driver, undefined, undefined, '0');
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedTokenBalanceIsDisplayed('25', 'ETH');
 
         const header = new HeaderNavbar(driver);
         await header.checkPageIsLoaded();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test is flaky because sometimes we go to the Accounts menu and the account 2 never syncs. This is mitigated by login in and waiting for the home page and balance to be loaded.

Caveat: the balance 25 ETH is not displayed as the main number but rather in the token list, so we need to use the check token for that. We should update the loginWithBalanceValidation eventually to point to that selector, but this is outside of the scope of this PR as this will impact all tests, and we could do it when all of them use the new setup.


<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/0f3a98b7-2dde-4167-aaa5-85925e089d36" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36844?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the e2e test to the new login flow with balance validation and HomePage checks to reduce flakiness.
> 
> - **Tests (e2e)**:
>   - Update `test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts` to use `loginWithBalanceValidation` instead of `unlockWallet`.
>   - Add `HomePage` checks: ensure page loads and verify expected token balance (`25 ETH`).
>   - Adjust imports and apply the same flow in both test phases before navigating to accounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38070473b4659c01fed26386bbbc68815236d8e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->