### PR TITLE
fix: cp-13.6.0 Update network row to be rendered in transaction confirmation if BIP44 is enabled

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/approve/approve-details/approve-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve-details/approve-details.tsx
@@ -20,6 +20,7 @@ import { getIsRevokeSetApprovalForAll } from '../../utils';
 import { useIsNFT } from '../hooks/use-is-nft';
 import { useTokenTransactionData } from '../../hooks/useTokenTransactionData';
 import { NetworkRow } from '../../shared/network-row/network-row';
+import { useIsBIP44 } from '../../../../../hooks/useIsBIP44';
 
 const Spender = ({
   isSetApprovalForAll = false,
@@ -74,11 +75,12 @@ export const ApproveDetails = ({
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
+  const isBIP44 = useIsBIP44();
 
   return (
     <ConfirmInfoSection data-testid="confirmation__approve-details">
       <Spender isSetApprovalForAll={isSetApprovalForAll} />
-      <NetworkRow isShownWithAlertsOnly />
+      <NetworkRow isShownWithAlertsOnly={!isBIP44} />
       <OriginRow />
       <SigningInWithRow />
       {showAdvancedDetails && (

--- a/ui/pages/confirmations/components/confirm/info/approve/revoke-details/revoke-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/revoke-details/revoke-details.tsx
@@ -3,11 +3,14 @@ import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/
 import { NetworkRow } from '../../shared/network-row/network-row';
 import { OriginRow } from '../../shared/transaction-details/transaction-details';
 import { SigningInWithRow } from '../../shared/sign-in-with-row/sign-in-with-row';
+import { useIsBIP44 } from '../../../../../hooks/useIsBIP44';
 
 export const RevokeDetails = () => {
+  const isBIP44 = useIsBIP44();
+
   return (
     <ConfirmInfoSection>
-      <NetworkRow isShownWithAlertsOnly />
+      <NetworkRow isShownWithAlertsOnly={!isBIP44} />
       <OriginRow />
       <SigningInWithRow />
     </ConfirmInfoSection>

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -30,6 +30,7 @@ import { hasValueAndNativeBalanceMismatch as checkValueAndNativeBalanceMismatch 
 import { NetworkRow } from '../network-row/network-row';
 import { SigningInWithRow } from '../sign-in-with-row/sign-in-with-row';
 import { isBatchTransaction } from '../../../../../../../../shared/lib/transactions.utils';
+import { useIsBIP44 } from '../../../../../hooks/useIsBIP44';
 
 export const OriginRow = () => {
   const t = useI18nContext();
@@ -168,6 +169,7 @@ const PaymasterRow = () => {
 };
 
 export const TransactionDetails = () => {
+  const isBIP44 = useIsBIP44();
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
@@ -192,7 +194,7 @@ export const TransactionDetails = () => {
   return (
     <>
       <ConfirmInfoSection data-testid="transaction-details-section">
-        <NetworkRow isShownWithAlertsOnly />
+        <NetworkRow isShownWithAlertsOnly={!isBIP44} />
         <OriginRow />
         {!isBatch && <RecipientRow />}
         {showAdvancedDetails && <MethodDataRow />}


### PR DESCRIPTION
… BIP44 flag is on

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix network row in transaction confirmations to be rendered if BIP44 is enabled as we don't have network indicator in header anymore.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37048?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix network row to be rendered in transaction confirmations

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37026

## **Manual testing steps**

See task details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1333" height="1443" alt="Screenshot 2025-10-22 at 12 04 18" src="https://github.com/user-attachments/assets/871312b1-8695-4ff5-8c83-3051d873f91f" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally render the full `NetworkRow` (not alerts-only) across confirmation views when BIP44 is enabled.
> 
> - **Confirmations UI**:
>   - **NetworkRow behavior**: Use `isShownWithAlertsOnly={!isBIP44}` to show full network row when BIP44 is enabled in:
>     - `approve-details.tsx`
>     - `revoke-details.tsx`
>     - `transaction-details.tsx`
>   - **Hook**: Import and use `useIsBIP44` to drive the conditional rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53279893f62d24b51d4eebb0eaeb38e5b8c20878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->