### PR TITLE
feat: add hide and pin options to account menu cp-13.6.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2812,6 +2812,9 @@
   "hexDataPlaceholder": {
     "message": "Enter hex data (optional)"
   },
+  "hidden": {
+    "message": "Hidden"
+  },
   "hiddenAccounts": {
     "message": "Hidden accounts"
   },
@@ -4866,6 +4869,9 @@
   },
   "pinToTop": {
     "message": "Pin to top"
+  },
+  "pinned": {
+    "message": "Pinned"
   },
   "pleaseConfirm": {
     "message": "Please confirm"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2812,6 +2812,9 @@
   "hexDataPlaceholder": {
     "message": "Enter hex data (optional)"
   },
+  "hidden": {
+    "message": "Hidden"
+  },
   "hiddenAccounts": {
     "message": "Hidden accounts"
   },
@@ -4866,6 +4869,9 @@
   },
   "pinToTop": {
     "message": "Pin to top"
+  },
+  "pinned": {
+    "message": "Pinned"
   },
   "pleaseConfirm": {
     "message": "Please confirm"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2523,6 +2523,15 @@ export default class MetamaskController extends EventEmitter {
           accountGroupName,
         );
       },
+      setAccountGroupPinned: (accountGroupId, pinned) => {
+        this.accountTreeController.setAccountGroupPinned(
+          accountGroupId,
+          pinned,
+        );
+      },
+      setAccountGroupHidden: (accountGroupId, hidden) => {
+        this.accountTreeController.setAccountGroupHidden(accountGroupId, hidden);
+      },
       syncAccountTreeWithUserStorage: async () => {
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         await this.getSnapKeyring();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2523,18 +2523,10 @@ export default class MetamaskController extends EventEmitter {
           accountGroupName,
         );
       },
