### PR TITLE
chore: use stable empty references

### DIFF
--- a/ui/selectors/alerts.ts
+++ b/ui/selectors/alerts.ts
@@ -3,13 +3,14 @@ import {
   Alert,
   ConfirmAlertsState,
 } from '../ducks/confirm-alerts/confirm-alerts';
+import { EMPTY_ARRAY } from './shared';
 
 export type AlertsState = {
   confirmAlerts: ConfirmAlertsState;
 };
 
 export function selectAlerts(state: AlertsState, ownerId: string): Alert[] {
-  return state.confirmAlerts?.alerts[ownerId] ?? [];
+  return state.confirmAlerts?.alerts[ownerId] ?? EMPTY_ARRAY;
 }
 
 export const selectGeneralAlerts = createSelector(

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -43,6 +43,7 @@ import { findAssetByAddress } from '../pages/asset/util';
 import { isEvmChainId } from '../../shared/lib/asset-utils';
 import { getSelectedInternalAccount } from './accounts';
 import { getMultichainBalances } from './multichain';
+import { EMPTY_OBJECT } from './shared';
 import {
   getCurrencyRates,
   getCurrentNetwork,
@@ -565,9 +566,8 @@ export const getMultichainNativeTokenBalance = createDeepEqualSelector(
  * @returns The `metamask` slice or an empty object.
  */
 const getMetamaskState = (state: BalanceCalculationState) =>
-  state.metamask ?? {};
+  state.metamask ?? EMPTY_OBJECT;
 
-const EMPTY_OBJ = Object.freeze({});
 const EMPTY_ACCOUNT_TREE = Object.freeze({
   wallets: {},
   selectedAccountGroup: '',
@@ -592,8 +592,8 @@ const selectAccountTreeStateForBalances = createSelector(
   ],
   (accountTree, accountGroupsMetadata, accountWalletsMetadata) => ({
     accountTree: accountTree ?? EMPTY_ACCOUNT_TREE,
-    accountGroupsMetadata: accountGroupsMetadata ?? EMPTY_OBJ,
-    accountWalletsMetadata: accountWalletsMetadata ?? EMPTY_OBJ,
+    accountGroupsMetadata: accountGroupsMetadata ?? EMPTY_OBJECT,
+    accountWalletsMetadata: accountWalletsMetadata ?? EMPTY_OBJECT,
   }),
 );
 
@@ -636,8 +636,8 @@ const selectTokenRatesStateForBalances = createSelector(
 const selectMultichainRatesStateForBalances = createSelector(
   [getAssetsRates, getHistoricalPrices],
   (conversionRates, historicalPrices) => ({
-    conversionRates: conversionRates ?? EMPTY_OBJ,
-    historicalPrices: historicalPrices ?? EMPTY_OBJ,
+    conversionRates: conversionRates ?? EMPTY_OBJECT,
+    historicalPrices: historicalPrices ?? EMPTY_OBJECT,
   }),
 );
 
@@ -657,9 +657,9 @@ const selectMultichainBalancesStateForBalances = createSelector(
 const selectTokensStateForBalances = createSelector(
   [(state: BalanceCalculationState) => getMetamaskState(state).allTokens],
   (allTokens) => ({
-    allTokens: allTokens ?? EMPTY_OBJ,
-    allIgnoredTokens: EMPTY_OBJ,
-    allDetectedTokens: EMPTY_OBJ,
+    allTokens: allTokens ?? EMPTY_OBJECT,
+    allIgnoredTokens: EMPTY_OBJECT,
+    allDetectedTokens: EMPTY_OBJECT,
   }),
 );
 
@@ -670,7 +670,7 @@ const selectCurrencyRateStateForBalances = createSelector(
   [getCurrentCurrency, getCurrencyRates],
   (currentCurrency, currencyRates) => ({
     currentCurrency: currentCurrency ?? 'usd',
-    currencyRates: currencyRates ?? {},
+    currencyRates: currencyRates ?? EMPTY_OBJECT,
   }),
 );
 

--- a/ui/selectors/nft.ts
+++ b/ui/selectors/nft.ts
@@ -2,6 +2,7 @@ import { Nft, NftContract } from '@metamask/assets-controllers';
 import { createSelector } from 'reselect';
 import { NetworkState } from '../../shared/modules/selectors/networks';
 import { getMemoizedCurrentChainId } from './selectors';
+import { EMPTY_OBJECT } from './shared';
 
 export type NftState = {
   metamask: {
@@ -19,7 +20,7 @@ export type NftState = {
 };
 
 function getNftContractsByChainByAccount(state: NftState) {
-  return state.metamask.allNftContracts ?? {};
+  return state.metamask.allNftContracts ?? EMPTY_OBJECT;
 }
 
 /**
@@ -29,7 +30,7 @@ function getNftContractsByChainByAccount(state: NftState) {
  * @returns All NFTs owned by the user, keyed by chain ID then account address.
  */
 export function getNftsByChainByAccount(state: NftState) {
-  return state.metamask.allNfts ?? {};
+  return state.metamask.allNfts ?? EMPTY_OBJECT;
 }
 
 export const getNftContractsByAddressByChain = createSelector(

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -132,6 +132,7 @@ import { hasTransactionData } from '../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
 import { isSnapIgnoredInProd } from '../helpers/utils/snaps';
+import { EMPTY_ARRAY } from './shared';
 import {
   getAllUnapprovedTransactions,
   getCurrentNetworkTransactions,
@@ -1286,7 +1287,7 @@ export const selectNftsByChainId = createSelector(
   (state) => state.metamask.allNfts,
   (_state, chainId) => chainId,
   (selectedAccount, nfts, chainId) => {
-    return nfts?.[selectedAccount.address]?.[chainId] ?? [];
+    return nfts?.[selectedAccount.address]?.[chainId] ?? EMPTY_ARRAY;
   },
 );
 
@@ -4064,7 +4065,8 @@ export function getShowUpdateModal(state) {
  */
 export const selectNonZeroUnusedApprovalsAllowList = createSelector(
   getRemoteFeatureFlags,
-  (remoteFeatureFlags) => remoteFeatureFlags?.nonZeroUnusedApprovals ?? [],
+  (remoteFeatureFlags) =>
+    remoteFeatureFlags?.nonZeroUnusedApprovals ?? EMPTY_ARRAY,
 );
 
 /**

--- a/ui/selectors/shared.ts
+++ b/ui/selectors/shared.ts
@@ -1,0 +1,2 @@
+export const EMPTY_ARRAY = Object.freeze([]);
+export const EMPTY_OBJECT = Object.freeze({});


### PR DESCRIPTION
## **Description**

When selectors return empty arrays or objects using the `??` or `||` operators, they create new instances every time the function is called if the value is undefined/null. This breaks reference equality and memoization and can cause excess re-renders.

## **Changelog**

CHANGELOG entry: chore: use stable empty references

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

```
useSelector(state => state.some.collection || []) // new array each time
```

### **After**
```
// stable instance
const EMPTY = []

useSelector(state => state.some.collection || EMPTY)
```
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ad-hoc []/{} fallbacks with shared frozen constants across selectors to stabilize memoization and references.
> 
> - **Selectors**:
>   - Alerts: `selectAlerts` now returns `EMPTY_ARRAY` fallback.
>   - Assets: use `EMPTY_OBJECT` for `getMetamaskState` and in balance-related selectors (account tree, rates, tokens, currency rates) instead of `{}`; remove local `EMPTY_OBJ` in favor of shared constant.
>   - NFTs: default `allNftContracts`/`allNfts` to `EMPTY_OBJECT`.
>   - General selectors: `selectNftsByChainId` and `selectNonZeroUnusedApprovalsAllowList` now return `EMPTY_ARRAY` when empty.
> - **Shared utils**:
>   - Add `ui/selectors/shared.ts` exporting frozen `EMPTY_ARRAY` and `EMPTY_OBJECT`; import and use where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9272811170d7b5af1e3bb234da61a4e461268f62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->