### PR TITLE
chore: remove unnecessary fields + function

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Von"
   },
-  "fromAddress": {
-    "message": "Von: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Von Token-Liste: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "An"
-  },
-  "toAddress": {
-    "message": "An: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Wir nutzen die Dienste von 4byte.directory und Sourcify, um Transaktionsdaten zu dekodieren und lesbarer anzuzeigen. Dadurch können Sie das Ergebnis ausstehender und vergangener Transaktionen leichter einsehen, allerdings kann dies zur Weitergabe Ihrer IP-Adresse führen."

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Από"
   },
-  "fromAddress": {
-    "message": "Από: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Από λίστες token: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Προς"
-  },
-  "toAddress": {
-    "message": "Προς: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Χρησιμοποιούμε τις υπηρεσίες 4byte.directory και Sourcify για να αποκωδικοποιήσουμε και να εμφανίσουμε πιο ευανάγνωστα τα δεδομένα συναλλαγών. Έτσι μπορείτε να κατανοήσετε το αποτέλεσμα των εκκρεμών και προηγούμενων συναλλαγών, αλλά μπορεί να προκαλέσει στην κοινοποίηση της διεύθυνσης IP σας."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2673,10 +2673,6 @@
   "from": {
     "message": "From"
   },
-  "fromAddress": {
-    "message": "From: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "From token lists: $1"
   },
@@ -7337,10 +7333,6 @@
   },
   "to": {
     "message": "To"
-  },
-  "toAddress": {
-    "message": "To: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "We use 4byte.directory and Sourcify services to decode and display more readable transaction data. This helps you understand the outcome of pending and past transactions, but can result in your IP address being shared."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2673,10 +2673,6 @@
   "from": {
     "message": "From"
   },
-  "fromAddress": {
-    "message": "From: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "From token lists: $1"
   },
@@ -7337,10 +7333,6 @@
   },
   "to": {
     "message": "To"
-  },
-  "toAddress": {
-    "message": "To: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "We use 4byte.directory and Sourcify services to decode and display more readable transaction data. This helps you understand the outcome of pending and past transactions, but can result in your IP address being shared."

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "De"
   },
-  "fromAddress": {
-    "message": "De: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "De las listas de tóken: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Para"
-  },
-  "toAddress": {
-    "message": "Para: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Utilizamos los servicios de 4byte.directory y Sourcify para decodificar y mostrar datos de transacciones de forma más legible. Esto le ayuda a comprender el resultado de las transacciones pendientes y pasadas, pero puede dar lugar a que se comparta su dirección IP."

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -751,10 +751,6 @@
   "from": {
     "message": "De"
   },
-  "fromAddress": {
-    "message": "De: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "gas": {
     "message": "Gas"
   },
@@ -1891,10 +1887,6 @@
   },
   "to": {
     "message": "Para"
-  },
-  "toAddress": {
-    "message": "Para: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "token": {
     "message": "Token"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "de"
   },
-  "fromAddress": {
-    "message": "De : $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "À partir des listes de tokens : $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Destinataire"
-  },
-  "toAddress": {
-    "message": "Vers : $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Nous utilisons les services de 4byte.directory et de Sourcify pour décoder et afficher des données de transaction plus compréhensibles. Cela vous aide à comprendre le résultat des transactions en cours et passées, mais peut entraîner le partage de votre adresse IP."

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -2606,10 +2606,6 @@
   "from": {
     "message": "Ó"
   },
-  "fromAddress": {
-    "message": "Ó: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Ó liostaí comharthaí: $1"
   },
@@ -7227,10 +7223,6 @@
   },
   "to": {
     "message": "Chuig"
-  },
-  "toAddress": {
-    "message": "Chuig: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Úsáidimid seirbhísí 4byte.directory agus Sourcify chun sonraí idirbhearta a dhíchódú agus a thaispeáint níos inléite. Cuidíonn sé seo leat toradh idirbhearta atá ar feitheamh agus san am atá thart a thuiscint, ach d’fhéadfadh sé go roinnfí do sheoladh IP dá bharr."

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "भेजने वाले"
   },
-  "fromAddress": {
-    "message": "भेजने वाले: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "टोकन लिस्टों से: $1"
   },