-      setAccountGroupPinned: (accountGroupId, pinned) => {
-        this.accountTreeController.setAccountGroupPinned(
-          accountGroupId,
-          pinned,
-        );
-      },
-      setAccountGroupHidden: (accountGroupId, hidden) => {
-        this.accountTreeController.setAccountGroupHidden(
-          accountGroupId,
-          hidden,
-        );
-      },
+      setAccountGroupPinned:
+        this.accountTreeController.setAccountGroupPinned.bind(this),
+      setAccountGroupHidden:
+        this.accountTreeController.setAccountGroupHidden.bind(this),
       syncAccountTreeWithUserStorage: async () => {
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         await this.getSnapKeyring();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2530,7 +2530,10 @@ export default class MetamaskController extends EventEmitter {
         );
       },
       setAccountGroupHidden: (accountGroupId, hidden) => {
-        this.accountTreeController.setAccountGroupHidden(accountGroupId, hidden);
+        this.accountTreeController.setAccountGroupHidden(
+          accountGroupId,
+          hidden,
+        );
       },
       syncAccountTreeWithUserStorage: async () => {
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -17,7 +17,8 @@ import {
 
 export type MultichainAccountCellProps = {
   accountId: AccountGroupId;
-  accountName: string;
+  accountName: string | React.ReactNode;
+  accountNameString?: string; // Optional string version for accessibility labels
   onClick?: (accountGroupId: AccountGroupId) => void;
   balance: string;
   startAccessory?: React.ReactNode;
@@ -31,6 +32,7 @@ export type MultichainAccountCellProps = {
 export const MultichainAccountCell = ({
   accountId,
   accountName,
+  accountNameString,
   onClick,
   balance,
   startAccessory,
@@ -41,6 +43,11 @@ export const MultichainAccountCell = ({
   privacyMode = false,
 }: MultichainAccountCellProps) => {
   const handleClick = () => onClick?.(accountId);
+
+  // Use accountNameString for aria-label, or fallback to accountName if it's a string
+  const ariaLabelName =
+    accountNameString ||
+    (typeof accountName === 'string' ? accountName : 'Account');
   const seedAddressIcon = useSelector((state) =>
     getIconSeedAddressByAccountGroupId(state, accountId),
   );
@@ -140,7 +147,7 @@ export const MultichainAccountCell = ({
           alignItems={AlignItems.center}
           justifyContent={JustifyContent.flexEnd}
           data-testid="multichain-account-cell-end-accessory"
-          aria-label={`${accountName} options`}
+          aria-label={`${ariaLabelName} options`}
         >
           {endAccessory}
         </Box>

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -313,6 +313,7 @@ describe('MultichainAccountList', () => {
       },
     );
 
+    // With displayWalletHeader=true (default), wallet header should be shown
     expect(screen.queryAllByTestId(walletHeaderTestId)).toHaveLength(1);
     expect(
       screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
@@ -845,6 +846,43 @@ describe('MultichainAccountList', () => {
       );
       // Should be 2 accounts total (both in pinned section)
       expect(accountCells.length).toBe(2);
+    });
+
+    it('shows wallet headers when there is one wallet with pinned accounts', () => {
+      const walletsWithOnePinnedAccount = {
+        [walletOneId]: {
+          ...mockWallets[walletOneId],
+          groups: {
+            [walletOneGroupId]: {
+              ...mockWallets[walletOneId].groups[walletOneGroupId],
+              metadata: {
+                ...mockWallets[walletOneId].groups[walletOneGroupId].metadata,
+                pinned: true,
+              },
+            },
+          },
+        },
+      };
+
+      renderComponent(
+        { wallets: walletsWithOnePinnedAccount },
+        {
+          ...mockDefaultState,
+          metamask: {
+            ...mockDefaultState.metamask,
+            accountTree: {
+              ...mockDefaultState.metamask.accountTree,
+              // @ts-expect-error - walletsWithOnePinnedAccount does not follow the exact structure due to test simplification
+              wallets: walletsWithOnePinnedAccount,
+            },
+          },
+        },
+      );
+
+      // With one wallet but pinned accounts, wallet header should be shown
+      expect(screen.getByTestId(walletHeaderTestId)).toBeInTheDocument();
+      expect(screen.getByText('Wallet 1')).toBeInTheDocument();
+      expect(screen.getByText('Pinned accounts')).toBeInTheDocument();
     });
   });
 

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -757,7 +757,7 @@ describe('MultichainAccountList', () => {
       renderComponent({ wallets: walletsWithPinnedAccounts });
 
       // Pinned section header should be present
-      expect(screen.getByText('Pinned accounts')).toBeInTheDocument();
+      expect(screen.getByText('Pinned')).toBeInTheDocument();
 
       // Pinned accounts should be rendered
       expect(screen.getByText('Account 1 from wallet 1')).toBeInTheDocument();
@@ -784,7 +784,7 @@ describe('MultichainAccountList', () => {
       renderComponent({ wallets: walletsWithOnePinnedAccount });
 
       // Pinned section header should be present even with just 1 pinned account
-      expect(screen.getByText('Pinned accounts')).toBeInTheDocument();
+      expect(screen.getByText('Pinned')).toBeInTheDocument();
       expect(screen.getByText('Account 1 from wallet 1')).toBeInTheDocument();
     });
 
@@ -832,7 +832,7 @@ describe('MultichainAccountList', () => {
       );
 
       // Pinned section should exist
-      expect(screen.getByText('Pinned accounts')).toBeInTheDocument();
+      expect(screen.getByText('Pinned')).toBeInTheDocument();
 
       // Wallet headers should still be present
       expect(screen.getByText('Wallet 1')).toBeInTheDocument();
@@ -882,7 +882,7 @@ describe('MultichainAccountList', () => {
       // With one wallet but pinned accounts, wallet header should be shown
       expect(screen.getByTestId(walletHeaderTestId)).toBeInTheDocument();
       expect(screen.getByText('Wallet 1')).toBeInTheDocument();
-      expect(screen.getByText('Pinned accounts')).toBeInTheDocument();
+      expect(screen.getByText('Pinned')).toBeInTheDocument();
     });
   });
 
@@ -911,7 +911,7 @@ describe('MultichainAccountList', () => {
         'multichain-account-tree-hidden-header',
       );
       expect(hiddenHeader).toBeInTheDocument();
-      expect(screen.getByText('Hidden accounts')).toBeInTheDocument();
+      expect(screen.getByText('Hidden')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument(); // count badge
 
       // Hidden account should NOT be visible initially (collapsed)

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -835,8 +835,14 @@ describe('MultichainAccountList', () => {
       expect(screen.getByText('Pinned')).toBeInTheDocument();
 
       // Wallet headers should still be present
-      expect(screen.getByText('Wallet 1')).toBeInTheDocument();
-      expect(screen.getByText('Wallet 2')).toBeInTheDocument();
+      const walletHeaders = screen.getAllByTestId(walletHeaderTestId);
+      expect(walletHeaders).toHaveLength(2);
+      expect(
+        within(walletHeaders[0]).getByText('Wallet 1'),
+      ).toBeInTheDocument();
+      expect(
+        within(walletHeaders[1]).getByText('Wallet 2'),
+      ).toBeInTheDocument();
 
       // Accounts should appear in pinned section, not in wallet sections
       // Only match the actual account cells, not indicators or accessories
@@ -880,8 +886,10 @@ describe('MultichainAccountList', () => {
       );
 
       // With one wallet but pinned accounts, wallet header should be shown
-      expect(screen.getByTestId(walletHeaderTestId)).toBeInTheDocument();
-      expect(screen.getByText('Wallet 1')).toBeInTheDocument();
+      const walletHeader = screen.getByTestId(walletHeaderTestId);
+      expect(walletHeader).toBeInTheDocument();
+      // Wallet name should be in the header
+      expect(within(walletHeader).getByText('Wallet 1')).toBeInTheDocument();
       expect(screen.getByText('Pinned')).toBeInTheDocument();
     });
   });
@@ -911,8 +919,7 @@ describe('MultichainAccountList', () => {
         'multichain-account-tree-hidden-header',
       );
       expect(hiddenHeader).toBeInTheDocument();
-      expect(screen.getByText('Hidden')).toBeInTheDocument();
-      expect(screen.getByText('1')).toBeInTheDocument(); // count badge
+      expect(screen.getByText('Hidden (1)')).toBeInTheDocument();
 
       // Hidden account should NOT be visible initially (collapsed)
       expect(

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -188,6 +188,7 @@ export const MultichainAccountList = ({
       groupId: string,
       groupData: (typeof wallets)[AccountWalletId]['groups'][AccountGroupId],
       walletId: string,
+      showWalletName = false,
     ) => {
       // If prop is provided, attempt render balance. Otherwise do not render balance.
       const account = allBalances?.wallets?.[walletId]?.groups?.[groupId];
@@ -210,6 +211,11 @@ export const MultichainAccountList = ({
             selected={selectedAccountGroupsSet.has(groupId as AccountGroupId)}
             onClick={handleAccountClickToUse}
             privacyMode={privacyMode}
+            walletName={
+              showWalletName
+                ? wallets[walletId as AccountWalletId]?.metadata?.name
+                : undefined
+            }
             startAccessory={
               showAccountCheckbox ? (
                 <Box marginRight={4}>
@@ -264,7 +270,7 @@ export const MultichainAccountList = ({
       result.push(pinnedHeader);
 
       pinnedGroups.forEach(({ groupId, groupData, walletId }) => {
-        result.push(renderAccountCell(groupId, groupData, walletId));
+        result.push(renderAccountCell(groupId, groupData, walletId, true));
       });
     }
 
@@ -372,7 +378,7 @@ export const MultichainAccountList = ({
       // Only render hidden accounts when expanded
       if (isHiddenAccountsExpanded) {
         hiddenGroups.forEach(({ groupId, groupData, walletId }) => {
-          result.push(renderAccountCell(groupId, groupData, walletId));
+          result.push(renderAccountCell(groupId, groupData, walletId, true));
         });
       }
     }

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -14,8 +14,6 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import {
-  AvatarIcon,
-  AvatarIconSize,
   Box,
   Checkbox,
   Icon,
@@ -190,7 +188,6 @@ export const MultichainAccountList = ({
       groupId: string,
       groupData: (typeof wallets)[AccountWalletId]['groups'][AccountGroupId],
       walletId: string,
-      isHidden = false,
     ) => {
       // If prop is provided, attempt render balance. Otherwise do not render balance.
       const account = allBalances?.wallets?.[walletId]?.groups?.[groupId];
@@ -200,31 +197,14 @@ export const MultichainAccountList = ({
       // TODO: Implement logic for removable accounts
       const isRemovable = false;
 
-      // Render account name with EyeSlash icon prefix if hidden
-      const accountNameElement: string | React.ReactNode = isHidden ? (
-        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
-          <Icon
-            name={IconName.EyeSlash}
-            size={IconSize.Xs}
-            color={IconColor.iconDefault}
-          />
-          <Text variant={TextVariant.bodyMdMedium}>
-            {groupData.metadata.name}
-          </Text>
-        </Box>
-      ) : (
-        groupData.metadata.name
-      );
-
       return (
         <Box
-          className={`multichain-account-menu-popover__list--menu-item${isHidden ? ' multichain-account-menu-popover__list--menu-item-hidden-account' : ''}`}
+          className="multichain-account-menu-popover__list--menu-item"
           key={`multichain-account-cell-${groupId}`}
-          style={isHidden ? { opacity: 0.5 } : undefined}
         >
           <MultichainAccountCell
             accountId={groupId as AccountGroupId}
-            accountName={accountNameElement as string | React.ReactNode}
+            accountName={groupData.metadata.name}
             accountNameString={groupData.metadata.name}
             balance={formatCurrencyWithMinThreshold(balance, currency)}
             selected={selectedAccountGroupsSet.has(groupId as AccountGroupId)}
@@ -261,7 +241,6 @@ export const MultichainAccountList = ({
     const result: React.ReactNode[] = [];
 
     // Render pinned section (if there are any pinned accounts)
-    // TODO: Add translation for 'Pinned accounts'
     if (pinnedGroups.length > 0) {
       const pinnedHeader = (
         <Box
@@ -273,15 +252,12 @@ export const MultichainAccountList = ({
           paddingRight={4}
           paddingTop={2}
           paddingBottom={2}
-          gap={2}
         >
-          <Icon
-            name={IconName.Pin}
-            size={IconSize.Sm}
-            color={IconColor.iconMuted}
-          />
-          <Text variant={TextVariant.bodyMdMedium} color={TextColor.textMuted}>
-            Pinned accounts
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.textAlternative}
+          >
+            {t('pinned')}
           </Text>
         </Box>
       );
@@ -315,7 +291,7 @@ export const MultichainAccountList = ({
           >
             <Text
               variant={TextVariant.bodyMdMedium}
-              color={TextColor.textMuted}
+              color={TextColor.textAlternative}
             >
               {walletName}
             </Text>
@@ -342,9 +318,13 @@ export const MultichainAccountList = ({
           );
         }
 
+        // Only show wallet header if we should show headers AND there are accounts to display in this wallet
+        const showThisWalletHeader =
+          shouldShowWalletHeaders && groupsItems.length > 0;
+
         return [
           ...walletsAccumulator,
-          shouldShowWalletHeaders ? walletHeader : null,
+          showThisWalletHeader ? walletHeader : null,
           ...groupsItems,
         ];
       },
@@ -362,49 +342,29 @@ export const MultichainAccountList = ({
           onClick={() => setIsHiddenAccountsExpanded(!isHiddenAccountsExpanded)}
           backgroundColor={BackgroundColor.backgroundDefault}
           display={Display.Flex}
-          padding={4}
-          alignItems={AlignItems.center}
-          width={BlockSize.Full}
           justifyContent={JustifyContent.spaceBetween}
+          alignItems={AlignItems.center}
+          paddingLeft={4}
+          paddingRight={4}
+          paddingTop={2}
+          paddingBottom={2}
+          width={BlockSize.Full}
           className="hidden-accounts-list"
           data-testid="multichain-account-tree-hidden-header"
         >
-          <Box
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            width={BlockSize.TwoThirds}
-            gap={2}
+          <Text
+            variant={TextVariant.bodyMdMedium}
+            color={TextColor.textAlternative}
           >
-            <AvatarIcon
-              iconName={IconName.EyeSlash}
-              color={IconColor.infoDefault}
-              backgroundColor={BackgroundColor.infoMuted}
-              size={AvatarIconSize.Sm}
-            />
-            <Box display={Display.Flex}>
-              <Text variant={TextVariant.bodyMdMedium}>
-                {t('hiddenAccounts')}
-              </Text>
-            </Box>
-          </Box>
-          <Box
-            gap={2}
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            width={BlockSize.OneThird}
-            justifyContent={JustifyContent.flexEnd}
-          >
-            <Text variant={TextVariant.bodyMdMedium}>
-              {hiddenGroups.length}
-            </Text>
-            <Icon
-              name={
-                isHiddenAccountsExpanded ? IconName.ArrowUp : IconName.ArrowDown
-              }
-              size={IconSize.Sm}
-              color={IconColor.iconDefault}
-            />
-          </Box>
+            {t('hidden')} ({hiddenGroups.length})
+          </Text>
+          <Icon
+            name={
+              isHiddenAccountsExpanded ? IconName.ArrowUp : IconName.ArrowDown
+            }
+            size={IconSize.Sm}
+            color={IconColor.iconDefault}
+          />
         </Box>
       );
       result.push(hiddenHeader);
@@ -412,7 +372,7 @@ export const MultichainAccountList = ({
       // Only render hidden accounts when expanded
       if (isHiddenAccountsExpanded) {
         hiddenGroups.forEach(({ groupId, groupData, walletId }) => {
-          result.push(renderAccountCell(groupId, groupData, walletId, true));
+          result.push(renderAccountCell(groupId, groupData, walletId));
         });
       }
     }

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -293,6 +293,10 @@ export const MultichainAccountList = ({
     }
 
     // Render wallets with their non-pinned, non-hidden accounts
+    // Show wallet headers if there are multiple wallets OR if there are pinned accounts
+    const shouldShowWalletHeaders =
+      displayWalletHeader || pinnedGroups.length > 0;
+
     const walletSections = Object.entries(wallets).reduce(
       (walletsAccumulator, [walletId, walletData]) => {
         const walletName = walletData.metadata?.name;
@@ -340,7 +344,7 @@ export const MultichainAccountList = ({
 
         return [
           ...walletsAccumulator,
-          displayWalletHeader ? walletHeader : null,
+          shouldShowWalletHeaders ? walletHeader : null,
           ...groupsItems,
         ];
       },

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, act } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import configureStore from '../../../store/store';
 import { MultichainAccountMenu } from './multichain-account-menu';
 import type { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
@@ -9,6 +10,51 @@ const menuButtonSelector = '.multichain-account-cell-popover-menu-button';
 const menuIconSelector = '.multichain-account-cell-popover-menu-button-icon';
 const menuItemSelector = '.multichain-account-cell-menu-item';
 const errorColorSelector = '.mm-box--color-error-default';
+
+const mockState = {
+  metamask: {
+    accountTree: {
+      wallets: {
+        'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
+          groups: {
+            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
+              metadata: {
+                name: 'Test Account',
+                pinned: false,
+                hidden: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+jest.mock('../../../store/actions', () => {
+  const actualActions = jest.requireActual('../../../store/actions');
+  return {
+    ...actualActions,
+    setAccountGroupPinned: jest.fn().mockImplementation(() => {
+      return async function () {
+        await Promise.resolve();
+      };
+    }),
+    setAccountGroupHidden: jest.fn().mockImplementation(() => {
+      return async function () {
+        await Promise.resolve();
+      };
+    }),
+  };
+});
+
+const mockSetAccountGroupPinned = jest.requireMock(
+  '../../../store/actions',
+).setAccountGroupPinned;
+
+const mockSetAccountGroupHidden = jest.requireMock(
+  '../../../store/actions',
+).setAccountGroupHidden;
 
 describe('MultichainAccountMenu', () => {
   const renderComponent = (
@@ -19,8 +65,13 @@ describe('MultichainAccountMenu', () => {
       onToggle: jest.fn(),
     },
   ) => {
-    return renderWithProvider(<MultichainAccountMenu {...props} />);
+    const store = configureStore(mockState);
+    return renderWithProvider(<MultichainAccountMenu {...props} />, store);
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders the menu button and popover is initially closed', () => {
     renderComponent();
@@ -80,7 +131,7 @@ describe('MultichainAccountMenu', () => {
     expect(mockOnToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('shows 3 menu items when menu is open', () => {
+  it('shows 5 menu items when menu is open (details, rename, addresses, pin, hide)', () => {
     renderComponent({
       accountGroupId: 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default',
       isRemovable: false,
@@ -92,7 +143,7 @@ describe('MultichainAccountMenu', () => {
     expect(popover).toBeInTheDocument();
 
     const menuItems = document.querySelectorAll(menuItemSelector);
-    expect(menuItems.length).toBe(3);
+    expect(menuItems.length).toBe(5);
   });
 
   it('adds the remove option to menu when isRemovable is true', () => {
@@ -104,7 +155,7 @@ describe('MultichainAccountMenu', () => {
     });
 
     const menuItems = document.querySelectorAll(menuItemSelector);
-    expect(menuItems.length).toBe(4);
+    expect(menuItems.length).toBe(6);
 
     const removeOption = document.querySelector(errorColorSelector);
     expect(removeOption).toBeInTheDocument();
@@ -148,7 +199,7 @@ describe('MultichainAccountMenu', () => {
 
     // Rename option should be the second menu item
     const menuItems = document.querySelectorAll(menuItemSelector);
-    expect(menuItems.length).toBe(3);
+    expect(menuItems.length).toBe(5);
 
     const renameOption = menuItems[1];
     expect(renameOption).not.toBeNull();
@@ -160,5 +211,205 @@ describe('MultichainAccountMenu', () => {
     }
 
     expect(mockHandleAccountRenameAction).toHaveBeenCalledWith(accountGroupId);
+  });
+
+  it('calls setAccountGroupPinned when clicking the pin option', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    renderComponent({
+      accountGroupId,
+      isRemovable: false,
+      isOpen: true,
+      onToggle: mockOnToggle,
+    });
+
+    // Pin option should be the fourth menu item (details, rename, addresses, pin)
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    expect(menuItems.length).toBe(5);
+
+    const pinOption = menuItems[3];
+    expect(pinOption).not.toBeNull();
+
+    if (pinOption) {
+      await act(async () => {
+        fireEvent.click(pinOption);
+      });
+    }
+
+    expect(mockSetAccountGroupPinned).toHaveBeenCalledWith(
+      accountGroupId,
+      true,
+    );
+    expect(mockOnToggle).toHaveBeenCalled();
+  });
+
+  it('calls setAccountGroupHidden when clicking the hide option', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    renderComponent({
+      accountGroupId,
+      isRemovable: false,
+      isOpen: true,
+      onToggle: mockOnToggle,
+    });
+
+    // Hide option should be the fifth menu item
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    expect(menuItems.length).toBe(5);
+
+    const hideOption = menuItems[4];
+    expect(hideOption).not.toBeNull();
+
+    if (hideOption) {
+      await act(async () => {
+        fireEvent.click(hideOption);
+      });
+    }
+
+    expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
+      accountGroupId,
+      true,
+    );
+    expect(mockOnToggle).toHaveBeenCalled();
+  });
+
+  it('unpins account before hiding when clicking hide on a pinned account', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    // Create state with pinned account
+    const stateWithPinnedAccount = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        accountTree: {
+          ...mockState.metamask.accountTree,
+          wallets: {
+            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
+              ...mockState.metamask.accountTree.wallets[
+                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+              ],
+              groups: {
+                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
+                  ...mockState.metamask.accountTree.wallets[
+                    'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+                  ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
+                  metadata: {
+                    ...mockState.metamask.accountTree.wallets[
+                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
+                      .metadata,
+                    pinned: true,
+                    hidden: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const store = configureStore(stateWithPinnedAccount);
+    renderWithProvider(
+      <MultichainAccountMenu
+        accountGroupId={accountGroupId}
+        isRemovable={false}
+        isOpen={true}
+        onToggle={mockOnToggle}
+      />,
+      store,
+    );
+
+    // Hide option should be the fifth menu item
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    const hideOption = menuItems[4];
+
+    if (hideOption) {
+      await act(async () => {
+        fireEvent.click(hideOption);
+      });
+    }
+
+    // Should unpin first, then hide
+    expect(mockSetAccountGroupPinned).toHaveBeenCalledWith(
+      accountGroupId,
+      false,
+    );
+    expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
+      accountGroupId,
+      true,
+    );
+  });
+
+  it('unhides account before pinning when clicking pin on a hidden account', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    // Create state with hidden account
+    const stateWithHiddenAccount = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        accountTree: {
+          ...mockState.metamask.accountTree,
+          wallets: {
+            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
+              ...mockState.metamask.accountTree.wallets[
+                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+              ],
+              groups: {
+                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
+                  ...mockState.metamask.accountTree.wallets[
+                    'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+                  ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
+                  metadata: {
+                    ...mockState.metamask.accountTree.wallets[
+                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
+                      .metadata,
+                    pinned: false,
+                    hidden: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const store = configureStore(stateWithHiddenAccount);
+    renderWithProvider(
+      <MultichainAccountMenu
+        accountGroupId={accountGroupId}
+        isRemovable={false}
+        isOpen={true}
+        onToggle={mockOnToggle}
+      />,
+      store,
+    );
+
+    // Pin option should be the fourth menu item
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    const pinOption = menuItems[3];
+
+    if (pinOption) {
+      await act(async () => {
+        fireEvent.click(pinOption);
+      });
+    }
+
+    // Should unhide first, then pin
+    expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
+      accountGroupId,
+      false,
+    );
+    expect(mockSetAccountGroupPinned).toHaveBeenCalledWith(
+      accountGroupId,
+      true,
+    );
   });
 });

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
   Icon,
@@ -22,6 +23,11 @@ import {
 } from '../../../helpers/constants/routes';
 import { MultichainAccountMenuItems } from '../multichain-account-menu-items/multichain-account-menu-items';
 import { MenuItemConfig } from '../multichain-account-menu-items/multichain-account-menu-items.types';
+import {
+  setAccountGroupPinned,
+  setAccountGroupHidden,
+} from '../../../store/actions';
+import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';
 import { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
 export const MultichainAccountMenu = ({
@@ -33,7 +39,24 @@ export const MultichainAccountMenu = ({
   onToggle,
 }: MultichainAccountMenuProps) => {
   const history = useHistory();
+  const dispatch = useDispatch();
   const popoverRef = useRef<HTMLDivElement>(null);
+  const accountTree = useSelector(getAccountTree);
+
+  // Get the account group metadata to check pinned/hidden state
+  const accountGroupMetadata = useMemo(() => {
+    const { wallets } = accountTree;
+    for (const wallet of Object.values(wallets)) {
+      const group = wallet.groups?.[accountGroupId];
+      if (group) {
+        return group.metadata;
+      }
+    }
+    return null;
+  }, [accountTree, accountGroupId]);
+
+  const isPinned = accountGroupMetadata?.pinned ?? false;
+  const isHidden = accountGroupMetadata?.hidden ?? false;
 
   const togglePopover = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
@@ -62,16 +85,30 @@ export const MultichainAccountMenu = ({
       history.push(multichainAccountAddressesPageRoute);
     };
 
-    const handleAccountPinClick = (mouseEvent: React.MouseEvent) => {
-      // TODO: Implement account pin click handling
+    const handleAccountPinClick = async (mouseEvent: React.MouseEvent) => {
       mouseEvent.stopPropagation();
       mouseEvent.preventDefault();
+
+      // If account is hidden, unhide it first before pinning
+      if (isHidden) {
+        await dispatch(setAccountGroupHidden(accountGroupId, false));
+      }
+
+      await dispatch(setAccountGroupPinned(accountGroupId, !isPinned));
+      onToggle?.();
     };
 
-    const handleAccountHideClick = (mouseEvent: React.MouseEvent) => {
-      // TODO: Implement account hide click handling
+    const handleAccountHideClick = async (mouseEvent: React.MouseEvent) => {
       mouseEvent.stopPropagation();
       mouseEvent.preventDefault();
+
+      // If account is pinned, unpin it first before hiding
+      if (isPinned) {
+        await dispatch(setAccountGroupPinned(accountGroupId, false));
+      }
+
+      await dispatch(setAccountGroupHidden(accountGroupId, !isHidden));
+      onToggle?.();
     };
 
     const handleAccountRemoveClick = (mouseEvent: React.MouseEvent) => {
@@ -97,16 +134,14 @@ export const MultichainAccountMenu = ({
         onClick: handleAccountAddressesClick,
       },
       {
-        textKey: 'pin',
-        iconName: IconName.Pin,
+        textKey: isPinned ? 'unpin' : 'pinToTop',
+        iconName: isPinned ? IconName.Unpin : IconName.Pin,
         onClick: handleAccountPinClick,
-        disabled: true,
       },
       {
-        textKey: 'hide',
-        iconName: IconName.EyeSlash,
+        textKey: isHidden ? 'showAccount' : 'hideAccount',
+        iconName: isHidden ? IconName.Eye : IconName.EyeSlash,
         onClick: handleAccountHideClick,
-        disabled: true,
       },
     ];
 
@@ -120,7 +155,16 @@ export const MultichainAccountMenu = ({
     }
 
     return baseMenuItems;
-  }, [accountGroupId, handleAccountRenameAction, history, isRemovable]);
+  }, [
+    accountGroupId,
+    handleAccountRenameAction,
+    history,
+    isRemovable,
+    isPinned,
+    isHidden,
+    dispatch,
+    onToggle,
+  ]);
 
   return (
     <>

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2523,6 +2523,58 @@ export function createNextMultichainAccountGroup(
 }
 
 /**
+ * Set the pinned state of an account group.
+ *
+ * @param accountGroupId - ID of an account group.
+ * @param pinned - Whether the account group should be pinned.
+ */
+export function setAccountGroupPinned(
+  accountGroupId: AccountGroupId,
+  pinned: boolean,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    log.debug(`background.setAccountGroupPinned`);
+    try {
+      await submitRequestToBackground('setAccountGroupPinned', [
+        accountGroupId,
+        pinned,
+      ]);
+      // Forcing update of the state speeds up the UI update process
+      // and makes UX better
+      await forceUpdateMetamaskState(dispatch);
+    } catch (error) {
+      logErrorWithMessage(error);
+    }
+  };
+}
+
+/**
+ * Set the hidden state of an account group.
+ *
+ * @param accountGroupId - ID of an account group.
+ * @param hidden - Whether the account group should be hidden.
+ */
+export function setAccountGroupHidden(
+  accountGroupId: AccountGroupId,
+  hidden: boolean,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    log.debug(`background.setAccountGroupHidden`);
+    try {
+      await submitRequestToBackground('setAccountGroupHidden', [
+        accountGroupId,
+        hidden,
+      ]);
+      // Forcing update of the state speeds up the UI update process
+      // and makes UX better
+      await forceUpdateMetamaskState(dispatch);
+    } catch (error) {
+      logErrorWithMessage(error);
+    }
+  };
+}
+
+/**
  * Set a new account group name (rename a multichain account).
  *
  * @param accountGroupId - ID of a multichain account group.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR is adding hide and pin options to the new account group list. Hidden accounts are working the same as the previous version of this feature. Pinned accounts now have their own section at the top of the accounts list.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added hide and pin options to account item menu

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37105
Jira issues:
https://consensyssoftware.atlassian.net/browse/MUL-1162
https://consensyssoftware.atlassian.net/browse/MUL-364
https://consensyssoftware.atlassian.net/browse/MUL-363

## **Manual testing steps**

1. Open account menu
2. Click "hide account"
3. Check if account has been added to the "hidden accounts" section in the bottom of the lsit
4. Open account menu
5. Click "Pin to top"
6. Check if account has been added to the first "Pinned accounts" section
7. Hidden account should have now "Show account" option in the menu
8. Pinned account should have now "Unpin" option in the menu

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/e3cf1f97-534e-4371-9dc7-cd5dc0b5eba2


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pin/unpin and hide/show actions for account groups, introducing a top "Pinned" section and a collapsible "Hidden" section, with controller wiring, Redux actions, i18n, and tests.
> 
> - **UI**:
>   - **Account List (`ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx`)**:
>     - Adds top `Pinned` section; excludes pinned accounts from wallet sections.
>     - Adds collapsible `Hidden (n)` section; excludes hidden accounts from wallet sections.
>     - Adjusts wallet header visibility logic; integrates i18n and icons.
>   - **Account Cell (`multichain-account-cell.tsx`)**: allows `accountName` as `ReactNode` and improves `aria-label` via optional `accountNameString`.
>   - **Account Menu (`multichain-account-menu.tsx`)**: adds Pin/Unpin and Hide/Show actions; unhide before pinning and unpin before hiding; navigations unchanged.
> - **State/Controller**:
>   - **Actions (`ui/store/actions.ts`)**: new thunks `setAccountGroupPinned` and `setAccountGroupHidden` (background call + state refresh).
>   - **Controller API (`app/scripts/metamask-controller.js`)**: exposes `setAccountGroupPinned` and `setAccountGroupHidden`.
> - **i18n**: Adds `pinned` and `hidden` strings in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Extend list tests for pinned/hidden sections and behaviors.
>   - Extend menu tests to cover pin/unpin and hide/show flows and interactions, including state preconditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358ea261e0dfbdc0eef9f3017dc0241fd93a4b2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->