### PR TITLE
fix: now consider non-EVM account names for group names - cp-13.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "@material-ui/core": "^4.12.4",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^0.12.0",
-    "@metamask/account-tree-controller": "^1.4.2",
+    "@metamask/account-tree-controller": "^1.5.0",
     "@metamask/account-watcher": "^4.1.3",
     "@metamask/accounts-controller": "^33.1.0",
     "@metamask/address-book-controller": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,9 +5414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "@metamask/account-tree-controller@npm:1.4.2"
+"@metamask/account-tree-controller@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@metamask/account-tree-controller@npm:1.5.0"
   dependencies:
     "@metamask/base-controller": "npm:^8.4.1"
     "@metamask/snaps-sdk": "npm:^9.0.0"
@@ -5434,7 +5434,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b1340ed8345a618565f63db3e5c93f5a8313f00cec10ab75136483bdebc10f5a7506c63cda3ae06573133ab2479af2ccf59ea7a456cf71cf2e466ba151ff5dee
+  checksum: 10/3d5147d7bf6cf85ac0d340b9d6481386bd8f1c60fcc53cfd925c45a14c280662db6d6ef959660cf21ced044507b121cdde60d1e2d1ccff675e9ac6ed8d0f8107
   languageName: node
   linkType: hard
 
@@ -31922,7 +31922,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.4"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^0.12.0"
-    "@metamask/account-tree-controller": "npm:^1.4.2"
+    "@metamask/account-tree-controller": "npm:^1.5.0"
     "@metamask/account-watcher": "npm:^4.1.3"
     "@metamask/accounts-controller": "npm:^33.1.0"
     "@metamask/address-book-controller": "npm:^6.1.0"


### PR DESCRIPTION
## **Description**

Migrating from an older version like 13.3.0 where your accounts were named that way:

- Index 1:
  * My EVM account (1)
  * Solana Account 1
  * Bitcoin Account 1
- Index 2
  * `<no EVM account>`
  * My Solana account (2)
  * Bitcoin Account 2
- Index 3
  * `<no EVM account>`
  * `<no Solana account>`
  * My Bitcoin account (3)

<img width="366" height="700" alt="Screenshot 2025-10-14 at 17 31 52" src="https://github.com/user-attachments/assets/024f49cc-0d2d-4d4f-abc9-418789461dd1" />

To:

<img width="603" height="438" alt="Screenshot 2025-10-14 at 17 34 25" src="https://github.com/user-attachments/assets/e8ddb238-4d7c-4033-8fba-c3412a888772" />

Group names have been computed based on each existing accounts.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36846?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
- https://github.com/MetaMask/metamask-extension/issues/36826

## **Manual testing steps**

TODO

## **Screenshots/Recordings**

### **Before**


### **After**



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `@metamask/account-tree-controller` from `^1.4.2` to `^1.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e1a3e1b1c30299541d86212ef50f2d7155b9ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->