### PR TITLE
fix: empty select RPC modal

### DIFF
--- a/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
@@ -137,9 +137,12 @@ export const useNetworkItemCallbacks = () => {
             }
           : undefined,
         onRpcSelect: () => {
-          history.push('/select-rpc', {
-            chainId: hexChainId,
-          });
+          dispatch(
+            setEditedNetwork({
+              chainId: hexChainId,
+            }),
+          );
+          history.push('/select-rpc');
         },
       };
     },

--- a/ui/components/multichain/network-manager/network-manager.tsx
+++ b/ui/components/multichain/network-manager/network-manager.tsx
@@ -1,4 +1,5 @@
 import {
+  type NetworkConfiguration,
   RpcEndpointType,
   UpdateNetworkFields,
 } from '@metamask/network-controller';
@@ -53,7 +54,9 @@ export const NetworkManager = () => {
       return undefined;
     }
     if (location.pathname === '/select-rpc') {
-      return evmNetworks[editingChainId as keyof typeof evmNetworks];
+      return editingChainId
+        ? evmNetworks[editingChainId as keyof typeof evmNetworks]
+        : undefined;
     }
     return !editingChainId || editCompleted
       ? undefined
@@ -270,7 +273,10 @@ export const NetworkManager = () => {
                 >
                   {t('selectRpcUrl')}
                 </ModalHeader>
-                <SelectRpcUrlModal onNetworkChange={handleClose} />
+                <SelectRpcUrlModal
+                  networkConfiguration={editedNetwork as NetworkConfiguration}
+                  onNetworkChange={handleClose}
+                />
               </>
             }
           />


### PR DESCRIPTION
## **Description**

Fix the empty Select RPC URL modal

## **Changelog**

CHANGELOG entry: fix: empty select rpc modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to chainlist.org
2. Add Ethereum, Base or another network that's enabled and already has an RPC endponit
3. Back in the home screen, click Network dropdown
4. Click Edit on the newly added network

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="320" height="276" alt="image" src="https://github.com/user-attachments/assets/89f9cfdd-aa2f-44dd-8497-37e0181255aa" />


### **After**

<img width="387" height="262" alt="image" src="https://github.com/user-attachments/assets/6de45923-8ee8-4753-ba94-7eaf7b4bce18" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure Select RPC URL modal is populated by dispatching the edited network before navigation and passing the network configuration, with a guard for missing editingChainId.
> 
> - **Network Manager (`network-manager.tsx`)**:
>   - Pass `networkConfiguration` to `SelectRpcUrlModal` to populate modal.
>   - Safely resolve `editedNetwork` on `/select-rpc` only when `editingChainId` exists.
> - **Hooks (`useNetworkItemCallbacks.ts`)**:
>   - Update `onRpcSelect` to `dispatch(setEditedNetwork({ chainId }))` then navigate to `/select-rpc` (no route state).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f9860f932a1b6cab766bc0eb4c84996afb74b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->