### PR TITLE
feat: Return tx hashes asap from the submitBatch hook

### DIFF
--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -884,8 +884,7 @@ describe('submitBatchSmartTransactionHook', () => {
 
   it('returns txHashes asap if extensionReturnTxHashAsapBatch feature flag is enabled', async () => {
     withRequest(async ({ request }) => {
-      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch =
-        true;
+      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch = true;
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           return {
@@ -905,8 +904,7 @@ describe('submitBatchSmartTransactionHook', () => {
 
   it('waits for transaction hash if extensionReturnTxHashAsapBatch is false', async () => {
     withRequest(async ({ request, messenger }) => {
-      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch =
-        false;
+      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch = false;
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           return {

--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -186,6 +186,7 @@ function withRequest<ReturnValue>(
         expectedDeadline: 45,
         maxDeadline: 150,
         extensionReturnTxHashAsap: false,
+        extensionReturnTxHashAsapBatch: false,
       },
     },
     ...options,
@@ -877,6 +878,58 @@ describe('submitBatchSmartTransactionHook', () => {
 
       expect(endFlowSpy).toHaveBeenCalledWith({
         id: 'approvalId',
+      });
+    });
+  });
+
+  it('returns txHashes asap if extensionReturnTxHashAsapBatch feature flag is enabled', async () => {
+    withRequest(async ({ request }) => {
+      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch =
+        true;
+      request.smartTransactionsController.submitSignedTransactions = jest.fn(
+        async (_) => {
+          return {
+            uuid,
+            txHashes: ['hash1', 'hash2'],
+          };
+        },
+      );
+
+      const result = await submitBatchSmartTransactionHook(request);
+
+      expect(result).toEqual({
+        results: [{ transactionHash: 'hash1' }, { transactionHash: 'hash2' }],
+      });
+    });
+  });
+
+  it('waits for transaction hash if extensionReturnTxHashAsapBatch is false', async () => {
+    withRequest(async ({ request, messenger }) => {
+      request.featureFlags.smartTransactions.extensionReturnTxHashAsapBatch =
+        false;
+      request.smartTransactionsController.submitSignedTransactions = jest.fn(
+        async (_) => {
+          return {
+            uuid,
+            txHashes: ['hash1', 'hash2'],
+          };
+        },
+      );
+
+      setImmediate(() => {
+        messenger.publish('SmartTransactionsController:smartTransaction', {
+          status: 'success',
+          uuid,
+          statusMetadata: {
+            minedHash: txHash,
+          },
+        } as SmartTransaction);
+      });
+
+      const result = await submitBatchSmartTransactionHook(request);
+
+      expect(result).toEqual({
+        results: [{ transactionHash: 'hash1' }, { transactionHash: 'hash2' }],
       });
     });
   });

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -62,6 +62,7 @@ export type FeatureFlags = {
     expectedDeadline?: number;
     maxDeadline?: number;
     extensionReturnTxHashAsap?: boolean;
+    extensionReturnTxHashAsapBatch?: boolean;
   };
 };
 
@@ -95,6 +96,7 @@ class SmartTransactionHook {
       expectedDeadline?: number;
       maxDeadline?: number;
       extensionReturnTxHashAsap?: boolean;
+      extensionReturnTxHashAsapBatch?: boolean;
     };
   };
 
@@ -243,16 +245,6 @@ class SmartTransactionHook {
 
       await this.#processApprovalIfNeeded(uuid);
 
-      const transactionHash = await this.#waitForTransactionHash({
-        uuid,
-      });
-
-      if (transactionHash === null) {
-        throw new Error(
-          'submitBatch: Transaction does not have a transaction hash, there was a problem',
-        );
-      }
-
       let submitBatchResponse;
       if (submitTransactionResponse?.txHashes) {
         submitBatchResponse = {
@@ -264,6 +256,26 @@ class SmartTransactionHook {
         submitBatchResponse = {
           results: [],
         };
+      }
+
+      const extensionReturnTxHashAsapBatch =
+        this.#featureFlags?.smartTransactions?.extensionReturnTxHashAsapBatch;
+
+      if (
+        extensionReturnTxHashAsapBatch &&
+        submitBatchResponse?.results?.length > 0
+      ) {
+        return submitBatchResponse;
+      }
+
+      const transactionHash = await this.#waitForTransactionHash({
+        uuid,
+      });
+
+      if (transactionHash === null) {
+        throw new Error(
+          'submitBatch: Transaction does not have a transaction hash, there was a problem',
+        );
       }
 
       return submitBatchResponse;

--- a/shared/modules/selectors/feature-flags.test.ts
+++ b/shared/modules/selectors/feature-flags.test.ts
@@ -103,6 +103,7 @@ describe('Feature Flags Selectors', () => {
                   batchStatusPollingInterval: 1000,
                   extensionActive: true,
                   extensionReturnTxHashAsap: true,
+                  extensionReturnTxHashAsapBatch: true,
                 },
               },
             }
@@ -145,6 +146,7 @@ describe('Feature Flags Selectors', () => {
           expectedDeadline: 45,
           maxDeadline: 150,
           extensionReturnTxHashAsap: false,
+          extensionReturnTxHashAsapBatch: false,
         },
       });
     });
@@ -175,6 +177,7 @@ describe('Feature Flags Selectors', () => {
           expectedDeadline: 60,
           maxDeadline: 180,
           extensionReturnTxHashAsap: false,
+          extensionReturnTxHashAsapBatch: false,
         },
       });
     });
@@ -190,6 +193,7 @@ describe('Feature Flags Selectors', () => {
           expectedDeadline: 45,
           maxDeadline: 150,
           extensionReturnTxHashAsap: false,
+          extensionReturnTxHashAsapBatch: false,
         },
       });
     });
