### PR TITLE
feat: Display dynamic gas station fee

### DIFF
--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -1,18 +1,19 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Anvil } from '@viem/anvil';
 import { Suite } from 'mocha';
 import { MockttpServer } from 'mockttp';
-import { Anvil } from '@viem/anvil';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { Driver } from '../../../webdriver/driver';
+import { RelayStatus } from '../../../../../app/scripts/lib/transaction/transaction-relay';
+import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
+import { decimalToHex } from '../../../../../shared/modules/conversion.utils';
 import FixtureBuilder from '../../../fixture-builder';
 import { WINDOW_TITLES, unlockWallet, withFixtures } from '../../../helpers';
 import { createDappTransaction } from '../../../page-objects/flows/transaction';
-import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
 import GasFeeTokenModal from '../../../page-objects/pages/confirmations/redesign/gas-fee-token-modal';
+import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import HomePage from '../../../page-objects/pages/home/homepage';
-import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
+import { Driver } from '../../../webdriver/driver';
 import { mockEip7702FeatureFlag } from '../helpers';
-import { RelayStatus } from '../../../../../app/scripts/lib/transaction/transaction-relay';
 
 const UUID = '1234-5678';
 const TRANSACTION_HASH =
@@ -176,6 +177,7 @@ async function mockSimulationResponse(mockServer: MockttpServer) {
                         feeRecipient:
                           '0xBAB951a55b61dfAe21Ff7C3501142B397367F026',
                         rateWei: '0x216FF33813A80',
+                        serviceFee: `0x${decimalToHex(430000)}`,
                       },
                       {
                         token: {

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
@@ -1,17 +1,18 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Anvil } from '@viem/anvil';
 import { Suite } from 'mocha';
 import { MockttpServer } from 'mockttp';
-import { Anvil } from '@viem/anvil';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { Driver } from '../../../webdriver/driver';
+import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
+import { decimalToHex } from '../../../../../shared/modules/conversion.utils';
 import FixtureBuilder from '../../../fixture-builder';
 import { WINDOW_TITLES, unlockWallet, withFixtures } from '../../../helpers';
 import { createDappTransaction } from '../../../page-objects/flows/transaction';
-import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
 import GasFeeTokenModal from '../../../page-objects/pages/confirmations/redesign/gas-fee-token-modal';
-import { mockSmartTransactionBatchRequests } from '../../smart-transactions/mocks';
+import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import HomePage from '../../../page-objects/pages/home/homepage';
-import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
+import { Driver } from '../../../webdriver/driver';
+import { mockSmartTransactionBatchRequests } from '../../smart-transactions/mocks';
 
 const TRANSACTION_HASH =
   '0xf25183af3bf64af01e9210201a2ede3c1dcd6d16091283152d13265242939fc4';
@@ -162,6 +163,7 @@ async function mockSimulationResponse(mockServer: MockttpServer) {
                         feeRecipient:
                           '0xBAB951a55b61dfAe21Ff7C3501142B397367F026',
                         rateWei: '0x216FF33813A80',
+                        serviceFee: `0x${decimalToHex(430000)}`,
                       },
                       {
                         token: {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
@@ -1,4 +1,4 @@
-import { Hex, add0x } from '@metamask/utils';
+import { Hex } from '@metamask/utils';
 import {
   BatchTransactionParams,
   GasFeeToken,
@@ -34,6 +34,9 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
     (token) => token.tokenAddress.toLowerCase() === tokenAddress?.toLowerCase(),
   );
 
+  // This is just a legacy fallback for if `useGasFeeToken` were to be called
+  // with no `tokenAddress`. Even if it's `NATIVE_TOKEN_ADDRESS` we don't rely
+  // on `useNativeGasFeeToken`.
   if (!gasFeeToken) {
     gasFeeToken = nativeFeeToken;
   }

--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
@@ -21,7 +21,6 @@ import {
 import { useFeeCalculations } from './useFeeCalculations';
 
 export const RATE_WEI_NATIVE = '0xDE0B6B3A7640000'; // 1x10^18
-export const METAMASK_FEE_PERCENTAGE = 0.35;
 
 export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
   const { currentConfirmation: transactionMeta } =
@@ -41,9 +40,7 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
 
   const { amount, decimals } = gasFeeToken ?? { amount: '0x0', decimals: 0 };
 
-  const metaMaskFee = add0x(
-    new BigNumber(amount).times(METAMASK_FEE_PERCENTAGE).toString(16),
-  );
+  const metaMaskFee = gasFeeToken?.fee;
 
   const amountFormatted = formatAmount(
     locale,

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -54,9 +54,10 @@ export const EditGasFeesRow = ({
   const tokenValue = gasFeeToken ? gasFeeToken.amountFormatted : nativeFee;
   const metamaskFeeFiat = gasFeeToken?.metamaskFeeFiat;
 
-  const tooltip = gasFeeToken
-    ? t('confirmGasFeeTokenTooltip', [metamaskFeeFiat])
-    : t('estimatedFeeTooltip');
+  const tooltip =
+    gasFeeToken?.metaMaskFee && gasFeeToken.metaMaskFee !== '0x0'
+      ? t('confirmGasFeeTokenTooltip', [metamaskFeeFiat])
+      : t('estimatedFeeTooltip');
 
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const isLoadingGasUsed = !simulationData || balanceChangesResult.pending;
@@ -122,7 +123,7 @@ export const EditGasFeesRow = ({
               color={TextColor.textAlternative}
               paddingBottom={gasFeeToken ? 2 : 0}
             >
-              {gasFeeToken
+              {gasFeeToken?.metaMaskFee && gasFeeToken?.metaMaskFee !== '0x0'
                 ? t('confirmGasFeeTokenMetaMaskFee', [metamaskFeeFiat])
                 : ' '}
             </Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The fee is being determined dynamically in the API already, so this is just displaying the correct value now, since 35% fee is capped at 10$.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36961?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6052

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="376" height="99" alt="Screenshot 2025-10-17 at 17 34 20" src="https://github.com/user-attachments/assets/117dcd50-1aad-4711-9bee-d138a9a6e3ac" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the API-provided service fee for gas fee tokens and only show the MetaMask fee in UI when present; update e2e mocks accordingly.
> 
> - **UI**:
>   - `useGasFeeToken`: stop calculating 35% fee and use `gasFeeToken.fee` from API; keep native fallback behavior.
>   - `edit-gas-fees-row`: show tooltip and MetaMask fee line only when `metaMaskFee` exists and is non-zero.
> - **Tests**:
>   - E2E mocks add `serviceFee` for token fees; expectations remain for displayed amounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 681baf486bd2d635cc306fd50e2b91773fe4a1a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->