### PR TITLE
fix: multichain support on dapp connected site popover cp-13.5.0

### DIFF
--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -407,6 +407,22 @@
       "0xeb9e64b93097bc15f01f13eae97015c57ab64823": {
         "address": "0xeb9e64b93097bc15f01f13eae97015c57ab64823",
         "balance": "0x0"
+      },
+      "0xd5e099c71b797516c10ed0f0d895f429c2781111": {
+        "address": "0xd5e099c71b797516c10ed0f0d895f429c2781111",
+        "balance": "0x0"
+      },
+      "0x1234567890123456789012345678901234567890": {
+        "address": "0x1234567890123456789012345678901234567890",
+        "balance": "0x0"
+      },
+      "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq": {
+        "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+        "balance": "0x0"
+      },
+      "2byhg1jregmqQx2VfLGLn7hb5mStJw2iVVU8sfM5xTYj": {
+        "address": "2byhg1jregmqQx2VfLGLn7hb5mStJw2iVVU8sfM5xTYj",
+        "balance": "0x0"
       }
     },
     "tokens": [

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -189,7 +189,10 @@
   "keyrings": [
     {
       "type": "HD Key Tree",
-      "accounts": ["0x03cf1158b58ccdfc04dd518f11f85c3ee7fa0189"]
+      "accounts": ["0x03cf1158b58ccdfc04dd518f11f85c3ee7fa0189"],
+      "metadata": {
+        "id": "test-keyring-id"
+      }
     }
   ],
   "knownMethodData": {},

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.test.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.test.js
@@ -142,8 +142,31 @@ describe('Connected Site Menu', () => {
           },
         },
       },
-      domains: {},
+      domains: {
+        'https://uniswap.org/': 'mainnet-infura',
+      },
       networkConfigurationsByChainId: defaultNetworkConfigurations,
