### PR TITLE
docs: mark deprecated component-library components with JSDoc and UI notices

### DIFF
--- a/ui/components/component-library/avatar-base/README.mdx
+++ b/ui/components/component-library/avatar-base/README.mdx
@@ -4,7 +4,7 @@ import { AvatarBase } from './avatar-base';
 
 ### This is a base component. It should not be used in your feature code directly but as a "base" for other UI components
 
-# AvatarBase
+# AvatarBase (deprecated use @metamask/design-system-react)
 
 The `AvatarBase` is a wrapper component responsible for enforcing dimensions and border radius for Avatar components
 

--- a/ui/components/component-library/avatar-base/avatar-base.stories.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.stories.tsx
@@ -33,7 +33,7 @@ const marginSizeKnobOptions = [
 ];
 
 export default {
-  title: 'Components/ComponentLibrary/AvatarBase',
+  title: 'Components/ComponentLibrary/AvatarBase (deprecated)',
   component: AvatarBase,
   parameters: {
     docs: {

--- a/ui/components/component-library/avatar-base/avatar-base.types.ts
+++ b/ui/components/component-library/avatar-base/avatar-base.types.ts
@@ -6,6 +6,9 @@ import {
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { TextStyleUtilityProps } from '../text';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum AvatarBaseSize {
   Xs = 'xs',
   Sm = 'sm',

--- a/ui/components/component-library/avatar-favicon/README.mdx
+++ b/ui/components/component-library/avatar-favicon/README.mdx
@@ -4,7 +4,7 @@ import { AvatarBase } from '../';
 
 import { AvatarFavicon } from './avatar-favicon';
 
-# AvatarFavicon
+# AvatarFavicon (deprecated use @metamask/design-system-react)
 
 The `AvatarFavicon` is an image component that represents a dapp or third party service
 

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.stories.tsx
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.stories.tsx
@@ -13,7 +13,7 @@ import { AvatarFavicon } from './avatar-favicon';
 import { AvatarFaviconSize } from './avatar-favicon.types';
 
 export default {
-  title: 'Components/ComponentLibrary/AvatarFavicon',
+  title: 'Components/ComponentLibrary/AvatarFavicon (deprecated)',
   component: AvatarFavicon,
   parameters: {
     docs: {

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
@@ -3,6 +3,9 @@ import type { AvatarBaseStyleUtilityProps } from '../avatar-base/avatar-base.typ
 import { PolymorphicComponentPropWithRef } from '../box';
 import { IconProps } from '../icon';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum AvatarFaviconSize {
   Xs = 'xs',
   Sm = 'sm',

--- a/ui/components/component-library/avatar-icon/README.mdx
+++ b/ui/components/component-library/avatar-icon/README.mdx
@@ -3,7 +3,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import { AvatarBase } from '../';
 import { AvatarIcon } from './avatar-icon';
 
-# AvatarIcon
+# AvatarIcon (deprecated use @metamask/design-system-react)
 
 The `AvatarIcon` is an avatar component that renders only an icon inside and is built off the [AvatarBase](/docs/components-componentlibrary-avatarbase--default-story)) component
 

--- a/ui/components/component-library/avatar-icon/avatar-icon.stories.tsx
+++ b/ui/components/component-library/avatar-icon/avatar-icon.stories.tsx
@@ -16,7 +16,7 @@ import { IconName } from '../icon';
 import { AvatarIconSize } from './avatar-icon.types';
 
 export default {
-  title: 'Components/ComponentLibrary/AvatarIcon',
+  title: 'Components/ComponentLibrary/AvatarIcon (deprecated)',
   component: AvatarIcon,
   parameters: {
     docs: {

--- a/ui/components/component-library/avatar-icon/avatar-icon.types.ts
+++ b/ui/components/component-library/avatar-icon/avatar-icon.types.ts
@@ -3,6 +3,9 @@ import { IconName, IconProps, IconSize } from '../icon';
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { AvatarBaseStyleUtilityProps } from '../avatar-base/avatar-base.types';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum AvatarIconSize {
   Xs = 'xs',
   Sm = 'sm',

--- a/ui/components/component-library/avatar-network/README.mdx
+++ b/ui/components/component-library/avatar-network/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { AvatarNetwork } from './avatar-network';
 
-# AvatarNetwork
+# AvatarNetwork (deprecated use @metamask/design-system-react)
 
 The `AvatarNetwork` is a component responsible for display of the image of a given network
 

--- a/ui/components/component-library/avatar-network/avatar-network.stories.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.stories.tsx
@@ -14,7 +14,7 @@ import { AvatarNetwork } from './avatar-network';
 import { Box } from '../box';
 
 export default {
-  title: 'Components/ComponentLibrary/AvatarNetwork',
+  title: 'Components/ComponentLibrary/AvatarNetwork (deprecated)',
   component: AvatarNetwork,
   parameters: {
     docs: {

--- a/ui/components/component-library/avatar-network/avatar-network.types.ts
+++ b/ui/components/component-library/avatar-network/avatar-network.types.ts
@@ -1,6 +1,9 @@
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { AvatarBaseStyleUtilityProps } from '../avatar-base/avatar-base.types';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum AvatarNetworkSize {
   Xs = 'xs',
   Sm = 'sm',

--- a/ui/components/component-library/avatar-token/README.mdx
+++ b/ui/components/component-library/avatar-token/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { AvatarToken } from './avatar-token';
 
-# AvatarToken
+# AvatarToken (deprecated use @metamask/design-system-react)
 
 The `AvatarToken` is a component responsible for display of the image of a given token
 

--- a/ui/components/component-library/avatar-token/avatar-token.stories.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.stories.tsx
@@ -17,7 +17,7 @@ import { AvatarNetwork, AvatarNetworkSize } from '../avatar-network';
 import { Text } from '../text';
 
 export default {
-  title: 'Components/ComponentLibrary/AvatarToken',
+  title: 'Components/ComponentLibrary/AvatarToken (deprecated)',
   component: AvatarToken,
   parameters: {
     docs: {

--- a/ui/components/component-library/avatar-token/avatar-token.types.ts
+++ b/ui/components/component-library/avatar-token/avatar-token.types.ts
@@ -1,6 +1,9 @@
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { AvatarBaseStyleUtilityProps } from '../avatar-base/avatar-base.types';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum AvatarTokenSize {
   Xs = 'xs',
   Sm = 'sm',

--- a/ui/components/component-library/badge-wrapper/README.mdx
+++ b/ui/components/component-library/badge-wrapper/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { BadgeWrapper } from './badge-wrapper';
 
-# BadgeWrapper
+# BadgeWrapper (deprecated use @metamask/design-system-react)
 
 The `BadgeWrapper` positions a badge on top of another component
 

--- a/ui/components/component-library/badge-wrapper/badge-wrapper.stories.tsx
+++ b/ui/components/component-library/badge-wrapper/badge-wrapper.stories.tsx
@@ -28,7 +28,7 @@ import { Icon, IconName, IconSize } from '../icon';
 import { Tag } from '../tag';
 
 export default {
-  title: 'Components/ComponentLibrary/BadgeWrapper',
+  title: 'Components/ComponentLibrary/BadgeWrapper (deprecated)',
   component: BadgeWrapper,
   parameters: {
     docs: {

--- a/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
+++ b/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
@@ -5,6 +5,9 @@ import type {
   StyleUtilityProps,
 } from '../box';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum BadgeWrapperPosition {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -20,6 +23,9 @@ export enum BadgeWrapperPosition {
   bottomLeft = 'bottom-left',
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum BadgeWrapperAnchorElementShape {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/components/component-library/box/README.mdx
+++ b/ui/components/component-library/box/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { Box } from './box';
 
-# Box
+# Box (deprecated use @metamask/design-system-react)
 
 The `Box` is a utility component that accepts many helper props to make styling easier.
 

--- a/ui/components/component-library/box/box.stories.tsx
+++ b/ui/components/component-library/box/box.stories.tsx
@@ -41,7 +41,7 @@ const sizeControlOptions = [
 const marginSizeControlOptions = [...sizeControlOptions, 'auto'];
 
 export default {
-  title: 'Components/ComponentLibrary/Box',
+  title: 'Components/ComponentLibrary/Box (deprecated)',
   component: Box,
   parameters: {
     docs: {

--- a/ui/components/component-library/button-base/README.mdx
+++ b/ui/components/component-library/button-base/README.mdx
@@ -3,7 +3,7 @@ import { ButtonBase } from './button-base';
 
 ### This is a base component. It should not be used in your feature code directly but as a "base" for other UI components
 
-# ButtonBase
+# ButtonBase (deprecated use @metamask/design-system-react)
 
 The `ButtonBase` is the base component for buttons.
 

--- a/ui/components/component-library/button-base/button-base.stories.tsx
+++ b/ui/components/component-library/button-base/button-base.stories.tsx
@@ -33,7 +33,7 @@ const marginSizeControlOptions = [
 ];
 
 export default {
-  title: 'Components/ComponentLibrary/ButtonBase',
+  title: 'Components/ComponentLibrary/ButtonBase (deprecated)',
 
   component: ButtonBase,
   parameters: {

--- a/ui/components/component-library/button-base/button-base.types.ts
+++ b/ui/components/component-library/button-base/button-base.types.ts
@@ -5,6 +5,9 @@ import { TextDirection, TextProps, TextStyleUtilityProps } from '../text';
 import { IconName } from '../icon';
 import type { IconProps } from '../icon';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonBaseSize {
   Sm = 'sm',
   Md = 'md',

--- a/ui/components/component-library/button-icon/README.mdx
+++ b/ui/components/component-library/button-icon/README.mdx
@@ -1,7 +1,7 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import { ButtonIcon } from './button-icon';
 
-# ButtonIcon
+# ButtonIcon (deprecated use @metamask/design-system-react)
 
 The `ButtonIcon` is used for icons associated with a user action.
 

--- a/ui/components/component-library/button-icon/button-icon.stories.tsx
+++ b/ui/components/component-library/button-icon/button-icon.stories.tsx
@@ -7,7 +7,7 @@ import README from './README.mdx';
 import { IconName } from '../icon';
 
 export default {
-  title: 'Components/ComponentLibrary/ButtonIcon',
+  title: 'Components/ComponentLibrary/ButtonIcon (deprecated)',
   component: ButtonIcon,
   parameters: {
     docs: {

--- a/ui/components/component-library/button-icon/button-icon.types.ts
+++ b/ui/components/component-library/button-icon/button-icon.types.ts
@@ -2,6 +2,9 @@ import { IconName, IconProps } from '../icon';
 import { IconColor } from '../../../helpers/constants/design-system';
 import { PolymorphicComponentPropWithRef, StyleUtilityProps } from '../box';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonIconSize {
   Sm = 'sm',
   Md = 'md',

--- a/ui/components/component-library/button-link/README.mdx
+++ b/ui/components/component-library/button-link/README.mdx
@@ -3,7 +3,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import { ButtonLink } from './button-link';
 import { ButtonBase } from '../button-base';
 
-# ButtonLink
+# ButtonLink (deprecated use @metamask/design-system-react)
 
 The `ButtonLink` is an extension of `ButtonBase` to support link styles
 

--- a/ui/components/component-library/button-link/button-link.stories.tsx
+++ b/ui/components/component-library/button-link/button-link.stories.tsx
@@ -15,7 +15,7 @@ import { ButtonLink } from './button-link';
 import { ButtonLinkSize } from './button-link.types';
 
 export default {
-  title: 'Components/ComponentLibrary/ButtonLink',
+  title: 'Components/ComponentLibrary/ButtonLink (deprecated)',
   component: ButtonLink,
   parameters: {
     docs: {

--- a/ui/components/component-library/button-link/button-link.types.ts
+++ b/ui/components/component-library/button-link/button-link.types.ts
@@ -3,6 +3,9 @@ import React from 'react';
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { ButtonBaseStyleUtilityProps } from '../button-base/button-base.types';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonLinkSize {
   Auto = 'auto',
   Sm = 'sm',

--- a/ui/components/component-library/button-primary/README.mdx
+++ b/ui/components/component-library/button-primary/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { ButtonPrimary } from './button-primary';
 
-# ButtonPrimary
+# ButtonPrimary (deprecated use @metamask/design-system-react)
 
 The `ButtonPrimary` is an extension of `ButtonBase` to support primary styles.
 

--- a/ui/components/component-library/button-primary/button-primary.stories.tsx
+++ b/ui/components/component-library/button-primary/button-primary.stories.tsx
@@ -7,7 +7,7 @@ import { ButtonPrimarySize } from './button-primary.types';
 import { Box } from '../box';
 
 export default {
-  title: 'Components/ComponentLibrary/ButtonPrimary',
+  title: 'Components/ComponentLibrary/ButtonPrimary (deprecated)',
   component: ButtonPrimary,
   parameters: {
     docs: {

--- a/ui/components/component-library/button-primary/button-primary.types.ts
+++ b/ui/components/component-library/button-primary/button-primary.types.ts
@@ -1,6 +1,9 @@
 import type { ButtonBaseStyleUtilityProps } from '../button-base/button-base.types';
 import type { PolymorphicComponentPropWithRef } from '../box';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonPrimarySize {
   Sm = 'sm',
   Md = 'md',

--- a/ui/components/component-library/button-secondary/README.mdx
+++ b/ui/components/component-library/button-secondary/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { ButtonSecondary } from './button-secondary';
 
-# ButtonSecondary
+# ButtonSecondary (deprecated use @metamask/design-system-react)
 
 The `ButtonSecondary` is an extension of `ButtonBase` to support secondary styles.
 

--- a/ui/components/component-library/button-secondary/button-secondary.stories.tsx
+++ b/ui/components/component-library/button-secondary/button-secondary.stories.tsx
@@ -26,7 +26,7 @@ const marginSizeControlOptions = [
 ];
 
 export default {
-  title: 'Components/ComponentLibrary/ButtonSecondary',
+  title: 'Components/ComponentLibrary/ButtonSecondary (deprecated)',
 
   component: ButtonSecondary,
   parameters: {

--- a/ui/components/component-library/button-secondary/button-secondary.types.ts
+++ b/ui/components/component-library/button-secondary/button-secondary.types.ts
@@ -1,6 +1,9 @@
 import type { ButtonBaseStyleUtilityProps } from '../button-base/button-base.types';
 import type { PolymorphicComponentPropWithRef } from '../box';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonSecondarySize {
   Sm = 'sm',
   Md = 'md',

--- a/ui/components/component-library/button/README.mdx
+++ b/ui/components/component-library/button/README.mdx
@@ -3,7 +3,7 @@ import { Button } from './button';
 import { ButtonBase } from '../button-base';
 import { ButtonLink } from '../button-link';
 
-# Button
+# Button (deprecated use @metamask/design-system-react)
 
 The `Button` is used for user actions. It unifies `ButtonPrimary`, `ButtonSecondary` and `ButtonLink`.
 

--- a/ui/components/component-library/button/button.stories.tsx
+++ b/ui/components/component-library/button/button.stories.tsx
@@ -14,7 +14,7 @@ import { ButtonSize, ButtonVariant } from './button.types';
 import { Box } from '../box';
 
 export default {
-  title: 'Components/ComponentLibrary/Button',
+  title: 'Components/ComponentLibrary/Button (deprecated)',
   component: Button,
   parameters: {
     docs: {

--- a/ui/components/component-library/button/button.types.ts
+++ b/ui/components/component-library/button/button.types.ts
@@ -3,6 +3,9 @@ import type { ButtonPrimaryStyleUtilityProps } from '../button-primary/button-pr
 import type { ButtonSecondaryStyleUtilityProps } from '../button-secondary/button-secondary.types';
 import type { ButtonLinkStyleUtilityProps } from '../button-link/button-link.types';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonSize {
   Sm = 'sm',
   Md = 'md',
@@ -11,6 +14,9 @@ export enum ButtonSize {
   Auto = 'auto',
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum ButtonVariant {
   Primary = 'primary',
   Secondary = 'secondary',

--- a/ui/components/component-library/checkbox/README.mdx
+++ b/ui/components/component-library/checkbox/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { Checkbox } from './checkbox';
 
-# Checkbox
+# Checkbox (deprecated use @metamask/design-system-react)
 
 Checkbox is a graphical element that allows users to select one or more options from a set of choices.
 

--- a/ui/components/component-library/checkbox/checkbox.stories.tsx
+++ b/ui/components/component-library/checkbox/checkbox.stories.tsx
@@ -13,7 +13,7 @@ import { Checkbox } from './checkbox';
 import { Box } from '../box';
 
 export default {
-  title: 'Components/ComponentLibrary/Checkbox',
+  title: 'Components/ComponentLibrary/Checkbox (deprecated)',
   component: Checkbox,
   parameters: {
     docs: {

--- a/ui/components/component-library/icon/README.mdx
+++ b/ui/components/component-library/icon/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { Icon } from './icon';
 
-# Icon
+# Icon (deprecated use @metamask/design-system-react)
 
 The `Icon` component in conjunction with `IconName` can be used for all icons in the extension
 

--- a/ui/components/component-library/icon/icon.stories.tsx
+++ b/ui/components/component-library/icon/icon.stories.tsx
@@ -30,7 +30,7 @@ import { ButtonIcon, ButtonIconSize } from '../button-icon';
 import { ButtonLink, ButtonLinkSize } from '../button-link';
 
 export default {
-  title: 'Components/ComponentLibrary/Icon',
+  title: 'Components/ComponentLibrary/Icon (deprecated)',
   component: Icon,
   parameters: {
     docs: {

--- a/ui/components/component-library/icon/icon.types.ts
+++ b/ui/components/component-library/icon/icon.types.ts
@@ -8,6 +8,9 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum IconSize {
   Xs = 'xs',
   Sm = 'sm',
@@ -24,6 +27,7 @@ export enum IconSize {
  *
  * Add an icon: https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#adding-a-new-icon
  *
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
  */
 
 export enum IconName {

--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import { Text } from '../text';
 
-# Text
+# Text (deprecated use @metamask/design-system-react)
 
 Good typography improves readability, legibility and hierarchy of information.
 

--- a/ui/components/component-library/text/text.stories.tsx
+++ b/ui/components/component-library/text/text.stories.tsx
@@ -24,7 +24,7 @@ import { Text } from './text';
 import { TextDirection } from './text.types';
 
 export default {
-  title: 'Components/ComponentLibrary/Text',
+  title: 'Components/ComponentLibrary/Text (deprecated)',
   component: Text,
   parameters: {
     docs: {

--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -308,6 +308,9 @@ export enum BorderColor {
   backgroundDefault = 'background-default', // exception for border color when element is meant to look "cut out"
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum TextColor {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -404,6 +407,9 @@ export enum TextColor {
   transparent = 'transparent',
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum IconColor {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -488,6 +494,9 @@ export enum IconColor {
   transparent = 'transparent',
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of TextVariant from @metamask/design-system-react
+ */
 export enum TypographyVariant {
   H1 = 'h1',
   H2 = 'h2',
@@ -506,6 +515,9 @@ export enum TypographyVariant {
   span = 'span',
 }
 
+/**
+ * @deprecated This type has been deprecated in favor of the one from @metamask/design-system-react
+ */
 export enum TextVariant {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
## **Description**

This PR enhances deprecation notices for 16 deprecated components and types in the component-library folder to improve developer experience and facilitate migration to `@metamask/design-system-react`

**Changes made:**
1. **JSDoc Comments**: Added `@deprecated` JSDoc comments to all enum types in deprecated component `.types.ts` files
2. **README Updates**: Added "(deprecated use @metamask/design-system-react)" to component titles in README.mdx files  
3. **Storybook Updates**: Added "(deprecated)" to Storybook story titles to make deprecation visible in the UI

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37024?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open Storybook and navigate to Components/ComponentLibrary
2. Verify deprecated components show "(deprecated)" in their titles
3. Check TypeScript editor for JSDoc deprecation warnings when using deprecated enums
5. Verify README files show deprecation notices in component titles
6. Test that existing functionality still works as expected

## **Screenshots/Recordings**

### **Before**
Components in storybook and types appeared normal without clear deprecation indication

https://github.com/user-attachments/assets/67eabe80-2828-4c16-b9fc-5ed38f2f7576

<img width="258" height="308" alt="Screenshot 2025-10-21 at 6 30 56 PM" src="https://github.com/user-attachments/assets/e9db5559-d0b3-4f73-b352-fbaa04d7f191" />

### **After**
- Storybook titles now show "(deprecated)" suffix for better visibility
- JSDoc comments provide IDE warnings for deprecated enum usage
- README titles clearly indicate deprecation with migration guidance


https://github.com/user-attachments/assets/52b56ac5-6611-4aa9-9b0b-d8c8435eea89

More strike throughs on types that accompany deprecated components

<img width="282" height="333" alt="Screenshot 2025-10-21 at 6 29 10 PM" src="https://github.com/user-attachments/assets/9f40e4e8-0c91-4d83-8abe-94c9468de1fd" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable  
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds deprecation markers to component docs and Storybook titles and annotates enums/types with @deprecated JSDoc, guiding migration to @metamask/design-system-react.
> 
> - **Docs & Storybook UI**
>   - Append "(deprecated use @metamask/design-system-react)" to component `README.mdx` titles (e.g., `Avatar*`, `BadgeWrapper`, `Box`, `Button*`, `Checkbox`, `Icon`, `Text`).
>   - Mark Storybook `title` fields with "(deprecated)" for corresponding stories.
> - **TypeScript JSDoc**
>   - Add `@deprecated` to enums in deprecated component `*.types.ts` (e.g., `Avatar*Size`, `BadgeWrapperPosition`, `BadgeWrapperAnchorElementShape`, `Button*Size`, `ButtonSize`, `ButtonVariant`, `ButtonIconSize`, `IconSize`, `IconName`).
>   - Add `@deprecated` to design-system enums in `ui/helpers/constants/design-system.ts` (`TextColor`, `IconColor`, `TypographyVariant`, `TextVariant`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a492c8c4d7d68205d87e4cf6b62db6ce89b412c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->