### PR TITLE
chore: enable watch only accounts on experimental builds

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -648,6 +648,7 @@ async function initialize(backup) {
     : {};
 
   const preinstalledSnaps = await loadPreinstalledSnaps();
+  console.log({ preinstalledSnaps });
   const cronjobControllerStorageManager = new CronjobControllerStorageManager();
   await cronjobControllerStorageManager.init();
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -648,7 +648,6 @@ async function initialize(backup) {
     : {};
 
   const preinstalledSnaps = await loadPreinstalledSnaps();
-  console.log({ preinstalledSnaps });
   const cronjobControllerStorageManager = new CronjobControllerStorageManager();
   await cronjobControllerStorageManager.init();
 

--- a/app/scripts/constants/snaps.ts
+++ b/app/scripts/constants/snaps.ts
@@ -15,12 +15,14 @@ export const PREINSTALLED_SNAPS_URLS = [
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   new URL(
     '@metamask/account-watcher/dist/preinstalled-snap.json',
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
+  ///: END:ONLY_INCLUDE_IF
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   new URL(
     '@metamask/preinstalled-example-snap/dist/preinstalled-snap.json',
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -163,7 +163,7 @@ export type PreferencesControllerState = Omit<
     hyperliquid: Record<Hex, ReferralStatus>;
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   watchEthereumAccountEnabled: boolean;
   ///: END:ONLY_INCLUDE_IF
 };
@@ -683,7 +683,7 @@ export class PreferencesController extends BaseController<
   }
   ///: END:ONLY_INCLUDE_IF
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   /**
    * Setter for the `watchEthereumAccountEnabled` property.
    *

--- a/app/scripts/lib/snap-keyring/account-watcher-snap.ts
+++ b/app/scripts/lib/snap-keyring/account-watcher-snap.ts
@@ -1,4 +1,4 @@
-// BEGIN:ONLY_INCLUDE_IF(build-flask)
+// BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
 import { SnapId } from '@metamask/snaps-sdk';
 
 export const ACCOUNT_WATCHER_SNAP_ID: SnapId =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2271,7 +2271,7 @@ export default class MetamaskController extends EventEmitter {
           preferencesController,
         ),
       ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+      ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
       setWatchEthereumAccountEnabled:
         preferencesController.setWatchEthereumAccountEnabled.bind(
           preferencesController,

--- a/builds.yml
+++ b/builds.yml
@@ -196,6 +196,9 @@ features:
       - src: ./node_modules/@metamask/gator-permissions-snap/dist/preinstalled-snap.json
         dest: snaps/gator-permissions-snap.json
   build-experimental:
+    assets:
+      - src: ./node_modules/@metamask/account-watcher/dist/preinstalled-snap.json
+        dest: snaps/account-watcher.json
 
 # Env variables that are required for all types of builds
 #

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -847,7 +847,7 @@ export enum MetaMetricsEventName {
   RehydrationPasswordAttempted = 'Rehydration Password Attempted',
   RehydrationCompleted = 'Rehydration Completed',
   RehydrationPasswordFailed = 'Rehydration Password Failed',
-  // BEGIN:ONLY_INCLUDE_IF(build-flask)
+  // BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   WatchEthereumAccountsToggled = 'Watch Ethereum Accounts Toggled',
   // END:ONLY_INCLUDE_IF
   AccountDetailMenuOpened = 'Account Details Menu Opened',

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -251,7 +251,7 @@ export type ControllerStatePropertiesEnumerated = {
   useMultiAccountBalanceChecker: PreferencesControllerState['useMultiAccountBalanceChecker'];
   use4ByteResolution: PreferencesControllerState['use4ByteResolution'];
   useCurrencyRateCheck: PreferencesControllerState['useCurrencyRateCheck'];
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   watchEthereumAccountEnabled: PreferencesControllerState['watchEthereumAccountEnabled'];
   ///: END:ONLY_INCLUDE_IF
   addSnapAccountEnabled?: PreferencesControllerState['addSnapAccountEnabled'];

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -38,7 +38,7 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import {
   getIsAddSnapAccountEnabled,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   getIsWatchEthereumAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
   getManageInstitutionalWallets,
@@ -50,7 +50,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
 import {
   ACCOUNT_WATCHER_NAME,
   ACCOUNT_WATCHER_SNAP_ID,
@@ -85,7 +85,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
   );
   const trackEvent = useContext(MetaMetricsContext);
   const addSnapAccountEnabled = useSelector(getIsAddSnapAccountEnabled);
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   const isAddWatchEthereumAccountEnabled = useSelector(
     getIsWatchEthereumAccountEnabled,
   );
@@ -158,7 +158,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
     });
   }, [trackEvent]);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   const handleAddWatchAccount = useCallback(async () => {
     await trackEvent({
       category: MetaMetricsEventCategory.Navigation,
@@ -268,7 +268,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
             </Box>
           )}
           {
-            ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+            ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
             isAddWatchEthereumAccountEnabled && (
               <Box
                 key="watch-ethereum-account"

--- a/ui/components/multichain/account-menu/account-menu.tsx
+++ b/ui/components/multichain/account-menu/account-menu.tsx
@@ -36,7 +36,7 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   getIsAddSnapAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   getIsWatchEthereumAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
@@ -64,7 +64,7 @@ import {
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
-///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
 import {
   ACCOUNT_WATCHER_NAME,
   ACCOUNT_WATCHER_SNAP_ID,
@@ -100,7 +100,7 @@ export const ACTION_MODES = {
   MENU: 'menu',
   // Displays the add account form controls
   ADD: 'add',
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   // Displays the add account form controls (for watch-only account)
   ADD_WATCH_ONLY: 'add-watch-only',
   ///: END:ONLY_INCLUDE_IF
@@ -152,7 +152,7 @@ export const getActionTitle = (
       return t('addAccountFromNetwork', [t('networkNameEthereum')]);
     case ACTION_MODES.MENU:
       return t('addAccount');
-    ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+    ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
     case ACTION_MODES.ADD_WATCH_ONLY:
       return t('addAccountFromNetwork', [t('networkNameEthereum')]);
     ///: END:ONLY_INCLUDE_IF
@@ -209,7 +209,7 @@ export const AccountMenu = ({
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const addSnapAccountEnabled = useSelector(getIsAddSnapAccountEnabled);
   ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   const isAddWatchEthereumAccountEnabled = useSelector(
     getIsWatchEthereumAccountEnabled,
   );
@@ -625,7 +625,7 @@ export const AccountMenu = ({
               ///: END:ONLY_INCLUDE_IF
             }
             {
-              ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+              ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
               isAddWatchEthereumAccountEnabled && (
                 <Box marginTop={4}>
                   <ButtonLink

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -559,7 +559,7 @@ const SETTINGS_CONSTANTS = [
     route: `${DEVELOPER_OPTIONS_ROUTE}#service-worker-keep-alive`,
     iconName: IconName.CodeCircle,
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   {
     tabMessage: (t) => t('experimental'),
     sectionMessage: (t) => t('watchEthereumAccountsToggle'),

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.tsx
@@ -183,7 +183,7 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
     });
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
   renderWatchAccountToggle() {
     const { t, trackEvent } = this.context;
     const { watchAccountEnabled, setWatchAccountEnabled } = this.props;
@@ -230,7 +230,7 @@ export default class ExperimentalTab extends PureComponent<ExperimentalTabProps>
           ///: END:ONLY_INCLUDE_IF
         }
         {
-          ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
+          ///: BEGIN:ONLY_INCLUDE_IF(build-flask,build-experimental)
           this.renderWatchAccountToggle()
           ///: END:ONLY_INCLUDE_IF
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37051?quickstart=1)

This PR should enable watch only accounts on experimental builds

## **Changelog**

CHANGELOG entry: enable watch only accounts on experimental builds

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1189

## **Manual testing steps**

1. Build in experimental mode `yarn && yarn start --build-type experimental`
2. Enable watch only accounts in the experimental section of the settings
3. Add a watch only account

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables watch-only Ethereum accounts and the Account Watcher Snap for experimental builds by expanding build guards, wiring preferences/API, updating UI surfaces, metrics, and packaging assets.
> 
> - **Build/Assets**
>   - Include `@metamask/account-watcher` preinstalled snap in `build-experimental` (`builds.yml`), and expand code fences to `ONLY_INCLUDE_IF(build-flask,build-experimental)`.
> - **Preferences/API**
>   - Expose `watchEthereumAccountEnabled` in state/types and background API for experimental builds (`preferences-controller.ts`, `metamask-controller.js`, `shared/types/background.ts`).
> - **Snaps/Constants**
>   - Enable Account Watcher Snap constants and preinstalled URLs for experimental builds (`app/scripts/constants/snaps.ts`, `app/scripts/lib/snap-keyring/account-watcher-snap.ts`).
> - **UI**
>   - Show watch-only account option and toggle in Add Wallet modal, Account Menu, and Experimental settings when experimental build is used (`add-wallet-modal.tsx`, `account-menu.tsx`, `settings.js`, `experimental-tab.component.tsx`).
> - **Metrics**
>   - Track watch-only toggle event for experimental builds (`shared/constants/metametrics.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f63591853aea02a17b4be9050de18d073e0732c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->