### PR TITLE
feat: update copywriting and font weight on shield plan page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5875,7 +5875,12 @@
     "description": "The $1 is the price of the monthly plan"
   },
   "shieldPlanNoFunds": {
-    "message": "No available funds"
+    "message": "Insufficient $1 or $2",
+    "description": "$1 or $2 shows the supported token eg. USDC, USDT or mUSD"
+  },
+  "shieldPlanNoFundsOneToken": {
+    "message": "Insufficient $1",
+    "description": "$1 is the one token supported"
   },
   "shieldPlanPayWith": {
     "message": "Pay with"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5875,7 +5875,12 @@
     "description": "The $1 is the price of the monthly plan"
   },
   "shieldPlanNoFunds": {
-    "message": "No available funds"
+    "message": "Insufficient $1 or $2",
+    "description": "$1 or $2 shows the supported token eg. USDC, USDT or mUSD"
+  },
+  "shieldPlanNoFundsOneToken": {
+    "message": "Insufficient $1",
+    "description": "$1 is the one token supported"
   },
   "shieldPlanPayWith": {
     "message": "Pay with"

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5757,7 +5757,8 @@
     "description": "The $1 is the price of the monthly plan"
   },
   "shieldPlanNoFunds": {
-    "message": "Gan aon chistí ar fáil"
+    "message": "Gan aon chistí ar fáil",
+    "description": "$1 or $2 shows the supported token eg. USDC, USDT or mUSD"
   },
   "shieldPlanPayWith": {
     "message": "Íoc le"

--- a/ui/pages/shield-plan/shield-payment-modal.stories.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.stories.tsx
@@ -18,6 +18,7 @@ export const DefaultStory = () => {
         onAssetChange={() => {}}
         hasStableTokenWithBalance={true}
         availableTokenBalances={[]}
+        tokensSupported={['USDC', 'USDT', 'mUSD']}
       />
     </div>
   );

--- a/ui/pages/shield-plan/shield-payment-modal.test.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.test.tsx
@@ -44,6 +44,7 @@ describe('Change payment method', () => {
         {...defaultProps}
         hasStableTokenWithBalance={true}
         availableTokenBalances={[]}
+        tokensSupported={['USDC', 'USDT', 'mUSD']}
       />,
       mockStore,
     );
@@ -59,6 +60,7 @@ describe('Change payment method', () => {
         onClose={onCloseStub}
         hasStableTokenWithBalance={true}
         availableTokenBalances={[]}
+        tokensSupported={['USDC', 'USDT', 'mUSD']}
       />,
       mockStore,
     );
@@ -80,6 +82,7 @@ describe('Change payment method', () => {
         setSelectedPaymentMethod={setSelectedPaymentMethodStub}
         hasStableTokenWithBalance={true}
         availableTokenBalances={[]}
+        tokensSupported={['USDC', 'USDT', 'mUSD']}
       />,
       mockStore,
     );

--- a/ui/pages/shield-plan/shield-payment-modal.test.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.test.tsx
@@ -33,6 +33,43 @@ const defaultProps = {
   onAssetChange: jest.fn(),
 };
 
+const mockAvailableTokenBalances = [
+  {
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'USDC',
+    image:
+      'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042194',
+    type: AssetType.token,
+    chainId: '0x1',
+    balance: '100',
+    string: '100',
+    decimals: 18,
+    approvalAmount: {
+      approveAmount: '100',
+      chainId: '0x1',
+      paymentAddress: '0x0000000000000000000000000000000000000001',
+      paymentTokenAddress: '0x0000000000000000000000000000000000000002',
+    },
+  },
+  {
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'USDT',
+    image:
+      'https://assets.coingecko.com/coins/images/325/large/Tether.png?1598003707',
+    type: AssetType.token,
+    chainId: '0x1',
+    balance: '100',
+    string: '100',
+    decimals: 18,
+    approvalAmount: {
+      approveAmount: '100',
+      chainId: '0x1',
+      paymentAddress: '0x0000000000000000000000000000000000000001',
+      paymentTokenAddress: '0x0000000000000000000000000000000000000002',
+    },
+  },
+] as TokenWithApprovalAmount[];
+
 describe('Change payment method', () => {
   const onCloseStub = jest.fn();
   const setSelectedPaymentMethodStub = jest.fn();
@@ -59,7 +96,7 @@ describe('Change payment method', () => {
         {...defaultProps}
         onClose={onCloseStub}
         hasStableTokenWithBalance={true}
-        availableTokenBalances={[]}
+        availableTokenBalances={mockAvailableTokenBalances}
         tokensSupported={['USDC', 'USDT', 'mUSD']}
       />,
       mockStore,

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -118,7 +118,7 @@ export const ShieldPaymentModal = ({
     const tokensSupportedCopy = [...tokensSupported];
     const lastToken = tokensSupportedCopy.pop();
 
-    if (tokensSupported.length > 0) {
+    if (tokensSupportedCopy.length > 0) {
       return t('shieldPlanNoFunds', [
         tokensSupportedCopy.join(', '),
         lastToken,

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -115,10 +115,14 @@ export const ShieldPaymentModal = ({
   }, [availableTokenBalances]);
 
   const noCryptoFundsText = useMemo(() => {
-    const lastToken = tokensSupported.pop();
+    const tokensSupportedCopy = [...tokensSupported];
+    const lastToken = tokensSupportedCopy.pop();
 
     if (tokensSupported.length > 0) {
-      return t('shieldPlanNoFunds', [tokensSupported.join(', '), lastToken]);
+      return t('shieldPlanNoFunds', [
+        tokensSupportedCopy.join(', '),
+        lastToken,
+      ]);
     }
 
     return t('shieldPlanNoFundsOneToken', [lastToken]);

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -77,11 +77,13 @@ export const ShieldPaymentModal = ({
       setSelectedPaymentMethod(selectedMethod);
 
       if (selectedMethod === PAYMENT_TYPES.byCrypto) {
+        // if there are multiple token options, show the asset picker modal
         if (hasMultipleTokenOptions) {
           setShowAssetPickerModal(true);
           return;
         }
 
+        // if there is only one token option, set it as the selected token
         onAssetChange(availableTokenBalances[0]);
       }
 
@@ -118,13 +120,14 @@ export const ShieldPaymentModal = ({
     const tokensSupportedCopy = [...tokensSupported];
     const lastToken = tokensSupportedCopy.pop();
 
+    // multiple tokens to display eg. Insufficient USDC, USDT or mUSD
     if (tokensSupportedCopy.length > 0) {
       return t('shieldPlanNoFunds', [
         tokensSupportedCopy.join(', '),
         lastToken,
       ]);
     }
-
+    // single token to display eg. Insufficient USDC
     return t('shieldPlanNoFundsOneToken', [lastToken]);
   }, [tokensSupported, t]);
 

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -68,17 +68,32 @@ export const ShieldPaymentModal = ({
   const t = useI18nContext();
   const [showAssetPickerModal, setShowAssetPickerModal] = useState(false);
 
+  const hasMultipleTokenOptions = useMemo(() => {
+    return availableTokenBalances.length > 1;
+  }, [availableTokenBalances]);
+
   const selectPaymentMethod = useCallback(
     (selectedMethod: PaymentType) => {
       setSelectedPaymentMethod(selectedMethod);
 
       if (selectedMethod === PAYMENT_TYPES.byCrypto) {
-        setShowAssetPickerModal(true);
-      } else {
-        onClose();
+        if (hasMultipleTokenOptions) {
+          setShowAssetPickerModal(true);
+          return;
+        }
+
+        onAssetChange(availableTokenBalances[0]);
       }
+
+      onClose();
     },
-    [setSelectedPaymentMethod, onClose],
+    [
+      setSelectedPaymentMethod,
+      onClose,
+      hasMultipleTokenOptions,
+      onAssetChange,
+      availableTokenBalances,
+    ],
   );
 
   // Create custom token list generator that filters for USDT/USDC with balance
@@ -209,7 +224,7 @@ export const ShieldPaymentModal = ({
                   </Text>
                 </Box>
               </Box>
-              {hasStableTokenWithBalance && (
+              {hasStableTokenWithBalance && hasMultipleTokenOptions && (
                 <Icon size={IconSize.Md} name={IconName.ArrowRight} />
               )}
             </Box>

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -53,6 +53,7 @@ export const ShieldPaymentModal = ({
   selectedToken,
   onAssetChange,
   hasStableTokenWithBalance,
+  tokensSupported,
 }: {
   isOpen: boolean;
   onClose: () => void;
@@ -62,6 +63,7 @@ export const ShieldPaymentModal = ({
   selectedToken?: TokenWithApprovalAmount;
   onAssetChange: (asset: TokenWithApprovalAmount) => void;
   hasStableTokenWithBalance: boolean;
+  tokensSupported: string[];
 }) => {
   const t = useI18nContext();
   const [showAssetPickerModal, setShowAssetPickerModal] = useState(false);
@@ -96,6 +98,16 @@ export const ShieldPaymentModal = ({
       }
     };
   }, [availableTokenBalances]);
+
+  const noCryptoFundsText = useMemo(() => {
+    const lastToken = tokensSupported.pop();
+
+    if (tokensSupported.length > 0) {
+      return t('shieldPlanNoFunds', [tokensSupported.join(', '), lastToken]);
+    }
+
+    return t('shieldPlanNoFundsOneToken', [lastToken]);
+  }, [tokensSupported, t]);
 
   return (
     <Modal
@@ -184,7 +196,7 @@ export const ShieldPaymentModal = ({
                     {t('shieldPlanPayWithToken', [
                       hasStableTokenWithBalance
                         ? (selectedToken?.symbol ?? '')
-                        : 'Crypto',
+                        : 'crypto',
                     ])}
                   </Text>
                   <Text
@@ -193,7 +205,7 @@ export const ShieldPaymentModal = ({
                   >
                     {hasStableTokenWithBalance
                       ? `${t('balance')}: ${selectedToken?.string ?? ''} ${selectedToken?.symbol ?? ''}`
-                      : t('shieldPlanNoFunds')}
+                      : noCryptoFundsText}
                   </Text>
                 </Box>
               </Box>

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -192,6 +192,18 @@ const ShieldPlan = () => {
       subscriptionPricing,
     ]);
 
+  const tokensSupported = useMemo(() => {
+    const chainsAndTokensSupported = cryptoPaymentMethod?.chains ?? [];
+
+    return [
+      ...new Set(
+        chainsAndTokensSupported.flatMap((chain) =>
+          chain.tokens.map((token) => token.symbol),
+        ),
+      ),
+    ];
+  }, [cryptoPaymentMethod?.chains]);
+
   const loading =
     subscriptionsLoading ||
     subscriptionPricingLoading ||
@@ -310,7 +322,7 @@ const ShieldPlan = () => {
                       className="shield-plan-page__save-badge"
                     >
                       <Text
-                        variant={TextVariant.bodyXs}
+                        variant={TextVariant.bodyXsMedium}
                         color={TextColor.iconInverse}
                       >
                         {t('shieldPlanSave')}
@@ -417,6 +429,7 @@ const ShieldPlan = () => {
               setSelectedPaymentMethod={setSelectedPaymentMethod}
               onAssetChange={setSelectedToken}
               availableTokenBalances={availableTokenBalances}
+              tokensSupported={tokensSupported}
             />
           </Content>
           <Footer


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Update `Save 16%` font weight
- Update `Pay with crypto` and insufficient funds copy
- Show asset picker only when there are more than one token
- If there is only one token Removed `>` icon. Auto selects that one token when option is clicked

https://consensyssoftware.atlassian.net/browse/SUBS-592
https://consensyssoftware.atlassian.net/browse/SUBS-588
https://consensyssoftware.atlassian.net/browse/SUBS-581

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37110?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated pay with crypto copywriting

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create an account without crypto balance and without shield subscription
2. Go to Menu > Settings > Transaction Shield
3. Should be redirected to Shield Plan
4. Click on `Pay with`
5. Check copy writing

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
**Yearly badge**
<img width="294" height="98" alt="Screenshot 2025-10-23 at 3 59 08 PM" src="https://github.com/user-attachments/assets/ee9e4a87-ae29-4eab-8c3f-360cb77a615d" />


**Insufficient crypto balance**
<img width="702" height="1040" alt="image" src="https://github.com/user-attachments/assets/d1944b55-74ae-46ae-8299-0ccf18cf60b1" />


**Payment method**
<img width="353" height="166" alt="Screenshot 2025-10-24 at 9 12 50 AM" src="https://github.com/user-attachments/assets/717bbcc3-ea78-4272-b67d-a43b12fc153f" />
<!-- [screenshots/recordings] -->

### **After**
**Yearly badge**
<img width="287" height="96" alt="Screenshot 2025-10-23 at 3 59 21 PM" src="https://github.com/user-attachments/assets/77dd9a98-ed64-43fd-8c5c-c299abb5dde7" />


**Insufficient crypto balance**
_**With multiple supported tokens**_
<img width="378" height="250" alt="Screenshot 2025-10-23 at 6 48 41 PM" src="https://github.com/user-attachments/assets/7dbdf411-fed5-407c-815c-4625834897a5" />

_**With one supported token**_
<img width="390" height="249" alt="Screenshot 2025-10-23 at 6 48 29 PM" src="https://github.com/user-attachments/assets/36efb849-9204-4572-bcb5-4b5ab76571c6" />

**Payment method**
<img width="614" height="315" alt="Screenshot 2025-10-24 at 9 03 45 AM" src="https://github.com/user-attachments/assets/75b17864-c8e1-48d7-9d14-a02fd4d54c6d" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Shield payment modal UX (asset picker only for multiple tokens, auto-select single token), updates insufficient funds copy to list supported tokens, and tweaks yearly badge font weight.
> 
> - **UI/Shield Plan**
>   - **Payment Modal (`ui/pages/shield-plan/shield-payment-modal.tsx`)**:
>     - Show asset picker only when multiple `availableTokenBalances`; auto-select the single token and close.
>     - Add `tokensSupported` prop to render dynamic "Insufficient $1 or $2"/"Insufficient $1" copy; lowercase "crypto" label.
>     - Hide arrow indicator unless multiple token options; adjust balance/insufficient funds text.
>   - **Plan Page (`ui/pages/shield-plan/shield-plan.tsx`)**:
>     - Derive `tokensSupported` from crypto payment method chains and pass to `ShieldPaymentModal`.
>     - Update yearly save badge font weight to `bodyXsMedium`.
> - **i18n (`app/_locales/en*.json`, `ga`)**
>   - Replace `shieldPlanNoFunds` with templated "Insufficient $1 or $2" and add `shieldPlanNoFundsOneToken`; add descriptions.
> - **Tests/Stories**
>   - Update story and tests to pass `tokensSupported`; add token balance fixtures and expectations for modal behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24b692ef9dfad0abf44fdaa5da9f2f6c43650d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->