### PR TITLE
Test: Guaranteed working baseline be2a698ffb for popover positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+### Building
+
+- `yarn start` - Start development build (MV3) with file watching and logging
+- `yarn start:mv2` - Start development build (MV2/Firefox)
+- `yarn dist` - Create production build for Chromium-based browsers
+- `yarn dist:mv2` - Create production build for Firefox
+- `yarn build:test` - Create test build for e2e testing
+- `yarn start:test` - Start test build with live recompilation for development
+- `yarn webpack` - Use alternative faster Webpack build system (development only)
+
+### Testing
+
+- `yarn test` - Run all tests (lint + unit tests)
+- `yarn test:unit` - Run Jest unit tests only
+- `yarn test:unit:watch` - Run Jest tests in watch mode
+- `yarn test:unit:coverage` - Run unit tests with coverage report
+- `yarn test:e2e:chrome` - Run e2e tests on Chrome
+- `yarn test:e2e:firefox` - Run e2e tests on Firefox
+- `yarn test:e2e:single test/e2e/tests/PATH.spec.js` - Run single e2e test
+- `yarn test:integration` - Run integration tests
+- `yarn test-storybook` - Run Storybook tests
+
+### Linting and Code Quality
+
+- `yarn lint` - Run all linters (Prettier, ESLint, TypeScript, Stylelint, image optimization)
+- `yarn lint:fix` - Fix all auto-fixable linting issues
+- `yarn lint:eslint` - Run ESLint only
+- `yarn lint:tsc` - Run TypeScript compiler checks
+- `yarn lint:prettier` - Check Prettier formatting
+- `yarn lint:changed` - Lint only changed files (fast)
+- `yarn circular-deps:check` - Check for circular dependencies
+
+### Test Environment Setup
+
+- `yarn build:test` or `yarn download-builds --build-type test` to prepare test builds before running e2e tests
+- Use `yarn start:with-state` to start development with preloaded wallet state (requires TEST_SRP and PASSWORD in .metamaskrc)
+
+## Project Architecture
+
+### High-Level Structure
+
+MetaMask Extension is a browser extension wallet with a complex multi-layered architecture:
+
+**Core Layers:**
+
+- **Background Scripts** (`app/scripts/`) - Main controller logic, handles wallet state, transactions, and communication
+- **UI Layer** (`ui/`) - React/Redux frontend for popup, fullscreen, and notification interfaces
+- **Content Scripts** (`app/scripts/contentscript.js`) - Injected into web pages to provide Web3 API
+- **Inpage Scripts** (`app/scripts/inpage.js`) - Provider interface exposed to dapps
+
+**Key Directories:**
+
+- `app/scripts/controllers/` - Business logic controllers (preferences, transactions, etc.)
+- `app/scripts/lib/` - Utility libraries and middleware
+- `ui/components/` - Reusable React components
+- `ui/pages/` - Main application pages/routes
+- `shared/` - Code shared between background and UI (constants, utilities, types)
+- `test/` - Test utilities, fixtures, and e2e test infrastructure
+
+### Controller Architecture
+
+The extension uses a controller-based architecture where:
+
+- Controllers manage specific domains (accounts, transactions, networks, etc.)
+- Controllers communicate via events and method calls
+- State flows from controllers to UI via selectors
+- UI actions dispatch to controllers via background connection
+
+### Build System
+
+- Uses Webpack with custom build pipeline in `development/webpack/`
+- Supports multiple browser targets (Chrome MV3, Firefox MV2)
+- LavaMoat integration for supply chain security
+- Source maps and Sentry integration for production debugging
+
+### Key Configuration Files
+
+- `.metamaskrc` - Local development configuration (copy from `.metamaskrc.dist`)
+- `lavamoat/` - Security policies for dependency access control
+- `app/manifest/` - Browser extension manifest files for different targets
+
+### Feature Flags
+
+Feature flags can be enabled by:
+
+- Setting flags in `.metamaskrc` file
+- Using environment variables during build (e.g., `MULTICHAIN=1 yarn build:test`)
+- Runtime flags via remote feature flag controller
+
+### Development Workflow
+
+1. Install dependencies: `yarn install`
+2. Copy configuration: `cp .metamaskrc{.dist,}`
+3. Add your Infura Project ID to `.metamaskrc`
+4. Start development: `yarn start`
+5. Load extension in browser (see docs/add-to-chrome.md or docs/add-to-firefox.md)
+
+### Testing Strategy
+
+- **Unit Tests**: Jest for component and utility testing
+- **Integration Tests**: For cross-component interactions
+- **E2E Tests**: Selenium-based browser automation tests
+- **Storybook**: Component documentation and testing
+
+When running e2e tests, always ensure you have a test build ready using `yarn build:test` or `yarn download-builds --build-type test` before executing test commands.


### PR DESCRIPTION
## **Description**

**This PR tests the guaranteed working baseline to confirm popover positioning works correctly.**

Testing from commit `be2a698ffb` ("release: Bump main version to 13.6.0") which is the commit directly after 13.5.0 was cut from main. This should be a guaranteed working baseline since 13.5.0 CI builds definitively have working popovers.

**Expected Result:** Popovers should position correctly in GitHub Actions builds.

**Purpose:** 
- Establish a confirmed working baseline for git bisect
- Rule out any environmental factors in current CI setup  
- Confirm our understanding that the issue started after 13.5.0

If this works as expected, we can use this as the "good" commit for `git bisect` between here and current main to find the exact breaking commit.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36913?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Testing baseline for popover positioning issue affecting ALL popover components in main branch CI builds.

## **Manual testing steps**

1. Wait for GitHub Actions to build this PR
2. Download the built extension artifacts 
3. Load the extension in browser
4. Test popover positioning:
   - Click the account menu (top-right)
   - Click the global menu (hamburger icon)  
   - Open network selector
   - Verify popovers anchor correctly to their reference elements

**Expected Result:** All popovers should position correctly since this is the guaranteed working 13.6.0 baseline.

## **Screenshots/Recordings**

### **Expected Result**
Popovers should correctly anchor to their reference elements in GitHub Actions builds, matching the behavior seen in 13.5.0 builds.

## **Technical Notes**

- **Baseline Commit:** `be2a698ffb` - Release bump to 13.6.0 (directly after 13.5.0)
- **Known Working:** 13.5.0 CI builds have functional popovers
- **Next Step:** If confirmed working, use for git bisect against main branch
- **Issue:** ALL popovers float unanchored in current main branch CI builds

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable (this IS the test)
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.