### PR TITLE
fix: cp-13.6.0 Tweak messaging in network connection banner

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1183,6 +1183,13 @@
   "changePasswordWarningDescription": {
     "message": "Changing your password here will lock MetaMask on other devices you’re using. You’ll need to log in again with your new password."
   },
+  "checkNetworkConnectivity": {
+    "message": "Check network connectivity."
+  },
+  "checkNetworkConnectivityOr": {
+    "message": "Check network connectivity, or $1.",
+    "description": "$1 is a link to update the network."
+  },
   "chooseYourNetwork": {
     "message": "Choose your network"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1183,6 +1183,13 @@
   "changePasswordWarningDescription": {
     "message": "Changing your password here will lock MetaMask on other devices you’re using. You’ll need to log in again with your new password."
   },
+  "checkNetworkConnectivity": {
+    "message": "Check network connectivity."
+  },
+  "checkNetworkConnectivityOr": {
+    "message": "Check network connectivity, or $1.",
+    "description": "$1 is a link to update the network."
+  },
   "chooseYourNetwork": {
     "message": "Choose your network"
   },

--- a/shared/constants/app-state.ts
+++ b/shared/constants/app-state.ts
@@ -56,4 +56,5 @@ export type NetworkConnectionBanner =
       networkName: string;
       networkClientId: NetworkClientId;
       chainId: Hex;
+      isInfuraEndpoint: boolean;
     };

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -41,12 +41,13 @@ describe('NetworkConnectionBanner', () => {
   });
 
   describe('when the status of the banner is "degraded"', () => {
-    it('renders the banner with a "Still connecting" message', () => {
+    it('renders the banner with a "Still connecting" message, including a "Update RPC" link if the network is not an Infura endpoint', () => {
       mockUseNetworkConnectionBanner.mockReturnValue({
         status: 'degraded',
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
+        isInfuraEndpoint: false,
         trackNetworkBannerEvent: jest.fn(),
       });
       const store = configureStore({});
@@ -62,6 +63,28 @@ describe('NetworkConnectionBanner', () => {
       expect(getByText('Update RPC')).toBeInTheDocument();
     });
 
+    it('renders the banner with a "Still connecting" message, excluding a "Update RPC" link if the network is an Infura endpoint', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'degraded',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+        isInfuraEndpoint: true,
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { getByText, queryByText } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(
+        getByText('Still connecting to Ethereum Mainnet...'),
+      ).toBeInTheDocument();
+      expect(queryByText('Update RPC')).not.toBeInTheDocument();
+    });
+
     describe('when the "Update RPC" link is clicked', () => {
       it('navigates to the edit form for the degraded network', () => {
         mockUseNetworkConnectionBanner.mockReturnValue({
@@ -69,6 +92,7 @@ describe('NetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: false,
           trackNetworkBannerEvent: jest.fn(),
         });
         const store = configureStore({});
@@ -92,6 +116,7 @@ describe('NetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: false,
           trackNetworkBannerEvent: trackNetworkBannerEventMock,
         });
         const store = configureStore({});
@@ -113,12 +138,13 @@ describe('NetworkConnectionBanner', () => {
   });
 
   describe('when the status of the banner is "unavailable"', () => {
-    it('renders the banner with a "Unable to connect" message', () => {
+    it('renders the banner with a "Unable to connect" message, including a "Update RPC" link if the network is not an Infura endpoint', () => {
       mockUseNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
+        isInfuraEndpoint: false,
         trackNetworkBannerEvent: jest.fn(),
       });
       const store = configureStore({});
@@ -131,7 +157,39 @@ describe('NetworkConnectionBanner', () => {
       expect(
         getByText('Unable to connect to Ethereum Mainnet.'),
       ).toBeInTheDocument();
-      expect(getByText('Update RPC')).toBeInTheDocument();
+      expect(
+        getByText('Check network connectivity', { exact: false }),
+      ).toBeInTheDocument();
+      expect(
+        getByText('update RPC', { selector: 'button' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the banner with a "Unable to connect" message, excluding a "Update RPC" link if the network is an Infura endpoint', () => {
+      mockUseNetworkConnectionBanner.mockReturnValue({
+        status: 'unavailable',
+        networkName: 'Ethereum Mainnet',
+        networkClientId: 'mainnet',
+        chainId: '0x1',
+        isInfuraEndpoint: true,
+        trackNetworkBannerEvent: jest.fn(),
+      });
+      const store = configureStore({});
+
+      const { getByText, queryByText } = renderWithProvider(
+        <NetworkConnectionBanner />,
+        store,
+      );
+
+      expect(
+        getByText('Unable to connect to Ethereum Mainnet.'),
+      ).toBeInTheDocument();
+      expect(
+        getByText('Check network connectivity', { exact: false }),
+      ).toBeInTheDocument();
+      expect(
+        queryByText('update RPC', { selector: 'button' }),
+      ).not.toBeInTheDocument();
     });
 
     describe('when the "Update RPC" link is clicked', () => {
@@ -141,6 +199,7 @@ describe('NetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: false,
           trackNetworkBannerEvent: jest.fn(),
         });
         const store = configureStore({});
@@ -151,7 +210,7 @@ describe('NetworkConnectionBanner', () => {
           <NetworkConnectionBanner />,
           store,
         );
-        fireEvent.click(getByText('Update RPC'));
+        fireEvent.click(getByText('update RPC'));
 
         expect(mockSetEditedNetwork).toHaveBeenCalledWith({ chainId: '0x1' });
         expect(navigateMock).toHaveBeenCalledWith('/settings/networks');
@@ -164,6 +223,7 @@ describe('NetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: false,
           trackNetworkBannerEvent: trackNetworkBannerEventMock,
         });
         const store = configureStore({});
@@ -172,7 +232,7 @@ describe('NetworkConnectionBanner', () => {
           <NetworkConnectionBanner />,
           store,
         );
-        fireEvent.click(getByText('Update RPC'));
+        fireEvent.click(getByText('update RPC'));
 
         expect(trackNetworkBannerEventMock).toHaveBeenCalledWith({
           bannerType: 'unavailable',

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -32,7 +32,7 @@ type BannerIcon = {
   className?: string;
 };
 
-const renderPrimaryMessage = ({
+const PrimaryMessage = ({
   t,
   primaryMessageKey,
   networkConnectionBanner,
@@ -58,7 +58,7 @@ const renderPrimaryMessage = ({
   );
 };
 
-const renderSecondaryMessage = (content: React.ReactNode) => {
+const SecondaryMessage = ({ content }: { content: React.ReactNode }) => {
   return (
     <Text
       variant={TextVariant.bodyXsMedium}
@@ -69,7 +69,7 @@ const renderSecondaryMessage = (content: React.ReactNode) => {
   );
 };
 
-const renderUpdateRpcButton = ({
+const UpdateRpcButton = ({
   t,
   isLowerCase,
   updateRpc,
@@ -114,20 +114,20 @@ const getBannerContent = (
   const verticalAdjustment = '0.25em';
 
   if (networkConnectionBanner.status === 'degraded') {
-    const primaryMessage = renderPrimaryMessage({
-      t,
-      primaryMessageKey: 'stillConnectingTo',
-      networkConnectionBanner,
-    });
-    const secondaryMessage = networkConnectionBanner.isInfuraEndpoint
-      ? null
-      : renderSecondaryMessage(
-          renderUpdateRpcButton({
-            t,
-            isLowerCase: false,
-            updateRpc,
-          }),
-        );
+    const primaryMessage = (
+      <PrimaryMessage
+        t={t}
+        primaryMessageKey="stillConnectingTo"
+        networkConnectionBanner={networkConnectionBanner}
+      />
+    );
+    const secondaryMessage = networkConnectionBanner.isInfuraEndpoint ? null : (
+      <SecondaryMessage
+        content={
+          <UpdateRpcButton t={t} isLowerCase={false} updateRpc={updateRpc} />
+        }
+      />
+    );
 
     return {
       primaryMessage,
@@ -142,21 +142,26 @@ const getBannerContent = (
     };
   }
 
-  const primaryMessage = renderPrimaryMessage({
-    t,
-    primaryMessageKey: 'unableToConnectTo',
-    networkConnectionBanner,
-  });
+  const primaryMessage = (
+    <PrimaryMessage
+      t={t}
+      primaryMessageKey="unableToConnectTo"
+      networkConnectionBanner={networkConnectionBanner}
+    />
+  );
   const secondaryMessageContent = networkConnectionBanner.isInfuraEndpoint
     ? t('checkNetworkConnectivity')
     : t('checkNetworkConnectivityOr', [
-        renderUpdateRpcButton({
-          t,
-          isLowerCase: true,
-          updateRpc,
-        }),
+        <UpdateRpcButton
+          key="updateRpc"
+          t={t}
+          isLowerCase={true}
+          updateRpc={updateRpc}
+        />,
       ]);
-  const secondaryMessage = renderSecondaryMessage(secondaryMessageContent);
+  const secondaryMessage = (
+    <SecondaryMessage content={secondaryMessageContent} />
+  );
 
   return {
     primaryMessage,

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -138,6 +138,7 @@ describe('useNetworkConnectionBanner', () => {
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
+            isInfuraEndpoint: true,
           });
           mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
@@ -154,6 +155,7 @@ describe('useNetworkConnectionBanner', () => {
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
+            isInfuraEndpoint: true,
           });
         });
 
@@ -162,6 +164,7 @@ describe('useNetworkConnectionBanner', () => {
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
+            isInfuraEndpoint: true,
           });
           mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
           const mockTrackEvent = jest.fn();
@@ -199,6 +202,7 @@ describe('useNetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
         mockGetNetworkConnectionBanner.mockReturnValue({
           status: 'available',
@@ -217,6 +221,7 @@ describe('useNetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
       });
     });
@@ -227,12 +232,14 @@ describe('useNetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
         mockGetNetworkConnectionBanner.mockReturnValue({
           status: 'degraded',
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
 
         renderHookWithProviderTyped(
@@ -248,6 +255,7 @@ describe('useNetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
       });
 
@@ -256,12 +264,14 @@ describe('useNetworkConnectionBanner', () => {
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
         mockGetNetworkConnectionBanner.mockReturnValue({
           status: 'degraded',
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
+          isInfuraEndpoint: true,
         });
         const mockTrackEvent = jest.fn();
 
@@ -298,6 +308,7 @@ describe('useNetworkConnectionBanner', () => {
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
+        isInfuraEndpoint: true,
       });
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
@@ -324,6 +335,7 @@ describe('useNetworkConnectionBanner', () => {
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
+        isInfuraEndpoint: true,
       });
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -62,7 +62,7 @@ export const useNetworkConnectionBanner =
     const clearTimers = useCallback(() => {
       clearDegradedTimer();
       clearUnavailableTimer();
-    }, []);
+    }, [clearDegradedTimer, clearUnavailableTimer]);
 
     const trackNetworkBannerEvent = useCallback(
       ({
@@ -141,6 +141,7 @@ export const useNetworkConnectionBanner =
               networkName: firstUnavailableEvmNetwork.networkName,
               networkClientId: firstUnavailableEvmNetwork.networkClientId,
               chainId: firstUnavailableEvmNetwork.chainId,
+              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
             }),
           );
         }
@@ -168,6 +169,7 @@ export const useNetworkConnectionBanner =
               networkName: firstUnavailableEvmNetwork.networkName,
               networkClientId: firstUnavailableEvmNetwork.networkClientId,
               chainId: firstUnavailableEvmNetwork.chainId,
+              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
             }),
           );
 

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -396,7 +396,7 @@ describe('Multichain network selectors', () => {
   });
 
   describe('selectFirstUnavailableEvmNetwork', () => {
-    it('returns the first EVM network that does not have a status of "available"', () => {
+    it('returns the first EVM Infura-powered network that does not have a status of "available"', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -422,7 +422,7 @@ describe('Multichain network selectors', () => {
               nativeCurrency: 'ETH',
               rpcEndpoints: [
                 {
-                  type: RpcEndpointType.Infura,
+                  type: RpcEndpointType.Infura as const,
                   url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
                   networkClientId: 'mainnet' as const,
                 },
@@ -437,7 +437,7 @@ describe('Multichain network selectors', () => {
               nativeCurrency: 'SepoliaETH',
               rpcEndpoints: [
                 {
-                  type: RpcEndpointType.Infura,
+                  type: RpcEndpointType.Infura as const,
                   url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
                   networkClientId: 'sepolia' as const,
                 },
@@ -459,6 +459,74 @@ describe('Multichain network selectors', () => {
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
+        isInfuraEndpoint: true,
+      });
+    });
+
+    it('returns the first EVM custom network that does not have a status of "available"', () => {
+      const mockStateWithMultipleUnavailableNetworks = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1000': true,
+              '0xaa36a7': true,
+            },
+          },
+          networksMetadata: {
+            'AAAA-BBBB-CCCC-DDDD': {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+            sepolia: {
+              EIPS: {},
+              status: NetworkStatus.Blocked,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1000': {
+              chainId: '0x1000' as const,
+              name: 'Custom Network',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Custom as const,
+                  url: 'https://custom.network',
+                  networkClientId: 'AAAA-BBBB-CCCC-DDDD' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'AAAA-BBBB-CCCC-DDDD',
+        },
+      };
+
+      expect(
+        selectFirstUnavailableEvmNetwork(
+          mockStateWithMultipleUnavailableNetworks,
+        ),
+      ).toStrictEqual({
+        networkName: 'Custom Network',
+        networkClientId: 'AAAA-BBBB-CCCC-DDDD',
+        chainId: '0x1000',
+        isInfuraEndpoint: false,
       });
     });
 
@@ -488,7 +556,7 @@ describe('Multichain network selectors', () => {
               nativeCurrency: 'ETH',
               rpcEndpoints: [
                 {
-                  type: RpcEndpointType.Infura,
+                  type: RpcEndpointType.Infura as const,
                   url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
                   networkClientId: 'mainnet' as const,
                 },
@@ -503,7 +571,7 @@ describe('Multichain network selectors', () => {
               nativeCurrency: 'SepoliaETH',
               rpcEndpoints: [
                 {
-                  type: RpcEndpointType.Infura,
+                  type: RpcEndpointType.Infura as const,
                   url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
                   networkClientId: 'sepolia' as const,
                 },
@@ -555,7 +623,7 @@ describe('Multichain network selectors', () => {
               nativeCurrency: 'ETH',
               rpcEndpoints: [
                 {
-                  type: RpcEndpointType.Infura,
+                  type: RpcEndpointType.Infura as const,
                   url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
                   networkClientId: 'mainnet' as const,
                 },

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -36,6 +36,8 @@ import {
 } from '../selectors';
 import { getInternalAccounts } from '../accounts';
 import { getEnabledNetworks } from '../../../shared/modules/selectors/multichain';
+import { getIsMetaMaskInfuraEndpointUrl } from '../../../shared/lib/network-utils';
+import { infuraProjectId } from '../../../shared/constants/network';
 
 // Selector types
 
@@ -354,13 +356,11 @@ export const selectFirstUnavailableEvmNetwork = createSelector(
   getNetworkConfigurationsByChainId,
   getNetworksMetadata,
   (enabledNetworks, networkConfigurationsByChainId, networksMetadata) => {
-    // Get all enabled EVM networks
     const enabledEvmNetworks = enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
     const enabledChainIds = Object.entries(enabledEvmNetworks)
       .filter(([, isEnabled]) => isEnabled)
       .map(([chainId]) => chainId as Hex);
 
-    // Find the first network that is not available
     for (const chainId of enabledChainIds) {
       const networkConfiguration = networkConfigurationsByChainId[chainId];
       if (networkConfiguration) {
@@ -377,9 +377,16 @@ export const selectFirstUnavailableEvmNetwork = createSelector(
             metadata.status !== NetworkStatus.Available
           ) {
             return {
-              networkName: name,
               networkClientId: rpcEndpoint.networkClientId,
               chainId,
+              networkName: name,
+              // We have to use this function to check whether the endpoint is
+              // an Infura endpoint because some Infura endpoint URLs use the
+              // wrong type.
+              isInfuraEndpoint: getIsMetaMaskInfuraEndpointUrl(
+                rpcEndpoint.url,
+                infuraProjectId ?? '',
+              ),
             };
           }
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently, when requests to any network are failing, we inform the user via a banner on the home screen, and we include a link that the user can click to update the default RPC endpoint for that network.

However there are a couple issues that we need to fix:

1. We don't want to show an "update RPC" link for built-in networks that are powered by Infura — we want people using Infura as we think that will be a superior experience than using a custom endpoint.
2. Users will receive the aforementioned banner even if their internet is down (and we can't even reach the network). This means that asking the user to update the network wouldn't even work. Ideally we should detect this and show them a special message, but we don't have a good way of doing this right now. Still, we need to tell users _something_.

To address both of these issues:

1. Don't show an "update RPC" link for failing Infura networks.
2. When the banner switches to a "cannot connect" message, suggest that the user check *their* connection.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37082?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Tweak messaging for degraded and unavailable networks

## **Related issues**

- https://github.com/MetaMask/metamask-extension/issues/37122 
- https://consensyssoftware.atlassian.net/browse/WPC-102

## **Manual testing steps**

### Prerequisites

1. Install [FoxyProxy](https://chromewebstore.google.com/detail/foxyproxy/gcknhkkoolaabfmlnjonogaaifnjlfnp). Pin it.
2. Open the options for FoxyProxy (click on its icon and go to Options).
3. Click on the Proxies tab, then click on Add. A new box should appear.
4. Under "Hostname", enter `localhost`; under "Port", enter `8080`; enter some name in "Title".
5. Next to "Proxy by Patterns", click the plus icon. You should see a new row appear.
6. In the `://example.com` field, enter `https://*.infura.io/*`; in the "title" field, enter some name, like "Localhost". (This will ensure that only requests to Infura go through the proxy.)
8. Install [`mitmproxy`](https://docs.mitmproxy.org/stable/overview/installation/).
10. Create a Python script somewhere on your computer with the following contents: https://gist.github.com/mcmire/1d43ce690d3a974217126cd584f79b7d. This script will cause all requests to Infura RPC endpoints to respond with 500, simulating an outage.
11. Run `mitmproxy -s <path to your script>` in an open terminal session. This will run the proxy server.
12. Go back to FoxyProxy and enable the proxy you created earlier by clicking on the icon, then choosing the name of the new proxy (e.g. Localhost).
13. Check out this branch. Run `yarn`, then `yarn start`.
14. Ensure that you've added the local version of MetaMask to your browser and no other versions are present.
15. Open MetaMask, and go through onboarding.

### Testing an Infura network

1. In MetaMask, switch to Ethereum Mainnet.
3. Restart the extension.
4. Reopen MetaMask. Ethereum should be selected.
5. Once on the home screen, wait 5 seconds. You should see a gray banner that says "Still connecting to Ethereum..." There should be no "Update RPC" link next to it.
6. After 30 seconds, the banner should change to "Unable to connect to Ethereum. Check your network connectivity." Again, there should be no "Update RPC" link next to it.

### Testing a custom network

1. Click the FoxyProxy icon and ensure that the proxy is disabled (click on "Disable").
2. Back in your terminal, start Ganache (run `yarn ganache` from your branch).
3. Back in MetaMask, add Ganache as a network, pointing to `http://localhost:8545` (chain 1337). Ensure that the network is selected.
7. Now stop Ganache.
8. Restart the extension.
9. Reopen MetaMask. Your local network should be selected.
10. Wait 5 seconds. You should see a gray banner that says "Still connecting to Localhost..." There _should_ be an "Update RPC" link next to it.
11. After 30 seconds, the banner should change to "Unable to connect to Localhost. Check your network connectivity." Again, there _should_ be an "Update RPC" link next to it.
12. Click on this link. It should open a modal to update the network.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1392" height="1169" alt="Screenshot 2025-10-22 at 2 56 45 PM" src="https://github.com/user-attachments/assets/be46b08c-689f-4f9b-91ae-74d021b9ba6f" />

<img width="1392" height="1169" alt="Screenshot 2025-10-22 at 2 57 10 PM" src="https://github.com/user-attachments/assets/ebc3c506-4769-400a-bf70-406065c2640e" />

<img width="1392" height="1169" alt="Screenshot 2025-10-22 at 2 57 37 PM" src="https://github.com/user-attachments/assets/37602915-6ebb-40f1-904f-da310f171dd1" />

<img width="1392" height="1169" alt="Screenshot 2025-10-22 at 2 58 01 PM" src="https://github.com/user-attachments/assets/881007e7-bf10-4843-b482-00da9c5268b9" />

### **After**

#### Screenshots

<img width="1306" height="1086" alt="extension - custom - full-screen" src="https://github.com/user-attachments/assets/0c27c930-6d26-4ff7-9b37-020d1787a51e" />

<img width="1306" height="1086" alt="extension - infura - full-screen" src="https://github.com/user-attachments/assets/4a673b2a-a662-45da-9a65-9db7c0c046ac" />

#### Videos

https://github.com/user-attachments/assets/da674340-ffe4-4084-8a91-e72b3e5576de

https://github.com/user-attachments/assets/cc5feb07-70f9-41b1-8363-b88dd16b847e

https://github.com/user-attachments/assets/c95aab3e-f08e-4311-907b-4c258f8c99f1

https://github.com/user-attachments/assets/d2143d9a-d782-4489-8146-815cb4467eff

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the network connection banner to suggest checking connectivity and only show Update RPC for non‑Infura endpoints, with supporting selector, hook, i18n, and tests updates.
> 
> - **UI**:
>   - Network banner now renders primary/secondary messages with inline `update RPC` link.
>   - Conditionally shows `Update RPC` only when `isInfuraEndpoint` is false; excluded for Infura.
>   - For `unavailable`, adds guidance to `checkNetworkConnectivity` (or `checkNetworkConnectivityOr` with inline link).
> - **State/Selectors/Hooks**:
>   - Extend `NetworkConnectionBanner` type with `isInfuraEndpoint`.
>   - `selectFirstUnavailableEvmNetwork` now returns `isInfuraEndpoint` (detected via `getIsMetaMaskInfuraEndpointUrl` and `infuraProjectId`).
>   - `useNetworkConnectionBanner` propagates `isInfuraEndpoint`, updates timers cleanup deps.
> - **Localization**:
>   - Add `checkNetworkConnectivity` and `checkNetworkConnectivityOr` strings (en, en_GB).
> - **Tests**:
>   - Update banner tests to assert presence/absence of `Update RPC` based on `isInfuraEndpoint` and new messages.
>   - Update hook tests to include `isInfuraEndpoint` in state transitions/metrics.
>   - Expand selector tests to cover Infura and custom networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07605f2f041f21570d08cd301634bbc3df5e0a56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->