### PR TITLE
test:  add e2e test for hide tokens without balance feature 

### DIFF
--- a/test/e2e/page-objects/pages/settings/general-settings.ts
+++ b/test/e2e/page-objects/pages/settings/general-settings.ts
@@ -13,6 +13,9 @@ class GeneralSettings {
     tag: 'h4',
   };
 
+  private readonly hideTokensWithoutBalanceToggle =
+    '[id="toggle-zero-balance"] .toggle-button';
+
   private readonly jazziconsAccountIdenticon = {
     tag: 'h6',
     text: 'Jazzicons',
@@ -99,6 +102,10 @@ class GeneralSettings {
 
   async checkNoLoadingOverlaySpinner(): Promise<void> {
     await this.driver.assertElementNotPresent(this.loadingOverlaySpinner);
+  }
+
+  async toggleHideTokensWithoutBalance(): Promise<void> {
+    await this.driver.clickElement(this.hideTokensWithoutBalanceToggle);
   }
 }
 

--- a/test/e2e/tests/settings/hide-token-without-balance.spec.ts
+++ b/test/e2e/tests/settings/hide-token-without-balance.spec.ts
@@ -1,0 +1,89 @@
+import { Suite } from 'mocha';
+import { toHex } from '@metamask/controller-utils';
+import { withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixture-builder';
+import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
+import AssetListPage from '../../page-objects/pages/home/asset-list';
+import GeneralSettings from '../../page-objects/pages/settings/general-settings';
+import HomePage from '../../page-objects/pages/home/homepage';
+import SettingsPage from '../../page-objects/pages/settings/settings-page';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+
+describe('Hide tokens without balance', function (this: Suite) {
+  // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // This script tests the "hide tokens without balance" feature in wallet settings, ensuring that tokens with zero        //
+  // balances are correctly hidden from the tokens list tab when corresponding toggle is enabled.                       //
+  // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  it('user can activate hide tokens without balance feature via settings', async function () {
+    const smartContract = SMART_CONTRACTS.HST;
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withTokensController({
+            allTokens: {
+              [toHex(1337)]: {
+                '0x5cfe73b6021e818b776b421b1c4db2474086a7e1': [
+                  {
+                    address: '0x581c3C1A2A4EBDE2A0Df29B5cf4c116E42945947',
+                    decimals: 4,
+                    image: null,
+                    isERC721: false,
+                    symbol: 'TST',
+                  },
+                  {
+                    address: '0x581c3C1A2A4EBDE2A0Df29B5cf4c116E42945948',
+                    decimals: 4,
+                    image: null,
+                    isERC721: false,
+                    symbol: 'TST2',
+                  },
+                ],
+              },
+            },
+            tokens: [
+              {
+                address: '0x581c3C1A2A4EBDE2A0Df29B5cf4c116E42945948',
+                decimals: 4,
+                image: null,
+                isERC721: false,
+                symbol: 'TST2',
+              },
+              {
+                address: '0x581c3C1A2A4EBDE2A0Df29B5cf4c116E42945947',
+                decimals: 4,
+                image: null,
+                isERC721: false,
+                symbol: 'TST',
+              },
+            ],
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        smartContract,
+      },
+      async ({ driver, localNodes }) => {
+        await loginWithBalanceValidation(driver, localNodes[0]);
+
+        // Verify that both zero-balance tokens and non-zero-balance tokens are displayed by default
+        const tokenList = new AssetListPage(driver);
+        await tokenList.checkTokenItemNumber(3);
+        await tokenList.checkTokenExistsInList('Ethereum');
+        await tokenList.checkTokenExistsInList('TST');
+        await tokenList.checkTokenExistsInList('TST2');
+
+        // Navigate to settings and toggle on "hide tokens without balance" feature
+        await new HomePage(driver).headerNavbar.openSettingsPage();
+        const generalSettings = new GeneralSettings(driver);
+        await generalSettings.checkPageIsLoaded();
+        await generalSettings.toggleHideTokensWithoutBalance();
+        await new SettingsPage(driver).closeSettingsPage();
+
+        // Check that tokens with zero balances are hidden, tokens with non-zero balances remain visible
+        await new HomePage(driver).checkPageIsLoaded();
+        await tokenList.checkTokenItemNumber(2);
+        await tokenList.checkTokenExistsInList('Ethereum');
+        await tokenList.checkTokenExistsInList('TST');
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR is to add an e2e test for the hide tokens without balance feature in settings. It is to catch this bug found during release testing: https://github.com/MetaMask/metamask-extension/issues/36764

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36918?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/36764

## **Manual testing steps**

Test should pass and be stable

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an e2e test verifying the settings toggle hides zero-balance tokens and extends General Settings page object with a toggle helper.
> 
> - **Tests**:
>   - Add `test/e2e/tests/settings/hide-token-without-balance.spec.ts` to verify enabling “hide tokens without balance” hides zero-balance tokens while keeping non-zero tokens visible.
>   - Uses fixtures to seed tokens (`TST`, `TST2`) and validates list counts before/after toggling.
> - **Page Objects**:
>   - Update `test/e2e/page-objects/pages/settings/general-settings.ts`:
>     - Add `hideTokensWithoutBalanceToggle` selector (`[id="toggle-zero-balance"] .toggle-button`).
>     - Add `toggleHideTokensWithoutBalance()` method to click the toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8427b1be8f68404371cce30938685796512293f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->