### PR TITLE
fix: do not block the UI after importing a new SRP

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4192,7 +4192,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {boolean} options.shouldCreateSocialBackup - whether to create a backup for the seedless onboarding flow
    * @param {boolean} options.shouldSelectAccount - whether to select the new account in the wallet
    * @param {boolean} options.shouldImportSolanaAccount - whether to import a Solana account
-   * @returns {Promise<string>} new account address
+   * @returns {Promise<void>}
    */
   async importMnemonicToVault(
     mnemonic,
@@ -4262,32 +4262,47 @@ export default class MetamaskController extends EventEmitter {
         this.accountsController.setSelectedAccount(account.id);
       }
 
-      if (this.isMultichainAccountsFeatureState2Enabled()) {
-        // We want to trigger a full sync of the account tree after importing a new SRP
-        // because `hasAccountTreeSyncingSyncedAtLeastOnce` is already true
-        await this.accountTreeController.syncWithUserStorage();
-      }
+      const syncAndDiscoverAccounts = async () => {
+        if (this.isMultichainAccountsFeatureState2Enabled()) {
+          // We want to trigger a full sync of the account tree after importing a new SRP
+          // because `hasAccountTreeSyncingSyncedAtLeastOnce` is already true
+          await this.accountTreeController.syncWithUserStorage();
+        }
 
-      let discoveredAccounts;
+        let discoveredAccounts;
 
-      if (
-        this.isMultichainAccountsFeatureState2Enabled() &&
-        shouldImportSolanaAccount
-      ) {
-        // We check if shouldImportSolanaAccount is true, because if it's false, we are in the middle of the onboarding flow.
-        // We just create the accounts at the end of the onboarding flow (including EVM).
-        discoveredAccounts = await this.discoverAndCreateAccounts(id);
-      } else {
-        discoveredAccounts = await this._addAccountsWithBalance(
-          id,
-          shouldImportSolanaAccount,
-        );
-      }
+        if (
+          this.isMultichainAccountsFeatureState2Enabled() &&
+          shouldImportSolanaAccount
+        ) {
+          // We check if shouldImportSolanaAccount is true, because if it's false, we are in the middle of the onboarding flow.
+          // We just create the accounts at the end of the onboarding flow (including EVM).
+          discoveredAccounts = await this.discoverAndCreateAccounts(id);
+        } else {
+          discoveredAccounts = await this._addAccountsWithBalance(
+            id,
+            shouldImportSolanaAccount,
+          );
+        }
 
-      return {
-        newAccountAddress,
-        discoveredAccounts,
+        const newHdEntropyIndex = this.getHDEntropyIndex();
+
+        this.metaMetricsController.trackEvent({
+          event: MetaMetricsEventName.ImportSecretRecoveryPhraseCompleted,
+          properties: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            hd_entropy_index: newHdEntropyIndex,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            number_of_solana_accounts_discovered: discoveredAccounts?.Solana,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            number_of_bitcoin_accounts_discovered: discoveredAccounts?.Bitcoin,
+          },
+        });
       };
+
+      // In order to avoid blocking the UI thread, we don't await for the sync and discover accounts to complete.
+      // eslint-disable-next-line no-void
+      void syncAndDiscoverAccounts();
     } finally {
       releaseLock();
     }

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -3556,6 +3556,9 @@ describe('MetaMaskController', () => {
         await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
         await metamaskController.importMnemonicToVault(TEST_SEED_ALT);
 
+        // Wait for the fire-and-forget sync and discover operation to complete
+        await new Promise((resolve) => setImmediate(resolve));
+
         // Assert that discoverAccounts was called correctly:
         // - 1 time for Bitcoin
         // - 3 times for Solana (twice with discovered accounts, once with empty array)
@@ -3638,6 +3641,9 @@ describe('MetaMaskController', () => {
         await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
         await metamaskController.importMnemonicToVault(TEST_SEED_ALT);
 
+        // Wait for the fire-and-forget sync and discover operation to complete
+        await new Promise((resolve) => setImmediate(resolve));
+
         // Assert that discoverAccounts was called correctly:
         // - 3 times for Bitcoin (twice with discovered accounts, once with empty array)
         // - 1 time for Solana
@@ -3702,6 +3708,13 @@ describe('MetaMaskController', () => {
           .mockReturnValue(true);
 
         jest
+          .spyOn(
+            metamaskController.accountTreeController,
+            'syncWithUserStorage',
+          )
+          .mockResolvedValue();
+
+        jest
           .spyOn(metamaskController, 'discoverAndCreateAccounts')
           .mockResolvedValue({});
 
@@ -3713,6 +3726,9 @@ describe('MetaMaskController', () => {
 
         await metamaskController.importMnemonicToVault(TEST_SEED_ALT);
 
+        // Wait for the fire-and-forget sync and discover operation to complete
+        await new Promise((resolve) => setImmediate(resolve));
+
         expect(metamaskController.discoverAndCreateAccounts).toHaveBeenCalled();
         expect(
           metamaskController._addAccountsWithBalance,
@@ -3723,6 +3739,13 @@ describe('MetaMaskController', () => {
         jest
           .spyOn(metamaskController, 'isMultichainAccountsFeatureState2Enabled')
           .mockReturnValue(true);
+
+        jest
+          .spyOn(
+            metamaskController.accountTreeController,
+            'syncWithUserStorage',
+          )
+          .mockResolvedValue();
 
         jest
           .spyOn(metamaskController, 'discoverAndCreateAccounts')
@@ -3739,6 +3762,9 @@ describe('MetaMaskController', () => {
           shouldSelectAccount: false,
           shouldImportSolanaAccount: false,
         });
+
+        // Wait for the fire-and-forget sync and discover operation to complete
+        await new Promise((resolve) => setImmediate(resolve));
 
         expect(metamaskController._addAccountsWithBalance).toHaveBeenCalled();
         expect(

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -44,7 +44,6 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { Header, Page } from '../../../components/multichain/pages/page';
 import ShowHideToggle from '../../../components/ui/show-hide-toggle';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import {
   getMetaMaskHdKeyrings,
   getIsSocialLoginFlow,
@@ -63,7 +62,6 @@ const defaultNumberOfWords = 12;
 export const ImportSrp = () => {
   const t = useI18nContext();
   const history = useHistory();
-  const trackEvent = useContext(MetaMetricsContext);
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const [srpError, setSrpError] = useState('');
   const [pasteFailed, setPasteFailed] = useState(false);
@@ -80,7 +78,6 @@ export const ImportSrp = () => {
   const isSocialLoginEnabled = useSelector(getIsSocialLoginFlow);
   const isSeedlessPasswordOutdated = useSelector(getIsSeedlessPasswordOutdated);
   const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
-  const newHdEntropyIndex = hdKeyrings.length;
 
   const [loading, setLoading] = useState(false);
 

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { isValidMnemonic } from '@ethersproject/hdnode';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
@@ -43,11 +37,7 @@ import { clearClipboard } from '../../../helpers/utils/util';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { Header, Page } from '../../../components/multichain/pages/page';
 import ShowHideToggle from '../../../components/ui/show-hide-toggle';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
-import {
-  getMetaMaskHdKeyrings,
-  getIsSocialLoginFlow,
-} from '../../../selectors';
+import { getIsSocialLoginFlow } from '../../../selectors';
 import { endTrace, trace, TraceName } from '../../../../shared/lib/trace';
 import { getIsSeedlessPasswordOutdated } from '../../../ducks/metamask/metamask';
 import PasswordOutdatedModal from '../../../components/app/password-outdated-modal';
@@ -77,7 +67,6 @@ export const ImportSrp = () => {
   );
   const isSocialLoginEnabled = useSelector(getIsSocialLoginFlow);
   const isSeedlessPasswordOutdated = useSelector(getIsSeedlessPasswordOutdated);
-  const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
 
   const [loading, setLoading] = useState(false);
 

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -104,32 +104,10 @@ export const ImportSrp = () => {
 
     const joinedSrp = secretRecoveryPhrase.join(' ');
     if (joinedSrp) {
-      const result = (await dispatch(
-        importMnemonicToVault(joinedSrp),
-      )) as unknown as {
-        newAccountAddress: string;
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        discoveredAccounts: { Bitcoin: number; Solana: number };
-      };
-
-      const { discoveredAccounts } = result;
+      await dispatch(importMnemonicToVault(joinedSrp));
 
       // Clear the secret recovery phrase after importing
       setSecretRecoveryPhrase(Array(defaultNumberOfWords).fill(''));
-
-      // Track the event with the discovered accounts
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      trackEvent({
-        event: MetaMetricsEventName.ImportSecretRecoveryPhraseCompleted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          hd_entropy_index: newHdEntropyIndex,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          number_of_solana_accounts_discovered: discoveredAccounts?.Solana,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          number_of_bitcoin_accounts_discovered: discoveredAccounts?.Bitcoin,
-        },
-      });
     }
 
     history.push(DEFAULT_ROUTE);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -734,23 +734,14 @@ export function createNewVaultAndRestore(
   };
 }
 
-export function importMnemonicToVault(mnemonic: string): ThunkAction<
-  Promise<{
-    newAccountAddress: string;
-    discoveredAccounts: { bitcoin: number; solana: number };
-  }>,
-  MetaMaskReduxState,
-  unknown,
-  AnyAction
-> {
+export function importMnemonicToVault(
+  mnemonic: string,
+): ThunkAction<Promise<void>, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.importMnemonicToVault`);
 
-    return new Promise<{
-      newAccountAddress: string;
-      discoveredAccounts: { bitcoin: number; solana: number };
-    }>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       callBackgroundMethod(
         'importMnemonicToVault',
         [mnemonic],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36882?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: improve perceived performance after importing a new SRP

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1161

## **Manual testing steps**

1. Onboard, add a new SRP
2. Verify that after clicking the import button, we directly come back to the wallet home page
3. Verify that syncing & discovery happens after coming back to the home page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make SRP import non-blocking by deferring sync/account discovery to background and moving metrics there; update UI and tests accordingly.
> 
> - **Controller (metamask-controller.js)**:
>   - Import SRP flow: wrap account-tree sync and multichain account discovery in a fire-and-forget task (no await) to avoid blocking UI.
>   - Move metrics tracking (`ImportSecretRecoveryPhraseCompleted` with `hd_entropy_index`, discovered Solana/Bitcoin counts) to background after discovery.
>   - Change `importMnemonicToVault` return type to `Promise<void>` and adjust JSDoc.
> - **UI (Import SRP page)**:
>   - Stop awaiting discovery results/metrics; dispatch `importMnemonicToVault` and immediately navigate; remove MetaMetrics usage and HD keyrings-derived entropy index.
> - **Actions (store/actions.ts)**:
>   - Update `importMnemonicToVault` thunk to return `Promise<void>`.
> - **Tests**:
>   - Await microtask (`setImmediate`) to let fire-and-forget work complete; add mocks for `syncWithUserStorage`; update expectations to reflect new async flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db4b81d6a8bebf6d15a459efa35a491011574ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->