### PR TITLE
fix: in redesigned send add filtering by chainId in address book contacts

### DIFF
--- a/ui/pages/confirmations/hooks/send/useContactRecipients.test.ts
+++ b/ui/pages/confirmations/hooks/send/useContactRecipients.test.ts
@@ -2,6 +2,7 @@ import { isAddress as isEvmAddress } from 'ethers/lib/utils';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers';
 import mockState from '../../../../../test/data/mock-state.json';
 import * as selectors from '../../../../selectors';
+import * as SendContext from '../../context/send';
 import { useContactRecipients } from './useContactRecipients';
 import * as useSendTypeModule from './useSendType';
 import { useSendType } from './useSendType';
@@ -47,7 +48,10 @@ describe('useContactRecipients', () => {
     mockGetCompleteAddressBook.mockReturnValue(mockAddressBookEntries);
   });
 
-  it('returns EVM contacts when isEvmSendType is true', () => {
+  it('returns EVM contacts filtered by chainId when isEvmSendType is true', () => {
+    jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+      chainId: '0x1',
+    } as unknown as SendContext.SendContextType);
     mockUseSendType.mockReturnValue({
       isEvmSendType: true,
       isSolanaSendType: false,
@@ -64,11 +68,7 @@ describe('useContactRecipients', () => {
         address: '0x1234567890abcdef1234567890abcdef12345678',
         contactName: 'John Doe',
         isContact: true,
-      },
-      {
-        address: '0xabcdef1234567890abcdef1234567890abcdef12',
-        contactName: 'Bob Wilson',
-        isContact: true,
+        seedIcon: undefined,
       },
     ]);
   });
@@ -104,6 +104,9 @@ describe('useContactRecipients', () => {
   });
 
   it('filters out non-EVM addresses when isEvmSendType is true', () => {
+    jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+      chainId: '0x1',
+    } as unknown as SendContext.SendContextType);
     mockUseSendType.mockReturnValue({
       isEvmSendType: true,
       isSolanaSendType: false,

--- a/ui/pages/confirmations/hooks/send/useContactRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useContactRecipients.ts
@@ -1,9 +1,8 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { isAddress as isEvmAddress } from 'ethers/lib/utils';
-import { AddressBookEntry } from '@metamask/address-book-controller';
 
 import { getCompleteAddressBook } from '../../../../selectors';
+import { useSendContext } from '../../context/send';
 import { type Recipient } from './useRecipients';
 import { useSendType } from './useSendType';
 import { useAccountAddressSeedIconMap } from './useAccountAddressSeedIconMap';
@@ -12,25 +11,26 @@ export const useContactRecipients = (): Recipient[] => {
   const { isEvmSendType } = useSendType();
   const addressBook = useSelector(getCompleteAddressBook);
   const { accountAddressSeedIconMap } = useAccountAddressSeedIconMap();
+  const { chainId } = useSendContext();
 
-  const processContacts = useCallback(
-    (contact: AddressBookEntry) => {
-      return {
-        address: contact.address,
-        contactName: contact.name,
-        isContact: true,
-        seedIcon: accountAddressSeedIconMap.get(contact.address.toLowerCase()),
-      };
-    },
-    [accountAddressSeedIconMap],
-  );
+  const contacts = useMemo(() => {
+    if (!isEvmSendType) {
+      return [];
+    }
 
-  // Contacts are only supported for EVM chains today - hence we only return contacts for EVM chains
-  if (isEvmSendType) {
-    return addressBook
-      .filter((contact) => isEvmAddress(contact.address))
-      .map(processContacts);
-  }
+    return (
+      addressBook
+        ?.filter((contact) => contact.chainId === chainId)
+        ?.map((contact) => ({
+          address: contact.address,
+          contactName: contact.name,
+          isContact: true,
+          seedIcon: accountAddressSeedIconMap.get(
+            contact.address.toLowerCase(),
+          ),
+        })) ?? []
+    );
+  }, [addressBook, chainId, isEvmSendType]);
 
-  return [];
+  return contacts;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

redesigned send add filtering by chainId in address book contacts

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6041

## **Manual testing steps**

1. Go to recipient input in new send flow
2. Check that contacts are filtered by chainId of the asset

## **Screenshots/Recordings**
<img width="1277" height="815" alt="Screenshot 2025-10-17 at 4 33 58 PM" src="https://github.com/user-attachments/assets/cc771f8d-b2b7-47e1-8762-c5e0e34fda34" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters EVM contact recipients by current `chainId` from send context and updates tests to reflect chain-scoped contacts.
> 
> - **Hooks**:
>   - Update `ui/pages/confirmations/hooks/send/useContactRecipients.ts` to:
>     - Use `useSendContext` `chainId` and return contacts only when `isEvmSendType`.
>     - Filter address book by `contact.chainId === chainId` (removes `isAddress`-based filtering).
>     - Memoize computed contacts with `useMemo`.
> - **Tests**:
>   - Adjust `ui/pages/confirmations/hooks/send/useContactRecipients.test.ts` to mock `useSendContext` and assert chainId-filtered EVM contacts; remove non-EVM address checks and update expected results (including `seedIcon`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900aea328d1d69dedabb3112452002c11da0411b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->