### PR TITLE
fix(unlock): personal_sign method does not bring up password prompt

### DIFF
--- a/app/scripts/lib/unlock-wrapper.test.ts
+++ b/app/scripts/lib/unlock-wrapper.test.ts
@@ -1,0 +1,164 @@
+import {
+  withUnlockPrompt,
+  createUnlockedMethodWrappers,
+} from './unlock-wrapper';
+
+describe('unlock-wrapper', () => {
+  describe('withUnlockPrompt', () => {
+    it('should call the function immediately if wallet is unlocked', async () => {
+      const mockFn = jest.fn().mockResolvedValue('result');
+      const mockGetUnlockPromise = jest.fn();
+      const mockIsUnlocked = jest.fn().mockReturnValue(true);
+
+      const wrappedFn = withUnlockPrompt(
+        mockFn,
+        mockGetUnlockPromise,
+        mockIsUnlocked,
+      );
+
+      const result = await wrappedFn('arg1', 'arg2');
+
+      expect(result).toBe('result');
+      expect(mockFn).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(mockGetUnlockPromise).not.toHaveBeenCalled();
+      expect(mockIsUnlocked).toHaveBeenCalled();
+    });
+
+    it('should wait for unlock if wallet is locked', async () => {
+      const mockFn = jest.fn().mockResolvedValue('result');
+      const mockGetUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const mockIsUnlocked = jest.fn().mockReturnValue(false);
+
+      const wrappedFn = withUnlockPrompt(
+        mockFn,
+        mockGetUnlockPromise,
+        mockIsUnlocked,
+      );
+
+      const result = await wrappedFn('arg1', 'arg2');
+
+      expect(result).toBe('result');
+      expect(mockGetUnlockPromise).toHaveBeenCalledWith(true);
+      expect(mockFn).toHaveBeenCalledWith('arg1', 'arg2');
+    });
+
+    it('should pass shouldShowUnlockRequest as true to trigger popup', async () => {
+      const mockFn = jest.fn().mockResolvedValue('result');
+      const mockGetUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const mockIsUnlocked = jest.fn().mockReturnValue(false);
+
+      const wrappedFn = withUnlockPrompt(
+        mockFn,
+        mockGetUnlockPromise,
+        mockIsUnlocked,
+      );
+
+      await wrappedFn();
+
+      expect(mockGetUnlockPromise).toHaveBeenCalledWith(true);
+    });
+
+    it('should propagate errors from the wrapped function', async () => {
+      const mockError = new Error('test error');
+      const mockFn = jest.fn().mockRejectedValue(mockError);
+      const mockGetUnlockPromise = jest.fn();
+      const mockIsUnlocked = jest.fn().mockReturnValue(true);
+
+      const wrappedFn = withUnlockPrompt(
+        mockFn,
+        mockGetUnlockPromise,
+        mockIsUnlocked,
+      );
+
+      await expect(wrappedFn()).rejects.toThrow('test error');
+      expect(mockFn).toHaveBeenCalled();
+    });
+
+    it('should preserve function context and arguments', async () => {
+      const mockFn = jest.fn(async (a, b, c) => `${a}-${b}-${c}`);
+      const mockGetUnlockPromise = jest.fn();
+      const mockIsUnlocked = jest.fn().mockReturnValue(true);
+
+      const wrappedFn = withUnlockPrompt(
+        mockFn,
+        mockGetUnlockPromise,
+        mockIsUnlocked,
+      );
+
+      const result = await wrappedFn('one', 'two', 'three');
+
+      expect(result).toBe('one-two-three');
+      expect(mockFn).toHaveBeenCalledWith('one', 'two', 'three');
+    });
+  });
+
+  describe('createUnlockedMethodWrappers', () => {
+    it('should create wrapper with bound methods', () => {
+      const mockAppStateController = {
+        getUnlockPromise: jest.fn(),
+      };
+      const mockKeyringController = {
+        state: {
+          isUnlocked: true,
+        },
+      };
+
+      const { wrapWithUnlock } = createUnlockedMethodWrappers({
+        appStateController: mockAppStateController,
+        keyringController: mockKeyringController,
+      });
+
+      expect(wrapWithUnlock).toBeInstanceOf(Function);
+    });
+
+    it('should correctly wrap methods with unlock logic', async () => {
+      const mockGetUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const mockAppStateController = {
+        getUnlockPromise: mockGetUnlockPromise,
+      };
+      const mockKeyringController = {
+        state: {
+          isUnlocked: false,
+        },
+      };
+
+      const { wrapWithUnlock } = createUnlockedMethodWrappers({
+        appStateController: mockAppStateController,
+        keyringController: mockKeyringController,
+      });
+
+      const mockFn = jest.fn().mockResolvedValue('wrapped-result');
+      const wrappedFn = wrapWithUnlock(mockFn);
+
+      const result = await wrappedFn('test-arg');
+
+      expect(result).toBe('wrapped-result');
+      expect(mockGetUnlockPromise).toHaveBeenCalledWith(true);
+      expect(mockFn).toHaveBeenCalledWith('test-arg');
+    });
+
+    it('should use keyring state to check unlock status', async () => {
+      const mockAppStateController = {
+        getUnlockPromise: jest.fn(),
+      };
+      const mockKeyringController = {
+        state: {
+          isUnlocked: true,
+        },
+      };
+
+      const { wrapWithUnlock } = createUnlockedMethodWrappers({
+        appStateController: mockAppStateController,
+        keyringController: mockKeyringController,
+      });
+
+      const mockFn = jest.fn().mockResolvedValue('result');
+      const wrappedFn = wrapWithUnlock(mockFn);
+
+      await wrappedFn();
+
+      expect(mockAppStateController.getUnlockPromise).not.toHaveBeenCalled();
+      expect(mockFn).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/scripts/lib/unlock-wrapper.ts
+++ b/app/scripts/lib/unlock-wrapper.ts
@@ -1,0 +1,63 @@
+/**
+ * Utility to wrap methods that require the wallet to be unlocked.
+ * If the wallet is locked, it will trigger the unlock prompt and wait for unlock.
+ */
+
+import type { AppStateController } from '../controllers/app-state-controller';
+import type { KeyringController } from '@metamask/keyring-controller';
+
+/**
+ * Wraps a function to ensure the wallet is unlocked before execution.
+ * If locked, triggers the unlock prompt and waits for the user to unlock.
+ *
+ * @param fn - The function to wrap
+ * @param getUnlockPromise - Function to get the unlock promise from AppStateController
+ * @param isUnlocked - Function to check if the wallet is unlocked
+ * @returns A wrapped function that waits for unlock before executing
+ */
+export function withUnlockPrompt<T extends (...args: any[]) => Promise<any>>(
+  fn: T,
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>,
+  isUnlocked: () => boolean,
+): T {
+  return (async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+    if (!isUnlocked()) {
+      await getUnlockPromise(true);
+    }
+
+    return fn(...args);
+  }) as T;
+}
+
+/**
+ * Creates wrapped versions of signature/decrypt/encryption methods
+ * that wait for unlock before processing.
+ *
+ * @param options - Configuration options
+ * @param options.appStateController - The AppStateController instance
+ * @param options.keyringController - The KeyringController instance
+ * @returns Object containing wrapped methods
+ */
+export function createUnlockedMethodWrappers({
+  appStateController,
+  keyringController,
+}: {
+  appStateController: AppStateController;
+  keyringController: KeyringController;
+}) {
+  const getUnlockPromise =
+    appStateController.getUnlockPromise.bind(appStateController);
+  const isUnlocked = () => keyringController.state.isUnlocked;
+
+  return {
+    /**
+     * Wraps a method to ensure unlock before execution
+     *
+     * @param fn - The function to wrap
+     * @returns Wrapped function
+     */
+    wrapWithUnlock: <T extends (...args: any[]) => Promise<any>>(fn: T): T => {
+      return withUnlockPrompt(fn, getUnlockPromise, isUnlocked);
+    },
+  };
+}

--- a/test/e2e/json-rpc/personal_sign.spec.ts
+++ b/test/e2e/json-rpc/personal_sign.spec.ts
@@ -1,0 +1,174 @@
+import { WINDOW_TITLES } from '../helpers';
+import { withFixtures } from '../helpers';
+import FixtureBuilder from '../fixture-builder';
+import { Driver } from '../webdriver/driver';
+import TestDapp from '../page-objects/pages/test-dapp';
+import LoginPage from '../page-objects/pages/login-page';
+import PersonalSignConfirmation from '../page-objects/pages/confirmations/redesign/personal-sign-confirmation';
+
+describe('personal_sign', function () {
+  it('prompts for unlock when the wallet is locked and the requesting origin has permission', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // personal_sign request
+        const message =
+          '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765';
+        const address = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
+        const request = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'personal_sign',
+          params: [message, address],
+          id: 0,
+        });
+
+        await driver.executeScript(
+          `window.signaturePromise = window.ethereum.request(${request})`,
+        );
+
+        // Should open unlock dialog
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show signature confirmation
+        const confirmation = new PersonalSignConfirmation(driver);
+        await confirmation.verifyConfirmationHeadingTitle();
+        await confirmation.clickFooterConfirmButton();
+
+        // Verify signature was returned
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+
+        const signature = await driver.executeScript(
+          'return window.signaturePromise',
+        );
+
+        // Signature should be a hex string
+        expect(signature).toMatch(/^0x[0-9a-f]{130}$/iu);
+      },
+    );
+  });
+
+  it('can reject signature after unlock', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // personal_sign request
+        const message =
+          '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765';
+        const address = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
+        const request = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'personal_sign',
+          params: [message, address],
+          id: 0,
+        });
+
+        await driver.executeScript(
+          `window.signaturePromise = window.ethereum.request(${request}).catch(err => err.message)`,
+        );
+
+        // Unlock
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // Reject signature
+        const confirmation = new PersonalSignConfirmation(driver);
+        await confirmation.verifyConfirmationHeadingTitle();
+        await confirmation.clickFooterCancelButton();
+
+        // Verify rejection error was returned
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+
+        const result = await driver.executeScript(
+          'return window.signaturePromise',
+        );
+
+        expect(result).toContain('User rejected');
+      },
+    );
+  });
+
+  it('works correctly when wallet is already unlocked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        // Login first
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // personal_sign request while unlocked
+        const message =
+          '0x4578616d706c652060706572736f6e616c5f7369676e60206d657373616765';
+        const address = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
+        const request = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'personal_sign',
+          params: [message, address],
+          id: 0,
+        });
+
+        await driver.executeScript(
+          `window.signaturePromise = window.ethereum.request(${request})`,
+        );
+
+        // Should NOT show unlock dialog, go straight to signature confirmation
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const confirmation = new PersonalSignConfirmation(driver);
+        await confirmation.verifyConfirmationHeadingTitle();
+        await confirmation.clickFooterConfirmButton();
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+
+        const signature = await driver.executeScript(
+          'return window.signaturePromise',
+        );
+
+        expect(signature).toMatch(/^0x[0-9a-f]{130}$/iu);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/signature-request-locked.spec.ts
+++ b/test/e2e/tests/signature-request-locked.spec.ts
@@ -1,0 +1,309 @@
+import { WINDOW_TITLES } from '../../helpers';
+import { withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixture-builder';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+import { Driver } from '../../webdriver/driver';
+import TestDapp from '../../page-objects/pages/test-dapp';
+import LoginPage from '../../page-objects/pages/login-page';
+import PersonalSignConfirmation from '../../page-objects/pages/confirmations/redesign/personal-sign-confirmation';
+
+describe('Signature Requests when Wallet is Locked', function () {
+  it('prompts for unlock when personal_sign is called while wallet is locked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        // Login first to establish connection
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // Lock the wallet
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to sign a message while locked
+        await testDapp.clickPersonalSign();
+
+        // Should open unlock popup
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show signature confirmation
+        const confirmation = new PersonalSignConfirmation(driver);
+        await confirmation.verifyConfirmationHeadingTitle();
+        await confirmation.clickFooterConfirmButton();
+
+        // Verify signature was successful
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#personalSign',
+          text: /0x[0-9a-f]{130}/iu,
+        });
+      },
+    );
+  });
+
+  it('prompts for unlock when eth_signTypedData_v3 is called while wallet is locked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // Lock the wallet
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to sign typed data while locked
+        await testDapp.clickSignTypedDataV3();
+
+        // Should open unlock popup
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show signature confirmation
+        await driver.clickElement('[data-testid="confirm-footer-button"]');
+
+        // Verify signature was successful
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#signTypedDataV3Result',
+          text: /0x[0-9a-f]{130}/iu,
+        });
+      },
+    );
+  });
+
+  it('prompts for unlock when eth_signTypedData_v4 is called while wallet is locked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // Lock the wallet
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to sign typed data v4 while locked
+        await testDapp.clickSignTypedDataV4();
+
+        // Should open unlock popup
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show signature confirmation
+        await driver.clickElement('[data-testid="confirm-footer-button"]');
+
+        // Verify signature was successful
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#signTypedDataV4Result',
+          text: /0x[0-9a-f]{130}/iu,
+        });
+      },
+    );
+  });
+
+  it('prompts for unlock when eth_getEncryptionPublicKey is called while wallet is locked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // Lock the wallet
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to get encryption public key while locked
+        await testDapp.clickGetEncryptionKeyButton();
+
+        // Should open unlock popup
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show encryption public key confirmation
+        await driver.clickElement('[data-testid="confirm-footer-button"]');
+
+        // Verify encryption public key was returned
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#encryptionKeyDisplay',
+          text: /^[A-Za-z0-9+/]+=*$/u,
+        });
+      },
+    );
+  });
+
+  it('prompts for unlock when eth_decrypt is called while wallet is locked', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // First get encryption key and encrypt a message
+        await testDapp.clickGetEncryptionKeyButton();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.clickElement('[data-testid="confirm-footer-button"]');
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+
+        await testDapp.clickEncryptButton();
+
+        // Lock the wallet
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to decrypt while locked
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.clickDecryptButton();
+
+        // Should open unlock popup
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // After unlock, should show decrypt confirmation
+        await driver.clickElement('[data-testid="confirm-footer-button"]');
+
+        // Verify decryption was successful
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#decryptResult',
+          text: 'My name is Satoshi Buterin',
+        });
+      },
+    );
+  });
+
+  it('does not hang when signature request is rejected after unlock', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        // Lock the wallet
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Lock MetaMask', tag: 'button' });
+
+        // Try to sign a message while locked
+        await testDapp.clickPersonalSign();
+
+        // Unlock
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+
+        // Reject the signature
+        const confirmation = new PersonalSignConfirmation(driver);
+        await confirmation.verifyConfirmationHeadingTitle();
+        await confirmation.clickFooterCancelButton();
+
+        // Verify error is returned to DApp
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
+        await driver.waitForSelector({
+          css: '#personalSign',
+          text: /User rejected/iu,
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## **Description**

Context
When MetaMask is locked after a DApp has been granted permissions, signature requests (such as personal_sign, eth_signTypedData_v3/v4, eth_getEncryptionPublicKey, and eth_decrypt) hang indefinitely without showing any UI prompt or returning an error to the DApp. This leaves the request Promise in a pending state forever, and users have no way to complete or cancel the request.

The root cause is that the SignatureController, DecryptMessageController, and EncryptionPublicKeyController do not check the wallet's lock state before processing requests.

Created [unlock-wrapper.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) - A new utility module containing:

withUnlockPrompt(): A generic wrapper function that adds unlock checking to any async function
[createUnlockedMethodWrappers()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): A factory function that creates wrapped methods bound to AppStateController and KeyringController

Flow after fix:

- When a DApp calls a signature method while the wallet is locked

  1. The wrapper detects the locked state via [keyringController.state.isUnlocked](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  2. It calls [appStateController.getUnlockPromise(true)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to trigger the unlock popup
  3. User unlocks the wallet
  4. The original request proceeds normally
  5. The signature confirmation is shown and the promise resolves
- When the wallet is already unlocked:
  1. The wrapper detects this immediately and proceeds without delay
  2. No behavior change from current functionality


## **Changelog**

CHANGELOG entry: Fixed hanging signature requests by prompting for unlock when the wallet is locked.

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: #36800, #36335

## **Manual testing steps**

1. Go to this page https://metamask.github.io/test-dapp/
2. Click use MetaMask Provider
3. Click Connect and approve the connection in MetaMask
4. After successful connection, lock MetaMask manually
5. Return to the Test DApp and click Personal Sign
6. Observe: the request now opens password modal.

## **Screenshots/Recordings**


### **Before**

https://github.com/user-attachments/assets/72c1da68-c3a8-4f93-bb48-acd0990efe69


### **After**

https://github.com/user-attachments/assets/1b9bc630-15d9-4a75-8f13-8f226cfe1c08

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
