### PR TITLE
fix: flaky tests `Metrics Sends a contract interaction type 2 transaction (EIP1559) with the right properties in the metric events`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -356,76 +356,37 @@ class TransactionConfirmation extends Confirmation {
     await this.clickSaveButton();
   }
 
-  async verifyAdvancedDetailsHexDataIsDisplayed() {
-    const advancedDetailsSection = await this.driver.findElement(
-      this.advancedDetailsSection,
-    );
-
-    await advancedDetailsSection.isDisplayed();
-    await advancedDetailsSection
-      .findElement({ css: this.advancedDetailsHexData.toString() })
-      .isDisplayed();
-
-    const hexDataInfo = (
-      await this.driver.findElement(this.advancedDetailsHexData)
-    ).getText();
-
-    assert.ok(
-      (await hexDataInfo).includes(
-        '0x3b4b13810000000000000000000000000000000000000000000000000000000000000001',
-      ),
-      'Expected hex data to be displayed',
-    );
+  async verifyAdvancedDetailsHexDataIsDisplayed(hexData: string) {
+    await this.driver.waitForSelector({
+      css: this.advancedDetailsHexData,
+      text: hexData,
+    });
   }
 
   async verifyAdvancedDetailsIsDisplayed(type: string) {
-    const advancedDetailsSection = await this.driver.findElement(
-      this.advancedDetailsSection,
-    );
+    await this.driver.waitForSelector(this.advancedDetailsSection);
 
-    await advancedDetailsSection.isDisplayed();
-    await advancedDetailsSection
-      .findElement({ css: this.advancedDetailsDataFunction.toString() })
-      .isDisplayed();
-    await advancedDetailsSection
-      .findElement({ css: this.advancedDetailsDataParam.toString() })
-      .isDisplayed();
-
-    const functionInfo = await this.driver.findElement(
-      this.advancedDetailsDataFunction,
-    );
-    const functionText = await functionInfo.getText();
-
-    assert.ok(
-      functionText.includes('Function'),
-      'Expected key "Function" to be included in the function text',
-    );
-    assert.ok(
-      functionText.includes('mintNFTs'),
-      'Expected "mintNFTs" to be included in the function text',
-    );
-
-    const paramsInfo = await this.driver.findElement(
-      this.advancedDetailsDataParam,
-    );
-    const paramsText = await paramsInfo.getText();
+    await this.driver.waitForSelector({
+      css: this.advancedDetailsDataFunction,
+      text: 'mintNFTs',
+    });
 
     if (type === '4Bytes') {
-      assert.ok(
-        paramsText.includes('Param #1'),
-        'Expected "Param #1" to be included in the param text',
-      );
+      await this.driver.waitForSelector({
+        css: this.advancedDetailsDataParam,
+        text: 'Param #1',
+      });
     } else if (type === 'Sourcify') {
-      assert.ok(
-        paramsText.includes('Number Of Tokens'),
-        'Expected "Number Of Tokens" to be included in the param text',
-      );
+      await this.driver.waitForSelector({
+        css: this.advancedDetailsDataParam,
+        text: 'Number Of Tokens',
+      });
     }
 
-    assert.ok(
-      paramsText.includes('1'),
-      'Expected "1" to be included in the param value',
-    );
+    await this.driver.waitForSelector({
+      css: this.advancedDetailsDataParam,
+      text: '1',
+    });
   }
 
   async verifyUniswapDecodedTransactionAdvancedDetails() {

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -68,7 +68,14 @@ describe('Metrics', function () {
         await testDapp.createDepositTransaction();
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.checkPageIsLoaded();
+        await transactionConfirmation.checkIsSenderAccountDisplayed(
+          'Account 1',
+        );
+        await transactionConfirmation.verifyAdvancedDetailsIsDisplayed('Sourcify');
         await transactionConfirmation.clickAdvancedDetailsButton();
+        await transactionConfirmation.verifyAdvancedDetailsHexDataIsDisplayed(
+          '0xd0e30db0',
+        );
 
         await assertAdvancedGasDetails(driver);
         await transactionConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
@@ -81,251 +88,131 @@ describe('Metrics', function () {
 
         // This is left for debugging purposes
         console.log(events);
-        assert.equal(events.length, 16, 'events length should be 16');
+        assert.equal(events.length, 16);
 
         // deployment tx -- no ui_customizations
         assert.equal(
           events[0].event,
           AnonymousTransactionMetaMetricsEvent.added,
-          'events[0].event should be AnonymousTransactionMetaMetricsEvent.added',
         );
         assert.equal(
           events[0].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[0].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[0].properties.transaction_advanced_view,
-          undefined,
-          'events[0].properties.transaction_advanced_view should be undefined',
-        );
-        assert.equal(
-          events[1].event,
-          TransactionMetaMetricsEvent.added,
-          'events[1].event should be TransactionMetaMetricsEvent.added',
-        );
+        assert.equal(events[0].properties.transaction_advanced_view, undefined);
+        assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
         assert.equal(
           events[1].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[1].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[1].properties.transaction_advanced_view,
-          undefined,
-          'events[1].properties.transaction_advanced_view should be undefined',
-        );
+        assert.equal(events[1].properties.transaction_advanced_view, undefined);
         assert.equal(
           events[2].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
-          'events[2].event should be AnonymousTransactionMetaMetricsEvent.submitted',
         );
         assert.equal(
           events[2].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[2].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[2].properties.transaction_advanced_view,
-          undefined,
-          'events[2].properties.transaction_advanced_view should be undefined',
-        );
-        assert.equal(
-          events[3].event,
-          TransactionMetaMetricsEvent.submitted,
-          'events[3].event should be TransactionMetaMetricsEvent.submitted',
-        );
+        assert.equal(events[2].properties.transaction_advanced_view, undefined);
+        assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
         assert.equal(
           events[3].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[3].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[3].properties.transaction_advanced_view,
-          undefined,
-          'events[3].properties.transaction_advanced_view should be undefined',
-        );
+        assert.equal(events[3].properties.transaction_advanced_view, undefined);
         assert.equal(
           events[4].event,
           AnonymousTransactionMetaMetricsEvent.approved,
-          'events[4].event should be AnonymousTransactionMetaMetricsEvent.approved',
         );
         assert.equal(
           events[4].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[4].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[4].properties.transaction_advanced_view,
-          undefined,
-          'events[4].properties.transaction_advanced_view should be undefined',
-        );
-        assert.equal(
-          events[5].event,
-          TransactionMetaMetricsEvent.approved,
-          'events[5].event should be TransactionMetaMetricsEvent.approved',
-        );
+        assert.equal(events[4].properties.transaction_advanced_view, undefined);
+        assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
         assert.equal(
           events[5].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[5].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[5].properties.transaction_advanced_view,
-          undefined,
-          'events[5].properties.transaction_advanced_view should be undefined',
-        );
+        assert.equal(events[5].properties.transaction_advanced_view, undefined);
         assert.equal(
           events[6].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
-          'events[6].event should be AnonymousTransactionMetaMetricsEvent.finalized',
         );
         assert.equal(
           events[6].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[6].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[6].properties.transaction_advanced_view,
-          undefined,
-          'events[6].properties.transaction_advanced_view should be undefined',
-        );
-        assert.equal(
-          events[7].event,
-          TransactionMetaMetricsEvent.finalized,
-          'events[7].event should be TransactionMetaMetricsEvent.finalized',
-        );
+        assert.equal(events[6].properties.transaction_advanced_view, undefined);
+        assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
         assert.equal(
           events[7].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[7].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[7].properties.transaction_advanced_view,
-          undefined,
-          'events[7].properties.transaction_advanced_view should be undefined',
-        );
+        assert.equal(events[7].properties.transaction_advanced_view, undefined);
 
         // deposit tx (contract interaction) -- ui_customizations is set
         assert.equal(
           events[8].event,
           AnonymousTransactionMetaMetricsEvent.added,
-          'events[8].event should be AnonymousTransactionMetaMetricsEvent.added',
         );
         assert.equal(
           events[8].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[8].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[8].properties.transaction_advanced_view,
-          undefined,
-          'events[8].properties.transaction_advanced_view should be undefined',
-        );
-        assert.equal(
-          events[9].event,
-          TransactionMetaMetricsEvent.added,
-          'events[9].event should be TransactionMetaMetricsEvent.added',
-        );
+        assert.equal(events[8].properties.transaction_advanced_view, undefined);
+        assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
         assert.equal(
           events[9].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[9].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[9].properties.transaction_advanced_view,
-          undefined,
-          'events[9].properties.transaction_advanced_view should be undefined',
-        );
+        assert.equal(events[9].properties.transaction_advanced_view, undefined);
         assert.equal(
           events[10].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
-          'events[10].event should be AnonymousTransactionMetaMetricsEvent.submitted',
         );
         assert.equal(
           events[10].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[10].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[10].properties.transaction_advanced_view,
-          true,
-          'events[10].properties.transaction_advanced_view should be true',
-        );
-        assert.equal(
-          events[11].event,
-          TransactionMetaMetricsEvent.submitted,
-          'events[11].event should be TransactionMetaMetricsEvent.submitted',
-        );
+        assert.equal(events[10].properties.transaction_advanced_view, true);
+        assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
         assert.equal(
           events[11].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[11].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[11].properties.transaction_advanced_view,
-          true,
-          'events[11].properties.transaction_advanced_view should be true',
-        );
+        assert.equal(events[11].properties.transaction_advanced_view, true);
         assert.equal(
           events[12].event,
           AnonymousTransactionMetaMetricsEvent.approved,
-          'events[12].event should be AnonymousTransactionMetaMetricsEvent.approved',
         );
         assert.equal(
           events[12].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[12].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[12].properties.transaction_advanced_view,
-          true,
-          'events[12].properties.transaction_advanced_view should be true',
-        );
-        assert.equal(
-          events[13].event,
-          TransactionMetaMetricsEvent.approved,
-          'events[13].event should be TransactionMetaMetricsEvent.approved',
-        );
+        assert.equal(events[12].properties.transaction_advanced_view, true);
+        assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
         assert.equal(
           events[13].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[13].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[13].properties.transaction_advanced_view,
-          true,
-          'events[13].properties.transaction_advanced_view should be true',
-        );
+        assert.equal(events[13].properties.transaction_advanced_view, true);
         assert.equal(
           events[14].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
-          'events[14].event should be AnonymousTransactionMetaMetricsEvent.finalized',
         );
         assert.equal(
           events[14].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[14].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[14].properties.transaction_advanced_view,
-          true,
-          'events[14].properties.transaction_advanced_view should be true',
-        );
-        assert.equal(
-          events[15].event,
-          TransactionMetaMetricsEvent.finalized,
-          'events[15].event should be TransactionMetaMetricsEvent.finalized',
-        );
+        assert.equal(events[14].properties.transaction_advanced_view, true);
+        assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
         assert.equal(
           events[15].properties.ui_customizations[0],
           'redesigned_confirmation',
-          'events[15].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(
-          events[15].properties.transaction_advanced_view,
-          true,
-          'events[15].properties.transaction_advanced_view should be true',
-        );
+        assert.equal(events[15].properties.transaction_advanced_view, true);
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -79,131 +79,253 @@ describe('Metrics', function () {
 
         const events = await getEventPayloads(driver, mockedEndpoints);
 
-        assert.equal(events.length, 16);
+        // This is left for debugging purposes
+        console.log(events);
+        assert.equal(events.length, 16, 'events length should be 16');
 
         // deployment tx -- no ui_customizations
         assert.equal(
           events[0].event,
           AnonymousTransactionMetaMetricsEvent.added,
+          'events[0].event should be AnonymousTransactionMetaMetricsEvent.added',
         );
         assert.equal(
           events[0].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[0].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[0].properties.transaction_advanced_view, undefined);
-        assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
+        assert.equal(
+          events[0].properties.transaction_advanced_view,
+          undefined,
+          'events[0].properties.transaction_advanced_view should be undefined',
+        );
+        assert.equal(
+          events[1].event,
+          TransactionMetaMetricsEvent.added,
+          'events[1].event should be TransactionMetaMetricsEvent.added',
+        );
         assert.equal(
           events[1].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[1].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[1].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[1].properties.transaction_advanced_view,
+          undefined,
+          'events[1].properties.transaction_advanced_view should be undefined',
+        );
         assert.equal(
           events[2].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
+          'events[2].event should be AnonymousTransactionMetaMetricsEvent.submitted',
         );
         assert.equal(
           events[2].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[2].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[2].properties.transaction_advanced_view, undefined);
-        assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
+        assert.equal(
+          events[2].properties.transaction_advanced_view,
+          undefined,
+          'events[2].properties.transaction_advanced_view should be undefined',
+        );
+        assert.equal(
+          events[3].event,
+          TransactionMetaMetricsEvent.submitted,
+          'events[3].event should be TransactionMetaMetricsEvent.submitted',
+        );
         assert.equal(
           events[3].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[3].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[3].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[3].properties.transaction_advanced_view,
+          undefined,
+          'events[3].properties.transaction_advanced_view should be undefined',
+        );
         assert.equal(
           events[4].event,
           AnonymousTransactionMetaMetricsEvent.approved,
+          'events[4].event should be AnonymousTransactionMetaMetricsEvent.approved',
         );
         assert.equal(
           events[4].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[4].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[4].properties.transaction_advanced_view, undefined);
-        assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
+        assert.equal(
+          events[4].properties.transaction_advanced_view,
+          undefined,
+          'events[4].properties.transaction_advanced_view should be undefined',
+        );
+        assert.equal(
+          events[5].event,
+          TransactionMetaMetricsEvent.approved,
+          'events[5].event should be TransactionMetaMetricsEvent.approved',
+        );
         assert.equal(
           events[5].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[5].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[5].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[5].properties.transaction_advanced_view,
+          undefined,
+          'events[5].properties.transaction_advanced_view should be undefined',
+        );
         assert.equal(
           events[6].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
+          'events[6].event should be AnonymousTransactionMetaMetricsEvent.finalized',
         );
         assert.equal(
           events[6].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[6].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[6].properties.transaction_advanced_view, undefined);
-        assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
+        assert.equal(
+          events[6].properties.transaction_advanced_view,
+          undefined,
+          'events[6].properties.transaction_advanced_view should be undefined',
+        );
+        assert.equal(
+          events[7].event,
+          TransactionMetaMetricsEvent.finalized,
+          'events[7].event should be TransactionMetaMetricsEvent.finalized',
+        );
         assert.equal(
           events[7].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[7].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[7].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[7].properties.transaction_advanced_view,
+          undefined,
+          'events[7].properties.transaction_advanced_view should be undefined',
+        );
 
         // deposit tx (contract interaction) -- ui_customizations is set
         assert.equal(
           events[8].event,
           AnonymousTransactionMetaMetricsEvent.added,
+          'events[8].event should be AnonymousTransactionMetaMetricsEvent.added',
         );
         assert.equal(
           events[8].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[8].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[8].properties.transaction_advanced_view, undefined);
-        assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
+        assert.equal(
+          events[8].properties.transaction_advanced_view,
+          undefined,
+          'events[8].properties.transaction_advanced_view should be undefined',
+        );
+        assert.equal(
+          events[9].event,
+          TransactionMetaMetricsEvent.added,
+          'events[9].event should be TransactionMetaMetricsEvent.added',
+        );
         assert.equal(
           events[9].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[9].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[9].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[9].properties.transaction_advanced_view,
+          undefined,
+          'events[9].properties.transaction_advanced_view should be undefined',
+        );
         assert.equal(
           events[10].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
+          'events[10].event should be AnonymousTransactionMetaMetricsEvent.submitted',
         );
         assert.equal(
           events[10].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[10].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[10].properties.transaction_advanced_view, true);
-        assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
+        assert.equal(
+          events[10].properties.transaction_advanced_view,
+          true,
+          'events[10].properties.transaction_advanced_view should be true',
+        );
+        assert.equal(
+          events[11].event,
+          TransactionMetaMetricsEvent.submitted,
+          'events[11].event should be TransactionMetaMetricsEvent.submitted',
+        );
         assert.equal(
           events[11].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[11].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[11].properties.transaction_advanced_view, true);
+        assert.equal(
+          events[11].properties.transaction_advanced_view,
+          true,
+          'events[11].properties.transaction_advanced_view should be true',
+        );
         assert.equal(
           events[12].event,
           AnonymousTransactionMetaMetricsEvent.approved,
+          'events[12].event should be AnonymousTransactionMetaMetricsEvent.approved',
         );
         assert.equal(
           events[12].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[12].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[12].properties.transaction_advanced_view, true);
-        assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
+        assert.equal(
+          events[12].properties.transaction_advanced_view,
+          true,
+          'events[12].properties.transaction_advanced_view should be true',
+        );
+        assert.equal(
+          events[13].event,
+          TransactionMetaMetricsEvent.approved,
+          'events[13].event should be TransactionMetaMetricsEvent.approved',
+        );
         assert.equal(
           events[13].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[13].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[13].properties.transaction_advanced_view, true);
+        assert.equal(
+          events[13].properties.transaction_advanced_view,
+          true,
+          'events[13].properties.transaction_advanced_view should be true',
+        );
         assert.equal(
           events[14].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
+          'events[14].event should be AnonymousTransactionMetaMetricsEvent.finalized',
         );
         assert.equal(
           events[14].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[14].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[14].properties.transaction_advanced_view, true);
-        assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
+        assert.equal(
+          events[14].properties.transaction_advanced_view,
+          true,
+          'events[14].properties.transaction_advanced_view should be true',
+        );
+        assert.equal(
+          events[15].event,
+          TransactionMetaMetricsEvent.finalized,
+          'events[15].event should be TransactionMetaMetricsEvent.finalized',
+        );
         assert.equal(
           events[15].properties.ui_customizations[0],
           'redesigned_confirmation',
+          'events[15].properties.ui_customizations[0] should be redesigned_confirmation',
         );
-        assert.equal(events[15].properties.transaction_advanced_view, true);
+        assert.equal(
+          events[15].properties.transaction_advanced_view,
+          true,
+          'events[15].properties.transaction_advanced_view should be true',
+        );
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -67,11 +67,15 @@ describe('Metrics', function () {
         // deposit contract
         await testDapp.createDepositTransaction();
         const transactionConfirmation = new TransactionConfirmation(driver);
+        // verify UI before clicking advanced details to give time for the Transaction Added event to be emitted without Advanced Details being displayed
         await transactionConfirmation.checkPageIsLoaded();
         await transactionConfirmation.checkIsSenderAccountDisplayed(
           'Account 1',
         );
-        await transactionConfirmation.verifyAdvancedDetailsIsDisplayed('Sourcify');
+        await transactionConfirmation.checkGasFeeSymbol('ETH');
+        await transactionConfirmation.checkGasFee('0.0009');
+
+        // enable the advanced view
         await transactionConfirmation.clickAdvancedDetailsButton();
         await transactionConfirmation.verifyAdvancedDetailsHexDataIsDisplayed(
           '0xd0e30db0',

--- a/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
@@ -115,7 +115,9 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
         await confirmation.checkPageIsLoaded();
         await confirmation.clickAdvancedDetailsButton();
         await confirmation.clickScrollToBottomButton();
-        await confirmation.verifyAdvancedDetailsHexDataIsDisplayed();
+        await confirmation.verifyAdvancedDetailsHexDataIsDisplayed(
+          '0x3b4b13810000000000000000000000000000000000000000000000000000000000000001',
+        );
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
@@ -173,6 +173,7 @@ async function mocked4BytesResponse(mockServer: MockttpServer) {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line @typescript-eslint/naming-convention
     .withQuery({ hex_signature: '0x3b4b1381' })
+    .always()
     .thenCallback(() => ({
       statusCode: 200,
       json: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition in the metrics events assertions, where we check for the Transaction Added event, that the `transaction_advanced_view` is undefined, as this value is not set yet.
Then we click on the Advance view button and the next events should have that property set to true.
However, if we click the Advance View right after the Confirmation screen appears, it can be the case where the TRansaction Added event is sent with that property already set to true.



<img width="1432" height="224" alt="image" src="https://github.com/user-attachments/assets/747dcc7f-387b-4040-9645-d6381920b509" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37013?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes metrics e2e by validating UI before opening Advanced Details and refactors transaction confirmation assertions to use targeted waitForSelector with parameterized hex, plus minor mock/update tweaks.
> 
> - **Tests (e2e)**
>   - **Metrics**: Validate sender, gas symbol/fee, and page load before opening Advanced Details; verify hex selector `'0xd0e30db0'`; collect events and add temporary logging; maintain metrics assertions.
>   - **Transaction Decoding**: Pass explicit hex to `verifyAdvancedDetailsHexDataIsDisplayed(...)`; ensure 4byte mock always responds.
> - **Page Objects**
>   - **TransactionConfirmation**:
>     - `verifyAdvancedDetailsHexDataIsDisplayed` now accepts a `hexData` param and uses `waitForSelector` with text.
>     - `verifyAdvancedDetailsIsDisplayed` simplified to `waitForSelector` checks (function name, params) with conditional param text.
>     - General shift from manual element/innerText assertions to targeted `waitForSelector` for stability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 249cd2a27896faa9a8a3120069ce116541a40bef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->