### PR TITLE
fix: Move extra $ to the argument of the locales string

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5812,8 +5812,8 @@
   "shieldEntryModalSupport": {
     "message": "Priority customer support"
   },
-  "shieldEstimatedChangesMonthlyTooltip": {
-    "message": "Authorize up to $$1 for the full year. You'll be billed $$2 each month, not the full amount now."
+  "shieldEstimatedChangesMonthlyTooltipText": {
+    "message": "Authorize up to $1 for the full year. You'll be billed $2 each month, not the full amount now."
   },
   "shieldFooterAgreement": {
     "message": "By continuing, I agree to Transaction Shield $1."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5812,8 +5812,8 @@
   "shieldEntryModalSupport": {
     "message": "Priority customer support"
   },
-  "shieldEstimatedChangesMonthlyTooltip": {
-    "message": "Authorize up to $$1 for the full year. You'll be billed $$2 each month, not the full amount now."
+  "shieldEstimatedChangesMonthlyTooltipText": {
+    "message": "Authorize up to $1 for the full year. You'll be billed $2 each month, not the full amount now."
   },
   "shieldFooterAgreement": {
     "message": "By continuing, I agree to Transaction Shield $1."

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5714,9 +5714,6 @@
   "shieldEntryModalSupport": {
     "message": "Tacaíocht do chustaiméirí tosaíochta"
   },
-  "shieldEstimatedChangesMonthlyTooltip": {
-    "message": "Údaraigh suas le $$1 don bhliain iomlán. Gearrfar $$2 ort gach mí, ní an méid iomlán anois."
-  },
   "shieldFooterAgreement": {
     "message": "Trí leanúint ar aghaidh, aontaím le Sciath Idirbhirt $1."
   },

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/estimated-changes.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/estimated-changes.tsx
@@ -36,9 +36,9 @@ export const EstimatedChanges = ({
         tooltip={
           isYearlySubscription
             ? null
-            : t('shieldEstimatedChangesMonthlyTooltip', [
-                approvalAmount,
-                Number(approvalAmount) / 12,
+            : t('shieldEstimatedChangesMonthlyTooltipText', [
+                `$${approvalAmount}`,
+                `$${Number(approvalAmount) / 12}`,
               ])
         }
       />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

As a general rule, we want to localize the currencies in display in the app. However, in the case of the shield subscription token approval, we want to hardcode "$" because the spent tokens will be USDC, USDT or mUSD.

However, the platform team doesn't allow having two $ in a row in the localization files, so I'm moving it to the argument on their request.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37055?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the shield monthly tooltip locale key and updates UI to pass dollar-formatted values as arguments; removes the GA translation entry.
> 
> - **i18n/locales**:
>   - Rename `shieldEstimatedChangesMonthlyTooltip` → `shieldEstimatedChangesMonthlyTooltipText` in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`, and change placeholders from `$$1/$$2` to `$1/$2`.
>   - Remove `shieldEstimatedChangesMonthlyTooltip` entry from `app/_locales/ga/messages.json`.
> - **UI**:
>   - In `ui/pages/confirmations/components/confirm/info/shield-subscription-approve/estimated-changes.tsx`, update tooltip to use `t('shieldEstimatedChangesMonthlyTooltipText', [...])` and pass formatted values ``[`$${approvalAmount}`, `$${Number(approvalAmount) / 12}`]``.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ba652cae7a63a5bb9033cb46ae553f111ae985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->