### PR TITLE
feat: handle crypto reapproval for shield

### DIFF
--- a/shared/modules/shield.ts
+++ b/shared/modules/shield.ts
@@ -1,4 +1,7 @@
-import { Subscription } from '@metamask/subscription-controller';
+import {
+  RECURRING_INTERVALS,
+  Subscription,
+} from '@metamask/subscription-controller';
 import { getIsShieldSubscriptionActive } from '../lib/shield';
 
 export async function getShieldGatewayConfig(
@@ -49,4 +52,35 @@ export async function getShieldGatewayConfig(
       authorization: undefined,
     };
   }
+}
+
+/**
+ * Calculate the remaining billing cycles for a subscription
+ *
+ * @param params
+ * @param params.currentPeriodEnd - The current period end date.
+ * @param params.endDate - The end date.
+ * @param params.interval - The interval.
+ * @returns The remaining billing cycles.
+ */
+export function calculateSubscriptionRemainingBillingCycles({
+  currentPeriodEnd,
+  endDate,
+  interval,
+}: {
+  currentPeriodEnd: Date;
+  endDate: Date;
+  interval: (typeof RECURRING_INTERVALS)[keyof typeof RECURRING_INTERVALS];
+}): number {
+  if (interval === RECURRING_INTERVALS.month) {
+    const yearDiff = endDate.getFullYear() - currentPeriodEnd.getFullYear();
+    const monthDiff = endDate.getMonth() - currentPeriodEnd.getMonth();
+    // Assume the period end and endDate have the same day of the month and time
+    // Current period is inclusive, so we need to add 1
+    return yearDiff * 12 + monthDiff + 1;
+  }
+  const yearDiff = endDate.getFullYear() - currentPeriodEnd.getFullYear();
+  // Assume the period end and endDate have the same month, day of the month and time
+  // Current period is inclusive, so we need to add 1
+  return yearDiff + 1;
 }

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.test.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.test.tsx
@@ -10,6 +10,7 @@ import {
   SUBSCRIPTION_STATUSES,
 } from '@metamask/subscription-controller';
 import { renderWithProvider } from '../../../../test/jest/rendering';
+import mockState from '../../../../test/data/mock-state.json';
 import TransactionShield from './transaction-shield';
 
 const mockUseNavigate = jest.fn();
