### PR TITLE
feat: control btc provider state via remote feature flag

### DIFF
--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -46,7 +46,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
       ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       btcProvider,
       ///: END:ONLY_INCLUDE_IF
-    ]
+    ],
   });
 
   const preferencesState = initMessenger.call('PreferencesController:getState');

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1622,7 +1622,6 @@ export async function withSolanaAccountSnap(
         // - If this flag is not set, the slides count will be 4.
         // - If this flag is set, the slides count will be 5.
         remoteFeatureFlags: {
-          addSolanaAccount: true, // NOTE: Will be deprecated soon.
           solanaAccounts: { enabled: true, minimumVersion: '13.6.0' },
           bridgeConfig: showSnapConfirmation
             ? featureFlagsWithSnapConfirmation

--- a/test/e2e/tests/solana/web-socket-connection.spec.ts
+++ b/test/e2e/tests/solana/web-socket-connection.spec.ts
@@ -17,7 +17,6 @@ describe('Solana Web Socket', function (this: Suite) {
         title: this.test?.fullTitle(),
         manifestFlags: {
           remoteFeatureFlags: {
-            addSolanaAccount: true, // NOTE: Will be deprecated soon.
             solanaAccounts: { enabled: true, minimumVersion: '13.6.0' },
           },
         },
@@ -52,7 +51,6 @@ describe('Solana Web Socket', function (this: Suite) {
         title: this.test?.fullTitle(),
         manifestFlags: {
           remoteFeatureFlags: {
-            addSolanaAccount: true, // NOTE: Will be deprecated soon.
             solanaAccounts: { enabled: true, minimumVersion: '13.6.0' },
           },
         },
@@ -97,7 +95,6 @@ describe('Solana Web Socket', function (this: Suite) {
         title: this.test?.fullTitle(),
         manifestFlags: {
           remoteFeatureFlags: {
-            addSolanaAccount: true, // NOTE: Will be deprecated soon.
             solanaAccounts: { enabled: true, minimumVersion: '13.6.0' },
           },
         },

--- a/ui/pages/multichain-accounts/wallet-details/wallet-details.component.test.tsx
+++ b/ui/pages/multichain-accounts/wallet-details/wallet-details.component.test.tsx
@@ -76,28 +76,8 @@ jest.mock('../../../store/actions', () => ({
 
 jest.mock('../../../selectors', () => ({
   getMetaMaskHdKeyrings: jest.fn(),
-  getIsBitcoinSupportEnabled: jest.fn((state) => {
-    const { bitcoinAccounts } = state.metamask.remoteFeatureFlags;
-    if (!bitcoinAccounts?.enabled) {
-      return false;
-    }
-    if (!bitcoinAccounts?.minimumVersion) {
-      return false;
-    }
-    // Check if current app version (13.6.0) >= minimum required version
-    return bitcoinAccounts.minimumVersion <= '13.6.0';
-  }),
-  getIsSolanaSupportEnabled: jest.fn((state) => {
-    const { solanaAccounts } = state.metamask.remoteFeatureFlags;
-    if (!solanaAccounts?.enabled) {
-      return false;
-    }
-    if (!solanaAccounts?.minimumVersion) {
-      return false;
-    }
-    // Check if current app version (13.6.0) >= minimum required version
-    return solanaAccounts.minimumVersion <= '13.6.0';
-  }),
+  getIsBitcoinSupportEnabled: jest.fn(() => true),
+  getIsSolanaSupportEnabled: jest.fn(() => true),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -33,25 +33,13 @@ import {
 jest.mock('../selectors', () => ({
   getIsBitcoinSupportEnabled: jest.fn((state) => {
     const { bitcoinAccounts } = state.metamask.remoteFeatureFlags;
-    if (!bitcoinAccounts?.enabled) {
-      return false;
-    }
-    if (!bitcoinAccounts?.minimumVersion) {
-      return false;
-    }
-    // Check if current app version (13.6.0) >= minimum required version
-    return bitcoinAccounts.minimumVersion <= '13.6.0';
+    // Keep this simple, only check if it's enabled or not.
+    return bitcoinAccounts?.enabled;
   }),
   getIsSolanaSupportEnabled: jest.fn((state) => {
     const { solanaAccounts } = state.metamask.remoteFeatureFlags;
-    if (!solanaAccounts?.enabled) {
-      return false;
-    }
-    if (!solanaAccounts?.minimumVersion) {
-      return false;
-    }
-    // Check if current app version (13.6.0) >= minimum required version
-    return solanaAccounts.minimumVersion <= '13.6.0';
+    // Keep this simple, only check if it's enabled or not.
+    return solanaAccounts?.enabled;
   }),
   getIsSolanaTestnetSupportEnabled: jest.fn(
     (state) => state.metamask.remoteFeatureFlags.solanaTestnetsEnabled,


### PR DESCRIPTION
## **Description**

More fixes/refactors.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36924?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes deprecated Solana flag from E2E tests and simplifies Bitcoin/Solana support mocks to ignore version checks; minor formatting cleanup.
> 
> - **Tests**:
>   - **Solana E2E**: Remove deprecated `remoteFeatureFlags.addSolanaAccount` from `test/e2e/tests/solana/common-solana.ts` and `test/e2e/tests/solana/web-socket-connection.spec.ts`.
>   - **Wallet Details test**: Simplify `getIsBitcoinSupportEnabled` and `getIsSolanaSupportEnabled` mocks to always return `true` in `ui/pages/multichain-accounts/wallet-details/wallet-details.component.test.tsx`.
>   - **Network selectors test**: Simplify `getIsBitcoinSupportEnabled`/`getIsSolanaSupportEnabled` mocks to only check the `enabled` flag in `ui/selectors/multichain/networks.test.ts`.
> - **Misc**:
>   - Formatting: add trailing comma in `app/scripts/controller-init/multichain/multichain-account-service-init.ts` `providers` array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08cad4cddd09c71f4176d5de8ac68cfe70aec27a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->