### PR TITLE
fix(action): reduce number of cases where the workflow remains pending

### DIFF
--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, edited, labeled, unlabeled, reopened]
   pull_request_target:
-    types: [opened, edited, labeled, unlabeled, reopened]
+    types: [opened, edited, labeled, unlabeled, reopened, synchronize]
   merge_group:
 
 jobs:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Like raised by @seaona [here](https://consensys.slack.com/archives/CTQAGKY5V/p1758900268182769?thread_ts=1758705272.933399&cid=CTQAGKY5V), there are some cases where, [check-template-and-add-labels](https://github.com/MetaMask/metamask-extension/blob/main/.github/workflows/check-template-and-add-labels.yml#L7) remains pending indefinitely.

Here are some repro steps shared by @seaona , however, I haven't been able to reproduce them on this [test PR](https://github.com/MetaMask/metamask-extension/pull/36823):

> 1. Have a PR with the `check-template-and-add-labels` job green
> 2. Push a new commit
> 3. Now the job will stay pending, until you update the PR description or labels

------

Based on these repro steps, adding `synchronize` to the list of trigger events could solve the issue.

```
  pull_request_target:
    types: [opened, edited, labeled, unlabeled, reopened, synchronize]
```

------

Another possible explanation could be that we're hitting [GitHub's internal rate limiting](https://docs.github.com/en/actions/reference/limits), in which case the workflow will not be queued, i.e. the workflow stays "pending" indefinitely. The argument in favor of that explanation is that we've started experiencing these pending workflow issues shortly after introducing [this commit](https://github.com/MetaMask/metamask-extension/pull/35339/commits/af47208d228285600dc868401287ff3a06241ee1), which significantly increased the number of workflow runs. Another argument in favor of that explanation is that it would explain the "random" aspect of the issue, which we sometimes manage to reproduce but sometimes don't.
An argument against that explanation is that the limits are very high and unlikely to be hit (500 workflow runs / 10 seconds).

------

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37058?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
