### PR TITLE
test: skip flaky phishing detection tests on Firefox

### DIFF
--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -48,6 +48,9 @@ describe('Phishing Detection', function (this: Suite) {
   });
 
   it('should display the MetaMask Phishing Detection page and take the user to the blocked page if they continue', async function () {
+    if (process.env.SELENIUM_BROWSER === 'firefox') {
+      this.skip();
+    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -107,6 +107,9 @@ describe('Phishing Detection', function (this: Suite) {
     };
 
     it('should redirect users to the the MetaMask Phishing Detection page when an iframe domain is on the phishing blocklist', async function () {
+      if (process.env.SELENIUM_BROWSER === 'firefox') {
+        this.skip();
+      }
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),
@@ -595,6 +598,9 @@ describe('Phishing Detection', function (this: Suite) {
 
     describe('whitelisted paths', function () {
       it('does not display the MetaMask Phishing Detection page when accessing a whitelisted path', async function () {
+        if (process.env.SELENIUM_BROWSER === 'firefox') {
+          this.skip();
+        }
         await withFixtures(
           {
             fixtures: new FixtureBuilder().build(),
@@ -633,6 +639,9 @@ describe('Phishing Detection', function (this: Suite) {
       });
 
       it('when the subpath is whitelisted, the phishing warning page is not displayed for the blocklisted path and all subpaths', async function () {
+        if (process.env.SELENIUM_BROWSER === 'firefox') {
+          this.skip();
+        }
         await withFixtures(
           {
             fixtures: new FixtureBuilder().build(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Temporarily skipping the following E2E tests on Firefox which are flaky:
- `should redirect users to the the MetaMask Phishing Detection page when an iframe domain is on the phishing blocklist`
- `does not display the MetaMask Phishing Detection page when accessing a whitelisted path`
- `when the subpath is whitelisted, the phishing warning page is not displayed for the blocklisted path and all subpaths`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36858?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips selected phishing detection E2E tests when running under Firefox by conditionally calling this.skip().
> 
> - **Tests** (`test/e2e/tests/phishing-controller/phishing-detection.spec.ts`):
>   - Conditionally skip on Firefox (`process.env.SELENIUM_BROWSER === 'firefox'`):
>     - `should display the MetaMask Phishing Detection page and take the user to the blocked page if they continue`
>     - `should redirect users to the the MetaMask Phishing Detection page when an iframe domain is on the phishing blocklist`
>     - `does not display the MetaMask Phishing Detection page when accessing a whitelisted path`
>     - `when the subpath is whitelisted, the phishing warning page is not displayed for the blocklisted path and all subpaths`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3545d8a6d652bfb6d82cfb51b846f8c64e93c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->