### PR TITLE
fix: prevent phishing redirect when still on google.com

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -274,10 +274,19 @@ const sendReadyMessageToTabs = async () => {
 function maybeDetectPhishing(theController) {
   async function redirectTab(tabId, url) {
     try {
+      const tab = await browser.tabs.get(tabId);
+
+      // Prevent redirect when due to Google pre-fetching
+      if (tab.url && tab.url.startsWith('https://www.google.com/search')) {
+        return;
+      }
+
+      // eslint-disable-next-line consistent-return
       return await browser.tabs.update(tabId, {
         url,
       });
     } catch (error) {
+      // eslint-disable-next-line consistent-return
       return sentry?.captureException(error);
     }
   }
@@ -288,6 +297,8 @@ function maybeDetectPhishing(theController) {
       if (details.tabId === browser.tabs.TAB_ID_NONE) {
         return {};
       }
+
+      console.log('details', details);
 
       const { completedOnboarding } = theController.onboardingController.state;
       if (!completedOnboarding) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -298,8 +298,6 @@ function maybeDetectPhishing(theController) {
         return {};
       }
 
-      console.log('details', details);
-
       const { completedOnboarding } = theController.onboardingController.state;
       if (!completedOnboarding) {
         return {};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where Googling a site on the eth-phishing-detect blocklist could result in blocking google.com before the user navigated to the URL. This is a result of Google pre-fetching the top URL, causing it to be caught by our phishing detection.

## Changelog
CHANGELOG entry: Fixed pre-emptive phishing page redirect on Google search results.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36802

## **Manual testing steps**

1. Google "tornado cash"
2. Observe phishing page being displayed (assuming it is the top search result). This is now fixed so that the phishing page will **not** be displayed until the user actually navigates there.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents phishing warning from triggering during Google search prefetches and emits metrics only when a real redirect occurs.
> 
> - **Phishing detection (background.js)**:
>   - `redirectTab` now checks the current tab URL and skips redirects for `https://www.google.com/search*` prefetches; returns boolean success and captures errors via Sentry.
>   - Introduces `trackPhishingMetrics()` and calls it only when a redirect actually occurs (including async tab redirects for non-`main_frame` and MV3 paths).
>   - MV2 `main_frame` requests still use blocking redirect; non-`main_frame`/MV3 use async tab redirect with conditional metrics.
>   - Adds JSDoc for `redirectTab` and refactors metric emission to avoid duplicate/false positives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac7c6b44228d30ecf58e9ea4ce482774ebef4e6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->