### PR TITLE
test: refactor dapp params in `withFixtures`

### DIFF
--- a/test/e2e/accounts/snap-account-eth-swap.spec.ts
+++ b/test/e2e/accounts/snap-account-eth-swap.spec.ts
@@ -11,6 +11,7 @@ import { TRADES_API_MOCK_RESULT } from '../../data/mock-data';
 import { installSnapSimpleKeyring } from '../page-objects/flows/snap-simple-keyring.flow';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import { Mockttp } from '../mock-e2e';
+import { DAPP_PATH } from '../constants';
 import { mockSnapSimpleKeyringAndSite } from '../tests/account/snap-keyring-site-mocks';
 
 const DAI = 'DAI';
@@ -41,7 +42,7 @@ describe('Snap Account - Swap', function () {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSwapsAndSimpleKeyringSnap,

--- a/test/e2e/accounts/snap-account-eth-swap.spec.ts
+++ b/test/e2e/accounts/snap-account-eth-swap.spec.ts
@@ -41,7 +41,6 @@ describe('Snap Account - Swap', function () {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/accounts/snap-account-eth-swap.spec.ts
+++ b/test/e2e/accounts/snap-account-eth-swap.spec.ts
@@ -39,8 +39,10 @@ describe('Snap Account - Swap', function () {
   it.skip('swaps ETH for DAI using a snap account', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSwapsAndSimpleKeyringSnap,
         title: this.test?.fullTitle(),

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -77,6 +77,15 @@ export const DAPP_PATHS: Readonly<Record<string, readonly string[]>> =
     'test-dapp-solana': mm('test-dapp-solana', 'dist'),
   });
 
+// Canonical dapp path keys to be used in tests
+export const DAPP_PATH = Object.freeze({
+  TEST_DAPP: 'test-dapp',
+  TEST_DAPP_MULTICHAIN: 'test-dapp-multichain',
+  TEST_DAPP_SOLANA: 'test-dapp-solana',
+  SNAP_SIMPLE_KEYRING_SITE: 'snap-simple-keyring-site',
+  SNAP_ACCOUNT_ABSTRACTION_KEYRING: 'snap-account-abstraction-keyring',
+} as const);
+
 /* Default BTC address created using test SRP */
 export const DEFAULT_BTC_ADDRESS = 'bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252';
 

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -52,6 +52,31 @@ export const DAPP_URL = `http://${DAPP_HOST_ADDRESS}`;
 export const DAPP_ONE_URL = `http://${DAPP_ONE_ADDRESS}`;
 export const DAPP_TWO_URL = 'http://127.0.0.1:8082';
 
+// Common base segments for resolving local test dapps from this file's location
+const NODE_MODULES_BASE = ['..', '..', 'node_modules'] as const;
+const METAMASK_SCOPE = '@metamask';
+
+// Helper to build MetaMask-scoped package paths
+const mm = (pkg: string, ...rest: string[]): readonly string[] => [
+  ...NODE_MODULES_BASE,
+  METAMASK_SCOPE,
+  pkg,
+  ...rest,
+];
+
+/** Mapping of dapp keys to relative path segments from this repo's test root */
+export const DAPP_PATHS: Readonly<Record<string, readonly string[]>> =
+  Object.freeze({
+    'snap-simple-keyring-site': mm('snap-simple-keyring-site', 'public'),
+    'snap-account-abstraction-keyring': mm(
+      'snap-account-abstraction-keyring-site',
+      'public',
+    ),
+    'test-dapp': mm('test-dapp', 'dist'),
+    'test-dapp-multichain': mm('test-dapp-multichain', 'build'),
+    'test-dapp-solana': mm('test-dapp-solana', 'dist'),
+  });
+
 /* Default BTC address created using test SRP */
 export const DEFAULT_BTC_ADDRESS = 'bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252';
 

--- a/test/e2e/flask/btc/common-btc.ts
+++ b/test/e2e/flask/btc/common-btc.ts
@@ -32,7 +32,7 @@ export async function withBtcAccountSnap(
         })
         .build(),
       title,
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       testSpecificMock: async (mockServer: Mockttp) => [
         await mockBitcoinFeatureFlag(mockServer),
         await mockInitialFullScan(mockServer),

--- a/test/e2e/flask/btc/common-btc.ts
+++ b/test/e2e/flask/btc/common-btc.ts
@@ -32,7 +32,7 @@ export async function withBtcAccountSnap(
         })
         .build(),
       title,
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       testSpecificMock: async (mockServer: Mockttp) => [
         await mockBitcoinFeatureFlag(mockServer),
         await mockInitialFullScan(mockServer),

--- a/test/e2e/flask/multi-srp/common-multi-srp.ts
+++ b/test/e2e/flask/multi-srp/common-multi-srp.ts
@@ -24,10 +24,10 @@ export async function withMultiSrp(
 ) {
   await withFixtures(
     {
+      dappOptions: { defaultTestDapp: 1 },
       fixtures: new FixtureBuilder().build(),
       testSpecificMock,
       title,
-      dapp: true,
     },
     async ({ driver }: { driver: Driver; mockServer: Mockttp }) => {
       await loginWithBalanceValidation(driver);

--- a/test/e2e/flask/multi-srp/common-multi-srp.ts
+++ b/test/e2e/flask/multi-srp/common-multi-srp.ts
@@ -24,7 +24,7 @@ export async function withMultiSrp(
 ) {
   await withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       fixtures: new FixtureBuilder().build(),
       testSpecificMock,
       title,

--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -72,7 +72,7 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockActiveNetworks,
         title: this.test?.fullTitle(),
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }: { driver: Driver; mockServer?: Mockttp }) => {
         await loginWithBalanceValidation(driver);

--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -72,7 +72,7 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockActiveNetworks,
         title: this.test?.fullTitle(),
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }: { driver: Driver; mockServer?: Mockttp }) => {
         await loginWithBalanceValidation(driver);

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { Browser } from 'selenium-webdriver';
 import {
   KnownRpcMethods,
@@ -20,17 +19,10 @@ export type FixtureCallbackArgs = { driver: Driver; extensionId: string };
  * Default options for setting up Multichain E2E test environment
  */
 export const DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS = {
-  dapp: true,
-  dappPaths: [
-    path.join(
-      '..',
-      '..',
-      'node_modules',
-      '@metamask',
-      'test-dapp-multichain',
-      'build',
-    ),
-  ],
+  dappOptions: {
+    defaultTestDapp: 1,
+    customDappPaths: ['test-dapp-multichain'],
+  },
   localNodeOptions: [
     {
       type: 'anvil',

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -21,7 +21,6 @@ export type FixtureCallbackArgs = { driver: Driver; extensionId: string };
  */
 export const DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS = {
   dappOptions: {
-    defaultTestDapp: 1,
     customDappPaths: [DAPP_PATH.TEST_DAPP_MULTICHAIN],
   },
   localNodeOptions: [

--- a/test/e2e/flask/multichain-api/testHelpers.ts
+++ b/test/e2e/flask/multichain-api/testHelpers.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/chain-agnostic-permission';
 import { JsonRpcRequest } from '@metamask/utils';
 import { Driver } from '../../webdriver/driver';
+import { DAPP_PATH } from '../../constants';
 import {
   CONTENT_SCRIPT,
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
@@ -21,7 +22,7 @@ export type FixtureCallbackArgs = { driver: Driver; extensionId: string };
 export const DEFAULT_MULTICHAIN_TEST_DAPP_FIXTURE_OPTIONS = {
   dappOptions: {
     defaultTestDapp: 1,
-    customDappPaths: ['test-dapp-multichain'],
+    customDappPaths: [DAPP_PATH.TEST_DAPP_MULTICHAIN],
   },
   localNodeOptions: [
     {

--- a/test/e2e/flask/solana-wallet-standard/testHelpers.ts
+++ b/test/e2e/flask/solana-wallet-standard/testHelpers.ts
@@ -1,14 +1,10 @@
-import * as path from 'path';
 import { strict as assert } from 'assert';
 import { By } from 'selenium-webdriver';
 import nacl from 'tweetnacl';
 import { largeDelayMs, regularDelayMs, WINDOW_TITLES } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
-import {
-  SOLANA_DEVNET_URL,
-  withSolanaAccountSnap,
-} from '../../tests/solana/common-solana';
+import { SOLANA_DEVNET_URL } from '../../tests/solana/common-solana';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import ConnectAccountConfirmation from '../../page-objects/pages/confirmations/redesign/connect-account-confirmation';
 import EditConnectedAccountsModal from '../../page-objects/pages/dialog/edit-connected-accounts-modal';
@@ -25,17 +21,11 @@ export const account2Short = 'ExTE...GNtt';
  * Default options for setting up Solana E2E test environment
  */
 export const DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS = {
-  dappPaths: [
-    path.join(
-      '..',
-      '..',
-      'node_modules',
-      '@metamask',
-      'test-dapp-solana',
-      'dist',
-    ),
-  ],
-} satisfies Parameters<typeof withSolanaAccountSnap>[0];
+  dappOptions: {
+    defaultTestDapp: 1,
+    customDappPaths: ['test-dapp-solana'],
+  },
+};
 
 const onboardSolanaAccount = async (driver: Driver): Promise<void> => {
   console.log('onboarding a new solana account');

--- a/test/e2e/flask/solana-wallet-standard/testHelpers.ts
+++ b/test/e2e/flask/solana-wallet-standard/testHelpers.ts
@@ -23,7 +23,6 @@ export const account2Short = 'ExTE...GNtt';
  */
 export const DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS = {
   dappOptions: {
-    defaultTestDapp: 1,
     customDappPaths: [DAPP_PATH.TEST_DAPP_SOLANA],
   },
 };

--- a/test/e2e/flask/solana-wallet-standard/testHelpers.ts
+++ b/test/e2e/flask/solana-wallet-standard/testHelpers.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert';
 import { By } from 'selenium-webdriver';
 import nacl from 'tweetnacl';
 import { largeDelayMs, regularDelayMs, WINDOW_TITLES } from '../../helpers';
+import { DAPP_PATH } from '../../constants';
 import { Driver } from '../../webdriver/driver';
 import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
 import { SOLANA_DEVNET_URL } from '../../tests/solana/common-solana';
@@ -23,7 +24,7 @@ export const account2Short = 'ExTE...GNtt';
 export const DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS = {
   dappOptions: {
     defaultTestDapp: 1,
-    customDappPaths: ['test-dapp-solana'],
+    customDappPaths: [DAPP_PATH.TEST_DAPP_SOLANA],
   },
 };
 

--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -200,8 +200,10 @@ async function withAccountSnap(
       title,
       useBundler: true,
       usePaymaster: Boolean(paymaster),
-      dapp: true,
-      dappPaths: ['test-dapp', 'snap-account-abstraction-keyring'],
+      dappOptions: {
+        defaultTestDapp: 1,
+        customDappPaths: ['snap-account-abstraction-keyring'],
+      },
       localNodeOptions: localNodeOptions || {
         hardfork: 'london',
         mnemonic:

--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -202,7 +202,7 @@ async function withAccountSnap(
       useBundler: true,
       usePaymaster: Boolean(paymaster),
       dappOptions: {
-        defaultTestDapp: 1,
+        numberOfTestDapps: 1,
         customDappPaths: [DAPP_PATH.SNAP_ACCOUNT_ABSTRACTION_KEYRING],
       },
       localNodeOptions: localNodeOptions || {

--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -7,6 +7,7 @@ import {
 import FixtureBuilder from '../fixture-builder';
 import {
   BUNDLER_URL,
+  DAPP_PATH,
   DAPP_URL,
   ENTRYPOINT,
   ERC_4337_ACCOUNT,
@@ -202,7 +203,7 @@ async function withAccountSnap(
       usePaymaster: Boolean(paymaster),
       dappOptions: {
         defaultTestDapp: 1,
-        customDappPaths: ['snap-account-abstraction-keyring'],
+        customDappPaths: [DAPP_PATH.SNAP_ACCOUNT_ABSTRACTION_KEYRING],
       },
       localNodeOptions: localNodeOptions || {
         hardfork: 'london',

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -191,8 +191,8 @@ async function withFixtures(options, testSuite) {
     dappOpts.customDappPaths.length > 0;
   const customCount = hasCustomPaths ? dappOpts.customDappPaths.length : 0;
   const defaultCount =
-    typeof dappOpts.defaultTestDapp === 'number' && dappOpts.defaultTestDapp > 0
-      ? dappOpts.defaultTestDapp
+    typeof dappOpts.numberOfTestDapps === 'number' && dappOpts.numberOfTestDapps > 0
+      ? dappOpts.numberOfTestDapps
       : 0;
   const numberOfDapps = customCount + defaultCount;
   const dappServer = [];

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -290,15 +290,18 @@ async function withFixtures(options, testSuite) {
 
     await phishingPageServer.start();
     if (numberOfDapps > 0) {
-      // numberOfDapps is precomputed in normalization
-
+      // Ensure the default test dapp occupies the lowest ports first (e.g., 8080),
+      // then any custom dapps follow (e.g., 8081, 8082, ...).
       for (let i = 0; i < numberOfDapps; i++) {
         let dappDirectory;
         let currentDappPath;
-        if (hasCustomPaths && i < customCount) {
-          currentDappPath = dappOpts.customDappPaths[i];
+        if (i < defaultCount) {
+          // First spin up the default test-dapp instances
+          currentDappPath = 'test-dapp';
+        } else if (hasCustomPaths) {
+          // Then start custom dapps on subsequent ports
+          currentDappPath = dappOpts.customDappPaths[i - defaultCount];
         } else {
-          // Use the standard test dapp for the remaining slots
           currentDappPath = 'test-dapp';
         }
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -191,7 +191,8 @@ async function withFixtures(options, testSuite) {
     dappOpts.customDappPaths.length > 0;
   const customCount = hasCustomPaths ? dappOpts.customDappPaths.length : 0;
   const defaultCount =
-    typeof dappOpts.numberOfTestDapps === 'number' && dappOpts.numberOfTestDapps > 0
+    typeof dappOpts.numberOfTestDapps === 'number' &&
+    dappOpts.numberOfTestDapps > 0
       ? dappOpts.numberOfTestDapps
       : 0;
   const numberOfDapps = customCount + defaultCount;

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -33,6 +33,7 @@ const {
   ACCOUNT_2,
   WALLET_PASSWORD,
   WINDOW_TITLES,
+  DAPP_PATHS,
 } = require('./constants');
 const {
   getServerMochaToBackground,
@@ -154,7 +155,6 @@ function normalizeSmartContracts(smartContract) {
  */
 async function withFixtures(options, testSuite) {
   const {
-    dapp,
     fixtures,
     localNodeOptions = 'anvil',
     smartContract,
@@ -163,9 +163,7 @@ async function withFixtures(options, testSuite) {
     staticServerOptions,
     title,
     ignoredConsoleErrors = [],
-    dappPath = undefined,
     disableServerMochaToBackground = false,
-    dappPaths,
     testSpecificMock = function () {
       // do nothing.
     },
@@ -187,7 +185,16 @@ async function withFixtures(options, testSuite) {
   const bundlerServer = new Bundler();
   const https = await mockttp.generateCACertificate();
   const mockServer = mockttp.getLocal({ https, cors: true });
-  let numberOfDapps = dapp ? 1 : 0;
+  const dappOpts = dappOptions || {};
+  const hasCustomPaths =
+    Array.isArray(dappOpts.customDappPaths) &&
+    dappOpts.customDappPaths.length > 0;
+  const customCount = hasCustomPaths ? dappOpts.customDappPaths.length : 0;
+  const defaultCount =
+    typeof dappOpts.defaultTestDapp === 'number' && dappOpts.defaultTestDapp > 0
+      ? dappOpts.defaultTestDapp
+      : 0;
+  const numberOfDapps = customCount + defaultCount;
   const dappServer = [];
   const phishingPageServer = new PhishingWarningPageServer();
 
@@ -282,75 +289,35 @@ async function withFixtures(options, testSuite) {
     }
 
     await phishingPageServer.start();
-    if (dapp) {
-      if (dappOptions?.numberOfDapps) {
-        numberOfDapps = dappOptions.numberOfDapps;
-        // Note: We don't cap numberOfDapps here even if dappPaths is shorter,
-        // because tests may need multiple dapps where some use default paths
-      } else if (dappPaths && Array.isArray(dappPaths)) {
-        numberOfDapps = dappPaths.length;
-      } else {
-        // Default to 1 dapp when dapp=true but no specific configuration
-        numberOfDapps = 1;
-      }
+    if (numberOfDapps > 0) {
+      // numberOfDapps is precomputed in normalization
 
       for (let i = 0; i < numberOfDapps; i++) {
         let dappDirectory;
         let currentDappPath;
-        if (dappPath) {
-          // Single dappPath takes precedence
-          currentDappPath = dappPath;
-        } else if (
-          dappPaths &&
-          Array.isArray(dappPaths) &&
-          i < dappPaths.length
-        ) {
-          // Use dappPaths[i] if within bounds
-          currentDappPath = dappPaths[i];
+        if (hasCustomPaths && i < customCount) {
+          currentDappPath = dappOpts.customDappPaths[i];
         } else {
-          // Fallback to default
+          // Use the standard test dapp for the remaining slots
           currentDappPath = 'test-dapp';
         }
 
-        switch (currentDappPath) {
-          case 'snap-simple-keyring-site':
-            dappDirectory = path.resolve(
-              __dirname,
-              '..',
-              '..',
-              'node_modules',
-              '@metamask/snap-simple-keyring-site',
-              'public',
-            );
-            break;
-          case 'snap-account-abstraction-keyring':
-            dappDirectory = path.resolve(
-              __dirname,
-              '..',
-              '..',
-              'node_modules',
-              '@metamask/snap-account-abstraction-keyring-site',
-              'public',
-            );
-            break;
-          case 'test-dapp':
-            dappDirectory = path.resolve(
-              __dirname,
-              '..',
-              '..',
-              'node_modules',
-              '@metamask/test-dapp',
-              'dist',
-            );
-            break;
-          default:
-            dappDirectory = path.resolve(__dirname, currentDappPath);
-            break;
+        if (DAPP_PATHS && DAPP_PATHS[currentDappPath]) {
+          dappDirectory = path.resolve(
+            __dirname,
+            ...DAPP_PATHS[currentDappPath],
+          );
+        } else {
+          dappDirectory = path.resolve(__dirname, currentDappPath);
         }
         dappServer.push(
           createStaticServer({ public: dappDirectory, ...staticServerOptions }),
         );
-        dappServer[i].listen(`${dappBasePort + i}`);
+        const basePort =
+          typeof dappOpts.basePort === 'number'
+            ? dappOpts.basePort
+            : dappBasePort;
+        dappServer[i].listen(`${basePort + i}`);
         await new Promise((resolve, reject) => {
           dappServer[i].on('listening', resolve);
           dappServer[i].on('error', reject);
@@ -536,7 +503,7 @@ async function withFixtures(options, testSuite) {
       if (webDriver) {
         shutdownTasks.push(driver.quit());
       }
-      if (dapp) {
+      if (numberOfDapps > 0) {
         for (let i = 0; i < numberOfDapps; i++) {
           if (dappServer[i] && dappServer[i].listening) {
             shutdownTasks.push(

--- a/test/e2e/json-rpc/eth_accounts.spec.ts
+++ b/test/e2e/json-rpc/eth_accounts.spec.ts
@@ -8,7 +8,7 @@ describe('eth_accounts', function () {
   it('returns permitted eth accounts when wallet is unlocked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()
@@ -43,7 +43,7 @@ describe('eth_accounts', function () {
   it('returns permitted eth accounts when wallet is locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()

--- a/test/e2e/json-rpc/eth_accounts.spec.ts
+++ b/test/e2e/json-rpc/eth_accounts.spec.ts
@@ -8,7 +8,7 @@ describe('eth_accounts', function () {
   it('returns permitted eth accounts when wallet is unlocked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()
@@ -43,7 +43,7 @@ describe('eth_accounts', function () {
   it('returns permitted eth accounts when wallet is locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()

--- a/test/e2e/json-rpc/eth_call.spec.ts
+++ b/test/e2e/json-rpc/eth_call.spec.ts
@@ -14,7 +14,7 @@ describe('eth_call', function () {
   it('executes a new message call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_call.spec.ts
+++ b/test/e2e/json-rpc/eth_call.spec.ts
@@ -14,7 +14,7 @@ describe('eth_call', function () {
   it('executes a new message call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_chainId.spec.ts
+++ b/test/e2e/json-rpc/eth_chainId.spec.ts
@@ -8,7 +8,7 @@ describe('eth_chainId', function () {
   it('returns the chain ID of the current network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_chainId.spec.ts
+++ b/test/e2e/json-rpc/eth_chainId.spec.ts
@@ -8,7 +8,7 @@ describe('eth_chainId', function () {
   it('returns the chain ID of the current network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_coinbase.spec.ts
+++ b/test/e2e/json-rpc/eth_coinbase.spec.ts
@@ -8,7 +8,7 @@ describe('eth_coinbase', function () {
   it('executes a eth_coinbase json rpc call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_coinbase.spec.ts
+++ b/test/e2e/json-rpc/eth_coinbase.spec.ts
@@ -8,7 +8,7 @@ describe('eth_coinbase', function () {
   it('executes a eth_coinbase json rpc call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_estimateGas.spec.ts
+++ b/test/e2e/json-rpc/eth_estimateGas.spec.ts
@@ -8,7 +8,7 @@ describe('eth_estimateGas', function () {
   it('executes a estimate gas json rpc call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_estimateGas.spec.ts
+++ b/test/e2e/json-rpc/eth_estimateGas.spec.ts
@@ -8,7 +8,7 @@ describe('eth_estimateGas', function () {
   it('executes a estimate gas json rpc call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_gasPrice.spec.ts
+++ b/test/e2e/json-rpc/eth_gasPrice.spec.ts
@@ -8,7 +8,7 @@ describe('eth_gasPrice', function () {
   it('executes gas price json rpc call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_gasPrice.spec.ts
+++ b/test/e2e/json-rpc/eth_gasPrice.spec.ts
@@ -8,7 +8,7 @@ describe('eth_gasPrice', function () {
   it('executes gas price json rpc call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
+++ b/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
@@ -11,7 +11,7 @@ describe('eth_newBlockFilter', function () {
   it('executes a new block filter call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
+++ b/test/e2e/json-rpc/eth_newBlockFilter.spec.ts
@@ -11,7 +11,7 @@ describe('eth_newBlockFilter', function () {
   it('executes a new block filter call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -11,7 +11,7 @@ describe('eth_requestAccounts', function () {
   it('returns permitted accounts when there are permitted accounts and the wallet is unlocked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -44,7 +44,7 @@ describe('eth_requestAccounts', function () {
   it('returns permitted accounts when there are permitted accounts and the wallet is locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -75,7 +75,7 @@ describe('eth_requestAccounts', function () {
   it('prompts for login when there are no permitted accounts and the wallet is locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -11,7 +11,7 @@ describe('eth_requestAccounts', function () {
   it('returns permitted accounts when there are permitted accounts and the wallet is unlocked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -44,7 +44,7 @@ describe('eth_requestAccounts', function () {
   it('returns permitted accounts when there are permitted accounts and the wallet is locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -75,7 +75,7 @@ describe('eth_requestAccounts', function () {
   it('prompts for login when there are no permitted accounts and the wallet is locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/json-rpc/eth_sendTransaction.spec.ts
+++ b/test/e2e/json-rpc/eth_sendTransaction.spec.ts
@@ -13,7 +13,7 @@ describe('eth_sendTransaction', function () {
   it('confirms a new transaction', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -64,7 +64,7 @@ describe('eth_sendTransaction', function () {
   it('rejects a new transaction', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -124,7 +124,7 @@ describe('eth_sendTransaction', function () {
   it('prompts for unlock when the wallet is locked and the requesting origin has permission for the account specified in the "from" parameter', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_sendTransaction.spec.ts
+++ b/test/e2e/json-rpc/eth_sendTransaction.spec.ts
@@ -13,7 +13,7 @@ describe('eth_sendTransaction', function () {
   it('confirms a new transaction', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -64,7 +64,7 @@ describe('eth_sendTransaction', function () {
   it('rejects a new transaction', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -124,7 +124,7 @@ describe('eth_sendTransaction', function () {
   it('prompts for unlock when the wallet is locked and the requesting origin has permission for the account specified in the "from" parameter', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_subscribe.spec.ts
+++ b/test/e2e/json-rpc/eth_subscribe.spec.ts
@@ -9,7 +9,7 @@ describe('eth_subscribe', function () {
   it('executes a subscription event', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/eth_subscribe.spec.ts
+++ b/test/e2e/json-rpc/eth_subscribe.spec.ts
@@ -9,7 +9,7 @@ describe('eth_subscribe', function () {
   it('executes a subscription event', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/switchEthereumChain.spec.ts
+++ b/test/e2e/json-rpc/switchEthereumChain.spec.ts
@@ -19,11 +19,10 @@ describe('Switch Ethereum Chain for two dapps', function () {
   it('switches the chainId of two dapps when switchEthereumChain of one dapp is confirmed', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -94,7 +93,6 @@ describe('Switch Ethereum Chain for two dapps', function () {
   it('queues switchEthereumChain request from second dapp after send tx request', async function () {
     await withFixtures(
       {
-        dapp: true,
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPreferencesControllerSmartTransactionsOptedOut()
@@ -102,7 +100,7 @@ describe('Switch Ethereum Chain for two dapps', function () {
         manifestFlags: {
           testing: { disableSmartTransactionsOverride: true },
         },
-        dappOptions: { numberOfDapps: 2 },
+        dappOptions: { defaultTestDapp: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -212,11 +210,10 @@ describe('Switch Ethereum Chain for two dapps', function () {
   it('queues send tx after switchEthereum request with a warning, if switchEthereum request is cancelled should show pending tx', async function () {
     await withFixtures(
       {
-        dapp: true,
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
+        dappOptions: { defaultTestDapp: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/json-rpc/switchEthereumChain.spec.ts
+++ b/test/e2e/json-rpc/switchEthereumChain.spec.ts
@@ -19,7 +19,7 @@ describe('Switch Ethereum Chain for two dapps', function () {
   it('switches the chainId of two dapps when switchEthereumChain of one dapp is confirmed', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
@@ -100,7 +100,7 @@ describe('Switch Ethereum Chain for two dapps', function () {
         manifestFlags: {
           testing: { disableSmartTransactionsOverride: true },
         },
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -213,7 +213,7 @@ describe('Switch Ethereum Chain for two dapps', function () {
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
+++ b/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
@@ -11,7 +11,7 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
   it('show alerts on permission network if user does not have permission on new network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
@@ -88,7 +88,7 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
   it('show alerts on switch network page if user does has permission on new network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDappWithChains([

--- a/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
+++ b/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
@@ -11,12 +11,11 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
   it('show alerts on permission network if user does not have permission on new network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -89,7 +88,7 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
   it('show alerts on switch network page if user does has permission on new network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDappWithChains([
@@ -97,7 +96,6 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
             '0x53a',
           ])
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
+++ b/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
@@ -44,7 +44,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added and no rpc endpoint previously existed for the chain', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder().build(),
           localNodeOptions: [
             {
@@ -109,7 +109,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -179,7 +179,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to switch to the chain when the rpc endpoint being added already exists', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -253,7 +253,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder().build(),
           title: this.test?.fullTitle(),
         },
@@ -309,7 +309,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to switch to the chain when the rpc endpoint being added already exists', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -372,7 +372,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains([
@@ -451,7 +451,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically switches to the chain when the rpc endpoint being added already exists for the chain', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains([
@@ -522,7 +522,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to add the rpc endpoint to the chain networkConfiguration and set it as the default', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
             .build(),
@@ -584,7 +584,7 @@ describe('Add Ethereum Chain', function () {
     it('alert user about pending confirmations', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])

--- a/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
+++ b/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
@@ -44,7 +44,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added and no rpc endpoint previously existed for the chain', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder().build(),
           localNodeOptions: [
             {
@@ -109,7 +109,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -179,7 +179,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to switch to the chain when the rpc endpoint being added already exists', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -253,7 +253,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically permits and switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder().build(),
           title: this.test?.fullTitle(),
         },
@@ -309,7 +309,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to switch to the chain when the rpc endpoint being added already exists', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .build(),
@@ -372,7 +372,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically switches to the chain when the rpc endpoint is added but a different rpc endpoint already existed for the chain', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains([
@@ -451,7 +451,7 @@ describe('Add Ethereum Chain', function () {
     it('automatically switches to the chain when the rpc endpoint being added already exists for the chain', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains([
@@ -522,7 +522,7 @@ describe('Add Ethereum Chain', function () {
     it('prompts to add the rpc endpoint to the chain networkConfiguration and set it as the default', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
             .build(),
@@ -584,7 +584,7 @@ describe('Add Ethereum Chain', function () {
     it('alert user about pending confirmations', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withNetworkControllerDoubleNode()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])

--- a/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
+++ b/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_getCapabilities', function () {
   it('should indicate auxiliaryFunds support for chains with bridge support', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x1'])
           .build(),
@@ -41,7 +41,7 @@ describe('wallet_getCapabilities', function () {
   it('should not include auxiliaryFunds for chains without bridge support', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),

--- a/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
+++ b/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_getCapabilities', function () {
   it('should indicate auxiliaryFunds support for chains with bridge support', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x1'])
           .build(),
@@ -41,7 +41,7 @@ describe('wallet_getCapabilities', function () {
   it('should not include auxiliaryFunds for chains without bridge support', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),

--- a/test/e2e/json-rpc/wallet_getPermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_getPermissions.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_getPermissions', function () {
   it('returns permissions when the wallet is unlocked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -46,7 +46,7 @@ describe('wallet_getPermissions', function () {
   it('returns permissions when the wallet is locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/wallet_getPermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_getPermissions.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_getPermissions', function () {
   it('returns permissions when the wallet is unlocked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -46,7 +46,7 @@ describe('wallet_getPermissions', function () {
   it('returns permissions when the wallet is locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/json-rpc/wallet_requestPermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_requestPermissions.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_requestPermissions', function () {
   it('executes a request permissions on eth_accounts event', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.title,
       },

--- a/test/e2e/json-rpc/wallet_requestPermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_requestPermissions.spec.ts
@@ -10,7 +10,7 @@ describe('wallet_requestPermissions', function () {
   it('executes a request permissions on eth_accounts event', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.title,
       },

--- a/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
@@ -9,7 +9,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for just "eth_accounts"', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -70,7 +70,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for just "endowment:permitted-chains"', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -129,7 +129,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for "eth_accounts" and "endowment:permitted-chains"', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -192,7 +192,7 @@ describe('Revoke Dapp Permissions', function () {
     it('rejects the pending confirmations as permissions are revoked for the network', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
             .build(),

--- a/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
@@ -9,7 +9,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for just "eth_accounts"', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -70,7 +70,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for just "endowment:permitted-chains"', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -129,7 +129,7 @@ describe('Revoke Dapp Permissions', function () {
   it('should revoke "eth_accounts" and "endowment:permitted-chains" when the dapp revokes permissions for "eth_accounts" and "endowment:permitted-chains"', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
           .build(),
@@ -192,7 +192,7 @@ describe('Revoke Dapp Permissions', function () {
     it('rejects the pending confirmations as permissions are revoked for the network', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
             .build(),

--- a/test/e2e/multi-injected-provider/multi-provider-injection-check.spec.ts
+++ b/test/e2e/multi-injected-provider/multi-provider-injection-check.spec.ts
@@ -7,7 +7,7 @@ describe('Multi injected provider interactions', function () {
   it('should check for multiple providers', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/multi-injected-provider/multi-provider-injection-check.spec.ts
+++ b/test/e2e/multi-injected-provider/multi-provider-injection-check.spec.ts
@@ -7,7 +7,7 @@ describe('Multi injected provider interactions', function () {
   it('should check for multiple providers', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/provider/bfcache.spec.js
+++ b/test/e2e/provider/bfcache.spec.js
@@ -28,7 +28,7 @@ describe('BFCache', function () {
   it('has a working provider stream when a dapp is restored from BFCache', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test.fullTitle(),
       },

--- a/test/e2e/provider/bfcache.spec.js
+++ b/test/e2e/provider/bfcache.spec.js
@@ -28,7 +28,7 @@ describe('BFCache', function () {
   it('has a working provider stream when a dapp is restored from BFCache', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test.fullTitle(),
       },

--- a/test/e2e/provider/eip-6963.spec.js
+++ b/test/e2e/provider/eip-6963.spec.js
@@ -13,7 +13,7 @@ describe('EIP-6963 Provider', function () {
   it('should respond to the request provider event', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/provider/eip-6963.spec.js
+++ b/test/e2e/provider/eip-6963.spec.js
@@ -13,7 +13,7 @@ describe('EIP-6963 Provider', function () {
   it('should respond to the request provider event', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -98,7 +98,7 @@ async function main() {
   // Multichain API excluding `wallet_invokeMethod`
   await withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       fixtures: new FixtureBuilder().build(),
       localNodeOptions: 'none',
       title: 'api-specs-multichain coverage',
@@ -163,7 +163,7 @@ async function main() {
   // requests made via wallet_invokeMethod
   await withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToMultichainTestDapp()
         .build(),

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -98,7 +98,7 @@ async function main() {
   // Multichain API excluding `wallet_invokeMethod`
   await withFixtures(
     {
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       fixtures: new FixtureBuilder().build(),
       localNodeOptions: 'none',
       title: 'api-specs-multichain coverage',
@@ -163,7 +163,7 @@ async function main() {
   // requests made via wallet_invokeMethod
   await withFixtures(
     {
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToMultichainTestDapp()
         .build(),

--- a/test/e2e/run-openrpc-api-test-coverage.ts
+++ b/test/e2e/run-openrpc-api-test-coverage.ts
@@ -25,7 +25,7 @@ async function main() {
   const chainId = 1337;
   await withFixtures(
     {
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       fixtures: new FixtureBuilder().build(),
       localNodeOptions: 'none',
       title: 'api-specs coverage',

--- a/test/e2e/run-openrpc-api-test-coverage.ts
+++ b/test/e2e/run-openrpc-api-test-coverage.ts
@@ -25,7 +25,7 @@ async function main() {
   const chainId = 1337;
   await withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       fixtures: new FixtureBuilder().build(),
       localNodeOptions: 'none',
       title: 'api-specs coverage',

--- a/test/e2e/snaps/test-snap-installed.spec.ts
+++ b/test/e2e/snaps/test-snap-installed.spec.ts
@@ -54,7 +54,7 @@ describe('Test Snap installed', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'fake-metrics-id',

--- a/test/e2e/snaps/test-snap-installed.spec.ts
+++ b/test/e2e/snaps/test-snap-installed.spec.ts
@@ -54,7 +54,7 @@ describe('Test Snap installed', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'fake-metrics-id',

--- a/test/e2e/snaps/test-snap-metrics.spec.js
+++ b/test/e2e/snaps/test-snap-metrics.spec.js
@@ -190,7 +190,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -303,7 +303,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -391,7 +391,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -476,7 +476,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -609,7 +609,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -769,7 +769,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -919,7 +919,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/snaps/test-snap-metrics.spec.js
+++ b/test/e2e/snaps/test-snap-metrics.spec.js
@@ -190,7 +190,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -303,7 +303,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -391,7 +391,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -476,7 +476,7 @@ describe('Test Snap Metrics', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -609,7 +609,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -769,7 +769,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -919,7 +919,7 @@ describe('Test Snap Metrics', function () {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -10,7 +10,7 @@ describe('Test Snap Signature Insights', function () {
   it('tests Signature Insights functionality', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/snaps/test-snap-siginsights.spec.js
+++ b/test/e2e/snaps/test-snap-siginsights.spec.js
@@ -10,7 +10,7 @@ describe('Test Snap Signature Insights', function () {
   it('tests Signature Insights functionality', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/snaps/test-snap-txinsights.spec.ts
+++ b/test/e2e/snaps/test-snap-txinsights.spec.ts
@@ -20,7 +20,7 @@ describe('Test Snap TxInsights', function () {
   it('shows insight for ERC20 transactions', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -54,7 +54,7 @@ describe('Test Snap TxInsights', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -99,7 +99,7 @@ describe('Test Snap TxInsights', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/snaps/test-snap-txinsights.spec.ts
+++ b/test/e2e/snaps/test-snap-txinsights.spec.ts
@@ -20,7 +20,7 @@ describe('Test Snap TxInsights', function () {
   it('shows insight for ERC20 transactions', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -54,7 +54,7 @@ describe('Test Snap TxInsights', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -99,7 +99,7 @@ describe('Test Snap TxInsights', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/account/account-modal-account-type-change.spec.ts
+++ b/test/e2e/tests/account/account-modal-account-type-change.spec.ts
@@ -16,7 +16,7 @@ describe('Switch Modal - Switch Account', function (this: Suite) {
   it('Account modal should have options to upgrade / downgrade the account', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         localNodeOptions: [
           {

--- a/test/e2e/tests/account/account-modal-account-type-change.spec.ts
+++ b/test/e2e/tests/account/account-modal-account-type-change.spec.ts
@@ -16,7 +16,7 @@ describe('Switch Modal - Switch Account', function (this: Suite) {
   it('Account modal should have options to upgrade / downgrade the account', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         localNodeOptions: [
           {

--- a/test/e2e/tests/account/create-remove-account-snap.spec.ts
+++ b/test/e2e/tests/account/create-remove-account-snap.spec.ts
@@ -14,8 +14,10 @@ describe('Create and remove Snap Account', function (this: Suite) {
   it('create snap account and remove it by removing snap', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/account/create-remove-account-snap.spec.ts
+++ b/test/e2e/tests/account/create-remove-account-snap.spec.ts
@@ -16,7 +16,6 @@ describe('Create and remove Snap Account', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/account/create-remove-account-snap.spec.ts
+++ b/test/e2e/tests/account/create-remove-account-snap.spec.ts
@@ -2,6 +2,7 @@ import { Suite } from 'mocha';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
 import { withFixtures, WINDOW_TITLES } from '../../helpers';
+import { DAPP_PATH } from '../../constants';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SnapListPage from '../../page-objects/pages/snap-list-page';
@@ -16,7 +17,7 @@ describe('Create and remove Snap Account', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,

--- a/test/e2e/tests/account/create-snap-account.spec.ts
+++ b/test/e2e/tests/account/create-snap-account.spec.ts
@@ -15,7 +15,6 @@ describe('Create Snap Account', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
@@ -43,7 +42,6 @@ describe('Create Snap Account', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
@@ -85,7 +83,6 @@ describe('Create Snap Account', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
@@ -123,7 +120,6 @@ describe('Create Snap Account', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/account/create-snap-account.spec.ts
+++ b/test/e2e/tests/account/create-snap-account.spec.ts
@@ -2,6 +2,7 @@ import { Suite } from 'mocha';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
 import { withFixtures, WINDOW_TITLES } from '../../helpers';
+import { DAPP_PATH } from '../../constants';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
@@ -15,7 +16,7 @@ describe('Create Snap Account', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
@@ -43,7 +44,7 @@ describe('Create Snap Account', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
@@ -85,7 +86,7 @@ describe('Create Snap Account', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
@@ -123,7 +124,7 @@ describe('Create Snap Account', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,

--- a/test/e2e/tests/account/create-snap-account.spec.ts
+++ b/test/e2e/tests/account/create-snap-account.spec.ts
@@ -13,8 +13,10 @@ describe('Create Snap Account', function (this: Suite) {
   it('create Snap account with custom name input ends in approval success', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         title: this.test?.fullTitle(),
@@ -39,8 +41,10 @@ describe('Create Snap Account', function (this: Suite) {
   it('creates multiple Snap accounts with increasing numeric suffixes', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         title: this.test?.fullTitle(),
@@ -79,8 +83,10 @@ describe('Create Snap Account', function (this: Suite) {
   it('create Snap account canceling on confirmation screen results in error on Snap', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         title: this.test?.fullTitle(),
@@ -115,8 +121,10 @@ describe('Create Snap Account', function (this: Suite) {
   it('create Snap account canceling on fill name screen results in error on Snap', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/account/incremental-security.spec.ts
+++ b/test/e2e/tests/account/incremental-security.spec.ts
@@ -18,8 +18,7 @@ describe('Incremental Security', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
-          customDappPaths: ['test-dapp-send-eth-with-private-key'],
+          customDappPaths: ['./send-eth-with-private-key-test'],
         },
         fixtures: new FixtureBuilder({ onboarding: true }).build(),
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/account/incremental-security.spec.ts
+++ b/test/e2e/tests/account/incremental-security.spec.ts
@@ -17,10 +17,12 @@ describe('Incremental Security', function (this: Suite) {
   it('Back up Secret Recovery Phrase from backup reminder', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['test-dapp-send-eth-with-private-key'],
+        },
         fixtures: new FixtureBuilder({ onboarding: true }).build(),
         title: this.test?.fullTitle(),
-        dappPath: 'send-eth-with-private-key-test',
       },
       async ({
         driver,

--- a/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
+++ b/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
@@ -22,8 +22,10 @@ describe('Snap Account Contract interaction', function (this: Suite) {
   it('deposits to piggybank contract', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['test-dapp', 'snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder()
           .withPermissionControllerSnapAccountConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
+++ b/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
@@ -24,7 +24,7 @@ describe('Snap Account Contract interaction', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
+          numberOfTestDapps: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder()

--- a/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
+++ b/test/e2e/tests/account/snap-account-contract-interaction.spec.ts
@@ -2,6 +2,7 @@ import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilder from '../../fixture-builder';
+import { DAPP_PATH } from '../../constants';
 import { Anvil } from '../../seeder/anvil';
 import { Ganache } from '../../seeder/ganache';
 import ContractAddressRegistry from '../../seeder/contract-address-registry';
@@ -24,7 +25,7 @@ describe('Snap Account Contract interaction', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder()
           .withPermissionControllerSnapAccountConnectedToTestDapp()

--- a/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
@@ -18,8 +18,10 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
   it('can connect to the Test Dapp, then #signTypedDataV3, disconnect then connect, then #signTypedDataV4 (async flow approve)', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['test-dapp', 'snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: async (mockServer: Mockttp) => {
           const snapMocks = await mockSnapSimpleKeyringAndSite(

--- a/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
@@ -20,7 +20,7 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
+          numberOfTestDapps: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
@@ -2,6 +2,7 @@ import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
 import { WINDOW_TITLES, withFixtures } from '../../helpers';
+import { DAPP_PATH } from '../../constants';
 import FixtureBuilder from '../../fixture-builder';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
@@ -20,7 +21,7 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: async (mockServer: Mockttp) => {

--- a/test/e2e/tests/account/snap-account-signatures.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures.spec.ts
@@ -9,6 +9,7 @@ import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
 import TestDapp from '../../page-objects/pages/test-dapp';
 import { installSnapSimpleKeyring } from '../../page-objects/flows/snap-simple-keyring.flow';
+import { DAPP_PATH } from '../../constants';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import {
   personalSignWithSnapAccount,
@@ -33,7 +34,7 @@ describe('Snap Account Signatures', function (this: Suite) {
         {
           dappOptions: {
             defaultTestDapp: 1,
-            customDappPaths: ['snap-simple-keyring-site'],
+            customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
           },
           fixtures: new FixtureBuilder().build(),
           testSpecificMock: async (mockServer: Mockttp) => {

--- a/test/e2e/tests/account/snap-account-signatures.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures.spec.ts
@@ -31,8 +31,10 @@ describe('Snap Account Signatures', function (this: Suite) {
     it(title, async function () {
       await withFixtures(
         {
-          dapp: true,
-          dappPaths: ['test-dapp', 'snap-simple-keyring-site'],
+          dappOptions: {
+            defaultTestDapp: 1,
+            customDappPaths: ['snap-simple-keyring-site'],
+          },
           fixtures: new FixtureBuilder().build(),
           testSpecificMock: async (mockServer: Mockttp) => {
             const snapMocks = await mockSnapSimpleKeyringAndSite(

--- a/test/e2e/tests/account/snap-account-signatures.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures.spec.ts
@@ -33,7 +33,7 @@ describe('Snap Account Signatures', function (this: Suite) {
       await withFixtures(
         {
           dappOptions: {
-            defaultTestDapp: 1,
+            numberOfTestDapps: 1,
             customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
           },
           fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/account/snap-account-transfers.spec.ts
+++ b/test/e2e/tests/account/snap-account-transfers.spec.ts
@@ -24,8 +24,10 @@ describe('Snap Account Transfers', function (this: Suite) {
       {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
@@ -68,8 +70,10 @@ describe('Snap Account Transfers', function (this: Suite) {
       {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
@@ -113,8 +117,10 @@ describe('Snap Account Transfers', function (this: Suite) {
       {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: ['Request rejected by user or snap.'],
       },

--- a/test/e2e/tests/account/snap-account-transfers.spec.ts
+++ b/test/e2e/tests/account/snap-account-transfers.spec.ts
@@ -25,7 +25,6 @@ describe('Snap Account Transfers', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),
@@ -71,7 +70,6 @@ describe('Snap Account Transfers', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),
@@ -118,7 +116,6 @@ describe('Snap Account Transfers', function (this: Suite) {
         fixtures: new FixtureBuilder().build(),
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/account/snap-account-transfers.spec.ts
+++ b/test/e2e/tests/account/snap-account-transfers.spec.ts
@@ -5,7 +5,7 @@ import {
   WINDOW_TITLES,
   withFixtures,
 } from '../../helpers';
-import { DEFAULT_FIXTURE_ACCOUNT } from '../../constants';
+import { DAPP_PATH, DEFAULT_FIXTURE_ACCOUNT } from '../../constants';
 import { Driver } from '../../webdriver/driver';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import ActivityListPage from '../../page-objects/pages/home/activity-list';
@@ -26,7 +26,7 @@ describe('Snap Account Transfers', function (this: Suite) {
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),
       },
@@ -72,7 +72,7 @@ describe('Snap Account Transfers', function (this: Suite) {
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),
       },
@@ -119,7 +119,7 @@ describe('Snap Account Transfers', function (this: Suite) {
         testSpecificMock: mockSnapSimpleKeyringAndSite,
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         title: this.test?.fullTitle(),
         ignoredConsoleErrors: ['Request rejected by user or snap.'],

--- a/test/e2e/tests/confirmations/alerts/insufficient-funds.spec.ts
+++ b/test/e2e/tests/confirmations/alerts/insufficient-funds.spec.ts
@@ -15,7 +15,7 @@ describe('Alert for insufficient funds', function () {
     };
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/alerts/insufficient-funds.spec.ts
+++ b/test/e2e/tests/confirmations/alerts/insufficient-funds.spec.ts
@@ -15,7 +15,7 @@ describe('Alert for insufficient funds', function () {
     };
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -37,7 +37,7 @@ export function withTransactionEnvelopeTypeFixtures(
   };
   return withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       driverOptions: { timeOut: 20000 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()
@@ -69,7 +69,7 @@ export function withSignatureFixtures(
 ) {
   return withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       driverOptions: { timeOut: 20000 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -37,7 +37,7 @@ export function withTransactionEnvelopeTypeFixtures(
   };
   return withFixtures(
     {
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       driverOptions: { timeOut: 20000 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()
@@ -69,7 +69,7 @@ export function withSignatureFixtures(
 ) {
   return withFixtures(
     {
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       driverOptions: { timeOut: 20000 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
@@ -104,7 +104,7 @@ describe('Confirmation Signature - Personal Sign', function (this: Suite) {
   it('can queue multiple personal signs and confirm', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/personal-sign.spec.ts
@@ -104,7 +104,7 @@ describe('Confirmation Signature - Personal Sign', function (this: Suite) {
   it('can queue multiple personal signs and confirm', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/signatures/signature-request.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-request.spec.ts
@@ -32,7 +32,7 @@ describe('Sign Typed Data Signature Request', function () {
     it(`can queue multiple Signature Requests of ${data.type} and confirm`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -80,7 +80,7 @@ describe('Sign Typed Data Signature Request', function () {
     it(`can queue multiple Signature Requests of ${data.type} and reject`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/signatures/signature-request.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-request.spec.ts
@@ -32,7 +32,7 @@ describe('Sign Typed Data Signature Request', function () {
     it(`can queue multiple Signature Requests of ${data.type} and confirm`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -80,7 +80,7 @@ describe('Sign Typed Data Signature Request', function () {
     it(`can queue multiple Signature Requests of ${data.type} and reject`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
@@ -13,7 +13,7 @@ describe('Confirmation Redesign Contract Deployment Component', function () {
   it(`Sends a contract deployment type 0 transaction (Legacy)`, async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -53,7 +53,7 @@ describe('Confirmation Redesign Contract Deployment Component', function () {
   it(`Sends a contract deployment type 2 transaction (EIP1559)`, async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
@@ -13,7 +13,7 @@ describe('Confirmation Redesign Contract Deployment Component', function () {
   it(`Sends a contract deployment type 0 transaction (Legacy)`, async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -53,7 +53,7 @@ describe('Confirmation Redesign Contract Deployment Component', function () {
   it(`Sends a contract deployment type 2 transaction (EIP1559)`, async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -34,7 +34,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 0 transaction (Legacy)`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -67,7 +67,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 2 transaction (EIP1559)`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -97,7 +97,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 0 transaction (Legacy) with a Trezor account`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withTrezorAccount()
             .withPermissionControllerConnectedToTestDapp({
@@ -149,7 +149,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Opens a contract interaction type 2 transaction that includes layer 1 fees breakdown on a layer 2`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.OPTIMISM })
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
@@ -192,7 +192,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction without custom nonce editing (EIP1559)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -221,7 +221,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction with custom nonce editing (EIP1559)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -254,7 +254,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction (EIP1559) and checks the advanced gas details', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -284,7 +284,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('If hex data is enabled, advanced details are shown', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -34,7 +34,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 0 transaction (Legacy)`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -67,7 +67,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 2 transaction (EIP1559)`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -97,7 +97,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Sends a contract interaction type 0 transaction (Legacy) with a Trezor account`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withTrezorAccount()
             .withPermissionControllerConnectedToTestDapp({
@@ -149,7 +149,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it(`Opens a contract interaction type 2 transaction that includes layer 1 fees breakdown on a layer 2`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.OPTIMISM })
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController({
@@ -192,7 +192,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction without custom nonce editing (EIP1559)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -221,7 +221,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction with custom nonce editing (EIP1559)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -254,7 +254,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('Sends a contract interaction type 2 transaction (EIP1559) and checks the advanced gas details', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -284,7 +284,7 @@ describe('Confirmation Redesign Contract Interaction Component', function () {
     it('If hex data is enabled, advanced details are shown', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/eip7702-eip5792-upgrade-account.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/eip7702-eip5792-upgrade-account.spec.ts
@@ -16,7 +16,7 @@ describe('Upgrade Account', function (this: Suite) {
   it('an EOA account can be upgraded when triggering a batch tx from a dapp in an odd chain id', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -99,7 +99,7 @@ describe('Upgrade Account', function (this: Suite) {
   it('an EOA account is not upgraded when rejecting a batch transaction, but can trigger a new send call', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/eip7702-eip5792-upgrade-account.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/eip7702-eip5792-upgrade-account.spec.ts
@@ -16,7 +16,7 @@ describe('Upgrade Account', function (this: Suite) {
   it('an EOA account can be upgraded when triggering a batch tx from a dapp in an odd chain id', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -99,7 +99,7 @@ describe('Upgrade Account', function (this: Suite) {
   it('an EOA account is not upgraded when rejecting a batch transaction, but can trigger a new send call', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
@@ -22,7 +22,7 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -59,7 +59,7 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
@@ -22,7 +22,7 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -59,7 +59,7 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
@@ -17,7 +17,7 @@ describe('Confirmation Redesign ERC721 Approve Component', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -55,7 +55,7 @@ describe('Confirmation Redesign ERC721 Approve Component', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
@@ -17,7 +17,7 @@ describe('Confirmation Redesign ERC721 Approve Component', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -55,7 +55,7 @@ describe('Confirmation Redesign ERC721 Approve Component', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -25,7 +25,7 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
   it('confirms transaction if successful', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerSmartTransactionsOptedOut()
@@ -81,7 +81,7 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
   it('fails transaction if error', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -25,7 +25,7 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
   it('confirms transaction if successful', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerSmartTransactionsOptedOut()
@@ -81,7 +81,7 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
   it('fails transaction if error', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -22,7 +22,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
   it('confirms transaction if successful', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerSmartTransactionsOptedOut()
@@ -89,7 +89,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
   it('fails transaction if error', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -22,7 +22,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
   it('confirms transaction if successful', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerSmartTransactionsOptedOut()
@@ -89,7 +89,7 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
   it('fails transaction if error', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
@@ -23,7 +23,7 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
   it('confirms two transactions if successful', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()
@@ -81,7 +81,7 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
   it('fails two transactions if error', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
@@ -23,7 +23,7 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
   it('confirms two transactions if successful', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()
@@ -81,7 +81,7 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
   it('fails two transactions if error', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
           .withPermissionControllerConnectedToTestDapp()
           .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
@@ -88,7 +88,7 @@ describe('Confirmation Redesign ERC20 Increase Allowance', function () {
 
 function generateFixtureOptionsForLegacyTx(mochaContext: Mocha.Context) {
   return {
-    dappOptions: { defaultTestDapp: 1 },
+    dappOptions: { numberOfTestDapps: 1 },
     fixtures: new FixtureBuilder()
       .withPermissionControllerConnectedToTestDapp()
       .build(),
@@ -103,7 +103,7 @@ function generateFixtureOptionsForLegacyTx(mochaContext: Mocha.Context) {
 
 function generateFixtureOptionsForEIP1559Tx(mochaContext: Mocha.Context) {
   return {
-    dappOptions: { defaultTestDapp: 1 },
+    dappOptions: { numberOfTestDapps: 1 },
     fixtures: new FixtureBuilder()
       .withPermissionControllerConnectedToTestDapp()
       .build(),

--- a/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
@@ -88,7 +88,7 @@ describe('Confirmation Redesign ERC20 Increase Allowance', function () {
 
 function generateFixtureOptionsForLegacyTx(mochaContext: Mocha.Context) {
   return {
-    dapp: true,
+    dappOptions: { defaultTestDapp: 1 },
     fixtures: new FixtureBuilder()
       .withPermissionControllerConnectedToTestDapp()
       .build(),
@@ -103,7 +103,7 @@ function generateFixtureOptionsForLegacyTx(mochaContext: Mocha.Context) {
 
 function generateFixtureOptionsForEIP1559Tx(mochaContext: Mocha.Context) {
   return {
-    dapp: true,
+    dappOptions: { defaultTestDapp: 1 },
     fixtures: new FixtureBuilder()
       .withPermissionControllerConnectedToTestDapp()
       .build(),

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -22,7 +22,7 @@ describe('Metrics', function () {
   it('Sends a contract interaction type 2 transaction (EIP1559) with the right properties in the metric events', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -22,7 +22,7 @@ describe('Metrics', function () {
   it('Sends a contract interaction type 2 transaction (EIP1559) with the right properties in the metric events', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/confirmations/transactions/multiple-dapp-network-confirmation-routing.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/multiple-dapp-network-confirmation-routing.spec.ts
@@ -17,11 +17,10 @@ describe('Routing confirmstions from Multiple Dapps and different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/confirmations/transactions/multiple-dapp-network-confirmation-routing.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/multiple-dapp-network-confirmation-routing.spec.ts
@@ -17,7 +17,7 @@ describe('Routing confirmstions from Multiple Dapps and different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
@@ -15,7 +15,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas (lower than 21000)', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -77,7 +77,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas limit (lower than 21000)', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -139,7 +139,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas (above estimated gas limit)', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -201,7 +201,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas limit (above estimated gas limit)', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
@@ -15,7 +15,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas (lower than 21000)', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -77,7 +77,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas limit (lower than 21000)', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -139,7 +139,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas (above estimated gas limit)', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -201,7 +201,7 @@ describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas limit (above estimated gas limit)', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
@@ -23,7 +23,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -66,7 +66,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
@@ -23,7 +23,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
     it('Sends a type 0 transaction (Legacy)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -66,7 +66,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
     it('Sends a type 2 transaction (EIP1559)', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -19,7 +19,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
     it('Successfully speeds up a pending transaction', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -75,7 +75,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
     it('Successfully cancels a pending transaction', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -19,7 +19,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
     it('Successfully speeds up a pending transaction', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -75,7 +75,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
     it('Successfully cancels a pending transaction', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),

--- a/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
@@ -20,7 +20,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
     it(`decodes 4 bytes transaction data`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -58,7 +58,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`decodes Sourcify transaction data`, async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -91,7 +91,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`falls back to raw hexadecimal when no data is retreived`, async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -123,7 +123,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`decodes uniswap transaction data`, async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withEnabledNetworks({

--- a/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
@@ -20,7 +20,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
     it(`decodes 4 bytes transaction data`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .build(),
@@ -58,7 +58,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`decodes Sourcify transaction data`, async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -91,7 +91,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`falls back to raw hexadecimal when no data is retreived`, async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -123,7 +123,7 @@ describe('Confirmation Redesign Contract Interaction Transaction Decoding', func
   it(`decodes uniswap transaction data`, async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withEnabledNetworks({

--- a/test/e2e/tests/connections/edit-account-permissions.spec.ts
+++ b/test/e2e/tests/connections/edit-account-permissions.spec.ts
@@ -19,7 +19,7 @@ describe('Edit Accounts Permissions', function () {
   it('should be able to edit accounts', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/tests/connections/edit-account-permissions.spec.ts
+++ b/test/e2e/tests/connections/edit-account-permissions.spec.ts
@@ -19,7 +19,7 @@ describe('Edit Accounts Permissions', function () {
   it('should be able to edit accounts', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/tests/connections/edit-networks-permissions.spec.ts
+++ b/test/e2e/tests/connections/edit-networks-permissions.spec.ts
@@ -12,7 +12,7 @@ describe('Edit Networks Permissions', function () {
   it('should be able to edit networks', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/tests/connections/edit-networks-permissions.spec.ts
+++ b/test/e2e/tests/connections/edit-networks-permissions.spec.ts
@@ -12,7 +12,7 @@ describe('Edit Networks Permissions', function () {
   it('should be able to edit networks', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/tests/connections/multiple-provider-connections.spec.ts
+++ b/test/e2e/tests/connections/multiple-provider-connections.spec.ts
@@ -173,7 +173,7 @@ describe('Multiple Standard Dapp Connections', function () {
   it('should default account selection to already permitted account(s) plus the selected account (if not already permissioned) when `wallet_requestPermissions` is called with no accounts specified', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()
@@ -223,7 +223,7 @@ describe('Multiple Standard Dapp Connections', function () {
   it('should default account selection to both accounts when `wallet_requestPermissions` is called with specific account while another is already connected', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()

--- a/test/e2e/tests/connections/multiple-provider-connections.spec.ts
+++ b/test/e2e/tests/connections/multiple-provider-connections.spec.ts
@@ -173,7 +173,7 @@ describe('Multiple Standard Dapp Connections', function () {
   it('should default account selection to already permitted account(s) plus the selected account (if not already permissioned) when `wallet_requestPermissions` is called with no accounts specified', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()
@@ -223,7 +223,7 @@ describe('Multiple Standard Dapp Connections', function () {
   it('should default account selection to both accounts when `wallet_requestPermissions` is called with specific account while another is already connected', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withKeyringControllerAdditionalAccountVault()
           .withPreferencesControllerAdditionalAccountIdentities()

--- a/test/e2e/tests/connections/review-switch-permission-page.spec.ts
+++ b/test/e2e/tests/connections/review-switch-permission-page.spec.ts
@@ -14,7 +14,7 @@ describe('Permissions Page when Dapp Switch to an enabled and non permissioned n
     const chainId: number = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/connections/review-switch-permission-page.spec.ts
+++ b/test/e2e/tests/connections/review-switch-permission-page.spec.ts
@@ -14,7 +14,7 @@ describe('Permissions Page when Dapp Switch to an enabled and non permissioned n
     const chainId: number = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/connections/revoke-permissions.spec.ts
+++ b/test/e2e/tests/connections/revoke-permissions.spec.ts
@@ -11,7 +11,7 @@ describe('Revoke Permissions', function () {
   it('should disconnect when click on Disconnect button in connections page', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/connections/revoke-permissions.spec.ts
+++ b/test/e2e/tests/connections/revoke-permissions.spec.ts
@@ -11,7 +11,7 @@ describe('Revoke Permissions', function () {
   it('should disconnect when click on Disconnect button in connections page', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
+++ b/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
@@ -11,10 +11,12 @@ describe('Content-Security-Policy', function (this: Suite) {
   it.skip('opening a restricted website should still load the extension', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: [
-          './tests/content-security-policy/content-security-policy-mock-page',
-        ],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: [
+            './tests/content-security-policy/content-security-policy-mock-page',
+          ],
+        },
         staticServerOptions: {
           headers: [
             {

--- a/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
+++ b/test/e2e/tests/content-security-policy/content-security-policy.spec.ts
@@ -12,7 +12,6 @@ describe('Content-Security-Policy', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [
             './tests/content-security-policy/content-security-policy-mock-page',
           ],

--- a/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
+++ b/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
@@ -57,7 +57,7 @@ describe('Block Explorer', function () {
     const smartContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             ...mockNetworkStateOld({

--- a/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
+++ b/test/e2e/tests/dapp-interactions/block-explorer.spec.ts
@@ -57,7 +57,7 @@ describe('Block Explorer', function () {
     const smartContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             ...mockNetworkStateOld({

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -18,7 +18,7 @@ describe('Dapp interactions', function () {
   it('should trigger the add chain confirmation despite MetaMask being locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         localNodeOptions: [
           {
@@ -56,11 +56,10 @@ describe('Dapp interactions', function () {
   it('should connect a second Dapp despite MetaMask being locked', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
@@ -111,7 +110,7 @@ describe('Dapp interactions', function () {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -18,7 +18,7 @@ describe('Dapp interactions', function () {
   it('should trigger the add chain confirmation despite MetaMask being locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         localNodeOptions: [
           {
@@ -56,7 +56,7 @@ describe('Dapp interactions', function () {
   it('should connect a second Dapp despite MetaMask being locked', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -110,7 +110,7 @@ describe('Dapp interactions', function () {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/encrypt-decrypt.spec.ts
+++ b/test/e2e/tests/dapp-interactions/encrypt-decrypt.spec.ts
@@ -16,7 +16,7 @@ describe('Encrypt Decrypt', function (this: Suite) {
   it('should decrypt an encrypted message', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -49,7 +49,7 @@ describe('Encrypt Decrypt', function (this: Suite) {
     const message2 = 'Hello, Alice!';
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/encrypt-decrypt.spec.ts
+++ b/test/e2e/tests/dapp-interactions/encrypt-decrypt.spec.ts
@@ -16,7 +16,7 @@ describe('Encrypt Decrypt', function (this: Suite) {
   it('should decrypt an encrypted message', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -49,7 +49,7 @@ describe('Encrypt Decrypt', function (this: Suite) {
     const message2 = 'Hello, Alice!';
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/eth-subscribe.spec.ts
+++ b/test/e2e/tests/dapp-interactions/eth-subscribe.spec.ts
@@ -7,11 +7,10 @@ describe('eth_subscribe', function () {
   it('only broadcasts subscription notifications on the page that registered the subscription', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {

--- a/test/e2e/tests/dapp-interactions/eth-subscribe.spec.ts
+++ b/test/e2e/tests/dapp-interactions/eth-subscribe.spec.ts
@@ -7,7 +7,7 @@ describe('eth_subscribe', function () {
   it('only broadcasts subscription notifications on the page that registered the subscription', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/permissions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/permissions.spec.ts
@@ -11,7 +11,7 @@ describe('Permissions', function (this: Suite) {
   it('sets permissions and connect to Dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/permissions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/permissions.spec.ts
@@ -11,7 +11,7 @@ describe('Permissions', function (this: Suite) {
   it('sets permissions and connect to Dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/provider-api.spec.ts
+++ b/test/e2e/tests/dapp-interactions/provider-api.spec.ts
@@ -10,7 +10,7 @@ describe('MetaMask', function (this: Suite) {
   it('should reject unsupported methods', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/provider-api.spec.ts
+++ b/test/e2e/tests/dapp-interactions/provider-api.spec.ts
@@ -10,7 +10,7 @@ describe('MetaMask', function (this: Suite) {
   it('should reject unsupported methods', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/revoke-permissions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/revoke-permissions.spec.ts
@@ -8,7 +8,7 @@ describe('Wallet Revoke Permissions', function (this: Suite) {
   it('should revoke "eth_accounts" permissions via test dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -35,7 +35,7 @@ describe('Wallet Revoke Permissions', function (this: Suite) {
   it('should revoke "endowment:permitted-chains" permissions', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/dapp-interactions/revoke-permissions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/revoke-permissions.spec.ts
@@ -8,7 +8,7 @@ describe('Wallet Revoke Permissions', function (this: Suite) {
   it('should revoke "eth_accounts" permissions via test dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -35,7 +35,7 @@ describe('Wallet Revoke Permissions', function (this: Suite) {
   it('should revoke "endowment:permitted-chains" permissions', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
@@ -16,7 +16,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('can create an ERC20 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -68,7 +68,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -137,7 +137,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -196,7 +196,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc20.spec.ts
@@ -16,6 +16,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('can create an ERC20 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -23,7 +24,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver, localNodes }) => {
         const symbol = 'TST';
@@ -68,6 +68,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -76,7 +77,6 @@ describe('Ledger Hardware', function (this: Suite) {
 
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,
@@ -137,6 +137,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -144,7 +145,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,
@@ -196,6 +196,7 @@ describe('Ledger Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -203,7 +204,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
@@ -17,7 +17,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('deploys an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -57,7 +57,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('mints an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -120,7 +120,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('approves an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -181,7 +181,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('sets approval for all an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
@@ -17,6 +17,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('deploys an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -24,7 +25,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver, localNodes }) => {
         (await localNodes?.[0]?.setAccountBalance(
@@ -57,6 +57,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('mints an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -64,7 +65,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc721,
@@ -120,6 +120,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('approves an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -127,7 +128,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc721,
@@ -181,6 +181,7 @@ describe('Ledger Hardware', function (this: Suite) {
   it('sets approval for all an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -188,7 +189,6 @@ describe('Ledger Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc721,

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-personal-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-personal-sign.spec.ts
@@ -10,7 +10,7 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
   it('personal sign', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-personal-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-personal-sign.spec.ts
@@ -10,6 +10,7 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
   it('personal sign', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -17,7 +18,6 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithoutBalanceValidation(driver);

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-sign.spec.ts
@@ -10,7 +10,7 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
   it('sign typed v4', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-sign.spec.ts
@@ -10,6 +10,7 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
   it('sign typed v4', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withLedgerAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -17,7 +18,6 @@ describe('Ledger Hardware Signatures', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithoutBalanceValidation(driver);

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
@@ -16,7 +16,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('can create an ERC20 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -68,7 +68,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -137,7 +137,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -196,7 +196,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
@@ -16,6 +16,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('can create an ERC20 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -23,7 +24,6 @@ describe('Trezor Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver, localNodes }) => {
         const symbol = 'TST';
@@ -68,6 +68,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -76,7 +77,6 @@ describe('Trezor Hardware', function (this: Suite) {
 
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,
@@ -137,6 +137,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -144,7 +145,6 @@ describe('Trezor Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,
@@ -196,6 +196,7 @@ describe('Trezor Hardware', function (this: Suite) {
     const erc20 = SMART_CONTRACTS.HST;
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -203,7 +204,6 @@ describe('Trezor Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: erc20,

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-erc721.spec.ts
@@ -19,7 +19,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('deploys an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -61,7 +61,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('mints an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -117,7 +117,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('approves an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -180,7 +180,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('sets approval for all an ERC-721 token', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-erc721.spec.ts
@@ -19,6 +19,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('deploys an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -27,7 +28,6 @@ describe('Trezor Hardware', function (this: Suite) {
           .build(),
         title: this.test?.fullTitle(),
         smartContract,
-        dapp: true,
       },
       async ({ driver, localNodes }) => {
         await localNodes?.[0]?.setAccountBalance(
@@ -61,6 +61,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('mints an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -69,7 +70,6 @@ describe('Trezor Hardware', function (this: Suite) {
           .build(),
         title: this.test?.fullTitle(),
         smartContract,
-        dapp: true,
       },
       async ({ driver, localNodes, contractRegistry }: TestSuiteArguments) => {
         await localNodes?.[0]?.setAccountBalance(
@@ -117,6 +117,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('approves an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -124,7 +125,6 @@ describe('Trezor Hardware', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
         smartContract: [
           {
             name: smartContract,
@@ -180,6 +180,7 @@ describe('Trezor Hardware', function (this: Suite) {
   it('sets approval for all an ERC-721 token', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -188,7 +189,6 @@ describe('Trezor Hardware', function (this: Suite) {
           .build(),
         title: this.test?.fullTitle(),
         smartContract,
-        dapp: true,
       },
       async ({ driver, localNodes, contractRegistry }: TestSuiteArguments) => {
         await localNodes?.[0]?.setAccountBalance(

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-sign.spec.ts
@@ -10,7 +10,7 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
   it('personal sign', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -35,7 +35,7 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
   it('sign typed v4', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-sign.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-sign.spec.ts
@@ -10,6 +10,7 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
   it('personal sign', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -17,7 +18,6 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithoutBalanceValidation(driver);
@@ -35,6 +35,7 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
   it('sign typed v4', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTrezorAccount()
           .withPermissionControllerConnectedToTestDapp({
@@ -42,7 +43,6 @@ describe('Trezor Hardware Signatures', function (this: Suite) {
           })
           .build(),
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithoutBalanceValidation(driver);

--- a/test/e2e/tests/metrics/app-opened.spec.ts
+++ b/test/e2e/tests/metrics/app-opened.spec.ts
@@ -74,7 +74,7 @@ describe('App Opened metric', function () {
   it('should send AppOpened metric when dapp opens MetaMask', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/metrics/app-opened.spec.ts
+++ b/test/e2e/tests/metrics/app-opened.spec.ts
@@ -74,7 +74,7 @@ describe('App Opened metric', function () {
   it('should send AppOpened metric when dapp opens MetaMask', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/metrics/dapp-viewed.spec.ts
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.ts
@@ -82,7 +82,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'invalid-metrics-id',
@@ -114,7 +114,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId, // 1% sample rate for dapp viewed event
@@ -153,7 +153,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -195,7 +195,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -240,7 +240,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -282,7 +282,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,

--- a/test/e2e/tests/metrics/dapp-viewed.spec.ts
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.ts
@@ -82,7 +82,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'invalid-metrics-id',
@@ -114,7 +114,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId, // 1% sample rate for dapp viewed event
@@ -153,7 +153,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -195,7 +195,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -240,7 +240,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,
@@ -282,7 +282,7 @@ describe('Dapp viewed Event', function () {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: validFakeMetricsId,

--- a/test/e2e/tests/metrics/marketing-cookieid.spec.ts
+++ b/test/e2e/tests/metrics/marketing-cookieid.spec.ts
@@ -45,8 +45,10 @@ describe('Marketing cookieId', function (this: Suite) {
   it('should be send to segment when preferences are enabled', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -90,8 +92,10 @@ describe('Marketing cookieId', function (this: Suite) {
   it('should not be send to segment when dataCollectionForMarketing is never toggled on', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,
@@ -135,8 +139,10 @@ describe('Marketing cookieId', function (this: Suite) {
   it('should not be send to segment when participateInMetaMetrics is never toggled on ', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        },
         fixtures: new FixtureBuilder().withMetaMetricsController().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockSegment,
@@ -173,8 +179,10 @@ describe('Marketing cookieId', function (this: Suite) {
   it('should updates marketingCampaignCookieId to null when dataCollectionForMarketing is toggled off ', async function () {
     await withFixtures(
       {
-        dapp: true,
-        dappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+        },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/tests/metrics/marketing-cookieid.spec.ts
+++ b/test/e2e/tests/metrics/marketing-cookieid.spec.ts
@@ -47,7 +47,7 @@ describe('Marketing cookieId', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
@@ -94,7 +94,7 @@ describe('Marketing cookieId', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
@@ -141,7 +141,7 @@ describe('Marketing cookieId', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder().withMetaMetricsController().build(),
         title: this.test?.fullTitle(),
@@ -181,7 +181,7 @@ describe('Marketing cookieId', function (this: Suite) {
       {
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({

--- a/test/e2e/tests/metrics/marketing-cookieid.spec.ts
+++ b/test/e2e/tests/metrics/marketing-cookieid.spec.ts
@@ -46,8 +46,7 @@ describe('Marketing cookieId', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
-          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
@@ -93,8 +92,7 @@ describe('Marketing cookieId', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
-          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
@@ -140,8 +138,7 @@ describe('Marketing cookieId', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
-          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder().withMetaMetricsController().build(),
         title: this.test?.fullTitle(),
@@ -180,8 +177,7 @@ describe('Marketing cookieId', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: {
-          defaultTestDapp: 1,
-          customDappPaths: ['../tests/metrics/marketing-cookieid-mock-page'],
+          customDappPaths: ['./tests/metrics/marketing-cookieid-mock-page'],
         },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({

--- a/test/e2e/tests/metrics/permissions-approved.spec.ts
+++ b/test/e2e/tests/metrics/permissions-approved.spec.ts
@@ -47,7 +47,7 @@ describe('Permissions Approved Event', function (this: Suite) {
   it('Successfully tracked when connecting to dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'fake-metrics-fd20',

--- a/test/e2e/tests/metrics/permissions-approved.spec.ts
+++ b/test/e2e/tests/metrics/permissions-approved.spec.ts
@@ -47,7 +47,7 @@ describe('Permissions Approved Event', function (this: Suite) {
   it('Successfully tracked when connecting to dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: 'fake-metrics-fd20',

--- a/test/e2e/tests/metrics/signature-approved.spec.ts
+++ b/test/e2e/tests/metrics/signature-approved.spec.ts
@@ -71,7 +71,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData_v4', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -130,7 +130,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData_v3', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -183,7 +183,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -236,7 +236,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for personalSign', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/metrics/signature-approved.spec.ts
+++ b/test/e2e/tests/metrics/signature-approved.spec.ts
@@ -71,7 +71,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData_v4', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -130,7 +130,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData_v3', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -183,7 +183,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
@@ -236,7 +236,7 @@ describe('Signature Approved Event', function () {
   it('Successfully tracked for personalSign', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -29,8 +29,7 @@ export async function withMultichainAccountsDesignEnabled(
     testSpecificMock,
     accountType = AccountType.MultiSRP,
     state = 2,
-    dapp,
-    dappPaths,
+    dappOptions,
   }: {
     title?: string;
     testSpecificMock?: (
@@ -38,8 +37,7 @@ export async function withMultichainAccountsDesignEnabled(
     ) => Promise<MockedEndpoint | MockedEndpoint[]>;
     accountType?: AccountType;
     state?: number;
-    dapp?: boolean;
-    dappPaths?: string[];
+    dappOptions?: { defaultTestDapp?: number; customDappPaths?: string[] };
   },
   test: (driver: Driver) => Promise<void>,
 ) {
@@ -65,8 +63,7 @@ export async function withMultichainAccountsDesignEnabled(
       testSpecificMock,
       title,
       forceBip44Version: state === 2 ? 2 : 0,
-      dapp,
-      dappPaths,
+      dappOptions,
     },
     async ({ driver }: { driver: Driver; mockServer: Mockttp }) => {
       // State 2 uses unified account group balance (fiat) and may not equal '25 ETH'.

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -37,7 +37,7 @@ export async function withMultichainAccountsDesignEnabled(
     ) => Promise<MockedEndpoint | MockedEndpoint[]>;
     accountType?: AccountType;
     state?: number;
-    dappOptions?: { defaultTestDapp?: number; customDappPaths?: string[] };
+    dappOptions?: { numberOfTestDapps?: number; customDappPaths?: string[] };
   },
   test: (driver: Driver) => Promise<void>,
 ) {

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -4,6 +4,7 @@ import { Driver } from '../../webdriver/driver';
 import { mockSnapSimpleKeyringAndSite } from '../account/snap-keyring-site-mocks';
 import { installSnapSimpleKeyring } from '../../page-objects/flows/snap-simple-keyring.flow';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
+import { DAPP_PATH } from '../../constants';
 import { WINDOW_TITLES } from '../../helpers';
 import { AccountType, withMultichainAccountsDesignEnabled } from './common';
 
@@ -70,7 +71,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         accountType: AccountType.SSK,
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         testSpecificMock: async (mockServer) => {
           return mockSnapSimpleKeyringAndSite(mockServer);

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -70,7 +70,6 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         title: this.test?.fullTitle(),
         accountType: AccountType.SSK,
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         testSpecificMock: async (mockServer) => {

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -68,8 +68,10 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
       {
         title: this.test?.fullTitle(),
         accountType: AccountType.SSK,
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         testSpecificMock: async (mockServer) => {
           return mockSnapSimpleKeyringAndSite(mockServer);
         },

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
@@ -4,6 +4,7 @@ import { Driver } from '../../webdriver/driver';
 import { mockSnapSimpleKeyringAndSite } from '../account/snap-keyring-site-mocks';
 import { installSnapSimpleKeyring } from '../../page-objects/flows/snap-simple-keyring.flow';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
+import { DAPP_PATH } from '../../constants';
 import { WINDOW_TITLES } from '../../helpers';
 import { AccountType, withMultichainAccountsDesignEnabled } from './common';
 
@@ -37,7 +38,7 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
         accountType: AccountType.SSK,
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['snap-simple-keyring-site'],
+          customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         testSpecificMock: async (mockServer) => {
           return mockSnapSimpleKeyringAndSite(mockServer);

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
@@ -37,7 +37,6 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
         title: this.test?.fullTitle(),
         accountType: AccountType.SSK,
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
         testSpecificMock: async (mockServer) => {

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-page.spec.ts
@@ -35,8 +35,10 @@ describe('Multichain Accounts - Multichain accounts list page', function (this: 
       {
         title: this.test?.fullTitle(),
         accountType: AccountType.SSK,
-        dapp: true,
-        dappPaths: ['snap-simple-keyring-site'],
+        dappOptions: {
+          defaultTestDapp: 1,
+          customDappPaths: ['snap-simple-keyring-site'],
+        },
         testSpecificMock: async (mockServer) => {
           return mockSnapSimpleKeyringAndSite(mockServer);
         },

--- a/test/e2e/tests/multichain/aggregated-balances.spec.ts
+++ b/test/e2e/tests/multichain/aggregated-balances.spec.ts
@@ -25,7 +25,7 @@ describe('Multichain Aggregated Balances', function (this: Suite) {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({

--- a/test/e2e/tests/multichain/aggregated-balances.spec.ts
+++ b/test/e2e/tests/multichain/aggregated-balances.spec.ts
@@ -25,7 +25,7 @@ describe('Multichain Aggregated Balances', function (this: Suite) {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({

--- a/test/e2e/tests/multichain/all-permissions-page.spec.ts
+++ b/test/e2e/tests/multichain/all-permissions-page.spec.ts
@@ -13,7 +13,7 @@ describe('Permissions Page', function () {
   it('should show connected site permissions when a single dapp is connected', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },
@@ -44,7 +44,7 @@ describe('Permissions Page', function () {
   it('should show all permissions listed when experimental settings toggle is off', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/multichain/all-permissions-page.spec.ts
+++ b/test/e2e/tests/multichain/all-permissions-page.spec.ts
@@ -13,7 +13,7 @@ describe('Permissions Page', function () {
   it('should show connected site permissions when a single dapp is connected', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },
@@ -44,7 +44,7 @@ describe('Permissions Page', function () {
   it('should show all permissions listed when experimental settings toggle is off', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/multichain/permission-page.spec.ts
+++ b/test/e2e/tests/multichain/permission-page.spec.ts
@@ -11,7 +11,7 @@ describe('Permissions Page', function () {
   it('should redirect users to connections page when users click on connected permission', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -35,7 +35,7 @@ describe('Permissions Page', function () {
   it('should navigate to home route when Gator Permissions Revocation feature is disabled', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/multichain/permission-page.spec.ts
+++ b/test/e2e/tests/multichain/permission-page.spec.ts
@@ -11,7 +11,7 @@ describe('Permissions Page', function () {
   it('should redirect users to connections page when users click on connected permission', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -35,7 +35,7 @@ describe('Permissions Page', function () {
   it('should navigate to home route when Gator Permissions Revocation feature is disabled', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/network/add-custom-rpc.spec.ts
+++ b/test/e2e/tests/network/add-custom-rpc.spec.ts
@@ -13,7 +13,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it('should show warning when adding chainId 0x1(ethereum) and be followed by an wrong chainId error', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -78,7 +78,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it("don't add bad rpc custom network", async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: true })
@@ -157,7 +157,7 @@ describe('Add Custom RPC', function (this: Suite) {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -198,7 +198,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it("don't add unreachable custom network", async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/network/add-custom-rpc.spec.ts
+++ b/test/e2e/tests/network/add-custom-rpc.spec.ts
@@ -13,7 +13,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it('should show warning when adding chainId 0x1(ethereum) and be followed by an wrong chainId error', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -78,7 +78,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it("don't add bad rpc custom network", async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: true })
@@ -157,7 +157,7 @@ describe('Add Custom RPC', function (this: Suite) {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -198,7 +198,7 @@ describe('Add Custom RPC', function (this: Suite) {
   it("don't add unreachable custom network", async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/network/deprecated-networks.spec.ts
+++ b/test/e2e/tests/network/deprecated-networks.spec.ts
@@ -14,7 +14,7 @@ describe('Deprecated networks', function (this: Suite) {
   it('User should not find goerli network when clicking on the network selector', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },
@@ -80,7 +80,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -150,7 +150,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -215,7 +215,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })

--- a/test/e2e/tests/network/deprecated-networks.spec.ts
+++ b/test/e2e/tests/network/deprecated-networks.spec.ts
@@ -14,7 +14,7 @@ describe('Deprecated networks', function (this: Suite) {
   it('User should not find goerli network when clicking on the network selector', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },
@@ -80,7 +80,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -150,7 +150,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })
@@ -215,7 +215,7 @@ describe('Deprecated networks', function (this: Suite) {
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({ useSafeChainsListValidation: false })

--- a/test/e2e/tests/network/network-connection.spec.ts
+++ b/test/e2e/tests/network/network-connection.spec.ts
@@ -62,7 +62,7 @@ networkConfigs.forEach((config) => {
     it(`should connect dapp to ${config.name} and verify ${config.tokenSymbol} network and tokens`, async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: config
             .fixtureMethod(new FixtureBuilder())
             .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/network/network-connection.spec.ts
+++ b/test/e2e/tests/network/network-connection.spec.ts
@@ -62,7 +62,7 @@ networkConfigs.forEach((config) => {
     it(`should connect dapp to ${config.name} and verify ${config.tokenSymbol} network and tokens`, async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: config
             .fixtureMethod(new FixtureBuilder())
             .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/network/network-manager.spec.ts
+++ b/test/e2e/tests/network/network-manager.spec.ts
@@ -152,7 +152,7 @@ describe('Network Manager', function (this: Suite) {
   it('should preserve existing enabled networks when adding a network via dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withEnabledNetworks({
@@ -237,7 +237,7 @@ describe('Network Manager', function (this: Suite) {
   it('should deselect all networks when adding a custom network via dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withEnabledNetworks({

--- a/test/e2e/tests/network/network-manager.spec.ts
+++ b/test/e2e/tests/network/network-manager.spec.ts
@@ -152,7 +152,7 @@ describe('Network Manager', function (this: Suite) {
   it('should preserve existing enabled networks when adding a network via dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withEnabledNetworks({
@@ -237,7 +237,7 @@ describe('Network Manager', function (this: Suite) {
   it('should deselect all networks when adding a custom network via dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withEnabledNetworks({

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -15,7 +15,7 @@ describe('Remove Network:', function (this: Suite) {
   it('should remove the chainId from existing permissions when a network configuration is removed entirely', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains([
             '0x539',
@@ -91,7 +91,7 @@ describe('Remove Network:', function (this: Suite) {
   it('should not remove the chainId from existing permissions when a network client is removed but other network clients still exist for the chainId', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains([
             '0x539',

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -15,7 +15,7 @@ describe('Remove Network:', function (this: Suite) {
   it('should remove the chainId from existing permissions when a network configuration is removed entirely', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains([
             '0x539',
@@ -91,7 +91,7 @@ describe('Remove Network:', function (this: Suite) {
   it('should not remove the chainId from existing permissions when a network client is removed but other network clients still exist for the chainId', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDappWithChains([
             '0x539',

--- a/test/e2e/tests/network/switch-custom-network.spec.ts
+++ b/test/e2e/tests/network/switch-custom-network.spec.ts
@@ -12,7 +12,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should successfully change the network in response to wallet_switchEthereumChain', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -54,7 +54,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should only show additional network requested when multiple network permissions already exist', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPopularNetworks()
           .withPermissionControllerConnectedToTestDappWithChains([
@@ -103,7 +103,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should incrementally add new requested network to existing permissions without overriding them', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp() // Connected to Localhost
           .build(),

--- a/test/e2e/tests/network/switch-custom-network.spec.ts
+++ b/test/e2e/tests/network/switch-custom-network.spec.ts
@@ -12,7 +12,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should successfully change the network in response to wallet_switchEthereumChain', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -54,7 +54,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should only show additional network requested when multiple network permissions already exist', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPopularNetworks()
           .withPermissionControllerConnectedToTestDappWithChains([
@@ -103,7 +103,7 @@ describe('Switch ethereum chain', function (this: Suite) {
   it('should incrementally add new requested network to existing permissions without overriding them', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp() // Connected to Localhost
           .build(),

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -90,7 +90,7 @@ describe('Petnames - Signatures', function (this: Suite) {
   it('can propose names using installed snaps', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withNoNames()

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -90,7 +90,7 @@ describe('Petnames - Signatures', function (this: Suite) {
   it('can propose names using installed snaps', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withNoNames()

--- a/test/e2e/tests/petnames/petnames-transactions.spec.ts
+++ b/test/e2e/tests/petnames/petnames-transactions.spec.ts
@@ -16,7 +16,7 @@ describe('Petnames - Transactions', function () {
   it('can save petnames for addresses in dapp send transactions', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withNoNames()

--- a/test/e2e/tests/petnames/petnames-transactions.spec.ts
+++ b/test/e2e/tests/petnames/petnames-transactions.spec.ts
@@ -16,7 +16,7 @@ describe('Petnames - Transactions', function () {
   it('can save petnames for addresses in dapp send transactions', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withNoNames()

--- a/test/e2e/tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection/index.html
+++ b/test/e2e/tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection/index.html
@@ -10,7 +10,7 @@
  `IN_TEST_BYPASS_EARLY_PHISHING_DETECTION` disables early protection when
  `process.env.IN_TEST` is `"true"`.
  -->
-<iframe src="http://127.0.0.1:8081/?IN_TEST_BYPASS_EARLY_PHISHING_DETECTION" width=900 height=900>
+<iframe src="http://127.0.0.1:8080/?IN_TEST_BYPASS_EARLY_PHISHING_DETECTION" width=900 height=900>
 </body>
 
 </html>

--- a/test/e2e/tests/phishing-controller/mock-page-with-iframe/index.html
+++ b/test/e2e/tests/phishing-controller/mock-page-with-iframe/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 	<div>Hello</div>
-<iframe src="http://127.0.0.1:8081" width=900 height=900 allow-popups sandbox>
+<iframe src="http://127.0.0.1:8080" width=900 height=900 allow-popups sandbox>
 </body>
 
 </html>

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -64,7 +64,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -101,10 +101,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
-        dappOptions: {
-          numberOfDapps: 2,
-        },
+        dappOptions: { defaultTestDapp: 2 },
         ...overrides,
       };
     };
@@ -116,7 +113,7 @@ describe('Phishing Detection', function (this: Suite) {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),
-          dappPaths: ['./tests/phishing-controller/mock-page-with-iframe'],
+          dappOptions: { customDappPaths: ['./tests/phishing-controller/mock-page-with-iframe'] },
         }),
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);
@@ -140,9 +137,7 @@ describe('Phishing Detection', function (this: Suite) {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),
-          dappPaths: [
-            './tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection',
-          ],
+          dappOptions: { customDappPaths: ['./tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection'] },
         }),
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);
@@ -173,12 +168,9 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
-        dappPaths: [
-          './tests/phishing-controller/mock-page-with-disallowed-iframe',
-        ],
         dappOptions: {
-          numberOfDapps: 2,
+          defaultTestDapp: 1,
+          customDappPaths: ['./tests/phishing-controller/mock-page-with-disallowed-iframe'],
         },
       },
       async ({ driver }) => {
@@ -217,7 +209,7 @@ describe('Phishing Detection', function (this: Suite) {
           });
           mockConfigLookupOnWarningPage(mockServer, { statusCode: 500 });
         },
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -257,7 +249,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -555,8 +547,7 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dapp: true,
-            dappPaths: ['./tests/phishing-controller/mock-page-with-paths'],
+            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);
@@ -583,8 +574,7 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dapp: true,
-            dappPaths: ['./tests/phishing-controller/mock-page-with-paths'],
+            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);
@@ -617,8 +607,7 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dapp: true,
-            dappPaths: ['./tests/phishing-controller/mock-page-with-paths'],
+            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -177,7 +177,6 @@ describe('Phishing Detection', function (this: Suite) {
           });
         },
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [
             './tests/phishing-controller/mock-page-with-disallowed-iframe',
           ],
@@ -298,7 +297,6 @@ describe('Phishing Detection', function (this: Suite) {
           });
         },
         dappOptions: {
-          defaultTestDapp: 1,
           customDappPaths: [
             './tests/phishing-controller/mock-page-with-disallowed-iframe',
           ],
@@ -557,7 +555,6 @@ describe('Phishing Detection', function (this: Suite) {
               });
             },
             dappOptions: {
-              defaultTestDapp: 1,
               customDappPaths: [
                 './tests/phishing-controller/mock-page-with-paths',
               ],
@@ -589,7 +586,6 @@ describe('Phishing Detection', function (this: Suite) {
               });
             },
             dappOptions: {
-              defaultTestDapp: 1,
               customDappPaths: [
                 './tests/phishing-controller/mock-page-with-paths',
               ],
@@ -627,7 +623,6 @@ describe('Phishing Detection', function (this: Suite) {
               });
             },
             dappOptions: {
-              defaultTestDapp: 1,
               customDappPaths: [
                 './tests/phishing-controller/mock-page-with-paths',
               ],
@@ -672,7 +667,6 @@ describe('Phishing Detection', function (this: Suite) {
               });
             },
             dappOptions: {
-              defaultTestDapp: 1,
               customDappPaths: [
                 './tests/phishing-controller/mock-page-with-paths',
               ],

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -64,7 +64,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -101,7 +101,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         ...overrides,
       };
     };
@@ -114,7 +114,7 @@ describe('Phishing Detection', function (this: Suite) {
         getFixtureOptions({
           title: this.test?.fullTitle(),
           dappOptions: {
-            defaultTestDapp: 1,
+            numberOfTestDapps: 1,
             customDappPaths: [
               './tests/phishing-controller/mock-page-with-iframe',
             ],
@@ -143,7 +143,7 @@ describe('Phishing Detection', function (this: Suite) {
         getFixtureOptions({
           title: this.test?.fullTitle(),
           dappOptions: {
-            defaultTestDapp: 1,
+            numberOfTestDapps: 1,
             customDappPaths: [
               './tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection',
             ],
@@ -220,7 +220,7 @@ describe('Phishing Detection', function (this: Suite) {
           });
           mockConfigLookupOnWarningPage(mockServer, { statusCode: 500 });
         },
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -260,7 +260,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -339,7 +339,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -364,7 +364,7 @@ describe('Phishing Detection', function (this: Suite) {
     const testPageURL = 'http://localhost:8080/';
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: async (mockServer: Mockttp) => {

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -113,7 +113,11 @@ describe('Phishing Detection', function (this: Suite) {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),
-          dappOptions: { customDappPaths: ['./tests/phishing-controller/mock-page-with-iframe'] },
+          dappOptions: {
+            customDappPaths: [
+              './tests/phishing-controller/mock-page-with-iframe',
+            ],
+          },
         }),
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);
@@ -137,7 +141,11 @@ describe('Phishing Detection', function (this: Suite) {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),
-          dappOptions: { customDappPaths: ['./tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection'] },
+          dappOptions: {
+            customDappPaths: [
+              './tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection',
+            ],
+          },
         }),
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);
@@ -170,7 +178,9 @@ describe('Phishing Detection', function (this: Suite) {
         },
         dappOptions: {
           defaultTestDapp: 1,
-          customDappPaths: ['./tests/phishing-controller/mock-page-with-disallowed-iframe'],
+          customDappPaths: [
+            './tests/phishing-controller/mock-page-with-disallowed-iframe',
+          ],
         },
       },
       async ({ driver }) => {
@@ -287,12 +297,11 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
-        dappPaths: [
-          './tests/phishing-controller/mock-page-with-disallowed-iframe',
-        ],
         dappOptions: {
-          numberOfDapps: 2,
+          defaultTestDapp: 1,
+          customDappPaths: [
+            './tests/phishing-controller/mock-page-with-disallowed-iframe',
+          ],
         },
       },
       async ({ driver }) => {
@@ -330,7 +339,7 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -355,6 +364,7 @@ describe('Phishing Detection', function (this: Suite) {
     const testPageURL = 'http://localhost:8080/';
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: async (mockServer: Mockttp) => {
@@ -367,7 +377,6 @@ describe('Phishing Detection', function (this: Suite) {
             blocklistPaths: [],
           });
         },
-        dapp: true,
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -547,7 +556,12 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
+            dappOptions: {
+              defaultTestDapp: 1,
+              customDappPaths: [
+                './tests/phishing-controller/mock-page-with-paths',
+              ],
+            },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);
@@ -574,7 +588,12 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
+            dappOptions: {
+              defaultTestDapp: 1,
+              customDappPaths: [
+                './tests/phishing-controller/mock-page-with-paths',
+              ],
+            },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);
@@ -607,7 +626,12 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dappOptions: { defaultTestDapp: 1, customDappPaths: ['./tests/phishing-controller/mock-page-with-paths'] },
+            dappOptions: {
+              defaultTestDapp: 1,
+              customDappPaths: [
+                './tests/phishing-controller/mock-page-with-paths',
+              ],
+            },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);
@@ -647,8 +671,12 @@ describe('Phishing Detection', function (this: Suite) {
                 blocklistPaths: ['127.0.0.1/path1'],
               });
             },
-            dapp: true,
-            dappPaths: ['./tests/phishing-controller/mock-page-with-paths'],
+            dappOptions: {
+              defaultTestDapp: 1,
+              customDappPaths: [
+                './tests/phishing-controller/mock-page-with-paths',
+              ],
+            },
           },
           async ({ driver }) => {
             await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -86,7 +86,7 @@ describe('Phishing Detection', function (this: Suite) {
   });
 
   describe('Via Iframe', function () {
-    const DAPP_WITH_IFRAMED_PAGE_ON_BLOCKLIST = 'http://localhost:8080/';
+    const DAPP_WITH_IFRAMED_PAGE_ON_BLOCKLIST = 'http://localhost:8081/';
     const IFRAMED_HOSTNAME = '127.0.0.1';
 
     const getFixtureOptions = (overrides: Record<string, unknown>) => {
@@ -114,6 +114,7 @@ describe('Phishing Detection', function (this: Suite) {
         getFixtureOptions({
           title: this.test?.fullTitle(),
           dappOptions: {
+            defaultTestDapp: 1,
             customDappPaths: [
               './tests/phishing-controller/mock-page-with-iframe',
             ],
@@ -142,6 +143,7 @@ describe('Phishing Detection', function (this: Suite) {
         getFixtureOptions({
           title: this.test?.fullTitle(),
           dappOptions: {
+            defaultTestDapp: 1,
             customDappPaths: [
               './tests/phishing-controller/mock-page-with-iframe-but-disable-early-detection',
             ],

--- a/test/e2e/tests/portfolio/portfolio-site.spec.ts
+++ b/test/e2e/tests/portfolio/portfolio-site.spec.ts
@@ -28,7 +28,7 @@ describe('Portfolio site', function () {
   it('should link to the portfolio site', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/tests/portfolio/portfolio-site.spec.ts
+++ b/test/e2e/tests/portfolio/portfolio-site.spec.ts
@@ -28,7 +28,7 @@ describe('Portfolio site', function () {
   it('should link to the portfolio site', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
             metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-contract-interaction.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-contract-interaction.spec.ts
@@ -226,7 +226,7 @@ describe('PPOM Blockaid Alert - Malicious Contract interaction', function (this:
   it('should show banner alert', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             selectedNetworkClientId: 'networkConfigurationId',

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-contract-interaction.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-contract-interaction.spec.ts
@@ -226,7 +226,7 @@ describe('PPOM Blockaid Alert - Malicious Contract interaction', function (this:
   it('should show banner alert', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             selectedNetworkClientId: 'networkConfigurationId',

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-approval.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-approval.spec.js
@@ -209,7 +209,7 @@ describe('PPOM Blockaid Alert - Malicious ERC20 Approval', function () {
   it.skip('should show banner alert', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-approval.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-approval.spec.js
@@ -209,7 +209,7 @@ describe('PPOM Blockaid Alert - Malicious ERC20 Approval', function () {
   it.skip('should show banner alert', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-transfer.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-transfer.spec.ts
@@ -81,7 +81,7 @@ describe('PPOM Blockaid Alert - Malicious ERC20 Transfer', function (this: Suite
     // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             selectedNetworkClientId: 'networkConfigurationId',

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-transfer.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-erc20-transfer.spec.ts
@@ -81,7 +81,7 @@ describe('PPOM Blockaid Alert - Malicious ERC20 Transfer', function (this: Suite
     // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkController({
             selectedNetworkClientId: 'networkConfigurationId',

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
@@ -255,7 +255,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should capture metrics when security alerts is shown', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
@@ -255,7 +255,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should capture metrics when security alerts is shown', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-networks-support.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-networks-support.spec.js
@@ -46,7 +46,7 @@ describe('PPOM Blockaid Alert - Multiple Networks Support', function () {
   it.skip('should show banner alert after switchinig to another supported network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-networks-support.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-networks-support.spec.js
@@ -46,7 +46,7 @@ describe('PPOM Blockaid Alert - Multiple Networks Support', function () {
   it.skip('should show banner alert after switchinig to another supported network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-simple-send.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-simple-send.spec.ts
@@ -142,7 +142,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
   it('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPreferencesController({
@@ -189,7 +189,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
       // we need to use localhost instead of the ip
       // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp({
@@ -234,7 +234,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
   it('should show "Be careful" if the PPOM request fails to check transaction', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPreferencesController({

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-simple-send.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-simple-send.spec.ts
@@ -142,7 +142,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
   it('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPreferencesController({
@@ -189,7 +189,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
       // we need to use localhost instead of the ip
       // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp({
@@ -234,7 +234,7 @@ describe('Simple Send Security Alert - Blockaid', function (this: Suite) {
   it('should show "Be careful" if the PPOM request fails to check transaction', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPreferencesController({

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-trade-order-farming.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-trade-order-farming.spec.ts
@@ -117,7 +117,7 @@ describe('PPOM Blockaid Alert - Set Trade farming order', function (this: Suite)
     // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp({
             useLocalhostHostname: true,

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-trade-order-farming.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-trade-order-farming.spec.ts
@@ -117,7 +117,7 @@ describe('PPOM Blockaid Alert - Set Trade farming order', function (this: Suite)
     // see issue: https://github.com/MetaMask/MetaMask-planning/issues/3560
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp({
             useLocalhostHostname: true,

--- a/test/e2e/tests/ppom/ppom-blockaid-alert.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert.spec.js
@@ -165,7 +165,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -227,7 +227,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should show security alerts for malicious requests', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -285,7 +285,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should show "Request may not be safe" if the PPOM request fails to check transaction', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-alert.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert.spec.js
@@ -165,7 +165,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -227,7 +227,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should show security alerts for malicious requests', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -285,7 +285,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
   it.skip('should show "Request may not be safe" if the PPOM request fails to check transaction', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-setApprovalForAll-farming.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-setApprovalForAll-farming.spec.js
@@ -246,7 +246,7 @@ describe('PPOM Blockaid Alert - Set Approval to All', function () {
   it.skip('should show banner alert', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-setApprovalForAll-farming.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-setApprovalForAll-farming.spec.js
@@ -246,7 +246,7 @@ describe('PPOM Blockaid Alert - Set Approval to All', function () {
   it.skip('should show banner alert', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.js
@@ -56,7 +56,7 @@ describe('PPOM Blockaid Alert - Metrics', function () {
   it.skip('Successfully track button toggle on/off', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.js
@@ -56,7 +56,7 @@ describe('PPOM Blockaid Alert - Metrics', function () {
   it.skip('Successfully track button toggle on/off', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
+++ b/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
@@ -8,7 +8,7 @@ describe('PPOM Settings', function () {
   it.skip('should not show the PPOM warning when toggle is off', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -45,7 +45,7 @@ describe('PPOM Settings', function () {
   it.skip('should show the PPOM warning when the toggle is on', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
+++ b/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
@@ -8,7 +8,7 @@ describe('PPOM Settings', function () {
   it.skip('should not show the PPOM warning when toggle is off', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()
@@ -45,7 +45,7 @@ describe('PPOM Settings', function () {
   it.skip('should show the PPOM warning when the toggle is on', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-diff-network.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-diff-network.spec.ts
@@ -17,7 +17,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-diff-network.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-diff-network.spec.ts
@@ -17,11 +17,10 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
@@ -19,7 +19,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-extra-tx.spec.ts
@@ -19,11 +19,10 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks', fun
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-same-network.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-same-network.spec.ts
@@ -16,7 +16,7 @@ describe('Request Queuing for Multiple Dapps and Txs on same networks', function
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 3 },
+        dappOptions: { numberOfTestDapps: 3 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/batch-txs-per-dapp-same-network.spec.ts
+++ b/test/e2e/tests/request-queuing/batch-txs-per-dapp-same-network.spec.ts
@@ -16,11 +16,10 @@ describe('Request Queuing for Multiple Dapps and Txs on same networks', function
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 3 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .build(),
-        dappOptions: { numberOfDapps: 3 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/chainid-check.spec.ts
+++ b/test/e2e/tests/request-queuing/chainid-check.spec.ts
@@ -20,7 +20,7 @@ describe('Request Queueing chainId proxy sync', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/request-queuing/chainid-check.spec.ts
+++ b/test/e2e/tests/request-queuing/chainid-check.spec.ts
@@ -20,7 +20,7 @@ describe('Request Queueing chainId proxy sync', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -17,7 +17,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -17,12 +17,11 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/dapp1-subscribe-network-switch.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-subscribe-network-switch.spec.ts
@@ -11,7 +11,7 @@ describe('Request Queueing', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/dapp1-subscribe-network-switch.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-subscribe-network-switch.spec.ts
@@ -11,7 +11,7 @@ describe('Request Queueing', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.ts
@@ -14,12 +14,11 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -100,12 +99,11 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTwoTestDapps()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-eth-request-accounts.spec.ts
@@ -14,7 +14,7 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()
@@ -99,7 +99,7 @@ describe('Request Queuing Dapp 1 Send Tx -> Dapp 2 Request Accounts Tx', functio
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTwoTestDapps()

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
@@ -21,7 +21,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()
@@ -152,7 +152,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withEnabledNetworks({

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
@@ -21,12 +21,11 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',
@@ -153,7 +152,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withEnabledNetworks({
@@ -163,7 +162,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
           })
           .withSelectedNetworkControllerPerDomain()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/multi-dapp-sendTx-revokePermission.spec.ts
+++ b/test/e2e/tests/request-queuing/multi-dapp-sendTx-revokePermission.spec.ts
@@ -15,7 +15,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks revok
 
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/multi-dapp-sendTx-revokePermission.spec.ts
+++ b/test/e2e/tests/request-queuing/multi-dapp-sendTx-revokePermission.spec.ts
@@ -15,11 +15,10 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks revok
 
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
+++ b/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
@@ -19,7 +19,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withEnabledNetworks({
             eip155: {
@@ -29,7 +29,6 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),
-        dappOptions: { numberOfDapps: 2 },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
+++ b/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
@@ -19,7 +19,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withEnabledNetworks({
             eip155: {

--- a/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
@@ -13,7 +13,7 @@ describe('Request Queuing', function () {
   it('should clear tx confirmation when revokePermission is called from origin dapp', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
@@ -13,7 +13,7 @@ describe('Request Queuing', function () {
   it('should clear tx confirmation when revokePermission is called from origin dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withSelectedNetworkControllerPerDomain()

--- a/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
@@ -16,7 +16,7 @@ describe('Request Queuing Send Tx -> SwitchChain -> SendTx', function (this: Sui
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
@@ -16,7 +16,7 @@ describe('Request Queuing Send Tx -> SwitchChain -> SendTx', function (this: Sui
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/switch-network.spec.ts
+++ b/test/e2e/tests/request-queuing/switch-network.spec.ts
@@ -12,7 +12,7 @@ describe('Request Queuing - Extension and Dapp on different networks.', function
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/switch-network.spec.ts
+++ b/test/e2e/tests/request-queuing/switch-network.spec.ts
@@ -12,7 +12,7 @@ describe('Request Queuing - Extension and Dapp on different networks.', function
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/switchChain-sendTx.spec.ts
+++ b/test/e2e/tests/request-queuing/switchChain-sendTx.spec.ts
@@ -10,7 +10,7 @@ describe('Request Queuing SwitchChain -> SendTx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/switchChain-sendTx.spec.ts
+++ b/test/e2e/tests/request-queuing/switchChain-sendTx.spec.ts
@@ -10,7 +10,7 @@ describe('Request Queuing SwitchChain -> SendTx', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/switchChain-watchAsset.spec.ts
@@ -15,7 +15,7 @@ describe('Request Queue SwitchChain -> WatchAsset', function (this: Suite) {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/switchChain-watchAsset.spec.ts
@@ -15,7 +15,7 @@ describe('Request Queue SwitchChain -> WatchAsset', function (this: Suite) {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),

--- a/test/e2e/tests/request-queuing/ui.spec.ts
+++ b/test/e2e/tests/request-queuing/ui.spec.ts
@@ -193,7 +193,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338; // 0x53a
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
@@ -209,7 +209,7 @@ describe('Request-queue UI changes', function () {
             },
           },
         ],
-        dappOptions: { numberOfDapps: 2 },
+
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {

--- a/test/e2e/tests/request-queuing/ui.spec.ts
+++ b/test/e2e/tests/request-queuing/ui.spec.ts
@@ -257,7 +257,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338; // 0x53a
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 3 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withPreferencesController({
@@ -289,7 +289,6 @@ describe('Request-queue UI changes', function () {
           },
         ],
 
-        dappOptions: { numberOfDapps: 3 },
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
@@ -401,7 +400,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPreferencesController({
@@ -421,7 +420,7 @@ describe('Request-queue UI changes', function () {
             },
           },
         ],
-        dappOptions: { numberOfDapps: 2 },
+
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
@@ -470,7 +469,7 @@ describe('Request-queue UI changes', function () {
   it('should signal from UI to dapp the network change', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         driverOptions: { constrainWindowSize: true },
@@ -509,7 +508,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withEnabledNetworks({
@@ -533,7 +532,7 @@ describe('Request-queue UI changes', function () {
         // This test intentionally quits the local node server while the extension is using it, causing
         // PollingBlockTracker errors and others. These are expected.
         ignoredConsoleErrors: ['ignore-all'],
-        dappOptions: { numberOfDapps: 2 },
+
         title: this.test?.fullTitle(),
       },
       async ({
@@ -588,7 +587,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 2 },
         // Presently confirmations take up to 10 seconds to display on a dead network
         driverOptions: { timeOut: 30000 },
         fixtures: new FixtureBuilder()
@@ -617,7 +616,7 @@ describe('Request-queue UI changes', function () {
         // This test intentionally quits the local node server while the extension is using it, causing
         // PollingBlockTracker errors and others. These are expected.
         ignoredConsoleErrors: ['ignore-all'],
-        dappOptions: { numberOfDapps: 2 },
+
         title: this.test?.fullTitle(),
       },
       async ({ driver, localNodes }) => {

--- a/test/e2e/tests/request-queuing/ui.spec.ts
+++ b/test/e2e/tests/request-queuing/ui.spec.ts
@@ -193,7 +193,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338; // 0x53a
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .build(),
@@ -257,7 +257,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338; // 0x53a
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 3 },
+        dappOptions: { numberOfTestDapps: 3 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerTripleNode()
           .withPreferencesController({
@@ -400,7 +400,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPreferencesController({
@@ -469,7 +469,7 @@ describe('Request-queue UI changes', function () {
   it('should signal from UI to dapp the network change', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         driverOptions: { constrainWindowSize: true },
@@ -508,7 +508,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withEnabledNetworks({
@@ -587,7 +587,7 @@ describe('Request-queue UI changes', function () {
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 2 },
+        dappOptions: { numberOfTestDapps: 2 },
         // Presently confirmations take up to 10 seconds to display on a dead network
         driverOptions: { timeOut: 30000 },
         fixtures: new FixtureBuilder()

--- a/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
@@ -18,7 +18,7 @@ describe('Request Queue WatchAsset -> SwitchChain -> WatchAsset', function (this
     const chainId = 1338;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
@@ -18,7 +18,7 @@ describe('Request Queue WatchAsset -> SwitchChain -> WatchAsset', function (this
     const chainId = 1338;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNetworkControllerDoubleNode()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/safe-window-close.spec.ts
+++ b/test/e2e/tests/safe-window-close.spec.ts
@@ -9,7 +9,7 @@ describe('Notification window closing', function () {
   it('closes the window when running in a popup', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.title,
       },

--- a/test/e2e/tests/safe-window-close.spec.ts
+++ b/test/e2e/tests/safe-window-close.spec.ts
@@ -9,7 +9,7 @@ describe('Notification window closing', function () {
   it('closes the window when running in a popup', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.title,
       },

--- a/test/e2e/tests/settings/ipfs-toggle.spec.ts
+++ b/test/e2e/tests/settings/ipfs-toggle.spec.ts
@@ -25,7 +25,7 @@ describe('Settings', function () {
   it('Shows nft default image when IPFS toggle is off and restore image once we toggle the ipfs modal', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/settings/ipfs-toggle.spec.ts
+++ b/test/e2e/tests/settings/ipfs-toggle.spec.ts
@@ -25,7 +25,7 @@ describe('Settings', function () {
   it('Shows nft default image when IPFS toggle is off and restore image once we toggle the ipfs modal', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -61,7 +61,7 @@ async function withFixturesForSimulationDetails(
         .build(),
       title,
       testSpecificMock: mockRequests,
-      dapp: true,
+      dappOptions: { defaultTestDapp: 1 },
       localNodeOptions: {
         hardfork: 'london',
         chainId: hexToNumber(inputChainId),

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -61,7 +61,7 @@ async function withFixturesForSimulationDetails(
         .build(),
       title,
       testSpecificMock: mockRequests,
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       localNodeOptions: {
         hardfork: 'london',
         chainId: hexToNumber(inputChainId),

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -28,7 +28,7 @@ async function withFixturesForSmartTransactions(
 ) {
   await withFixtures(
     {
-      dappOptions: { defaultTestDapp: 1 },
+      dappOptions: { numberOfTestDapps: 1 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()
         .withNetworkControllerOnMainnet()

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -28,6 +28,7 @@ async function withFixturesForSmartTransactions(
 ) {
   await withFixtures(
     {
+      dappOptions: { defaultTestDapp: 1 },
       fixtures: new FixtureBuilder()
         .withPermissionControllerConnectedToTestDapp()
         .withNetworkControllerOnMainnet()
@@ -43,7 +44,6 @@ async function withFixturesForSmartTransactions(
         chainId: '1',
       },
       testSpecificMock,
-      dapp: true,
     },
     async ({ driver }) => {
       await unlockWallet(driver);

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1580,7 +1580,7 @@ export async function withSolanaAccountSnap(
     mockSwapWithNoQuotes?: boolean;
     walletConnect?: boolean;
     dappOptions?: {
-      defaultTestDapp?: number;
+      numberOfTestDapps?: number;
       customDappPaths?: string[];
     };
     withProtocolSnap?: boolean;
@@ -1620,7 +1620,7 @@ export async function withSolanaAccountSnap(
       fixtures: fixtures.build(),
       title,
       forceBip44Version: state === 2 ? 2 : 0,
-      dappOptions: dappOptions ?? { defaultTestDapp: 1 },
+      dappOptions: dappOptions ?? { numberOfTestDapps: 1 },
       manifestFlags: {
         // This flag is used to enable/disable the remote mode for the carousel
         // component, which will impact to the slides count.

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1560,7 +1560,7 @@ export async function withSolanaAccountSnap(
     mockSwapSOLtoUSDC,
     mockSwapWithNoQuotes,
     walletConnect = false,
-    dappPaths,
+    dappOptions,
     withProtocolSnap,
     withCustomMocks,
     withFixtureBuilder,
@@ -1579,7 +1579,10 @@ export async function withSolanaAccountSnap(
     mockSwapSOLtoUSDC?: boolean;
     mockSwapWithNoQuotes?: boolean;
     walletConnect?: boolean;
-    dappPaths?: string[];
+    dappOptions?: {
+      defaultTestDapp?: boolean;
+      customDappPaths?: string[];
+    };
     withProtocolSnap?: boolean;
     withCustomMocks?: (
       mockServer: Mockttp,
@@ -1617,7 +1620,7 @@ export async function withSolanaAccountSnap(
       fixtures: fixtures.build(),
       title,
       forceBip44Version: state === 2 ? 2 : 0,
-      dapp: true,
+      dappOptions: dappOptions ?? { defaultTestDapp: true },
       manifestFlags: {
         // This flag is used to enable/disable the remote mode for the carousel
         // component, which will impact to the slides count.
@@ -1630,7 +1633,6 @@ export async function withSolanaAccountSnap(
             : featureFlags,
         },
       },
-      dappPaths,
       testSpecificMock: async (mockServer: Mockttp) => {
         const mockList: MockedEndpoint[] = [];
         mockList.push(await simulateSolanaTransaction(mockServer));

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1580,7 +1580,7 @@ export async function withSolanaAccountSnap(
     mockSwapWithNoQuotes?: boolean;
     walletConnect?: boolean;
     dappOptions?: {
-      defaultTestDapp?: boolean;
+      defaultTestDapp?: number;
       customDappPaths?: string[];
     };
     withProtocolSnap?: boolean;
@@ -1620,7 +1620,7 @@ export async function withSolanaAccountSnap(
       fixtures: fixtures.build(),
       title,
       forceBip44Version: state === 2 ? 2 : 0,
-      dappOptions: dappOptions ?? { defaultTestDapp: true },
+      dappOptions: dappOptions ?? { defaultTestDapp: 1 },
       manifestFlags: {
         // This flag is used to enable/disable the remote mode for the carousel
         // component, which will impact to the slides count.

--- a/test/e2e/tests/survey/survey.spec.ts
+++ b/test/e2e/tests/survey/survey.spec.ts
@@ -52,7 +52,7 @@ describe('Test Survey', function () {
   it('should show 2 surveys, and then none', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesController()
           .withMetaMetricsController({

--- a/test/e2e/tests/survey/survey.spec.ts
+++ b/test/e2e/tests/survey/survey.spec.ts
@@ -52,7 +52,7 @@ describe('Test Survey', function () {
   it('should show 2 surveys, and then none', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesController()
           .withMetaMetricsController({

--- a/test/e2e/tests/tokens/add-multiple-tokens.spec.ts
+++ b/test/e2e/tests/tokens/add-multiple-tokens.spec.ts
@@ -11,7 +11,7 @@ describe('Multiple ERC20 Watch Asset', function () {
     const tokenContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/add-multiple-tokens.spec.ts
+++ b/test/e2e/tests/tokens/add-multiple-tokens.spec.ts
@@ -11,7 +11,7 @@ describe('Multiple ERC20 Watch Asset', function () {
     const tokenContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
+++ b/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
@@ -24,7 +24,7 @@ describe('Transfer custom tokens', function () {
     it('send custom tokens from extension customizing gas values', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder().withTokensControllerERC20().build(),
           localNodeOptions: { hardfork: 'muirGlacier' },
           smartContract,
@@ -77,7 +77,7 @@ describe('Transfer custom tokens', function () {
     it('transfer custom tokens from dapp customizing gas values', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withTokensControllerERC20()
@@ -145,7 +145,7 @@ describe('Transfer custom tokens', function () {
     it('transfer custom tokens from dapp without specifying gas', async function () {
       await withFixtures(
         {
-          dappOptions: { defaultTestDapp: 1 },
+          dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withTokensControllerERC20()

--- a/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
+++ b/test/e2e/tests/tokens/custom-token-send-transfer.spec.ts
@@ -24,7 +24,7 @@ describe('Transfer custom tokens', function () {
     it('send custom tokens from extension customizing gas values', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder().withTokensControllerERC20().build(),
           localNodeOptions: { hardfork: 'muirGlacier' },
           smartContract,
@@ -77,7 +77,7 @@ describe('Transfer custom tokens', function () {
     it('transfer custom tokens from dapp customizing gas values', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withTokensControllerERC20()
@@ -145,7 +145,7 @@ describe('Transfer custom tokens', function () {
     it('transfer custom tokens from dapp without specifying gas', async function () {
       await withFixtures(
         {
-          dapp: true,
+          dappOptions: { defaultTestDapp: 1 },
           fixtures: new FixtureBuilder()
             .withPermissionControllerConnectedToTestDapp()
             .withTokensControllerERC20()

--- a/test/e2e/tests/tokens/defi/view-defi-details.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-details.spec.ts
@@ -16,7 +16,7 @@ describe('View DeFi details', function () {
   it('user should be able to view Aave Positions details', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withEnabledNetworks({
             eip155: {

--- a/test/e2e/tests/tokens/defi/view-defi-details.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-details.spec.ts
@@ -16,7 +16,7 @@ describe('View DeFi details', function () {
   it('user should be able to view Aave Positions details', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withEnabledNetworks({
             eip155: {

--- a/test/e2e/tests/tokens/defi/view-defi-error-message.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-error-message.spec.ts
@@ -10,7 +10,7 @@ describe('View DeFi error state', function () {
   it('user should be able to view error message', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockDefiPositionsFailure,

--- a/test/e2e/tests/tokens/defi/view-defi-error-message.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-error-message.spec.ts
@@ -10,7 +10,7 @@ describe('View DeFi error state', function () {
   it('user should be able to view error message', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockDefiPositionsFailure,

--- a/test/e2e/tests/tokens/defi/view-defi-no-positions-message.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-no-positions-message.spec.ts
@@ -14,7 +14,7 @@ describe('Check DeFi empty state when no defi positions', function () {
   it('user should be able to view empty', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockNoDeFiPositionFeatureFlag,

--- a/test/e2e/tests/tokens/defi/view-defi-no-positions-message.spec.ts
+++ b/test/e2e/tests/tokens/defi/view-defi-no-positions-message.spec.ts
@@ -14,7 +14,7 @@ describe('Check DeFi empty state when no defi positions', function () {
   it('user should be able to view empty', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockNoDeFiPositionFeatureFlag,

--- a/test/e2e/tests/tokens/nft/filter-nfts.spec.ts
+++ b/test/e2e/tests/tokens/nft/filter-nfts.spec.ts
@@ -15,7 +15,7 @@ describe('View NFT details', function () {
   it('user should be able to view ERC721 NFT details', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNftController({
             allNftContracts: {

--- a/test/e2e/tests/tokens/nft/filter-nfts.spec.ts
+++ b/test/e2e/tests/tokens/nft/filter-nfts.spec.ts
@@ -15,7 +15,7 @@ describe('View NFT details', function () {
   it('user should be able to view ERC721 NFT details', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNftController({
             allNftContracts: {

--- a/test/e2e/tests/tokens/nft/import-erc1155.spec.ts
+++ b/test/e2e/tests/tokens/nft/import-erc1155.spec.ts
@@ -11,7 +11,7 @@ describe('Import ERC1155 NFT', function () {
   it('should be able to import an ERC1155 NFT that user owns', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -39,7 +39,7 @@ describe('Import ERC1155 NFT', function () {
   it('should not be able to import an ERC1155 NFT that does not belong to user', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/nft/import-erc1155.spec.ts
+++ b/test/e2e/tests/tokens/nft/import-erc1155.spec.ts
@@ -11,7 +11,7 @@ describe('Import ERC1155 NFT', function () {
   it('should be able to import an ERC1155 NFT that user owns', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -39,7 +39,7 @@ describe('Import ERC1155 NFT', function () {
   it('should not be able to import an ERC1155 NFT that does not belong to user', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/nft/import-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/import-nft.spec.ts
@@ -14,7 +14,7 @@ describe('Import NFT', function () {
   it('should be able to import an NFT that user owns', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -39,7 +39,7 @@ describe('Import NFT', function () {
   it('should continue to display an imported NFT after importing, adding a new account, and switching back', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -85,7 +85,7 @@ describe('Import NFT', function () {
   it('should not be able to import an NFT that does not belong to user', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/nft/import-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/import-nft.spec.ts
@@ -14,7 +14,7 @@ describe('Import NFT', function () {
   it('should be able to import an NFT that user owns', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -39,7 +39,7 @@ describe('Import NFT', function () {
   it('should continue to display an imported NFT after importing, adding a new account, and switching back', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -85,7 +85,7 @@ describe('Import NFT', function () {
   it('should not be able to import an NFT that does not belong to user', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/nft/remove-erc1155.spec.ts
+++ b/test/e2e/tests/tokens/nft/remove-erc1155.spec.ts
@@ -28,7 +28,7 @@ describe('Remove ERC1155 NFT', function () {
   it('user should be able to remove ERC1155 NFT on details page', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC1155()
           .withEnabledNetworks({

--- a/test/e2e/tests/tokens/nft/remove-erc1155.spec.ts
+++ b/test/e2e/tests/tokens/nft/remove-erc1155.spec.ts
@@ -28,7 +28,7 @@ describe('Remove ERC1155 NFT', function () {
   it('user should be able to remove ERC1155 NFT on details page', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC1155()
           .withEnabledNetworks({

--- a/test/e2e/tests/tokens/nft/remove-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/remove-nft.spec.ts
@@ -33,7 +33,7 @@ describe('Remove NFT', function () {
     }
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC721()
           .withMetaMetricsController({

--- a/test/e2e/tests/tokens/nft/remove-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/remove-nft.spec.ts
@@ -33,7 +33,7 @@ describe('Remove NFT', function () {
     }
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC721()
           .withMetaMetricsController({

--- a/test/e2e/tests/tokens/nft/send-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/send-nft.spec.ts
@@ -17,7 +17,7 @@ describe('Send NFTs', function () {
   it('user should not be able to view ERC721 NFTs in send flow when on wrong network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesController({
             preferences: {
@@ -58,7 +58,7 @@ describe('Send NFTs', function () {
   it('user should only be able to view ERC721 NFTs on send flow that belong on selected network', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/nft/send-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/send-nft.spec.ts
@@ -17,7 +17,7 @@ describe('Send NFTs', function () {
   it('user should not be able to view ERC721 NFTs in send flow when on wrong network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesController({
             preferences: {
@@ -58,7 +58,7 @@ describe('Send NFTs', function () {
   it('user should only be able to view ERC721 NFTs on send flow that belong on selected network', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/nft/view-erc1155-details.spec.ts
+++ b/test/e2e/tests/tokens/nft/view-erc1155-details.spec.ts
@@ -23,7 +23,7 @@ describe('View ERC1155 NFT details', function () {
   it('user should be able to view ERC1155 NFT details', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/nft/view-erc1155-details.spec.ts
+++ b/test/e2e/tests/tokens/nft/view-erc1155-details.spec.ts
@@ -23,7 +23,7 @@ describe('View ERC1155 NFT details', function () {
   it('user should be able to view ERC1155 NFT details', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/nft/view-nft-details.spec.ts
+++ b/test/e2e/tests/tokens/nft/view-nft-details.spec.ts
@@ -14,7 +14,7 @@ describe('View NFT details', function () {
   it('user should be able to view ERC721 NFT details', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/nft/view-nft-details.spec.ts
+++ b/test/e2e/tests/tokens/nft/view-nft-details.spec.ts
@@ -14,7 +14,7 @@ describe('View NFT details', function () {
   it('user should be able to view ERC721 NFT details', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/send-erc20-to-contract.spec.ts
+++ b/test/e2e/tests/tokens/send-erc20-to-contract.spec.ts
@@ -13,7 +13,7 @@ describe('Send ERC20 token to contract address', function () {
   it('should display the token contract warning to the user', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withTokensControllerERC20().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/send-erc20-to-contract.spec.ts
+++ b/test/e2e/tests/tokens/send-erc20-to-contract.spec.ts
@@ -13,7 +13,7 @@ describe('Send ERC20 token to contract address', function () {
   it('should display the token contract warning to the user', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withTokensControllerERC20().build(),
         smartContract,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/tokens/watch-asset-call-add-token.spec.ts
+++ b/test/e2e/tests/tokens/watch-asset-call-add-token.spec.ts
@@ -12,7 +12,7 @@ describe('Add token using wallet_watchAsset', function () {
   it('opens a notification that adds a token when wallet_watchAsset is executed, then approves', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -57,7 +57,7 @@ describe('Add token using wallet_watchAsset', function () {
   it('opens a notification that adds a token when wallet_watchAsset is executed, then rejects', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/tokens/watch-asset-call-add-token.spec.ts
+++ b/test/e2e/tests/tokens/watch-asset-call-add-token.spec.ts
@@ -12,7 +12,7 @@ describe('Add token using wallet_watchAsset', function () {
   it('opens a notification that adds a token when wallet_watchAsset is executed, then approves', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -57,7 +57,7 @@ describe('Add token using wallet_watchAsset', function () {
   it('opens a notification that adds a token when wallet_watchAsset is executed, then rejects', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -19,7 +19,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),
@@ -68,7 +68,7 @@ describe('Change assets', function () {
     const tokenContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withTokensControllerERC20()
           .withNftControllerERC721()
@@ -120,7 +120,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),
@@ -172,7 +172,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC721()
           .withPreferencesController({

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -19,7 +19,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),
@@ -68,7 +68,7 @@ describe('Change assets', function () {
     const tokenContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withTokensControllerERC20()
           .withNftControllerERC721()
@@ -120,7 +120,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder().withNftControllerERC721().build(),
         smartContract,
         title: this.test?.fullTitle(),
@@ -172,7 +172,7 @@ describe('Change assets', function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withNftControllerERC721()
           .withPreferencesController({

--- a/test/e2e/tests/transaction/edit-gas-fee.spec.ts
+++ b/test/e2e/tests/transaction/edit-gas-fee.spec.ts
@@ -123,7 +123,7 @@ describe('Editing Confirm Transaction', function () {
   it('should use dapp suggested estimates for transaction coming from dapp', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController(PREFERENCES_STATE_MOCK)

--- a/test/e2e/tests/transaction/edit-gas-fee.spec.ts
+++ b/test/e2e/tests/transaction/edit-gas-fee.spec.ts
@@ -123,13 +123,13 @@ describe('Editing Confirm Transaction', function () {
   it('should use dapp suggested estimates for transaction coming from dapp', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController(PREFERENCES_STATE_MOCK)
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test?.fullTitle(),
-        dapp: true,
       },
       async ({ driver }) => {
         // login to extension

--- a/test/e2e/tests/transaction/multiple-transactions.spec.js
+++ b/test/e2e/tests/transaction/multiple-transactions.spec.js
@@ -7,7 +7,7 @@ describe('Multiple transactions', function () {
   it('creates multiple queued transactions, then confirms', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -69,7 +69,7 @@ describe('Multiple transactions', function () {
   it('creates multiple queued transactions, then rejects', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/transaction/multiple-transactions.spec.js
+++ b/test/e2e/tests/transaction/multiple-transactions.spec.js
@@ -7,7 +7,7 @@ describe('Multiple transactions', function () {
   it('creates multiple queued transactions, then confirms', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
@@ -69,7 +69,7 @@ describe('Multiple transactions', function () {
   it('creates multiple queued transactions, then rejects', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),

--- a/test/e2e/tests/transaction/navigate-transactions.spec.js
+++ b/test/e2e/tests/transaction/navigate-transactions.spec.js
@@ -24,7 +24,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -57,7 +57,7 @@ describe('Navigate transactions', function () {
   it('should add a transaction while the confirm page is in focus', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerTxSimulationsDisabled()
@@ -98,7 +98,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -123,7 +123,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -142,7 +142,7 @@ describe('Navigate transactions', function () {
   it('should reject and remove all unapproved transactions', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerTxSimulationsDisabled()
           .withPermissionControllerConnectedToTestDapp()

--- a/test/e2e/tests/transaction/navigate-transactions.spec.js
+++ b/test/e2e/tests/transaction/navigate-transactions.spec.js
@@ -24,7 +24,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -57,7 +57,7 @@ describe('Navigate transactions', function () {
   it('should add a transaction while the confirm page is in focus', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .withPreferencesControllerTxSimulationsDisabled()
@@ -98,7 +98,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -123,7 +123,7 @@ describe('Navigate transactions', function () {
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
@@ -142,13 +142,13 @@ describe('Navigate transactions', function () {
   it('should reject and remove all unapproved transactions', async function () {
     await withFixtures(
       {
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerTxSimulationsDisabled()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
         localNodeOptions: { hardfork: 'london' },
         title: this.test.fullTitle(),
-        dapp: true,
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/transaction/send-eth.spec.js
+++ b/test/e2e/tests/transaction/send-eth.spec.js
@@ -222,7 +222,7 @@ describe('Send ETH', function () {
       it('should display the correct gas price on the legacy transaction', async function () {
         await withFixtures(
           {
-            dapp: true,
+            dappOptions: { defaultTestDapp: 1 },
             fixtures: new FixtureBuilder()
               .withPermissionControllerConnectedToTestDapp()
               .withPreferencesController(PREFERENCES_STATE_MOCK)
@@ -305,7 +305,7 @@ describe('Send ETH', function () {
       it('should display correct gas values for EIP-1559 transaction', async function () {
         await withFixtures(
           {
-            dapp: true,
+            dappOptions: { defaultTestDapp: 1 },
             fixtures: new FixtureBuilder()
               .withPermissionControllerConnectedToTestDapp()
               .withPreferencesController(PREFERENCES_STATE_MOCK)

--- a/test/e2e/tests/transaction/send-eth.spec.js
+++ b/test/e2e/tests/transaction/send-eth.spec.js
@@ -222,7 +222,7 @@ describe('Send ETH', function () {
       it('should display the correct gas price on the legacy transaction', async function () {
         await withFixtures(
           {
-            dappOptions: { defaultTestDapp: 1 },
+            dappOptions: { numberOfTestDapps: 1 },
             fixtures: new FixtureBuilder()
               .withPermissionControllerConnectedToTestDapp()
               .withPreferencesController(PREFERENCES_STATE_MOCK)
@@ -305,7 +305,7 @@ describe('Send ETH', function () {
       it('should display correct gas values for EIP-1559 transaction', async function () {
         await withFixtures(
           {
-            dappOptions: { defaultTestDapp: 1 },
+            dappOptions: { numberOfTestDapps: 1 },
             fixtures: new FixtureBuilder()
               .withPermissionControllerConnectedToTestDapp()
               .withPreferencesController(PREFERENCES_STATE_MOCK)

--- a/test/e2e/tests/transaction/send-hex-address.spec.js
+++ b/test/e2e/tests/transaction/send-hex-address.spec.js
@@ -104,7 +104,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
   it('should ensure the address is prefixed with 0x when pasted and should send TST to a valid hexadecimal address', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerPetnamesDisabled()
           .withTokensControllerERC20()
@@ -166,7 +166,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
   it('should ensure the address is prefixed with 0x when typed and should send TST to a valid hexadecimal address', async function () {
     await withFixtures(
       {
-        dapp: true,
+        dappOptions: { defaultTestDapp: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerPetnamesDisabled()
           .withTokensControllerERC20()

--- a/test/e2e/tests/transaction/send-hex-address.spec.js
+++ b/test/e2e/tests/transaction/send-hex-address.spec.js
@@ -104,7 +104,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
   it('should ensure the address is prefixed with 0x when pasted and should send TST to a valid hexadecimal address', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerPetnamesDisabled()
           .withTokensControllerERC20()
@@ -166,7 +166,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
   it('should ensure the address is prefixed with 0x when typed and should send TST to a valid hexadecimal address', async function () {
     await withFixtures(
       {
-        dappOptions: { defaultTestDapp: 1 },
+        dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilder()
           .withPreferencesControllerPetnamesDisabled()
           .withTokensControllerERC20()


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR consolidates `dapp`, `dappPath`, `dappPaths` and `dappOptions` into just `dappOptions` in our `wtihFixtures` method. Similarly as we have `localNodeOptions` for anything related to setting up local nodes
It also moves all the local test dapp paths into the constants file, and adds an object, to make it easier to call from tests.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37102?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ci should pass as always

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors withFixtures to use a single dappOptions API and centralizes test dapp path resolution via constants, updating all E2E tests accordingly.
> 
> - **Testing infrastructure (withFixtures)**:
>   - Replace `dapp`, `dappPath`, and `dappPaths` with unified `dappOptions` (`numberOfTestDapps`, `customDappPaths`, optional `basePort`).
>   - Compute dapp count from `dappOptions`, start default `test-dapp` first, then custom dapps; resolve directories via `DAPP_PATHS`.
>   - Update server startup/shutdown logic to use computed dapp count; remove legacy path-switch logic.
> - **Constants**:
>   - Add `DAPP_PATHS` and `DAPP_PATH` in `test/e2e/constants.ts` for canonical dapp keys and path resolution.
> - **Test helpers**:
>   - Switch helpers (e.g., multichain, Solana, user-ops) to `dappOptions` and `DAPP_PATH` keys; drop direct `path` usage.
> - **E2E tests**:
>   - Update all specs to use `dappOptions` and, where needed, `DAPP_PATH.*` (e.g., snap sites, multichain, Solana, metrics, PPOM, network, tokens, confirmations).
> - **Phishing mock pages**:
>   - Adjust iframe sources/ports (8081→8080) to align with new dapp startup ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95bb5b80190897e419e42dcd12ea522d8a23d96b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->