### PR TITLE
feat: enhance AppHeaderUnlockedContent with network address copy icon

### DIFF
--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -12,6 +12,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Link } from 'react-router-dom-v5-compat';
 import {
+  Icon,
+  IconName as IconNameDesignSystem,
+  IconSize as IconSizeDesignSystem,
+  IconColor as IconColorDesignSystem,
+} from '@metamask/design-system-react';
+import {
   AlignItems,
   BackgroundColor,
   BlockSize,
@@ -29,7 +35,6 @@ import {
   ButtonBaseSize,
   ButtonIcon,
   ButtonIconSize,
-  Icon,
   IconName,
   IconSize,
   Text,
@@ -265,9 +270,9 @@ export const AppHeaderUnlockedContent = ({
               {networksLabel}
             </Text>
             <Icon
-              name={IconName.Copy}
-              size={IconSize.Xs}
-              color={IconColor.iconAlternative}
+              name={IconNameDesignSystem.Copy}
+              size={IconSizeDesignSystem.Xs}
+              color={IconColorDesignSystem.IconAlternative}
               data-testid="copy-network-addresses-icon"
             />
           </Box>

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -29,6 +29,7 @@ import {
   ButtonBaseSize,
   ButtonIcon,
   ButtonIconSize,
+  Icon,
   IconName,
   IconSize,
   Text,
@@ -250,14 +251,26 @@ export const AppHeaderUnlockedContent = ({
           to={`${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedMultichainAccountId)}`}
           data-testid="networks-subtitle-test-id"
         >
-          <Text
+          <Box
+            display={Display.Flex}
             className="networks-subtitle"
-            color={TextColor.textAlternative}
-            variant={TextVariant.bodyXsMedium}
+            alignItems={AlignItems.center}
+            gap={1}
             paddingInline={2}
           >
-            {networksLabel}
-          </Text>
+            <Text
+              color={TextColor.textAlternative}
+              variant={TextVariant.bodyXsMedium}
+            >
+              {networksLabel}
+            </Text>
+            <Icon
+              name={IconName.Copy}
+              size={IconSize.Xs}
+              color={IconColor.iconAlternative}
+              data-testid="copy-network-addresses-icon"
+            />
+          </Box>
         </Link>
       </Box>
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR is adding copy icon to network addresses in the account header.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37112?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added copy icon to network addresses in the account header

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/TMCU-156

## **Manual testing steps**

1. Unlock extension
2. See "network addresses" under account picker

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="401" height="598" alt="Screenshot 2025-10-23 at 13 33 32" src="https://github.com/user-attachments/assets/9ae92eaa-4946-41e2-aba9-4440e3f0698f" />

<!-- [screenshots/recordings] -->

### **After**
<img width="400" height="597" alt="Screenshot 2025-10-23 at 13 24 25" src="https://github.com/user-attachments/assets/5261b84b-8ec2-4004-89f1-c0a2de5e6325" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a copy icon next to the "network address(es)" link in the app header and wraps the subtitle in a flex container for alignment.
> 
> - **UI (AppHeaderUnlockedContent)**
>   - Add `Icon` from `@metamask/design-system-react` to display a copy icon beside the networks subtitle (`data-testid="copy-network-addresses-icon"`).
>   - Wrap networks subtitle in a `Box` with `display: Flex`, `alignItems: center`, `gap: 1`, and `paddingInline: 2`; keep label in `Text`.
>   - Link still navigates to `MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE` using `selectedMultichainAccountId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c151db1e67b8373f2f143831f6ea52a0e67732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->