### PR TITLE
fix: Popper.js used for dropdowns, tooltips, and popovers positioning  cp-13.6.0

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -152,7 +152,7 @@ async function defineAndRunBuildTasks() {
       'getSelection',
       // globals `opera` needs to function
       'opr',
-      // for Popper.js and snap simple keyring site
+      // for @popperjs/core and snap simple keyring site
       'devicePixelRatio',
     ];
 

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -152,6 +152,8 @@ async function defineAndRunBuildTasks() {
       'getSelection',
       // globals `opera` needs to function
       'opr',
+      // for Popper.js and snap simple keyring site
+      'devicePixelRatio',
     ];
 
     if (
@@ -168,7 +170,6 @@ async function defineAndRunBuildTasks() {
         'browser', // for testing vault corruption
         'chrome', // for testing vault corruption
         `indexedDB`, // for testing vault corruption
-        'devicePixelRatio', // for using snap simple keyring site
       ];
     }
 


### PR DESCRIPTION
## **Description**

This PR fixes an issue where Popper.js(used for dropdowns, tooltips, and popovers) fails to access `window.devicePixelRatio` in production builds due to LavaMoat scuttling. The issue was introduced by a recent @popperjs/core update in [PR #36557](https://github.com/MetaMask/metamask-extension/pull/36557/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR9408). The problem stems from [this upstream change in floating-ui](https://github.com/floating-ui/floating-ui/pull/2229/) which modified how Popper.js accesses the window object.

- Popper.js now gets a reference to the real window via a DOM node rather than using the global window supplied to the LavaMoat compartment
- LavaMoat's scuttling removes `devicePixelRatio` from the real global window object for security
- The LavaMoat policy grants compartments access to specified globals, but Popper.js is trying to access them from the wrong window context
- The upstream change was intended to handle iframe scenarios (pages with iframes where popovers from inside iframes render outside)

Two approaches were considered:
1. **Patching Popper.js** - Would require ongoing maintenance with library updates
2. **Adding scuttling exception** - Simpler, more maintainable approach that follows existing patterns

This solution was reached through collaborative investigation by @MarkStacey and @DavidMurdoch, who identified the root cause, evaluated multiple approaches, and confirmed that the scuttling exception approach works effectively  https://consensys.slack.com/archives/CTQAGKY5V/p1760559149075479 🙏 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36967?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36951
Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-468

## **Manual testing steps**

1. Go to the latest build of the extension in this PR
2. Test UI components that use Popper.js:
   - Open dropdowns in the UI
   - Hover over elements that show tooltips
   - Test any popover menus
4. Verify that these components position correctly without console errors
5. Check browser developer tools for any `devicePixelRatio` related errors (should be none)

## **Screenshots/Recordings**

### **Before**
Popper.js would fail to access devicePixelRatio in production builds causing positioning issues

<img width="413" height="640" alt="Screenshot 2025-10-17 at 3 20 36 PM" src="https://github.com/user-attachments/assets/a04c16f2-7cdc-4b4b-b866-66917a2de87d" />


https://github.com/user-attachments/assets/91eb5594-1694-4718-804b-20613e6446bb

### **After**

Popper.js components work correctly with proper positioning in all build types 

<img width="417" height="644" alt="Screenshot 2025-10-17 at 2 53 17 PM" src="https://github.com/user-attachments/assets/1bb75f03-a569-45f5-9da5-a6451fa33463" />

https://github.com/user-attachments/assets/2a2f13f1-a607-447b-bcf1-6631163f915c

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `devicePixelRatio` to the default LavaMoat scuttle exceptions (and removes the test-only entry) so Popper.js can read it in production.
> 
> - **Build/LavaMoat**:
>   - Add `devicePixelRatio` to default `scuttleGlobalThisExceptions` in `development/build/index.js` for `@popperjs/core`.
>   - Remove `devicePixelRatio` from the test-only exceptions list to avoid duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e27ff471099c2584b687f94aff5541445314b166. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->