@@ -6592,10 +6588,6 @@
   },
   "to": {
     "message": "प्रति"
-  },
-  "toAddress": {
-    "message": "प्रति: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "हम अधिक पठनीय ट्रांसेक्शन डेटा को डिकोड करने और प्रदर्शित करने के लिए 4byte.directory और Sourcify सेवाओं का उपयोग करते हैं। इससे आपको लंबित और पिछले ट्रांसेक्शन के परिणाम को समझने में मदद मिलती है, लेकिन इसके परिणामस्वरूप आपका आईपी ​​एड्रेस साझा किया जा सकता है।"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Dari"
   },
-  "fromAddress": {
-    "message": "Dari: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Dari daftar token: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Untuk"
-  },
-  "toAddress": {
-    "message": "Ke: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Kami menggunakan layanan 4byte.directory dan Sourcify untuk mengonversi kode dan menampilkan data transaksi yang lebih mudah dibaca. Ini membantu Anda memahami hasil transaksi yang tertunda dan yang sudah lewat, tetapi alamat IP Anda berpotensi tersebar."

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -684,10 +684,6 @@
   "from": {
     "message": "Da"
   },
-  "fromAddress": {
-    "message": "Da: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "gasLimit": {
     "message": "Gas Limite"
   },
@@ -1346,10 +1342,6 @@
   },
   "to": {
     "message": "A"
-  },
-  "toAddress": {
-    "message": "A: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "tokenAlreadyAdded": {
     "message": "Il token è già stato aggiunto."

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "移動元"
   },
-  "fromAddress": {
-    "message": "移動元: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "トークンリストから: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "移動先"
-  },
-  "toAddress": {
-    "message": "移動先: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "当社は4byte.directoryとSourcifyサービスを使用してトランザクションデータを解読し、より読みやすい形で表示しています。これにより、保留中および過去のトランザクションの結果を理解しやすくなりますが、IPアドレスが共有される可能性があります。"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "발신"
   },
-  "fromAddress": {
-    "message": "발신: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "가져올 토큰 목록: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "수신"
-  },
-  "toAddress": {
-    "message": "수신: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "트랜잭션 데이터는 4byte.directory와 Sourcify 서비스를 사용하여 디코딩하고 읽기 쉬운 형식으로 표시합니다. 이는 대기 중이거나 과거 트랜잭션의 결과를 이해하는 데 도움이 되지만, IP 주소를 공유하는 결과가 초래될 수 있습니다."

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "De"
   },
-  "fromAddress": {
-    "message": "De: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Das listas de tokens: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Para"
-  },
-  "toAddress": {
-    "message": "Para: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Usamos os serviços do 4byte.directory e do Sourcify para decodificar e exibir dados de transações de forma mais legível. Isso ajuda você a entender o resultado de transações pendentes e passadas, mas pode resultar em compartilhamento do seu endereço IP."

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -751,10 +751,6 @@
   "from": {
     "message": "De"
   },
-  "fromAddress": {
-    "message": "De: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "gas": {
     "message": "Gás"
   },
@@ -1891,10 +1887,6 @@
   },
   "to": {
     "message": "Para"
-  },
-  "toAddress": {
-    "message": "Para: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "token": {
     "message": "Token"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "От"
   },
-  "fromAddress": {
-    "message": "От: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Из списков токенов: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Адресат"
-  },
-  "toAddress": {
-    "message": "Адресат: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Мы используем сервисы 4byte.directory и Sourcify для декодирования и отображения более читаемых данных транзакций. Это поможет Вам понять результат ожидающих и прошлых транзакций, но может привести к раскрытию вашего IP-адреса."

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Mula kay/sa"
   },
-  "fromAddress": {
-    "message": "Mula kay/sa: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Mula sa mga listahan ng token: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Para kay/sa"
-  },
-  "toAddress": {
-    "message": "Para kay/sa: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Ginagamit namin ang mga serbisyo ng 4byte.directory at Sourcify para i-decode at ipakita ang mas nababasang data ng transaksyon. Tinutulungan ka nito na maunawaan ang kinalabasan ng mga nakabinbin at nakalipas na transaksyon, ngunit maaaring humantong sa pagbabahagi ng iyong IP address."

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Kimden"
   },
-  "fromAddress": {
-    "message": "Kimden: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Token listelerinden: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Kime"
-  },
-  "toAddress": {
-    "message": "Alıcı: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Şifre çözmek ve daha okunabilir işlem verileri göstermek için 4byte.directory ve Sourcify hizmetlerini kullanıyoruz. Bu da, bekleyen ve geçmiş işlemlerinin sonucunu anlamanıza yardımcı olur ancak IP adresinizin paylaşılmasıyla sonuçlanabilir."

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "Từ"
   },
