### PR TITLE
fix(release branch name): cleanup deprecated release branch name cp-13.6.0

### DIFF
--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
 
   // Extract semver version number from the branch name
   const releaseVersionNumberMatch = branchName.match(
-    /^(?:Version-v|release\/)(\d+\.\d+\.\d+)$/,
+    /^release\/(\d+\.\d+\.\d+)$/,
   );
 
   if (!releaseVersionNumberMatch) {

--- a/.github/scripts/extract-semver.sh
+++ b/.github/scripts/extract-semver.sh
@@ -4,13 +4,11 @@ set -euo pipefail
 
 ref_name="${GITHUB_REF#refs/heads/}"
 
-# Extract semver based on prefix
-if [[ "$ref_name" == Version-v* ]]; then
-  semver="${ref_name#Version-v}"
-elif [[ "$ref_name" == release/* ]]; then
+# Extract semver
+if [[ "$ref_name" == release/* ]]; then
   semver="${ref_name#release/}"
 else
-  echo "Error: Branch name must be Version-vX.Y.Z or release/X.Y.Z where X, Y, Z are numbers. Got: $ref_name" >&2
+  echo "Error: Branch name must be release/X.Y.Z where X, Y, Z are numbers. Got: $ref_name" >&2
   exit 1
 fi
 

--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -9,14 +9,11 @@ then
   exit 0
 fi
 
-# Pattern for Version-vX.Y.Z branches
-VERSION_BRANCHES_VERSION_V=$(git branch -r | grep -o 'Version-v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
-# Default pattern for release/x.y.z branches
-VERSION_BRANCHES_RELEASE=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
+# Get the highest version from release branches
+VERSION_BRANCHES=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
 
 # Compare versions and keep the highest one
-HIGHEST_VERSION=$(printf "%s\n%s" "$VERSION_BRANCHES_VERSION_V" "$VERSION_BRANCHES_RELEASE" | sort --version-sort | tail -n 1)
-echo "HIGHEST_VERSION=${HIGHEST_VERSION}, VERSION_BRANCHES_VERSION_V=${VERSION_BRANCHES_VERSION_V}, VERSION_BRANCHES_RELEASE=${VERSION_BRANCHES_RELEASE}"
+HIGHEST_VERSION=$(printf "%s" "$VERSION_BRANCHES" | sort --version-sort | tail -n 1)
 
 # Increment the minor version of the highest version found and reset the patch version to 0
 NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')

--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   extract:
-    if: ${{ github.ref_type == 'branch' && (startsWith(github.ref, 'refs/heads/Version-v') || startsWith(github.ref, 'refs/heads/release/')) }}
+    if: ${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:

--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -3,7 +3,6 @@ name: Auto-update for PR targeting release branch
 on:
   pull_request:
     branches:
-      - Version-v*
       - release/*
 
 jobs:

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -3,7 +3,6 @@ name: Check Attributions
 on:
   push:
     branches:
-      - Version-v*
       - release/*
 
 jobs:

--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -9,7 +9,6 @@ on:
     branches-ignore:
       # Do not count lines on PRs targeting stable or releases
       - stable
-      - Version-v*
       - release/*
 
 permissions:

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -11,7 +11,7 @@ jobs:
   close-bug-report:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event.pull_request.merged == true && ( startsWith(github.event.pull_request.head.ref, 'Version-v') || startsWith(github.event.pull_request.head.ref, 'release/') )
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Extract version from branch name if release branch
         id: extract_version
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/(Version-v|release/)[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version=$(echo "$GITHUB_REF" | sed -E 's#^refs/heads/(Version-v|release/)##')
+          if [[ "$GITHUB_REF" =~ ^refs/heads/release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            version="${GITHUB_REF#refs/heads/release/}"
             echo "New release branch($version), continue next steps"
             echo "version=$version" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/create-release-pr-legacy.yml
+++ b/.github/workflows/create-release-pr-legacy.yml
@@ -15,13 +15,13 @@ on:
 jobs:
   create-release-pr:
     name: Create Release Pull Request using Github Tools
-    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
+    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@3b4244a675e7bb1eec7309a11e89697f53a25d9a
     with:
       platform: extension
       base-branch: ${{ inputs.base-branch }}
       semver-version: ${{ inputs.semver-version }}
       previous-version-tag: release/${{ inputs.previous-semver-version }}
-      github-tools-version: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
+      github-tools-version: 3b4244a675e7bb1eec7309a11e89697f53a25d9a
     secrets:
       # This token needs write permissions to metamask-extension & read permissions to metamask-planning
       github-token: ${{ secrets.PR_TOKEN }}

--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   get-release-timelines:
-    uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@b39d2cf87af5e31c4a85a83221e3a40b79edf06c
+    uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@3b4244a675e7bb1eec7309a11e89697f53a25d9a
     with:
       version: ${{ inputs.version }}
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - stable
-      - Version-v*
       - release/*
       - trigger-ci*
   pull_request:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -35,7 +35,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Find the associated PR
-        if: ${{ (startsWith(env.BRANCH, 'Version-v') || startsWith(env.BRANCH, 'release/')) && (!env.PR_NUMBER || !env.BASE_COMMIT_HASH || !env.HEAD_COMMIT_HASH) }}
+        if: ${{ startsWith(env.BRANCH, 'release/') && (!env.PR_NUMBER || !env.BASE_COMMIT_HASH || !env.HEAD_COMMIT_HASH) }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/release-pr-approval.yml
+++ b/.github/workflows/release-pr-approval.yml
@@ -3,7 +3,6 @@ name: Release PR Approval
 on:
   pull_request:
     branches:
-      - Version-v*
       - release/*
 
 jobs:

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -24,11 +24,11 @@ jobs:
         run: ./development/shellcheck.sh
 
       - name: Validate changelog
-        if: ${{ !startsWith(env.BRANCH, 'Version-v') && !startsWith(env.BRANCH, 'release/') }}
+        if: ${{ !startsWith(env.BRANCH, 'release/') }}
         run: yarn lint:changelog
 
       - name: Validate release candidate changelog
-        if: ${{ startsWith(env.BRANCH, 'Version-v') || startsWith(env.BRANCH, 'release/') }}
+        if: ${{ startsWith(env.BRANCH, 'release/') }}
         run: .github/scripts/validate-changelog-in-rc.sh
 
       - name: Lint lockfile

--- a/.github/workflows/tag-release-branch.yml
+++ b/.github/workflows/tag-release-branch.yml
@@ -40,13 +40,13 @@ jobs:
           # Set working branch variable
           BRANCH="${PROVIDED_BRANCH}"
 
-          # Extract version from branch name (supports Version-vX.Y.Z or release/X.Y.Z)
+          # Extract version from branch name (release/X.Y.Z)
           SEMVER_PATTERN='[0-9]+\.[0-9]+\.[0-9]+'
-          if [[ "${BRANCH}" =~ ^Version-v(${SEMVER_PATTERN})$ ]] || [[ "${BRANCH}" =~ ^release/(${SEMVER_PATTERN})$ ]]; then
+          if [[ "${BRANCH}" =~ ^release/(${SEMVER_PATTERN})$ ]]; then
             VERSION="${BASH_REMATCH[1]}"
           else
             echo "::error::Could not extract version from branch name: ${BRANCH}"
-            echo "::error::Expected 'Version-vX.Y.Z' or 'release/X.Y.Z'"
+            echo "::error::Expected 'release/X.Y.Z'"
             exit 1
           fi
 

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -127,10 +127,7 @@ function getEnvironment({ buildTarget }) {
     return ENVIRONMENT.DEVELOPMENT;
   } else if (isTestBuild(buildTarget)) {
     return ENVIRONMENT.TESTING;
-  } else if (
-    /^Version-v(\d+)[.](\d+)[.](\d+)/u.test(branch) ||
-    /^release\/(\d+)[.](\d+)[.](\d+)/u.test(branch)
-  ) {
+  } else if (/^release\/(\d+)[.](\d+)[.](\d+)/u.test(branch)) {
     return ENVIRONMENT.RELEASE_CANDIDATE;
   } else if (branch === 'main') {
     return ENVIRONMENT.STAGING;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Since we've aligned Extension and Mobile release branch names, we no longer use the deprecated format: `Version-vx.y.z`.
The purpose of this PR is to cleanup the repo and remove all traces of the deprecated format for release branch names.

Similar changes from github-tools repo can be found in this PR and have been imported: https://github.com/MetaMask/github-tools/pull/146

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36991?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes on `release/X.Y.Z` by removing `Version-vX.Y.Z` support across workflows, scripts, and build utils.
> 
> - **CI/Workflows**:
>   - Restrict triggers and conditions to `release/*` (remove `Version-v*`) in `auto-create-release-pr.yml`, `auto-update-pr-targeting-release.yml`, `check-attributions.yml`, `check-pr-max-lines.yml`, `close-bug-report.yml`, `create-bug-report.yml`, `main.yml`, `publish-prerelease.yml`, `release-pr-approval.yml`, `repository-health-checks.yml`, `tag-release-branch.yml`.
> - **Scripts**:
>   - `scripts/extract-semver.sh`: accept only `release/X.Y.Z`; update error message.
>   - `scripts/get-next-semver-version.sh`: derive next version from `release/*` branches only.
>   - `scripts/close-release-bug-report-issue.ts`: extract version only from `release/X.Y.Z`.
> - **Build**:
>   - `development/build/utils.js`: detect release-candidate env only for `release/X.Y.Z` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33a53097db05549aaa88fa979f0da51ec91915a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->