### PR TITLE
fix: flaky test `Multichain API Calling wallet_invokeMethod`

### DIFF
--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -265,14 +265,7 @@ describe('Multichain API', function () {
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
               const confirmation = new Confirmation(driver);
               await confirmation.checkPageIsLoaded();
-              if (i < totalNumberOfScopes - 1) {
-                // if pending tx's, verify navigation and confirm
-                await confirmation.checkPageNumbers(1, totalNumberOfScopes - i);
-                await confirmation.clickFooterConfirmButton();
-              } else {
-                // if no pending tx's, confirm and wait for window to close
-                await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
-              }
+              await confirmation.clickFooterConfirmButton();
             }
 
             await driver.switchToWindowWithTitle(
@@ -290,12 +283,14 @@ describe('Multichain API', function () {
             );
             await testDapp.checkPageIsLoaded();
             for (const scope of GANACHE_SCOPES) {
+              const methodCount = 0;
               await driver.waitUntil(
                 async () => {
                   const currentBalance =
                     await testDapp.invokeMethodAndReturnResult({
                       scope,
                       method: 'eth_getBalance',
+                      methodCount: methodCount + 1,
                     });
                   // Normalize balance to make strict comparison
                   const normalizedBalance =
@@ -304,13 +299,6 @@ describe('Multichain API', function () {
                     currentBalance.endsWith('"')
                       ? JSON.parse(currentBalance)
                       : currentBalance;
-                  // Left for debugging purposes
-                  console.log('Scope', scope);
-                  console.log('Current Balance', normalizedBalance);
-                  console.log(
-                    'Initial Balance',
-                    DEFAULT_INITIAL_BALANCE_HEX,
-                  );
                   return normalizedBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
                 { timeout: 10000, interval: 1000 },

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -222,7 +222,7 @@ describe('Multichain API', function () {
         );
       });
 
-      it('should have less balance due to gas after transaction is sent', async function () {
+      it.only('should have less balance due to gas after transaction is sent', async function () {
         await withFixtures(
           {
             title: this.test?.fullTitle(),
@@ -283,15 +283,16 @@ describe('Multichain API', function () {
             );
             await testDapp.checkPageIsLoaded();
             for (const scope of GANACHE_SCOPES) {
-              const methodCount = 0;
+              let methodCount = 1;
               await driver.waitUntil(
                 async () => {
                   const currentBalance =
                     await testDapp.invokeMethodAndReturnResult({
                       scope,
                       method: 'eth_getBalance',
-                      methodCount: methodCount + 1,
+                      methodCount,
                     });
+                  methodCount += 1;
                   // Normalize balance to make strict comparison
                   const normalizedBalance =
                     typeof currentBalance === 'string' &&

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -222,7 +222,7 @@ describe('Multichain API', function () {
         );
       });
 
-      it.only('should have less balance due to gas after transaction is sent', async function () {
+      it('should have less balance due to gas after transaction is sent', async function () {
         await withFixtures(
           {
             title: this.test?.fullTitle(),

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -297,9 +297,10 @@ describe('Multichain API', function () {
                     currentBalance.endsWith('"')
                       ? JSON.parse(currentBalance)
                       : currentBalance;
-                  console.log("==========Normalized Balance", normalizedBalance);
-                  console.log("==========Default Initial Balance", DEFAULT_INITIAL_BALANCE_HEX);
-                  console.log("==========Scope", scope);
+                  // Left for debugging purposes
+                  console.log('Normalized Balance', normalizedBalance);
+                  console.log('Default Initial Balance', DEFAULT_INITIAL_BALANCE_HEX);
+                  console.log('Scope', scope);
                   return normalizedBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
                 { timeout: 10000, interval: 1000 },

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -12,7 +12,6 @@ import { DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC } from '../../../constants';
 import TestDappMultichain from '../../../page-objects/pages/test-dapp-multichain';
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
-import Confirmation from '../../../page-objects/pages/confirmations/redesign/confirmation';
 import ConnectAccountConfirmation from '../../../page-objects/pages/confirmations/redesign/connect-account-confirmation';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
@@ -263,9 +262,20 @@ describe('Multichain API', function () {
             const totalNumberOfScopes = GANACHE_SCOPES.length;
             for (let i = 0; i < totalNumberOfScopes; i++) {
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-              const confirmation = new Confirmation(driver);
+              const confirmation = new TransactionConfirmation(driver);
               await confirmation.checkPageIsLoaded();
-              await confirmation.clickFooterConfirmButton();
+              if (i < totalNumberOfScopes - 1) {
+                // if pending tx's, verify navigation and confirm
+                await confirmation.checkPageNumbers(1, totalNumberOfScopes - i);
+                await confirmation.checkNetworkIsDisplayed(
+                  `Localhost ${8545 + i}`,
+                );
+                await confirmation.clickFooterConfirmButton();
+              } else {
+                await confirmation.checkNetworkIsDisplayed('Localhost 7777');
+                // if no pending tx's, confirm and wait for window to close
+                await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+              }
             }
 
             await driver.switchToWindowWithTitle(

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -4,7 +4,6 @@ import {
   ACCOUNT_1,
   ACCOUNT_2,
   convertETHToHexGwei,
-  largeDelayMs,
   WINDOW_TITLES,
   withFixtures,
 } from '../../../helpers';
@@ -284,17 +283,16 @@ describe('Multichain API', function () {
             );
             await testDapp.checkPageIsLoaded();
             for (const scope of GANACHE_SCOPES) {
-              await driver.delay(largeDelayMs);
-              const currentBalance = await testDapp.invokeMethodAndReturnResult(
-                {
-                  scope,
-                  method: 'eth_getBalance',
+              await driver.waitUntil(
+                async () => {
+                  const currentBalance =
+                    await testDapp.invokeMethodAndReturnResult({
+                      scope,
+                      method: 'eth_getBalance',
+                    });
+                  return currentBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
-              );
-              assert.notStrictEqual(
-                currentBalance,
-                `"${DEFAULT_INITIAL_BALANCE_HEX}"`,
-                `${scope} scope balance should be different after eth_sendTransaction due to gas`,
+                { timeout: 10000, interval: 1000 },
               );
             }
           },

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -297,6 +297,9 @@ describe('Multichain API', function () {
                     currentBalance.endsWith('"')
                       ? JSON.parse(currentBalance)
                       : currentBalance;
+                  console.log("==========Normalized Balance", normalizedBalance);
+                  console.log("==========Default Initial Balance", DEFAULT_INITIAL_BALANCE_HEX);
+                  console.log("==========Scope", scope);
                   return normalizedBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
                 { timeout: 10000, interval: 1000 },

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -265,7 +265,14 @@ describe('Multichain API', function () {
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
               const confirmation = new Confirmation(driver);
               await confirmation.checkPageIsLoaded();
-              await confirmation.clickFooterConfirmButton();
+              if (i < totalNumberOfScopes - 1) {
+                // if pending tx's, verify navigation and confirm
+                await confirmation.checkPageNumbers(1, totalNumberOfScopes - i);
+                await confirmation.clickFooterConfirmButton();
+              } else {
+                // if no pending tx's, confirm and wait for window to close
+                await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+              }
             }
 
             await driver.switchToWindowWithTitle(
@@ -298,9 +305,12 @@ describe('Multichain API', function () {
                       ? JSON.parse(currentBalance)
                       : currentBalance;
                   // Left for debugging purposes
-                  console.log('Normalized Balance', normalizedBalance);
-                  console.log('Default Initial Balance', DEFAULT_INITIAL_BALANCE_HEX);
                   console.log('Scope', scope);
+                  console.log('Current Balance', normalizedBalance);
+                  console.log(
+                    'Initial Balance',
+                    DEFAULT_INITIAL_BALANCE_HEX,
+                  );
                   return normalizedBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
                 { timeout: 10000, interval: 1000 },

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -290,7 +290,14 @@ describe('Multichain API', function () {
                       scope,
                       method: 'eth_getBalance',
                     });
-                  return currentBalance !== DEFAULT_INITIAL_BALANCE_HEX;
+                  // Normalize balance to make strict comparison
+                  const normalizedBalance =
+                    typeof currentBalance === 'string' &&
+                    currentBalance.startsWith('"') &&
+                    currentBalance.endsWith('"')
+                      ? JSON.parse(currentBalance)
+                      : currentBalance;
+                  return normalizedBalance !== DEFAULT_INITIAL_BALANCE_HEX;
                 },
                 { timeout: 10000, interval: 1000 },
               );

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -169,20 +169,24 @@ class TestDappMultichain {
    * @param params - The parameters for retrieving the method result.
    * @param params.scope - The scope identifier for the method invocation.
    * @param params.method - The method name that was invoked.
+   * @param params.methodCount - The 1-based index of the method result to return. Defaults to 1.
    * @returns The result as string.
    */
   async getInvokeMethodResult({
     scope,
     method,
+    methodCount,
   }: {
     scope: string;
     method: string;
+    methodCount: number;
   }): Promise<string> {
     console.log(
       `Getting invoke method result for scope ${scope} and method ${method} on multichain test dapp.`,
     );
+    const index = Math.max(0, methodCount - 1);
     const result = await this.driver.findElement(
-      `[id="invoke-method-${replaceColon(scope)}-${method}-result-0"]`,
+      `[id="invoke-method-${replaceColon(scope)}-${method}-result-${index}"]`,
     );
     await this.driver.waitForNonEmptyElement(result);
     return await result.getText();
@@ -286,19 +290,22 @@ class TestDappMultichain {
    * @param params.scope - The CAIP-2 scope.
    * @param params.method - The JSON-RPC method to invoke.
    * @param params.params - The parameters for the JSON-RPC method.
+   * @param params.methodCount - The 1-based index of the method result to return. Defaults to 1.
    * @returns The result as string.
    */
   async invokeMethodAndReturnResult({
     scope,
     method,
     params = {},
+    methodCount = 1,
   }: {
     scope: string;
     method: string;
     params?: Json;
+    methodCount?: number;
   }): Promise<string> {
     await this.invokeMethod({ scope, method, params });
-    return this.getInvokeMethodResult({ scope, method });
+    return this.getInvokeMethodResult({ scope, method, methodCount });
   }
 
   /**

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -375,11 +375,22 @@ class TestDappMultichain {
     console.log(
       `Selecting ${method} for scope ${scope} on multichain test dapp.`,
     );
-    await this.driver.clickElement(
-      `[data-testid="${replaceColon(scope)}-select"]`,
-    );
-    await this.driver.clickElement(
-      `[data-testid="${replaceColon(scope)}-${method}-option"]`,
+    // With the waitUntil, we ensure the dropdown element is set to the correct method before clicking it
+    await this.driver.waitUntil(
+      async () => {
+        await this.driver.clickElement(
+          `[data-testid="${replaceColon(scope)}-select"]`,
+        );
+        await this.driver.clickElement(
+          `[data-testid="${replaceColon(scope)}-${method}-option"]`,
+        );
+        const selectEl = await this.driver.findElement(
+          `[data-testid="${replaceColon(scope)}-select"]`,
+        );
+        const selectedValue = await selectEl.getAttribute('value');
+        return selectedValue === method;
+      },
+      { interval: 100, timeout: 5000 },
     );
   }
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -175,11 +175,11 @@ class TestDappMultichain {
   async getInvokeMethodResult({
     scope,
     method,
-    methodCount,
+    methodCount = 1,
   }: {
     scope: string;
     method: string;
-    methodCount: number;
+    methodCount?: number;
   }): Promise<string> {
     console.log(
       `Getting invoke method result for scope ${scope} and method ${method} on multichain test dapp.`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We assert that the balance is different using the API request `eth_getBalance`. If this is done right away and the balance takes a bit to update, then the balance is still the same and the assertion fails.
We had a largeDelay in the spec to avoid this, but sometimes is not enough. A robust approach is to use the `waitUntil` method instead.

<img width="2042" height="232" alt="image" src="https://github.com/user-attachments/assets/27f86cf8-2044-436b-9ac6-0a8a5fbe3ef2" />

Given that each time we click Invoke Method a new element is created, we'll need to access that new element by its index , on each waitUntil loop.

<img width="790" height="1438" alt="image" src="https://github.com/user-attachments/assets/477d6382-79b6-4477-b462-f1a7531da425" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37040?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deflakes multichain wallet_invokeMethod e2e by polling indexed results for balance changes, ensuring method selection stability, and using TransactionConfirmation with network/page checks.
> 
> - **E2E Tests (`wallet_invokeMethod.spec.ts`)**:
>   - Replace `Confirmation` with `TransactionConfirmation`; add page count and network checks; wait for last window to close on final confirmation.
>   - Remove fixed delay; use `driver.waitUntil` to poll `eth_getBalance`, incrementing `methodCount` to read the latest result; normalize value before comparison.
> - **Test Dapp Page Object (`test-dapp-multichain.ts`)**:
>   - `getInvokeMethodResult`/`invokeMethodAndReturnResult`: add `methodCount` param to select the correct result index.
>   - `selectMethod`: wrap selection in `waitUntil` to verify the dropdown reflects the chosen method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55244c311144af7de45ee478033c7f036c21ab26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->