### PR TITLE
chore: more unnecessary fields

### DIFF
--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -1,9 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useRef, useState } from 'react';
-import {
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
 import {
   getAllDetectedTokens,
@@ -23,7 +20,6 @@ import {
   getTokenAddressParam,
   getTokenIdParam,
 } from '../helpers/utils/token-util';
-import { formatDateWithYearContext } from '../helpers/utils/util';
 
 import {
   PENDING_STATUS_HASH,
@@ -83,10 +79,8 @@ const signatureTypes = [
  * @property {string} status - the status of the transaction
  * @property {string} title - the primary title of the tx that will be displayed in the activity list
  * @property {string} [secondaryCurrency] - the currency string to display in the secondary position
- * @property {string} date - the formatted date of the transaction
  * @property {string} displayedStatusKey - the key representing the displayed status of the transaction
  * @property {boolean} isPending - indicates if the transaction is pending
- * @property {boolean} isSubmitted - indicates if the transaction has been submitted
  */
 
 /**
@@ -143,11 +137,9 @@ export function useTransactionDisplayData(transactionGroup) {
 
   const displayedStatusKey = getStatusKey(primaryTransaction);
   const isPending = displayedStatusKey in PENDING_STATUS_HASH;
-  const isSubmitted = displayedStatusKey === TransactionStatus.submitted;
   const mounted = useRef(true);
 
   const primaryValue = primaryTransaction.txParams?.value;
-  const date = formatDateWithYearContext(initialTransaction.time);
 
   let prefix = '-';
   let recipientAddress = to;
@@ -463,7 +455,6 @@ export function useTransactionDisplayData(transactionGroup) {
   return {
     title,
     category,
-    date,
     primaryCurrency:
       type === TransactionType.swap && isPending ? '' : primaryCurrency,
     senderAddress,
@@ -478,7 +469,6 @@ export function useTransactionDisplayData(transactionGroup) {
         : secondaryCurrency,
     displayedStatusKey,
     isPending,
-    isSubmitted,
     detailsTitle,
   };
 }

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -18,7 +18,6 @@ import { ASSET_ROUTE, DEFAULT_ROUTE } from '../helpers/constants/routes';
 import { TransactionGroupCategory } from '../../shared/constants/transaction';
 import { KeyringType } from '../../shared/constants/keyring';
 import { createMockInternalAccount } from '../../test/jest/mocks';
-import { formatDateWithYearContext } from '../helpers/utils/util';
 import { getMessage } from '../helpers/utils/i18n-helper';
 import { mockNetworkState } from '../../test/stub/networks';
 import { CHAIN_IDS } from '../../shared/constants/network';
@@ -30,20 +29,17 @@ const expectedResults = [
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    date: formatDateWithYearContext(1589314601567),
     primaryCurrency: '-1 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
     secondaryCurrency: '-1 ETH',
     isPending: false,
     displayedStatusKey: TransactionStatus.confirmed,
-    isSubmitted: false,
     detailsTitle: 'Sent',
   },
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    date: formatDateWithYearContext(1589314355872),
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x0ccc8aeeaf5ce790f3b448325981a143fdef8848',
@@ -54,7 +50,6 @@ const expectedResults = [
   {
     title: 'Sent',
     category: TransactionGroupCategory.send,
-    date: formatDateWithYearContext(1589314345433),
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
@@ -65,7 +60,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    date: formatDateWithYearContext(1589314295000),
     primaryCurrency: '18.75 ETH',
     senderAddress: '0x31b98d14007bdee637298086988a0bbd31184523',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -76,7 +70,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    date: formatDateWithYearContext(1588972833000),
     primaryCurrency: '0 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -87,7 +80,6 @@ const expectedResults = [
   {
     title: 'Received',
     category: TransactionGroupCategory.receive,
-    date: formatDateWithYearContext(1585087013000),
     primaryCurrency: '1 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -98,7 +90,6 @@ const expectedResults = [
   {
     title: 'Swap ETH to ABC',
     category: TransactionType.swap,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '+1 ABC',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
@@ -108,7 +99,6 @@ const expectedResults = [
   {
     title: 'Contract deployment',
     category: TransactionGroupCategory.interaction,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-0 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: undefined,
@@ -139,7 +129,6 @@ const expectedResults = [
   {
     title: 'Sent BAT as ETH',
     category: TransactionType.swapAndSend,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-33.425656732428330864 BAT',
     senderAddress: '0x0a985a957b490f4d05bef05bc7ec556dd8535946',
     recipientAddress: '0xc6f6ca03d790168758285264bcbf7fb30d27322b',
@@ -150,7 +139,6 @@ const expectedResults = [
   {
     title: 'Sent USDC as DAI',
     category: TransactionType.swapAndSend,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-5 USDC',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -161,7 +149,6 @@ const expectedResults = [
   {
     title: 'Sent BNB as USDC',
     category: TransactionType.swapAndSend,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-0.05 BNB',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -172,7 +159,6 @@ const expectedResults = [
   {
     title: 'Sent ABC',
     category: TransactionGroupCategory.send,
-    date: formatDateWithYearContext(1585088013000),
     primaryCurrency: '-1.234 ABC',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',


### PR DESCRIPTION
## **Description**

Removing more unnecessary properties exported by useTransactionDisplayData: date and isSubmitted

Part of cleaning up the Activity tab

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `date` and `isSubmitted` from `useTransactionDisplayData` and updates tests accordingly.
> 
> - **Hooks**:
>   - **`ui/hooks/useTransactionDisplayData`**:
>     - Remove `date` and `isSubmitted` fields from returned `TransactionDisplayData`.
>     - Delete related computations and imports (e.g., `formatDateWithYearContext`, `TransactionStatus` usage for `isSubmitted`).
> - **Tests**:
>   - **`ui/hooks/useTransactionDisplayData.test.js`**:
>     - Update `expectedResults` and assertions to drop `date` and `isSubmitted`.
>     - Remove `formatDateWithYearContext` import and related expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a0fee75830080cc1bdea215b4803b19227a4193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->