### PR TITLE
fix: Sponsored transaction by normalising calldata handling

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -370,7 +370,11 @@ export async function publishHook({
     transactionMeta.chainId,
   );
 
-  if (!isSmartTransaction || !sendBundleSupport) {
+  if (
+    !isSmartTransaction ||
+    !sendBundleSupport ||
+    transactionMeta.isGasFeeSponsored
+  ) {
     const hook = new Delegation7702PublishHook({
       isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(
         transactionController,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

 - Added a shared #normalizeCallData helper in Delegation7702PublishHook so we always feed canonical 0x calldata into both the caveat builder and execution encoder, preventing stray zero bytes from drifting into caveat terms.
 - Updated exactExecutionBuilder to reuse encodeSingleExecution so the stored caveat terms are guaranteed to match the execution payload, and relaxed validation so empty calldata is treated as 0x instead of 0x0.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36902?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes calldata and keeps caveat terms byte-identical to execution, while sending sponsored transactions through the delegation publish hook.
> 
> - **EIP-7702 Delegation flow**:
>   - Add `#normalizeCallData` to canonicalize `txParams.data` (lowercase, `0x`-prefixed, even-length) and use it in `#buildExecutions` and `#buildCaveats`.
>   - Route when to use delegation: include `transactionMeta.isGasFeeSponsored` in the non-smart/non-send-bundle condition in `publishHook`.
> - **Caveats/encoding**:
>   - `exactExecutionBuilder`: reuse `encodeSingleExecution` so `terms` match the execution payload; relax data validation to accept empty calldata as `0x` (not `0x0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1403824e3138bac4bc76af2564b5bd468d3184b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->