### PR TITLE
fix: flaky test `Account syncing - Multiple SRPs adds accounts across multiple SRPs and sync them`

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -525,17 +525,16 @@ class AccountListPage {
     console.log(
       `Open multichain account menu in account list for account ${options.accountLabel}`,
     );
-    // We make sure the Wallet SRP is loaded and then click the account label for that SRP
+    // To ensure no pending Create Account action is in progress
     await this.driver.assertElementNotPresent(this.creatingAccountMessage, {
       waitAtLeastGuard: largeDelayMs,
     });
-    const walletSrp = await this.driver.findElement({
-      text: `Wallet ${(options.srpIndex ?? 0) + 1}`,
-    });
-    const accountElement = await this.driver.findNestedElement(walletSrp, {
-      text: options.accountLabel,
-    });
-    await accountElement.click();
+
+    const multichainAccountMenuIcons = await this.driver.findElements(
+      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
+    );
+
+    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -84,6 +84,11 @@ class AccountListPage {
   private readonly closeMultichainAccountsPageButton =
     '.multichain-page-header button[aria-label="Back"]';
 
+  private readonly creatingAccountMessage = {
+    text: 'Creating account...',
+    tag: 'div',
+  };
+
   private readonly addMultichainWalletButton =
     '[data-testid="account-list-add-wallet-button"]';
 
@@ -520,6 +525,9 @@ class AccountListPage {
     console.log(
       `Open multichain account menu in account list for account ${options.accountLabel}`,
     );
+    await this.driver.assertElementNotPresent(this.creatingAccountMessage, {
+      waitAtLeastGuard: largeDelayMs,
+    });
     const multichainAccountMenuIcons = await this.driver.findElements(
       `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
     );

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -525,14 +525,17 @@ class AccountListPage {
     console.log(
       `Open multichain account menu in account list for account ${options.accountLabel}`,
     );
+    // We make sure the Wallet SRP is loaded and then click the account label for that SRP
     await this.driver.assertElementNotPresent(this.creatingAccountMessage, {
       waitAtLeastGuard: largeDelayMs,
     });
-    const multichainAccountMenuIcons = await this.driver.findElements(
-      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
-    );
-
-    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
+    const walletSrp = await this.driver.findElement({
+      text: `Wallet ${(options.srpIndex ?? 0) + 1}`,
+    });
+    const accountElement = await this.driver.findNestedElement(walletSrp, {
+      text: options.accountLabel,
+    });
+    await accountElement.click();
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -86,7 +86,7 @@ class AccountListPage {
 
   private readonly creatingAccountMessage = {
     text: 'Creating account...',
-    tag: 'div',
+    tag: 'p',
   };
 
   private readonly addMultichainWalletButton =

--- a/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
@@ -3,13 +3,14 @@ import {
   USER_STORAGE_GROUPS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_KEY,
 } from '@metamask/account-tree-controller';
-import { withFixtures, unlockWallet } from '../../../helpers';
+import { withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixture-builder';
 import { mockIdentityServices } from '../mocks';
 import {
   UserStorageMockttpController,
   UserStorageMockttpControllerEvents,
 } from '../../../helpers/identity/user-storage/userStorageMockttpController';
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 import HeaderNavbar from '../../../page-objects/pages/header-navbar';
 import AccountListPage from '../../../page-objects/pages/account-list-page';
 import HomePage from '../../../page-objects/pages/home/homepage';
@@ -54,7 +55,12 @@ describe('Account syncing - Multiple SRPs', function () {
         testSpecificMock: sharedMockSetup,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
+        // Balance is 0 because aggregated balance has changed and doesn't display dev networks
+        // The method should be udpdated to use the new selector and we can then remove checkExpectedTokenBalanceIsDisplayed
+        await loginWithBalanceValidation(driver, undefined, undefined, '0');
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedTokenBalanceIsDisplayed('25', 'ETH');
 
         const header = new HeaderNavbar(driver);
         await header.checkPageIsLoaded();
@@ -120,7 +126,6 @@ describe('Account syncing - Multiple SRPs', function () {
           srpIndex: 1, // Second SRP
         });
 
-        const homePage = new HomePage(driver);
         await homePage.checkHasAccountSyncingSyncedAtLeastOnce();
 
         await driver.delay(2000); // Since we'll have two potential 'Account 2's, it's difficult to wait for the new one to appear, so just wait a bit
@@ -154,12 +159,15 @@ describe('Account syncing - Multiple SRPs', function () {
         testSpecificMock: sharedMockSetup,
       },
       async ({ driver }) => {
-        await unlockWallet(driver);
-
+        // Balance is 0 because aggregated balance has changed and doesn't display dev networks
+        // The method should be udpdated to use the new selector and we can then remove checkExpectedTokenBalanceIsDisplayed
+        await loginWithBalanceValidation(driver, undefined, undefined, '0');
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedTokenBalanceIsDisplayed('25', 'ETH');
         const header = new HeaderNavbar(driver);
         await header.checkPageIsLoaded();
 
-        const homePage = new HomePage(driver);
         await homePage.checkHasAccountSyncingSyncedAtLeastOnce();
         // await driver.delay(2000); // Wait for potential sync to complete
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The click fails because the element is not there yet (Account 2) because the account is being created

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/64423f5d-1eeb-48b0-b824-865d28ff81ad" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36939?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Waits for "Creating account..." to clear before opening multichain account menu and updates the multi-SRP e2e to use loginWithBalanceValidation with balance checks.
> 
> - **E2E Page Objects**:
>   - `test/e2e/page-objects/pages/account-list-page.ts`: Add `creatingAccountMessage` selector and assert it's not present (with `largeDelayMs` guard) before `openMultichainAccountMenu` clicks the menu icon.
> - **E2E Tests**:
>   - `test/e2e/tests/identity/account-syncing/multi-srp.spec.ts`:
>     - Replace `unlockWallet` with `loginWithBalanceValidation`, add `HomePage` load + balance checks (`0` aggregated, then `25 ETH`).
>     - Minor cleanup of redundant `HomePage` instantiation and ordering around account creation/rename steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41bf9deaf018d209eec2191c09934b594a978e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->