### PR TITLE
feat: Shield: Add origin to sentinel URL

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -87,7 +87,7 @@ export const TransactionControllerInit: ControllerInitFunction<
         chainId
       ] as unknown as SavedGasFees | undefined;
     },
-    getSimulationConfig: async (url) => {
+    getSimulationConfig: async (url, opts) => {
       const getToken = () =>
         initMessenger.call('AuthenticationController:getBearerToken');
       const getShieldSubscription = () =>
@@ -95,7 +95,10 @@ export const TransactionControllerInit: ControllerInitFunction<
           'SubscriptionController:getSubscriptionByProduct',
           PRODUCT_TYPES.SHIELD,
         );
-      return getShieldGatewayConfig(getToken, getShieldSubscription, url);
+      const origin = opts?.txMeta?.origin;
+      return getShieldGatewayConfig(getToken, getShieldSubscription, url, {
+        origin,
+      });
     },
     incomingTransactions: {
       client: `extension-${process.env.METAMASK_VERSION?.replace(/\./gu, '-')}`,

--- a/package.json
+++ b/package.json
@@ -361,7 +361,7 @@
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/streams": "^0.4.0",
     "@metamask/subscription-controller": "^2.0.0",
-    "@metamask/transaction-controller": "^60.6.0",
+    "@metamask/transaction-controller": "^60.7.0",
     "@metamask/user-operation-controller": "^39.0.0",
     "@metamask/utils": "^11.4.2",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/shared/modules/shield.ts
+++ b/shared/modules/shield.ts
@@ -5,6 +5,9 @@ export async function getShieldGatewayConfig(
   getToken: () => Promise<string>,
   getShieldSubscription: () => Subscription | undefined,
   url: string,
+  opts?: {
+    origin?: string;
+  },
 ): Promise<{ newUrl: string; authorization: string | undefined }> {
   const shieldSubscription = getShieldSubscription();
   const isShieldSubscriptionActive = shieldSubscription
@@ -24,10 +27,17 @@ export async function getShieldGatewayConfig(
   }
 
   try {
-    const token = await getToken();
+    let newUrl = `${host}/proxy?url=${encodeURIComponent(url)}`;
+    const origin = opts?.origin;
+    if (origin) {
+      newUrl += `&origin=${encodeURIComponent(origin)}`;
+    }
+
+    const authorization = await getToken();
+
     return {
-      newUrl: `${host}/proxy?url=${encodeURIComponent(url)}`,
-      authorization: token,
+      newUrl,
+      authorization,
     };
   } catch (error) {
     console.error('Failed to get bearer token', error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8097,43 +8097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.2.0":
-  version: 60.6.0
-  resolution: "@metamask/transaction-controller@npm:60.6.0"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/base-controller": "npm:^8.4.0"
-    "@metamask/controller-utils": "npm:^11.14.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
-    async-mutex: "npm:^0.5.0"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^33.0.0
-    "@metamask/approval-controller": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-    "@metamask/gas-fee-controller": ^24.0.0
-    "@metamask/network-controller": ^24.0.0
-    "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/c23f146d625fc92093361785950cd950421615f91e781950a66e61f8c689806e61c7db03bd3cecf7b44fa4406c12204ad7e69f9b40c18062f77f14175ee7bf2a
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@npm:^60.7.0":
+"@metamask/transaction-controller@npm:^60.2.0, @metamask/transaction-controller@npm:^60.7.0":
   version: 60.7.0
   resolution: "@metamask/transaction-controller@npm:60.7.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8097,7 +8097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.2.0, @metamask/transaction-controller@npm:^60.6.0":
+"@metamask/transaction-controller@npm:^60.2.0":
   version: 60.6.0
   resolution: "@metamask/transaction-controller@npm:60.6.0"
   dependencies:
@@ -8130,6 +8130,42 @@ __metadata:
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
   checksum: 10/c23f146d625fc92093361785950cd950421615f91e781950a66e61f8c689806e61c7db03bd3cecf7b44fa4406c12204ad7e69f9b40c18062f77f14175ee7bf2a
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@npm:^60.7.0":
+  version: 60.7.0
+  resolution: "@metamask/transaction-controller@npm:60.7.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^8.4.1"
+    "@metamask/controller-utils": "npm:^11.14.1"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.8.1"
+    async-mutex: "npm:^0.5.0"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/accounts-controller": ^33.0.0
+    "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+    "@metamask/gas-fee-controller": ^24.0.0
+    "@metamask/network-controller": ^24.0.0
+    "@metamask/remote-feature-flag-controller": ^1.5.0
+  checksum: 10/5aa7b5479094f9e12813b3b18c13513ef2e68519afe753657ab23c594b88c7e3d42c740621d7e952cd966efea797dd6de3e15f127578b02c275084ed6ada48fe
   languageName: node
   linkType: hard
 
@@ -32039,7 +32075,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
-    "@metamask/transaction-controller": "npm:^60.6.0"
+    "@metamask/transaction-controller": "npm:^60.7.0"
     "@metamask/user-operation-controller": "npm:^39.0.0"
     "@metamask/utils": "npm:^11.4.2"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We identified an attack vector on the Shield backend, because the transaction `origin` is currently not hashed into the coverage identifier that is used to identify coverage requests. In order to hash the `origin` into the coverageId, we need to make it available to all proxy backend services, so that they can derive the coverageId correctly.

Previously, the coverageId was not available to the sentinel proxy. We here make use of a recent change to the transaction controller, that allows identifying the origin corresponding to a sentinel request. If Shield is enabled, we attach the `origin` as a URL parameter to the proxy URL.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36901?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass transaction origin to the Shield gateway by appending it to the proxy URL; update TransactionController integration and dependency to ^60.7.0.
> 
> - **Shield integration**:
>   - `shared/modules/shield.ts`: `getShieldGatewayConfig` now accepts `opts` with optional `origin` and appends `&origin=` to the proxy `newUrl` when present; returns `authorization` from `getToken`.
>   - `app/scripts/controller-init/confirmations/transaction-controller-init.ts`: `getSimulationConfig` now takes `(url, opts)` and forwards `opts?.txMeta?.origin` to `getShieldGatewayConfig`.
> - **Dependencies**:
>   - Bump `@metamask/transaction-controller` to `^60.7.0` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff2810e5b4dcd45560f2648665bfae748f44faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->