### PR TITLE
fix: Fix send flow navigation directly initiated from asset page

### DIFF
--- a/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
+++ b/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
@@ -1,11 +1,9 @@
-import { Hex, isHexString } from '@metamask/utils';
-import { isSolanaChainId } from '@metamask/bridge-controller';
+import { Hex } from '@metamask/utils';
 import { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useLocation, useSearchParams } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 
-import { toHex } from '../../../../../shared/lib/delegation/utils';
 import { SEND_ROUTE } from '../../../../helpers/constants/routes';
 import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
 import { Asset } from '../../types/send';
@@ -120,14 +118,10 @@ export const useSendQueryParams = () => {
     if (asset || !paramChainId) {
       return;
     }
-    const chainId =
-      !isSolanaChainId(paramChainId) && !isHexString(paramChainId)
-        ? toHex(paramChainId)
-        : paramChainId;
 
     let newAsset: Asset | undefined = flatAssets?.find(
       ({ assetId, chainId: tokenChainId, isNative }) =>
-        chainId === tokenChainId &&
+        paramChainId === tokenChainId &&
         ((paramAsset && assetId?.toLowerCase() === paramAsset.toLowerCase()) ||
           (!paramAsset && isNative)),
     );
@@ -135,7 +129,7 @@ export const useSendQueryParams = () => {
     if (!newAsset) {
       newAsset = nfts?.find(
         ({ address, chainId: tokenChainId, isNative }) =>
-          chainId === tokenChainId &&
+          paramChainId === tokenChainId &&
           ((paramAsset &&
             address?.toLowerCase() === paramAsset.toLowerCase()) ||
             (!paramAsset && isNative)),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove unnecessary logic from `updateAsset` caller in send flow which fixes BTC send flow initiated from asset details page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37018?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6062

## **Manual testing steps**

1. Have BTC
2. Go to BTC asset detail page
3. Click send - you should be able to see send flow now

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/7e722f46-f7e9-4ee4-914d-1dbf1093bd12



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `useSendQueryParams` by removing chainId normalization and matching assets/NFTs directly against `paramChainId`.
> 
> - **Send flow**:
>   - **Query param handling**: In `ui/pages/confirmations/hooks/send/useSendQueryParams.ts`, remove chainId normalization and compare assets/NFTs directly to `paramChainId` when inferring `asset` from URL params.
>   - Cleans up related imports by dropping unused normalization utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc93c1f0161685b91c076c9e4ea4c7f6431f2e00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->