-  "fromAddress": {
-    "message": "Từ: $1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "Từ danh sách token: $1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "Đến"
-  },
-  "toAddress": {
-    "message": "Đến: $1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "Chúng tôi sử dụng các dịch vụ 4byte.directory và Sourcify để giải mã và hiển thị dữ liệu giao dịch dễ đọc hơn. Điều này giúp bạn hiểu rõ kết quả của các giao dịch đang chờ xử lý và đã thực hiện, nhưng có thể dẫn đến việc địa chỉ IP của bạn được chia sẻ."

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -2463,10 +2463,6 @@
   "from": {
     "message": "自"
   },
-  "fromAddress": {
-    "message": "从：$1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "fromTokenLists": {
     "message": "从代币列表：$1"
   },
@@ -6598,10 +6594,6 @@
   },
   "to": {
     "message": "至"
-  },
-  "toAddress": {
-    "message": "至：$1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleDecodeDescription": {
     "message": "我们使用 4byte.directory 和 Sourcify 服务来解码和显示更易读的交易数据。这可以帮助您了解待定交易和过去交易的结果，但可能会导致您的 IP 地址共享。"

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -475,10 +475,6 @@
   "from": {
     "message": "來源帳戶"
   },
-  "fromAddress": {
-    "message": "來自：$1",
-    "description": "$1 is the address to include in the From label. It is typically shortened first using shortenAddress"
-  },
   "gasLimit": {
     "message": "Gas 上限"
   },
@@ -1096,10 +1092,6 @@
   },
   "to": {
     "message": "目的帳戶"
-  },
-  "toAddress": {
-    "message": "傳送到：$1",
-    "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "token": {
     "message": "代碼"

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -332,18 +332,6 @@ export function sortSelectedInternalAccounts(accounts) {
 
 /**
  * Strips the following schemes from URL strings:
- * - http
- * - https
- *
- * @param {string} urlString - The URL string to strip the scheme from.
- * @returns {string} The URL string, without the scheme, if it was stripped.
- */
-export function stripHttpSchemes(urlString) {
-  return urlString.replace(/^https?:\/\//u, '');
-}
-
-/**
- * Strips the following schemes from URL strings:
  * - https
  *
  * @param {string} urlString - The URL string to strip the scheme from.

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -23,11 +23,7 @@ import {
   getTokenAddressParam,
   getTokenIdParam,
 } from '../helpers/utils/token-util';
-import {
-  formatDateWithYearContext,
-  shortenAddress,
-  stripHttpSchemes,
-} from '../helpers/utils/util';
+import { formatDateWithYearContext } from '../helpers/utils/util';
 
 import {
   PENDING_STATUS_HASH,
@@ -85,8 +81,6 @@ const signatureTypes = [
  * @property {string} recipientAddress - the Ethereum address of the recipient
  * @property {string} senderAddress - the Ethereum address of the sender
  * @property {string} status - the status of the transaction
- * @property {string} subtitle - the supporting text describing the transaction
- * @property {boolean} subtitleContainsOrigin - true if the subtitle includes the origin of the tx
  * @property {string} title - the primary title of the tx that will be displayed in the activity list
  * @property {string} [secondaryCurrency] - the currency string to display in the secondary position
  * @property {string} date - the formatted date of the transaction
@@ -156,8 +150,6 @@ export function useTransactionDisplayData(transactionGroup) {
   const date = formatDateWithYearContext(initialTransaction.time);
 
   let prefix = '-';
-  let subtitle;
-  let subtitleContainsOrigin = false;
   let recipientAddress = to;
   const senderAddress = from;
   const transactionData = initialTransaction?.txParams?.data;
@@ -271,10 +263,6 @@ export function useTransactionDisplayData(transactionGroup) {
     true,
   );
 
-  const origin = stripHttpSchemes(
-    initialTransaction.origin || initialTransaction.msgParams?.origin || '',
-  );
-
   // used to append to the primary display value. initialized to either token.symbol or undefined
   // but can later be modified if dealing with a swap
   let primarySuffix = isTokenCategory ? token?.symbol : undefined;
@@ -300,8 +288,6 @@ export function useTransactionDisplayData(transactionGroup) {
   if (signatureTypes.includes(type)) {
     category = TransactionGroupCategory.signatureRequest;
     title = t('signatureRequest');
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (type === TransactionType.swap) {
     category = TransactionGroupCategory.swap;
     title = t('swapTokenToToken', [
@@ -310,8 +296,6 @@ export function useTransactionDisplayData(transactionGroup) {
       bridgeTokenDisplayData.destinationTokenSymbol ??
         initialTransaction.destinationTokenSymbol,
     ]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
     const symbolFromTx =
       bridgeTokenDisplayData.sourceTokenSymbol ??
       initialTransaction.sourceTokenSymbol;
@@ -343,8 +327,6 @@ export function useTransactionDisplayData(transactionGroup) {
       initialTransaction.sourceTokenSymbol,
       initialTransaction.destinationTokenSymbol,
     ]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
     primarySuffix =
       isViewingReceivedTokenFromSwap && isSenderTokenRecipient
         ? currentAsset.symbol
@@ -365,8 +347,6 @@ export function useTransactionDisplayData(transactionGroup) {
       bridgeTokenDisplayData.sourceTokenSymbol ??
         primaryTransaction.sourceTokenSymbol,
     ]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
     primarySuffix =
       bridgeTokenDisplayData.sourceTokenSymbol ??
       primaryTransaction.sourceTokenSymbol;
@@ -376,8 +356,6 @@ export function useTransactionDisplayData(transactionGroup) {
     title = t('approveSpendingCap', [
       token?.symbol || t('token').toLowerCase(),
     ]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (type === TransactionType.tokenMethodSetApprovalForAll) {
     const isRevoke = !tokenData?.args?.[1];
 
@@ -386,14 +364,10 @@ export function useTransactionDisplayData(transactionGroup) {
     title = isRevoke
       ? t('revokePermissionTitle', [token?.symbol || nft?.name || t('token')])
       : t('setApprovalForAllTitle', [token?.symbol || t('token')]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (type === TransactionType.tokenMethodIncreaseAllowance) {
     category = TransactionGroupCategory.approval;
     prefix = '';
     title = t('approveIncreaseAllowance', [token?.symbol || t('token')]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (
     type === TransactionType.contractInteraction ||
     type === TransactionType.batch ||
@@ -404,19 +378,14 @@ export function useTransactionDisplayData(transactionGroup) {
     title =
       (methodData?.name && camelCaseToCapitalize(methodData.name)) ||
       transactionTypeTitle;
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (type === TransactionType.deployContract) {
     // @todo Should perhaps be a separate group?
     category = TransactionGroupCategory.interaction;
     title = getTransactionTypeTitle(t, type);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
   } else if (type === TransactionType.incoming) {
     category = TransactionGroupCategory.receive;
     title = t('received');
     prefix = '';
-    subtitle = t('fromAddress', [shortenAddress(senderAddress)]);
   } else if (
     type === TransactionType.tokenMethodTransferFrom ||
     type === TransactionType.tokenMethodTransfer
@@ -426,21 +395,16 @@ export function useTransactionDisplayData(transactionGroup) {
       token?.symbol || nft?.name || t('token'),
     ]);
     recipientAddress = getTokenAddressParam(tokenData);
-    subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
   } else if (type === TransactionType.tokenMethodSafeTransferFrom) {
     category = TransactionGroupCategory.send;
     title = t('safeTransferFrom');
     recipientAddress = getTokenAddressParam(tokenData);
-    subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
   } else if (type === TransactionType.simpleSend) {
     category = TransactionGroupCategory.send;
     title = t('sent');
-    subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
   } else if (type === TransactionType.bridgeApproval) {
     category = TransactionGroupCategory.approval;
     title = t('bridgeApproval', [bridgeTokenDisplayData.sourceTokenSymbol]);
-    subtitle = origin;
-    subtitleContainsOrigin = true;
     primarySuffix = bridgeTokenDisplayData.sourceTokenSymbol;
   } else if (type === TransactionType.bridge) {
     title = destChainName ? t('bridgedToChain', [destChainName]) : t('bridged');
@@ -500,8 +464,6 @@ export function useTransactionDisplayData(transactionGroup) {
     title,
     category,
     date,
-    subtitle,
-    subtitleContainsOrigin,
     primaryCurrency:
       type === TransactionType.swap && isPending ? '' : primaryCurrency,
     senderAddress,

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -30,8 +30,6 @@ const expectedResults = [
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    subtitle: 'To: 0xffe5b...91a97',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1589314601567),
     primaryCurrency: '-1 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -45,8 +43,6 @@ const expectedResults = [
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    subtitle: 'To: 0x0ccc8...f8848',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1589314355872),
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -58,8 +54,6 @@ const expectedResults = [
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    subtitle: 'To: 0xffe5b...91a97',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1589314345433),
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -71,8 +65,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    subtitle: 'From: 0x31b98...84523',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1589314295000),
     primaryCurrency: '18.75 ETH',
     senderAddress: '0x31b98d14007bdee637298086988a0bbd31184523',
@@ -84,8 +76,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    subtitle: 'From: 0x9eca6...6a149',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1588972833000),
     primaryCurrency: '0 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -97,8 +87,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    subtitle: 'From: 0xee014...efebb',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1585087013000),
     primaryCurrency: '1 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
@@ -110,8 +98,6 @@ const expectedResults = [
   {
     title: 'Swap ETH to ABC',
     category: TransactionType.swap,
-    subtitle: '',
-    subtitleContainsOrigin: false,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '+1 ABC',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
@@ -122,8 +108,6 @@ const expectedResults = [
   {
     title: 'Contract deployment',
     category: TransactionGroupCategory.interaction,
-    subtitle: 'metamask.github.io',
-    subtitleContainsOrigin: true,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-0 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
@@ -135,8 +119,6 @@ const expectedResults = [
   {
     title: 'Safe transfer from',
     category: TransactionGroupCategory.send,
-    subtitle: 'To: 0xe7d52...0dd98',
-    subtitleContainsOrigin: true,
     primaryCurrency: '-0 ETH',
     senderAddress: '0x806627172af48bd5b0765d3449a7def80d6576ff',
     recipientAddress: '0xe7d522230eff653bb0a9b4385f0be0815420dd98',
@@ -147,8 +129,6 @@ const expectedResults = [
   {
     title: 'Approve ABC spending cap',
     category: TransactionGroupCategory.approval,
-    subtitle: `metamask.github.io`,
-    subtitleContainsOrigin: true,
     primaryCurrency: '0.00000000000005 ABC',
     senderAddress: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
@@ -159,8 +139,6 @@ const expectedResults = [
   {
     title: 'Sent BAT as ETH',
     category: TransactionType.swapAndSend,
-    subtitle: 'metamask',
-    subtitleContainsOrigin: true,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-33.425656732428330864 BAT',
     senderAddress: '0x0a985a957b490f4d05bef05bc7ec556dd8535946',
@@ -172,8 +150,6 @@ const expectedResults = [
   {
     title: 'Sent USDC as DAI',
     category: TransactionType.swapAndSend,
-    subtitle: 'metamask',
-    subtitleContainsOrigin: true,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-5 USDC',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -185,8 +161,6 @@ const expectedResults = [
   {
     title: 'Sent BNB as USDC',
     category: TransactionType.swapAndSend,
-    subtitle: 'metamask',
-    subtitleContainsOrigin: true,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-0.05 BNB',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -198,8 +172,6 @@ const expectedResults = [
   {
     title: 'Sent ABC',
     category: TransactionGroupCategory.send,
-    subtitle: 'To: ',
-    subtitleContainsOrigin: true,
     date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-1.234 ABC',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -320,14 +292,6 @@ describe('useTransactionDisplayData', () => {
           tokenAddress,
         );
         expect(result.current.title).toStrictEqual(expected.title);
-      });
-
-      it(`should return a subtitle of ${expected.subtitle}`, () => {
-        const { result } = renderHookWithRouter(
-          () => useTransactionDisplayData(transactionGroup),
-          tokenAddress,
-        );
-        expect(result.current.subtitle).toStrictEqual(expected.subtitle);
       });
 
       it(`should return a category of ${expected.category}`, () => {


### PR DESCRIPTION
## **Description**

Part of reviewing the Activity feed, this removes unnecessary fields that are not used in the UI and subsequently a no longer used function. Also remove tests against these unused fields.

## **Changelog**

CHANGELOG entry: null 

## **Related issues**

Fixes:

## **Manual testing steps**

Activity tab should render normally

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused transaction subtitle fields and origin/address labels, deletes `stripHttpSchemes`, updates hook/tests, and prunes related i18n keys.
> 
> - **Activity/Transactions UI**:
>   - Remove `subtitle` and `subtitleContainsOrigin` from `useTransactionDisplayData` output; drop origin/address subtitle logic and related imports.
> - **Utils**:
>   - Delete `stripHttpSchemes`; keep `stripHttpsScheme`.
> - **i18n**:
>   - Remove unused keys `fromAddress` and `toAddress` across all locale `app/_locales/*/messages.json`.
> - **Tests**:
>   - Update `useTransactionDisplayData.test.js` to remove assertions for `subtitle` and `subtitleContainsOrigin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b25df33475627e869753f209983d3241c56a7e2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->