### PR TITLE
feat: shield subscriptions billing date

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5849,6 +5849,9 @@
     "message": "Auto renews for $1 until canceled",
     "description": "The $1 is the price of the monthly plan"
   },
+  "shieldPlanBillingDate": {
+    "message": "Billing date"
+  },
   "shieldPlanCard": {
     "message": "Card"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5849,6 +5849,9 @@
     "message": "Auto renews for $1 until canceled",
     "description": "The $1 is the price of the monthly plan"
   },
+  "shieldPlanBillingDate": {
+    "message": "Billing date"
+  },
   "shieldPlanCard": {
     "message": "Card"
   },

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
@@ -1,7 +1,11 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import BillingDetails from "./billing-details";
-import { ProductPrice, RECURRING_INTERVALS } from "@metamask/subscription-controller";
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  ProductPrice,
+  RECURRING_INTERVALS,
+} from '@metamask/subscription-controller';
+import { DateTime } from 'luxon';
+import BillingDetails from './billing-details';
 
 describe('BillingDetails', () => {
   const mockProductPrice: ProductPrice = {
@@ -14,8 +18,27 @@ describe('BillingDetails', () => {
   };
 
   it('should render', () => {
-    const { getByText, getByTestId } = render(<BillingDetails productPrice={mockProductPrice} />)
+    const { getByText, getByTestId } = render(
+      <BillingDetails
+        productPrice={mockProductPrice}
+        isTrialSubscription={true}
+      />,
+    );
     expect(getByText('Billing Date')).toBeInTheDocument();
     expect(getByTestId('shield-subscription-billing_date')).toBeInTheDocument();
+  });
+
+  it('should render the correct billing date for a non-trial subscription', () => {
+    const { getByTestId } = render(
+      <BillingDetails
+        productPrice={mockProductPrice}
+        isTrialSubscription={false}
+      />,
+    );
+
+    const expectedBillingDate = DateTime.now().toFormat('MMMM d, y');
+    expect(getByTestId('shield-subscription-billing_date')).toHaveTextContent(
+      expectedBillingDate,
+    );
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
@@ -4,10 +4,10 @@ import {
   ProductPrice,
   RECURRING_INTERVALS,
 } from '@metamask/subscription-controller';
-import { getShortDateFormatterV2 } from '../../../../../asset/util';
 import BillingDetails from './billing-details';
 
 describe('BillingDetails', () => {
+  const mockSubscriptionDate = 'Oct 23, 2025';
   const mockProductPrice: ProductPrice = {
     interval: RECURRING_INTERVALS.year,
     minBillingCycles: 1,
@@ -16,6 +16,15 @@ describe('BillingDetails', () => {
     currency: 'usd',
     trialPeriodDays: 7,
   };
+
+  beforeAll(() => {
+    jest.resetAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date(mockSubscriptionDate));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('should render', () => {
     const { getByTestId } = render(
@@ -28,6 +37,9 @@ describe('BillingDetails', () => {
       getByTestId('shield-subscription-billing_date_label'),
     ).toBeInTheDocument();
     expect(getByTestId('shield-subscription-billing_date')).toBeInTheDocument();
+    expect(getByTestId('shield-subscription-billing_date')).toHaveTextContent(
+      'Oct 30, 2025', // 7 days after the subscription date
+    );
   });
 
   it('should render the correct billing date for a non-trial subscription', () => {
@@ -38,9 +50,8 @@ describe('BillingDetails', () => {
       />,
     );
 
-    const expectedBillingDate = getShortDateFormatterV2().format(new Date());
     expect(getByTestId('shield-subscription-billing_date')).toHaveTextContent(
-      expectedBillingDate,
+      'Oct 23, 2025',
     );
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import BillingDetails from "./billing-details";
+import { ProductPrice, RECURRING_INTERVALS } from "@metamask/subscription-controller";
+
+describe('BillingDetails', () => {
+  const mockProductPrice: ProductPrice = {
+    interval: RECURRING_INTERVALS.year,
+    minBillingCycles: 1,
+    unitAmount: 80000000,
+    unitDecimals: 6,
+    currency: 'usd',
+    trialPeriodDays: 7,
+  };
+
+  it('should render', () => {
+    const { getByText, getByTestId } = render(<BillingDetails productPrice={mockProductPrice} />)
+    expect(getByText('Billing Date')).toBeInTheDocument();
+    expect(getByTestId('shield-subscription-billing_date')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.test.tsx
@@ -4,7 +4,7 @@ import {
   ProductPrice,
   RECURRING_INTERVALS,
 } from '@metamask/subscription-controller';
-import { DateTime } from 'luxon';
+import { getShortDateFormatterV2 } from '../../../../../asset/util';
 import BillingDetails from './billing-details';
 
 describe('BillingDetails', () => {
@@ -18,13 +18,15 @@ describe('BillingDetails', () => {
   };
 
   it('should render', () => {
-    const { getByText, getByTestId } = render(
+    const { getByTestId } = render(
       <BillingDetails
         productPrice={mockProductPrice}
         isTrialSubscription={true}
       />,
     );
-    expect(getByText('Billing Date')).toBeInTheDocument();
+    expect(
+      getByTestId('shield-subscription-billing_date_label'),
+    ).toBeInTheDocument();
     expect(getByTestId('shield-subscription-billing_date')).toBeInTheDocument();
   });
 
@@ -36,7 +38,7 @@ describe('BillingDetails', () => {
       />,
     );
 
-    const expectedBillingDate = DateTime.now().toFormat('MMMM d, y');
+    const expectedBillingDate = getShortDateFormatterV2().format(new Date());
     expect(getByTestId('shield-subscription-billing_date')).toHaveTextContent(
       expectedBillingDate,
     );

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
@@ -6,6 +6,7 @@ import {
   ConfirmInfoRowText,
 } from '../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
+import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 
 const BillingDetails = ({
   productPrice,
@@ -14,6 +15,7 @@ const BillingDetails = ({
   productPrice: ProductPrice;
   isTrialSubscription: boolean;
 }) => {
+  const t = useI18nContext();
   const billingDate = useMemo(() => {
     // If it's not a trial subscription, return the billing date as today
     if (!isTrialSubscription) {
@@ -28,7 +30,7 @@ const BillingDetails = ({
   return (
     <ConfirmInfoSection data-testid="shield-subscription-billing_details_section">
       <ConfirmInfoRow
-        label="Billing Date"
+        label={t('shieldPlanBillingDate')}
         style={{ color: 'var(--color-text-alternative)' }}
       >
         <ConfirmInfoRowText

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
@@ -1,16 +1,29 @@
 import React, { useMemo } from 'react';
-import { ConfirmInfoRow, ConfirmInfoRowText } from "../../../../../../components/app/confirm/info/row";
-import { ConfirmInfoSection } from "../../../../../../components/app/confirm/info/row/section";
 import { ProductPrice } from '@metamask/subscription-controller';
 import { DateTime } from 'luxon';
+import {
+  ConfirmInfoRow,
+  ConfirmInfoRowText,
+} from '../../../../../../components/app/confirm/info/row';
+import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
 
-const BillingDetails = ({ productPrice }: { productPrice: ProductPrice }) => {
+const BillingDetails = ({
+  productPrice,
+  isTrialSubscription,
+}: {
+  productPrice: ProductPrice;
+  isTrialSubscription: boolean;
+}) => {
   const billingDate = useMemo(() => {
+    // If it's not a trial subscription, return the billing date as today
+    if (!isTrialSubscription) {
+      return DateTime.now().toFormat('MMMM d, y');
+    }
     const { trialPeriodDays } = productPrice;
     const trialEndDate = DateTime.now().plus({ days: trialPeriodDays });
 
     return trialEndDate.toFormat('MMMM d, y');
-  }, [productPrice]);
+  }, [productPrice, isTrialSubscription]);
 
   return (
     <ConfirmInfoSection data-testid="shield-subscription-billing_details_section">
@@ -18,10 +31,13 @@ const BillingDetails = ({ productPrice }: { productPrice: ProductPrice }) => {
         label="Billing Date"
         style={{ color: 'var(--color-text-alternative)' }}
       >
-        <ConfirmInfoRowText text={billingDate} data-testid="shield-subscription-billing_date" />
+        <ConfirmInfoRowText
+          text={billingDate}
+          data-testid="shield-subscription-billing_date"
+        />
       </ConfirmInfoRow>
     </ConfirmInfoSection>
   );
-}
+};
 
 export default BillingDetails;

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react';
 import { ProductPrice } from '@metamask/subscription-controller';
-import { DateTime } from 'luxon';
 import {
   ConfirmInfoRow,
   ConfirmInfoRowText,
 } from '../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
+import { getShortDateFormatterV2 } from '../../../../../asset/util';
 
 const BillingDetails = ({
   productPrice,
@@ -17,14 +17,15 @@ const BillingDetails = ({
 }) => {
   const t = useI18nContext();
   const billingDate = useMemo(() => {
-    // If it's not a trial subscription, return the billing date as today
-    if (!isTrialSubscription) {
-      return DateTime.now().toFormat('MMMM d, y');
-    }
+    const trialEndDate = new Date();
     const { trialPeriodDays } = productPrice;
-    const trialEndDate = DateTime.now().plus({ days: trialPeriodDays });
 
-    return trialEndDate.toFormat('MMMM d, y');
+    // If it's a trial subscription, return the billing date as today plus the trial period days
+    if (isTrialSubscription) {
+      trialEndDate.setDate(trialEndDate.getDate() + trialPeriodDays);
+    }
+
+    return getShortDateFormatterV2().format(trialEndDate);
   }, [productPrice, isTrialSubscription]);
 
   return (
@@ -32,6 +33,7 @@ const BillingDetails = ({
       <ConfirmInfoRow
         label={t('shieldPlanBillingDate')}
         style={{ color: 'var(--color-text-alternative)' }}
+        data-testid="shield-subscription-billing_date_label"
       >
         <ConfirmInfoRowText
           text={billingDate}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/billing-details.tsx
@@ -1,0 +1,27 @@
+import React, { useMemo } from 'react';
+import { ConfirmInfoRow, ConfirmInfoRowText } from "../../../../../../components/app/confirm/info/row";
+import { ConfirmInfoSection } from "../../../../../../components/app/confirm/info/row/section";
+import { ProductPrice } from '@metamask/subscription-controller';
+import { DateTime } from 'luxon';
+
+const BillingDetails = ({ productPrice }: { productPrice: ProductPrice }) => {
+  const billingDate = useMemo(() => {
+    const { trialPeriodDays } = productPrice;
+    const trialEndDate = DateTime.now().plus({ days: trialPeriodDays });
+
+    return trialEndDate.toFormat('MMMM d, y');
+  }, [productPrice]);
+
+  return (
+    <ConfirmInfoSection data-testid="shield-subscription-billing_details_section">
+      <ConfirmInfoRow
+        label="Billing Date"
+        style={{ color: 'var(--color-text-alternative)' }}
+      >
+        <ConfirmInfoRowText text={billingDate} data-testid="shield-subscription-billing_date" />
+      </ConfirmInfoRow>
+    </ConfirmInfoSection>
+  );
+}
+
+export default BillingDetails;

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.tsx
@@ -14,6 +14,7 @@ import { AccountDetails } from './account-details';
 import { EstimatedChanges } from './estimated-changes';
 import ShieldSubscriptionApproveLoader from './shield-subscription-approve-loader';
 import { SubscriptionDetails } from './subscription-details';
+import BillingDetails from './billing-details';
 
 const ShieldSubscriptionApproveInfo = () => {
   const { currentConfirmation: transactionMeta } =
@@ -68,6 +69,7 @@ const ShieldSubscriptionApproveInfo = () => {
         accountAddress={transactionMeta?.txParams?.from as Hex}
         chainId={transactionMeta?.chainId}
       />
+      {productPrice && <BillingDetails productPrice={productPrice} />}
       <GasFeesSection />
     </Box>
   );

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.tsx
@@ -69,7 +69,12 @@ const ShieldSubscriptionApproveInfo = () => {
         accountAddress={transactionMeta?.txParams?.from as Hex}
         chainId={transactionMeta?.chainId}
       />
-      {productPrice && <BillingDetails productPrice={productPrice} />}
+      {productPrice && (
+        <BillingDetails
+          productPrice={productPrice}
+          isTrialSubscription={!isTrialed}
+        />
+      )}
       <GasFeesSection />
     </Box>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR adds Billing Start Date in shield-subscription confirmation screen.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37103?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: adds Billing Start Date in shield-subscription confirmation screen.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="401" height="603" alt="Screenshot 2025-10-23 at 5 52 18 PM" src="https://github.com/user-attachments/assets/e37f226a-4bf5-4a77-b6fd-7805fc18a7f9" />

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds billing date to Shield subscription approval info, including trial-aware date calculation, tests, and i18n strings.
> 
> - **UI (Shield Subscription Approve)**:
>   - Add `BillingDetails` component to show `shieldPlanBillingDate` with formatted date.
>   - Trial-aware billing date: today + `productPrice.trialPeriodDays`; otherwise today.
>   - Integrate `BillingDetails` into `shield-subscription-approve.tsx` when `productPrice` is available.
> - **Tests**:
>   - Add `billing-details.test.tsx` verifying trial and non-trial billing dates.
> - **i18n**:
>   - Add `shieldPlanBillingDate` key to `app/_locales/en/messages.json` and `en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0361166f265aba187266df0296552ef33b8eec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->