@@ -206,6 +210,7 @@ describe('Feature Flags Selectors', () => {
             expectedDeadline: 45,
             maxDeadline: 150,
             extensionReturnTxHashAsap: true,
+            extensionReturnTxHashAsapBatch: true,
           },
         });
       });
@@ -221,6 +226,7 @@ describe('Feature Flags Selectors', () => {
             expectedDeadline: 45,
             maxDeadline: 150,
             extensionReturnTxHashAsap: false,
+            extensionReturnTxHashAsapBatch: false,
           },
         });
       });
@@ -236,6 +242,7 @@ describe('Feature Flags Selectors', () => {
             expectedDeadline: 60,
             maxDeadline: 180,
             extensionReturnTxHashAsap: true,
+            extensionReturnTxHashAsapBatch: true,
           },
         });
       });

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -29,6 +29,7 @@ export type SmartTransactionNetwork = {
   extensionActive?: boolean;
   sentinelUrl?: string;
   extensionReturnTxHashAsap?: boolean;
+  extensionReturnTxHashAsapBatch?: boolean;
   batchStatusPollingInterval?: number;
 };
 
@@ -65,12 +66,15 @@ export function getFeatureFlagsByChainId(
   const defaultConfig = smartTransactionsNetworks?.default;
   const extensionReturnTxHashAsap =
     defaultConfig?.extensionReturnTxHashAsap ?? false;
+  const extensionReturnTxHashAsapBatch =
+    defaultConfig?.extensionReturnTxHashAsapBatch ?? false;
 
   return {
     smartTransactions: {
       ...featureFlags.smartTransactions,
       ...featureFlags[networkName].smartTransactions,
       extensionReturnTxHashAsap,
+      extensionReturnTxHashAsapBatch,
     },
   };
 }


### PR DESCRIPTION
## **Description**

We were already returning a tx hash asap from the `submit` hook and with this PR we will return an array of tx hashes from the `submitBatch` hook.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37113?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Return tx hashes asap from the submitBatch hook

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to a dapp
2. Do a swap that triggers MetaMask
3. On the Confirmation page choose an ERC-20 token to pay for gas fees
4. Dapp UI will update asap right after submitting the transaction in MetaMask

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `extensionReturnTxHashAsapBatch` to return `submitBatch` tx hashes immediately when enabled and updates selectors and tests.
> 
> - **Smart Transactions**:
>   - `submitBatch` now conditionally returns tx hashes immediately when `smartTransactions.extensionReturnTxHashAsapBatch` is enabled; otherwise waits for mined hash.
>   - Extend feature flag types (`FeatureFlags`, internal `#featureFlags`) to include `extensionReturnTxHashAsapBatch`.
> - **Selectors**:
>   - Add `extensionReturnTxHashAsapBatch` to `SmartTransactionNetwork` and surface it from `remoteFeatureFlags.smartTransactionsNetworks.default` via `getFeatureFlagsByChainId`.
> - **Tests**:
>   - Add tests for ASAP vs wait behavior in `submitBatchSmartTransactionHook`.
>   - Update feature-flag selector tests to include and assert `extensionReturnTxHashAsapBatch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b90dddcddebb752609877791113611c4f7b725b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->