@@ -23,6 +24,7 @@ jest.mock('react-router-dom-v5-compat', () => {
 describe('Transaction Shield Page', () => {
   const STATE_MOCK = {
     metamask: {
+      ...mockState.metamask,
       customerId: '1',
       trialedProducts: [],
       subscriptions: [

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -1,6 +1,13 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import classnames from 'classnames';
 import {
+  CRYPTO_PAYMENT_METHOD_ERRORS,
   PAYMENT_TYPES,
   Product,
   PRODUCT_TYPES,
@@ -41,6 +48,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   useCancelSubscription,
   useOpenGetSubscriptionBillingPortal,
+  useSubscriptionCryptoApprovalTransaction,
   useUnCancelSubscription,
   useUpdateSubscriptionCardPaymentMethod,
   useUserSubscriptionByProduct,
@@ -81,6 +89,7 @@ import {
   getIsShieldSubscriptionEndingSoon,
   getIsShieldSubscriptionPaused,
 } from '../../../../shared/lib/shield';
+import { calculateSubscriptionRemainingBillingCycles } from '../../../../shared/modules/shield';
 import CancelMembershipModal from './cancel-membership-modal';
 import { isCryptoPaymentMethod } from './types';
 
@@ -314,13 +323,95 @@ const TransactionShield = () => {
     shieldSubscription &&
     isCryptoPaymentMethod(shieldSubscription.paymentMethod) &&
     (shieldSubscription.paymentMethod.crypto.error ===
-      'insufficient_allowance' ||
-      shieldSubscription.paymentMethod.crypto.error ===
-        'approval_transaction_too_old' ||
-      shieldSubscription.paymentMethod.crypto.error ===
-        'approval_transaction_reverted' ||
-      shieldSubscription.paymentMethod.crypto.error ===
-        'approval_transaction_max_verification_attempts_reached');
+      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_ALLOWANCE ||
+      shieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_TOO_OLD ||
+      shieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_REVERTED ||
+      shieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_MAX_VERIFICATION_ATTEMPTS_REACHED);
+
+  const paymentToken = useMemo(() => {
+    if (
+      !shieldSubscription ||
+      !currentToken ||
+      !isCryptoPaymentMethod(shieldSubscription.paymentMethod) ||
+      !shieldSubscription.endDate ||
+      !productInfo
+    ) {
+      return undefined;
+    }
+
+    const remainingBillingCycles = calculateSubscriptionRemainingBillingCycles({
+      currentPeriodEnd: new Date(shieldSubscription.currentPeriodEnd),
+      endDate: new Date(shieldSubscription.endDate),
+      interval: shieldSubscription.interval,
+    });
+    // no need to use BigInt since max unitDecimals are always 2 for price
+    const priceAmount =
+      (productInfo.unitAmount / 10 ** productInfo.unitDecimals) *
+      remainingBillingCycles;
+
+    // TODO: consider moving this calculation logic to controller ?
+    // conversionRate is in usd decimal. In most currencies, we only care about 2 decimals (cents)
+    // So, scale must be max of 10 ** 4 (most exchanges trade with max 4 decimals of usd)
+    const SCALE = 10n ** 4n;
+    const conversionRate = currentToken.conversionRate[productInfo.currency];
+    const conversionRateScaled =
+      BigInt(Math.round(Number(conversionRate) * Number(SCALE))) / SCALE;
+    const priceAmountScaled =
+      BigInt(Math.round(priceAmount * Number(SCALE))) / SCALE;
+
+    const tokenDecimal = BigInt(10) ** BigInt(currentToken.decimals);
+
+    const tokenAmount =
+      (priceAmountScaled * tokenDecimal) / conversionRateScaled;
+    const approveAmount = tokenAmount.toString();
+
+    return {
+      chainId: shieldSubscription.paymentMethod.crypto.chainId,
+      address: currentToken.address,
+      approvalAmount: {
+        approveAmount,
+        chainId: shieldSubscription.paymentMethod.crypto.chainId,
+        paymentAddress: shieldSubscription.paymentMethod.crypto.payerAddress,
+        paymentTokenAddress: currentToken.address,
+      },
+    };
+  }, [productInfo, currentToken, shieldSubscription]);
+
+  const { execute: executeSubscriptionCryptoApprovalTransaction } =
+    useSubscriptionCryptoApprovalTransaction(paymentToken);
+
+  const handlePaymenError = useCallback(async () => {
+    if (
+      shieldSubscription &&
+      isCryptoPaymentMethod(shieldSubscription.paymentMethod)
+    ) {
+      if (isInsufficientFundsCrypto) {
+        // TODO: handle add funds crypto
+        // then use subscription controller to trigger subscription check
+        setIsAddFundsModalOpen(true);
+        // await dispatch(updateSubscriptionCryptoPaymentMethod({
+        //   ...params,
+        //   rawTransaction: undefined // no raw transaction to trigger server to check for new funded balance
+        // }))
+      } else if (isAllowanceNeededCrypto) {
+        await executeSubscriptionCryptoApprovalTransaction();
+      } else {
+        throw new Error('Unknown crypto error action');
+      }
+    } else {
+      await executeUpdateSubscriptionCardPaymentMethod();
+    }
+  }, [
+    shieldSubscription,
+    isInsufficientFundsCrypto,
+    isAllowanceNeededCrypto,
+    executeUpdateSubscriptionCardPaymentMethod,
+    setIsAddFundsModalOpen,
+    executeSubscriptionCryptoApprovalTransaction,
+  ]);
 
   const membershipErrorBanner = useMemo(() => {
     if (isPaused) {
@@ -334,34 +425,7 @@ const TransactionShield = () => {
               ? 'shieldTxMembershipErrorAddFunds'
               : 'shieldTxMembershipErrorUpdatePayment',
           )}
-          actionButtonOnClick={async () => {
-            if (
-              shieldSubscription &&
-              isCryptoPaymentMethod(shieldSubscription.paymentMethod)
-            ) {
-              if (isInsufficientFundsCrypto) {
-                // TODO: handle add funds crypto
-                // then use subscription controller to trigger subscription check
-                setIsAddFundsModalOpen(true);
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: undefined // no raw transaction to trigger server to check for new funded balance
-                // }))
-              } else if (isAllowanceNeededCrypto) {
-                // TODO: handle add approval transaction crypto
-                // then use subscription controller to udpate the subscription with new raw transaction
-                console.log('add allowance');
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: newApprovalRawTransaction
-                // }))
-              } else {
-                throw new Error('Unknown crypto error action');
-              }
-            } else {
-              await executeUpdateSubscriptionCardPaymentMethod();
-            }
-          }}
+          actionButtonOnClick={handlePaymenError}
         />
       );
     }
@@ -380,31 +444,7 @@ const TransactionShield = () => {
               ? t('shieldTxMembershipRenew')
               : t('shieldTxMembershipErrorAddFunds')
           }
-          actionButtonOnClick={() => {
-            if (isCryptoPaymentMethod(shieldSubscription.paymentMethod)) {
-              if (isInsufficientFundsCrypto) {
-                // TODO: handle add funds crypto
-                setIsAddFundsModalOpen(true);
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: undefined // no raw transaction to trigger server to check for new funded balance
-                // }))
-              } else if (isAllowanceNeededCrypto) {
-                // TODO: handle add allowance crypto
-                console.log('add allowance');
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: newApprovalRawTransaction
-                // }))
-              } else {
-                throw new Error('Unknown crypto error action');
-              }
-            } else {
-              throw new Error(
-                'Only crypto payment method is supported when ending soon',
-              );
-            }
-          }}
+          actionButtonOnClick={handlePaymenError}
         />
       );
     }
@@ -416,9 +456,9 @@ const TransactionShield = () => {
     shieldSubscription,
     t,
     isCryptoPayment,
-    executeUpdateSubscriptionCardPaymentMethod,
     isInsufficientFundsCrypto,
     isAllowanceNeededCrypto,
+    handlePaymenError,
   ]);
 
   const paymentMethod = useMemo(() => {
@@ -440,29 +480,7 @@ const TransactionShield = () => {
             startIconProps={{
               size: IconSize.Md,
             }}
-            onClick={async () => {
-              if (isCryptoPayment) {
-                if (isInsufficientFundsCrypto) {
-                  // TODO: handle add funds crypto
-                  setIsAddFundsModalOpen(true);
-                  // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                  //   ...params,
-                  //   rawTransaction: undefined // no raw transaction to trigger server to check for new funded balance
-                  // }))
-                } else if (isAllowanceNeededCrypto) {
-                  // TODO: handle add allowance crypto
-                  console.log('add allowance');
-                  // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                  //   ...params,
-                  //   rawTransaction: newApprovalRawTransaction
-                  // }))
-                } else {
-                  throw new Error('Unknown crypto error action');
-                }
-              } else {
-                await executeUpdateSubscriptionCardPaymentMethod();
-              }
-            }}
+            onClick={handlePaymenError}
             danger
           >
             {t(
@@ -489,31 +507,7 @@ const TransactionShield = () => {
             color: IconColor.warningDefault,
           }}
           color={TextColor.warningDefault}
-          onClick={() => {
-            if (isCryptoPaymentMethod(shieldSubscription.paymentMethod)) {
-              if (isInsufficientFundsCrypto) {
-                // TODO: handle add funds crypto
-                setIsAddFundsModalOpen(true);
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: undefined // no raw transaction to trigger server to check for new funded balance
-                // }))
-              } else if (isAllowanceNeededCrypto) {
-                // TODO: handle add allowance crypto
-                console.log('add allowance');
-                // await dispatch(updateSubscriptionCryptoPaymentMethod({
-                //   ...params,
-                //   rawTransaction: newApprovalRawTransaction
-                // }))
-              } else {
-                throw new Error('Unknown crypto error action');
-              }
-            } else {
-              throw new Error(
-                'Only crypto payment method is supported when ending soon',
-              );
-            }
-          }}
+          onClick={handlePaymenError}
         >
           {isCryptoPaymentMethod(shieldSubscription.paymentMethod)
             ? shieldSubscription.paymentMethod.crypto.tokenSymbol
@@ -530,9 +524,7 @@ const TransactionShield = () => {
     isCryptoPayment,
     isSubscriptionEndingSoon,
     t,
-    executeUpdateSubscriptionCardPaymentMethod,
-    isInsufficientFundsCrypto,
-    isAllowanceNeededCrypto,
+    handlePaymenError,
   ]);
 
   return (

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -341,7 +341,7 @@ const TransactionShield = () => {
       ) {
         return undefined;
       }
-      const amount = getSubscriptionCryptoApprovalAmount({
+      const amount = await getSubscriptionCryptoApprovalAmount({
         chainId: shieldSubscription.paymentMethod.crypto.chainId,
         paymentTokenAddress: currentToken.address,
         productType: PRODUCT_TYPES.SHIELD,

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -383,7 +383,7 @@ const TransactionShield = () => {
   const { execute: executeSubscriptionCryptoApprovalTransaction } =
     useSubscriptionCryptoApprovalTransaction(paymentToken);
 
-  const handlePaymenError = useCallback(async () => {
+  const handlePaymentError = useCallback(async () => {
     if (
       shieldSubscription &&
       isCryptoPaymentMethod(shieldSubscription.paymentMethod)
@@ -425,7 +425,7 @@ const TransactionShield = () => {
               ? 'shieldTxMembershipErrorAddFunds'
               : 'shieldTxMembershipErrorUpdatePayment',
           )}
-          actionButtonOnClick={handlePaymenError}
+          actionButtonOnClick={handlePaymentError}
         />
       );
     }
@@ -444,7 +444,7 @@ const TransactionShield = () => {
               ? t('shieldTxMembershipRenew')
               : t('shieldTxMembershipErrorAddFunds')
           }
-          actionButtonOnClick={handlePaymenError}
+          actionButtonOnClick={handlePaymentError}
         />
       );
     }
@@ -458,7 +458,7 @@ const TransactionShield = () => {
     isCryptoPayment,
     isInsufficientFundsCrypto,
     isAllowanceNeededCrypto,
-    handlePaymenError,
+    handlePaymentError,
   ]);
 
   const paymentMethod = useMemo(() => {
@@ -480,7 +480,7 @@ const TransactionShield = () => {
             startIconProps={{
               size: IconSize.Md,
             }}
-            onClick={handlePaymenError}
+            onClick={handlePaymentError}
             danger
           >
             {t(
@@ -507,7 +507,7 @@ const TransactionShield = () => {
             color: IconColor.warningDefault,
           }}
           color={TextColor.warningDefault}
-          onClick={handlePaymenError}
+          onClick={handlePaymentError}
         >
           {isCryptoPaymentMethod(shieldSubscription.paymentMethod)
             ? shieldSubscription.paymentMethod.crypto.tokenSymbol
@@ -524,7 +524,7 @@ const TransactionShield = () => {
     isCryptoPayment,
     isSubscriptionEndingSoon,
     t,
-    handlePaymenError,
+    handlePaymentError,
   ]);
 
   return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Handle crypto re-approval from shield settings in case subscription paused error because of new approval needed

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37057?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Handle crypto approval in shield settings update payment method

## **Related issues**

Fixes:

## **Manual testing steps**

1. After subscribed to shield
2. Go to shield settings page with a paused subscription because of insufficient approval
3. Press update payment method
4. User should go through shield crypto approval transaction for remaining billing cycles

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reusable hook to initiate ERC-20 approval for Shield subscriptions and wires the settings/plan UIs to trigger it, switches to typed crypto payment errors, and introduces a billing cycles calculator.
> 
> - **Shield Subscription (UI logic)**:
>   - **New Hook**: `useSubscriptionCryptoApprovalTransaction` creates an ERC-20 approval tx (based on selected token/pricing/network) and navigates to confirm.
>   - **Settings Page** (`ui/pages/settings/transaction-shield-tab/transaction-shield.tsx`):
>     - Centralizes payment error handling via `handlePaymentError` and triggers crypto approval when allowance is needed.
>     - Fetches approval amount with `getSubscriptionCryptoApprovalAmount` and passes it to the approval hook.
>     - Replaces string literals with `CRYPTO_PAYMENT_METHOD_ERRORS`.
>   - **Plan Page** (`ui/pages/shield-plan/shield-plan.tsx`):
>     - Replaces inline approval tx construction with the new hook.
> - **Shared Utils** (`shared/modules/shield.ts`):
>   - Adds `calculateSubscriptionRemainingBillingCycles` using `RECURRING_INTERVALS`.
> - **Tests**:
>   - Update settings page test to use enriched mock state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09b19dd5fd157103fe85fb88d5b7354a15709b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->