+      selectedNetworkClientId: 'mainnet-infura',
+      keyrings: [
+        {
+          type: 'HD Key Tree',
+          accounts: [mockAccount1.address, mockAccount2.address],
+          metadata: {
+            id: 'test-keyring-id',
+          },
+        },
+      ],
+      // Add multichain network state
+      selectedMultichainNetworkChainId: 'eip155:1',
+      isEvmSelected: true,
+      // Add permission history for the selector
+      permissionHistory: {
+        'https://uniswap.org/': {
+          eth_accounts: {
+            accounts: [`eip155:1:${mockAccount1.address}`],
+          },
+        },
+      },
       ...customState.metamask,
     };
 

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.test.tsx
@@ -41,6 +41,7 @@ const render = () => {
       // Add multichain network state
       selectedMultichainNetworkChainId: 'eip155:5',
       isEvmSelected: true,
+      selectedNetworkClientId: 'goerli-test-client',
       multichainNetworkConfigurationsByChainId: {
         ...mockState.metamask.multichainNetworkConfigurationsByChainId,
         'eip155:5': {
@@ -50,6 +51,41 @@ const render = () => {
           isEvm: true,
         },
       },
+      // Add internal accounts for the new selector
+      internalAccounts: {
+        accounts: {
+          'eip155:5:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
+            id: 'eip155:5:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+            address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+            type: 'eip155:eoa',
+            metadata: {
+              name: 'Test Account',
+              lastSelected: Date.now(),
+            },
+            scopes: ['eip155:5'],
+            methods: [],
+            options: {},
+          },
+        },
+        selectedAccount: 'eip155:5:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      },
+      // Add accounts for compatibility
+      accounts: {
+        '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
+          address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+          balance: '0x0',
+        },
+      },
+      // Add keyrings for compatibility
+      keyrings: [
+        {
+          type: 'HD Key Tree',
+          accounts: ['0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'],
+          metadata: {
+            id: 'test-keyring-id',
+          },
+        },
+      ],
       // Add permissions for the test dapp
       subjects: {
         'https://metamask.github.io': {

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, RefObject, useMemo } from 'react';
+import React, { useContext, RefObject } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { parseCaipChainId } from '@metamask/utils';
 import {
@@ -20,11 +20,11 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { I18nContext } from '../../../contexts/i18n';
-import { getOriginOfCurrentTab, getAllDomains } from '../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
+import { getOriginOfCurrentTab } from '../../../selectors';
 import { getURLHost } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { toggleNetworkMenu } from '../../../store/actions';
+import { getDappActiveNetwork } from '../../../selectors/dapp';
 
 type ConnectedSitePopoverProps = {
   referenceElement: RefObject<HTMLElement>;
@@ -43,36 +43,9 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
 }) => {
   const t = useContext(I18nContext);
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
+  const dappActiveNetwork = useSelector(getDappActiveNetwork);
   const siteName = getURLHost(activeTabOrigin);
-  const allDomains = useSelector(getAllDomains);
-  const networkConfigurationsByChainId = useSelector(
-    getNetworkConfigurationsByChainId,
-  );
   const dispatch = useDispatch();
-
-  // Get the network that this dapp is actually connected to using domain mapping
-  const dappActiveNetwork = useMemo(() => {
-    if (!activeTabOrigin || !allDomains) {
-      return null;
-    }
-
-    // Get the networkClientId for this domain
-    const networkClientId = allDomains[activeTabOrigin];
-    if (!networkClientId) {
-      return null;
-    }
-
-    // Find the network configuration that has this networkClientId
-    const networkConfiguration = Object.values(
-      networkConfigurationsByChainId,
-    ).find((network) => {
-      return network.rpcEndpoints.some(
-        (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
-      );
-    });
-
-    return networkConfiguration || null;
-  }, [activeTabOrigin, allDomains, networkConfigurationsByChainId]);
 
   const getChainIdForImage = (chainId: `${string}:${string}`): string => {
     const { namespace, reference } = parseCaipChainId(chainId);

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -172,6 +172,15 @@ describe('Routes Component', () => {
           tokenBalances: {
             '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': '0x176270e2b862e4ed3',
           },
+          permissionHistory: {
+            'https://metamask.github.io': {
+              eth_accounts: {
+                accounts: [
+                  'eip155:1:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+                ],
+              },
+            },
+          },
         },
         send: {
           ...mockSendState.send,
@@ -311,6 +320,25 @@ describe('toast display', () => {
           [mockSolanaAccount.id]: mockSolanaAccount,
         },
         selectedAccount: selectedAccountId ?? mockAccount.id,
+      },
+      accounts: {
+        ...mockState.metamask.accounts,
+        [mockAccount.address]: {
+          balance: '0x0',
+          address: mockAccount.address,
+        },
+        [mockAccount2.address]: {
+          balance: '0x0',
+          address: mockAccount2.address,
+        },
+        [mockNonEvmAccount.address]: {
+          balance: '0x0',
+          address: mockNonEvmAccount.address,
+        },
+        [mockSolanaAccount.address]: {
+          balance: '0x0',
+          address: mockSolanaAccount.address,
+        },
       },
       accountsAssets: {
         [selectedAccountId ?? mockAccount.id]: [],

--- a/ui/selectors/dapp.test.ts
+++ b/ui/selectors/dapp.test.ts
@@ -4,9 +4,16 @@ import {
 } from '@metamask/network-controller';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
 import { getDappActiveNetwork } from './dapp';
-import { getAllDomains, getOriginOfCurrentTab } from './selectors';
+import {
+  getOrderedConnectedAccountsForActiveTab,
+  getOriginOfCurrentTab,
+  getAllDomains,
+} from './selectors';
+import { getMultichainNetworkConfigurationsByChainId } from './multichain';
 
+// Mock the selectors that the new getDappActiveNetwork uses
 jest.mock('./selectors', () => ({
+  getOrderedConnectedAccountsForActiveTab: jest.fn(),
   getOriginOfCurrentTab: jest.fn(),
   getAllDomains: jest.fn(),
 }));
@@ -15,10 +22,20 @@ jest.mock('../../shared/modules/selectors/networks', () => ({
   getNetworkConfigurationsByChainId: jest.fn(),
 }));
 
+jest.mock('./multichain', () => ({
+  getMultichainNetworkConfigurationsByChainId: jest.fn(),
+}));
+
+const mockGetOrderedConnectedAccountsForActiveTab = jest.mocked(
+  getOrderedConnectedAccountsForActiveTab,
+);
 const mockGetOriginOfCurrentTab = jest.mocked(getOriginOfCurrentTab);
 const mockGetAllDomains = jest.mocked(getAllDomains);
 const mockGetNetworkConfigurationsByChainId = jest.mocked(
   getNetworkConfigurationsByChainId,
+);
+const mockGetMultichainNetworkConfigurationsByChainId = jest.mocked(
+  getMultichainNetworkConfigurationsByChainId,
 );
 
 describe('getDappActiveNetwork selector', () => {
@@ -43,57 +60,119 @@ describe('getDappActiveNetwork selector', () => {
     nativeCurrency: '',
   };
 
-  const arrangeMocks = () => {
-    mockGetOriginOfCurrentTab.mockReturnValue(mockOrigin);
+  const mockEvmAccount = {
+    id: 'eip155:1:0x1234567890123456789012345678901234567890',
+    address: '0x1234567890123456789012345678901234567890',
+    type: 'eip155:eoa',
+    metadata: {
+      name: 'Test Account',
+      lastSelected: Date.now(),
+    },
+    scopes: ['eip155:1'],
+    methods: [],
+    options: {},
+  };
 
+  const mockSolanaAccount = {
+    id: 'solana:mainnet:0x1234567890123456789012345678901234567890',
+    address: '0x1234567890123456789012345678901234567890',
+    type: 'solana:data-account',
+    metadata: {
+      name: 'Test Solana Account',
+      lastSelected: Date.now(),
+    },
+    scopes: ['solana:mainnet'],
+    methods: [],
+    options: {},
+  };
+
+  const mockMultichainNetworkConfig: NetworkConfiguration = {
+    chainId: '0x1' as `0x${string}`,
+    name: 'Solana Mainnet',
+    nativeCurrency: 'SOL',
+    blockExplorerUrls: [],
+    defaultRpcEndpointIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'solana-mainnet',
+        type: RpcEndpointType.Custom,
+        url: '',
+      },
+    ],
+  };
+
+  const arrangeMocks = () => {
+    mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
+      mockEvmAccount,
+    ]);
+    mockGetOriginOfCurrentTab.mockReturnValue(mockOrigin);
     mockGetAllDomains.mockReturnValue({
       [mockOrigin]: mockNetworkClientId,
     });
-
     mockGetNetworkConfigurationsByChainId.mockReturnValue({
       '0x1': mockNetworkConfig,
     });
+    mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({});
 
     return {
       mockOrigin,
       mockNetworkClientId,
-      mockGetAllDomains,
+      mockGetOrderedConnectedAccountsForActiveTab,
       mockGetOriginOfCurrentTab,
+      mockGetAllDomains,
       mockGetNetworkConfigurationsByChainId,
+      mockGetMultichainNetworkConfigurationsByChainId,
       mockState: {},
     };
   };
 
-  it('returns correct network configuration when all data is available', () => {
+  it('returns correct EVM network configuration when all data is available', () => {
     const mocks = arrangeMocks();
     const result = getDappActiveNetwork(mocks.mockState);
-    expect(result).toEqual(mockNetworkConfig);
+    expect(result).toEqual({ ...mockNetworkConfig, isEvm: true });
   });
 
-  it('returns null when activeTabOrigin is null', () => {
+  it('returns correct non-EVM network configuration for Solana account', () => {
     const mocks = arrangeMocks();
-    mocks.mockGetOriginOfCurrentTab.mockReturnValue(null);
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
+      mockSolanaAccount,
+    ]);
+    mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({
+      'solana:mainnet': mockMultichainNetworkConfig,
+    });
+
+    const result = getDappActiveNetwork(mocks.mockState);
+    expect(result).toEqual({ ...mockMultichainNetworkConfig, isEvm: false });
+  });
+
+  it('returns null when no connected accounts', () => {
+    const mocks = arrangeMocks();
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([]);
     const result = getDappActiveNetwork(mocks.mockState);
     expect(result).toBeNull();
   });
 
-  it('returns null when allDomains is null', () => {
+  it('returns null when orderedConnectedAccounts is null', () => {
     const mocks = arrangeMocks();
-    mocks.mockGetAllDomains.mockReturnValue(null);
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue(null);
     const result = getDappActiveNetwork(mocks.mockState);
     expect(result).toBeNull();
   });
 
-  it('returns null when networkClientId not found for origin', () => {
-    const mocks = arrangeMocks();
-    mocks.mockGetAllDomains.mockReturnValue({});
-    const result = getDappActiveNetwork(mocks.mockState);
-    expect(result).toBeNull();
-  });
-
-  it('returns null when no matching network configuration exists', () => {
+  it('returns null when no matching EVM network configuration exists', () => {
     const mocks = arrangeMocks();
     mocks.mockGetNetworkConfigurationsByChainId.mockReturnValue({});
+    const result = getDappActiveNetwork(mocks.mockState);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no matching non-EVM network configuration exists', () => {
+    const mocks = arrangeMocks();
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
+      mockSolanaAccount,
+    ]);
+    mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({});
+
     const result = getDappActiveNetwork(mocks.mockState);
     expect(result).toBeNull();
   });

--- a/ui/selectors/dapp.ts
+++ b/ui/selectors/dapp.ts
@@ -1,37 +1,73 @@
+import { isEvmAccountType } from '@metamask/keyring-api';
 import { getNetworkConfigurationsByChainId } from '../../shared/modules/selectors/networks';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
-import { getAllDomains, getOriginOfCurrentTab } from './selectors';
+import {
+  getOrderedConnectedAccountsForActiveTab,
+  getOriginOfCurrentTab,
+  getAllDomains,
+} from './selectors';
+import { getMultichainNetworkConfigurationsByChainId } from './multichain';
 
 export const getDappActiveNetwork = createDeepEqualSelector(
+  getOrderedConnectedAccountsForActiveTab,
   getOriginOfCurrentTab,
   getAllDomains,
   getNetworkConfigurationsByChainId,
-  (activeTabOrigin, allDomains, networkConfigurationsByChainId) => {
-    if (!activeTabOrigin || !allDomains) {
+  getMultichainNetworkConfigurationsByChainId,
+  (
+    orderedConnectedAccounts,
+    activeTabOrigin,
+    allDomains,
+    networkConfigurationsByChainId,
+    multichainNetworkConfigurationsByChainId,
+  ) => {
+    if (!orderedConnectedAccounts || orderedConnectedAccounts.length === 0) {
       return null;
     }
+    const selectedAccount = orderedConnectedAccounts[0];
 
-    const networkClientId = allDomains[activeTabOrigin];
-    if (!networkClientId) {
-      return null;
-    }
+    // Check if account is EVM or non-EVM using existing helper
+    const isEvmAccount = isEvmAccountType(selectedAccount.type);
 
-    for (const chainId in networkConfigurationsByChainId) {
-      if (
-        Object.prototype.hasOwnProperty.call(
-          networkConfigurationsByChainId,
-          chainId,
-        )
-      ) {
-        const network =
-          networkConfigurationsByChainId[
-            chainId as keyof typeof networkConfigurationsByChainId
-          ];
-        const hasMatchingEndpoint = network.rpcEndpoints.some(
-          (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
-        );
-        if (hasMatchingEndpoint) {
-          return network;
+    if (isEvmAccount) {
+      if (!activeTabOrigin || !allDomains) {
+        return null;
+      }
+
+      const networkClientId = allDomains[activeTabOrigin];
+      if (!networkClientId) {
+        return null;
+      }
+
+      for (const chainId in networkConfigurationsByChainId) {
+        if (
+          Object.prototype.hasOwnProperty.call(
+            networkConfigurationsByChainId,
+            chainId,
+          )
+        ) {
+          const network =
+            networkConfigurationsByChainId[
+              chainId as keyof typeof networkConfigurationsByChainId
+            ];
+          const hasMatchingEndpoint = network.rpcEndpoints.some(
+            (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
+          );
+          if (hasMatchingEndpoint) {
+            return { ...network, isEvm: true };
+          }
+        }
+      }
+    } else {
+      // TODO: Add support for other networks (Bitcoin, Solana)
+      const nonEvmScope = selectedAccount.scopes.find((scope: string) =>
+        scope.startsWith('solana:'),
+      );
+
+      if (nonEvmScope) {
+        const network = multichainNetworkConfigurationsByChainId[nonEvmScope];
+        if (network) {
+          return { ...network, isEvm: false };
         }
       }
     }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -956,7 +956,9 @@ export const getMetaMaskAccountsOrdered = createDeepEqualSelector(
   (internalAccounts, accounts) => {
     return internalAccounts.map((internalAccount) => ({
       ...internalAccount,
-      ...accounts[internalAccount.address],
+      ...(internalAccount?.address
+        ? accounts[internalAccount.address] || {}
+        : {}),
     }));
   },
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes issue with the DaPP permissions icon showing wrong network for Solana only DaPP.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug with the DaPP permissions icon showing wrong network for Solana only DaPP

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36825

## **Manual testing steps**

1. Navigate to SOL only dapp (Orca, Jupiter)
2. Connect to DaPP
3. Notice Badge icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="398" height="596" alt="Screenshot 2025-10-15 at 16 37 41" src="https://github.com/user-attachments/assets/350edb96-5c1d-4904-8601-c1f04f1a5c8c" />

<!-- [screenshots/recordings] -->

### **After**
<img width="398" height="598" alt="Screenshot 2025-10-15 at 16 35 33" src="https://github.com/user-attachments/assets/c212b838-246d-4bb3-8e96-99c4ddeadf88" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors active network detection to be multichain-aware (EVM and Solana) via a selector, updates the connected site popover to use it, adds safeguards, and adjusts/extends tests and fixtures.
> 
> - **Selectors**:
>   - `getDappActiveNetwork`: Derives active network from ordered connected accounts; supports EVM and non‑EVM (Solana) via scopes; returns `{ ...network, isEvm }`; uses `getMultichainNetworkConfigurationsByChainId`.
>   - Adds use of `getOrderedConnectedAccountsForActiveTab`; updates tests for new logic.
>   - `getMetaMaskAccountsOrdered`: Safeguards spreading when `address` missing.
> - **UI**:
>   - `ConnectedSitePopover`: Replaces manual domain-based lookup with `getDappActiveNetwork`; removes `useMemo` and unused selectors.
> - **Tests**:
>   - New/updated tests for selector (`ui/selectors/dapp.test.ts`) covering EVM, Solana, and null paths.
>   - Updates to popover/menu/routes tests to include required state (`domains`, `selectedNetworkClientId`, `keyrings.metadata`, `internalAccounts`, `permissionHistory`, multichain configs/accounts).
> - **Test data**:
>   - Extend fixtures with additional accounts/addresses and keyring metadata in `mock-send-state.json` and onboarding data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98c125e7c7c6f7d2621c66fc68bdb85d45f9b4d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->