### PR TITLE
fix: Missing env var declarations in `builds.yml`

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -312,8 +312,16 @@ env:
   - PHISHING_WARNING_PAGE_URL: null
   # Modified in <root>/development/build/scripts.js:@getInfuraProjectId
   - INFURA_PROJECT_ID
+  - INFURA_PROD_PROJECT_ID
+  - INFURA_BETA_PROJECT_ID
+  - INFURA_FLASK_PROJECT_ID
+  - INFURA_EXPERIMENTAL_PROJECT_ID
   # Modified in <root>/development/build/scripts.js:@getSegmentWriteKey
   - SEGMENT_WRITE_KEY: ''
+  - SEGMENT_PROD_WRITE_KEY: ''
+  - SEGMENT_BETA_WRITE_KEY: ''
+  - SEGMENT_FLASK_WRITE_KEY: ''
+  - SEGMENT_EXPERIMENTAL_WRITE_KEY: ''
   # Modified in <root>/development/build/scripts.js:@getAnalyticsDataDeletionSourceId
   - ANALYTICS_DATA_DELETION_SOURCE_ID: null
   # Modified in <root>/development/build/scripts.js:@getAnalyticsDataDeletionEndpoint
@@ -424,7 +432,15 @@ env:
   - APPLE_CLIENT_ID_REF
   - SEEDLESS_ONBOARDING_ENABLED: 'true'
   - GOOGLE_CLIENT_ID: ''
+  - GOOGLE_PROD_CLIENT_ID: ''
+  - GOOGLE_BETA_CLIENT_ID: ''
+  - GOOGLE_FLASK_CLIENT_ID: ''
+  - GOOGLE_EXPERIMENTAL_CLIENT_ID: ''
   - APPLE_CLIENT_ID: ''
+  - APPLE_PROD_CLIENT_ID: ''
+  - APPLE_BETA_CLIENT_ID: ''
+  - APPLE_FLASK_CLIENT_ID: ''
+  - APPLE_EXPERIMENTAL_CLIENT_ID: ''
   # OAuth (Social login) for UAT(QA) builds
   - GOOGLE_CLIENT_ID_FLASK_UAT: ''
   - APPLE_CLIENT_ID_FLASK_UAT: ''


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Cherry-picks https://github.com/MetaMask/metamask-extension/pull/36942 into main.

Fixes the following error in the `validate-lavamoat-policies` workflow:
```shell
[experimental] scripts:core:dist:disable-console: MetaMask build: Encountered an error while running task "scripts:core:dist:disable-console".
[experimental] TypeError: Tried to access a declared, but not defined environmental variable "APPLE_EXPERIMENTAL_CLIENT_ID"
[experimental] 	Why am I seeing this: "APPLE_EXPERIMENTAL_CLIENT_ID" is declared in builds.yml, but had no actual value when we tried loading it.
[experimental] 	How do I fix this: You could provide a default value for the variable in builds.yml under "env" property and commit to git. For example:
[experimental] 		env:
[experimental] 		 - APPLE_EXPERIMENTAL_CLIENT_ID: ''
[experimental]   at Variables.get (/home/runner/work/metamask-extension/metamask-extension/development/lib/variables.js:32:7)
[experimental]   at assertAndLoadEnvVar (/home/runner/work/metamask-extension/metamask-extension/development/build/set-environment-variables.js:134:33)
[experimental]   at getAppleClientId (/home/runner/work/metamask-extension/metamask-extension/development/build/set-environment-variables.js:266:12)
[experimental]   at setEnvironmentVariables (/home/runner/work/metamask-extension/metamask-extension/development/build/set-environment-variables.js:32:23)
[experimental]   at eval (/home/runner/work/metamask-extension/metamask-extension/development/build/scripts.js:903:5)
[experimental]   at async Object.eval [as scripts:core:dist:disable-console] (/home/runner/work/metamask-extension/metamask-extension/development/build/task.js:124:5)
[experimental]   at async runTask (/home/runner/work/metamask-extension/metamask-extension/development/build/task.js:31:5)
[experimental]   at async defineAndRunBuildTasks (/home/runner/work/metamask-extension/metamask-extension/development/build/index.js:312:3)
[experimental] MetaMask build: Encountered an error while running task "scripts:dist".
[experimental] Error: MetaMask build: runInChildProcess for task "scripts:core:dist:disable-console" encountered an error "1".
[experimental]   at ChildProcess.eval (/home/runner/work/metamask-extension/metamask-extension/development/build/task.js:108:13)
[experimental]   at Object.onceWrapper (node:events:633:26)
[experimental]   at ChildProcess.emit (node:events:518:28)
[experimental]   at ChildProcess._handle.onexit (node:internal/child_process:293:12)
[experimental] yarn build scripts:dist --policy-only --lint-fence-files=false --build-type=experimental exited with code 1
Policy generation failed. [
  {
    command: Command {
      close: [Subject],
      error: [Subject],
      stdout: [Subject],
      stderr: [Subject],
      timer: [Subject],
      killed: false,
      exited: true,
      index: 0,
      name: 'experimental',
      command: 'yarn build scripts:dist --policy-only --lint-fence-files=false --build-type=experimental',
      prefixColor: '',
      env: [Object],
      cwd: '',
      killProcess: [Function (anonymous)],
      spawn: [Function (anonymous)],
      spawnOpts: [Object],
      process: undefined,
      pid: 2203,
      stdin: [Socket]
    },
    index: 0,
    exitCode: 1,
    killed: false,
    timings: {
      startDate: 2025-10-17T09:54:47.212Z,
      endDate: 2025-10-17T09:56:34.494Z,
      durationSeconds: 107.281811431
    }
  }
]
Error: Process completed with exit code 1.
```
> https://github.com/MetaMask/metamask-extension/actions/runs/18587897859/job/52999961365

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36944?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Declare per-environment Infura, Segment, and Google/Apple OAuth client ID env vars in builds.yml.
> 
> - **Build config (`builds.yml`)**:
>   - **Declare missing env vars**:
>     - Infura: `INFURA_PROD_PROJECT_ID`, `INFURA_BETA_PROJECT_ID`, `INFURA_FLASK_PROJECT_ID`, `INFURA_EXPERIMENTAL_PROJECT_ID`
>     - Segment: `SEGMENT_PROD_WRITE_KEY`, `SEGMENT_BETA_WRITE_KEY`, `SEGMENT_FLASK_WRITE_KEY`, `SEGMENT_EXPERIMENTAL_WRITE_KEY`
>     - OAuth IDs:
>       - Google: `GOOGLE_PROD_CLIENT_ID`, `GOOGLE_BETA_CLIENT_ID`, `GOOGLE_FLASK_CLIENT_ID`, `GOOGLE_EXPERIMENTAL_CLIENT_ID`
>       - Apple: `APPLE_PROD_CLIENT_ID`, `APPLE_BETA_CLIENT_ID`, `APPLE_FLASK_CLIENT_ID`, `APPLE_EXPERIMENTAL_CLIENT_ID`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a14540552aa9b61f5fbe897ebe481bde88fc25b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->