### PR TITLE
feat: Support sponsored transactions through smart transactions

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -375,11 +375,7 @@ export async function publishHook({
     transactionMeta.chainId,
   );
 
-  if (
-    !isSmartTransaction ||
-    !sendBundleSupport ||
-    transactionMeta.isGasFeeSponsored
-  ) {
+  if (!isSmartTransaction || !sendBundleSupport) {
     const hook = new Delegation7702PublishHook({
       isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(
         transactionController,

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -80,6 +80,11 @@ describe('ConfirmFooter', () => {
       shouldThrottleOrigin: false,
     });
 
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSmartTransaction: false,
+      isSupported: false,
+    });
+
     useIsGaslessLoadingMock.mockReturnValue({
       isGaslessLoading: false,
     });

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -20,6 +20,7 @@ import {
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { getPreferences } from '../../../../../../../selectors';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { useIsGaslessSupported } from '../../../../../hooks/gas/useIsGaslessSupported';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { useBalanceChanges } from '../../../../simulation-details/useBalanceChanges';
 import { useSelectedGasFeeToken } from '../../hooks/useGasFeeToken';
@@ -47,7 +48,11 @@ export const EditGasFeesRow = ({
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
-  const { chainId, isGasFeeSponsored, simulationData } = transactionMeta;
+  const {
+    chainId,
+    isGasFeeSponsored: doesSentinelAllowSponsorship,
+    simulationData,
+  } = transactionMeta;
   const gasFeeToken = useSelectedGasFeeToken();
   const showFiat = useShowFiat(chainId);
   const fiatValue = gasFeeToken ? gasFeeToken.amountFiat : fiatFee;
@@ -60,6 +65,11 @@ export const EditGasFeesRow = ({
 
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const isLoadingGasUsed = !simulationData || balanceChangesResult.pending;
+
+  // This prevents the gas fee row from showing as sponsored if stx is disabled
+  // by the user and 7702 is not supported in the chain.
+  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
+  const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column}>

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -2,17 +2,18 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { useDispatch, useSelector } from 'react-redux';
 import { cloneDeep } from 'lodash';
 import { useCallback, useMemo } from 'react';
-import { getCustomNonceValue } from '../../../../selectors';
-import { useConfirmContext } from '../../context/confirm';
-import { useSelectedGasFeeToken } from '../../components/confirm/info/hooks/useGasFeeToken';
-import { updateAndApproveTx } from '../../../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   getIsSmartTransaction,
   type SmartTransactionsState,
 } from '../../../../../shared/modules/selectors';
+import { getCustomNonceValue } from '../../../../selectors';
+import { updateAndApproveTx } from '../../../../store/actions';
+import { useSelectedGasFeeToken } from '../../components/confirm/info/hooks/useGasFeeToken';
+import { useConfirmContext } from '../../context/confirm';
+import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 
 export function useTransactionConfirm() {
   const dispatch = useDispatch();
@@ -23,6 +24,7 @@ export function useTransactionConfirm() {
   const isSmartTransaction = useSelector((state: SmartTransactionsState) =>
     getIsSmartTransaction(state, transactionMeta?.chainId),
   );
+  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
 
   const newTransactionMeta = useMemo(
     () => cloneDeep(transactionMeta),
@@ -44,13 +46,35 @@ export function useTransactionConfirm() {
     newTransactionMeta.txParams.gas = selectedGasFeeToken.gas;
     newTransactionMeta.txParams.maxFeePerGas = selectedGasFeeToken.maxFeePerGas;
 
+    // If the gasless flow is not supported (e.g. stx is disabled by the user,
+    // or 7702 is not supported in the chain), we override the
+    // `isGasFeeSponsored` flag to `false` so the transaction meta object in
+    // state has the correct value for the transaction details on the activity
+    // list to not show as sponsored. One limitation on the activity list will
+    // be that pre-populated transactions on fresh installs will not show as
+    // sponsored even if they were because this is not easily observable onchain
+    // for all cases.
+    newTransactionMeta.isGasFeeSponsored =
+      isGaslessSupported && transactionMeta.isGasFeeSponsored;
+
     newTransactionMeta.txParams.maxPriorityFeePerGas =
       selectedGasFeeToken.maxPriorityFeePerGas;
-  }, [selectedGasFeeToken, newTransactionMeta]);
+  }, [
+    isGaslessSupported,
+    newTransactionMeta,
+    selectedGasFeeToken,
+    transactionMeta.isGasFeeSponsored,
+  ]);
 
   const handleGasless7702 = useCallback(() => {
     newTransactionMeta.isExternalSign = true;
-  }, [newTransactionMeta]);
+    newTransactionMeta.isGasFeeSponsored =
+      isGaslessSupported && transactionMeta.isGasFeeSponsored;
+  }, [
+    isGaslessSupported,
+    newTransactionMeta,
+    transactionMeta.isGasFeeSponsored,
+  ]);
 
   const onTransactionConfirm = useCallback(async () => {
     newTransactionMeta.customNonceValue = customNonceValue;

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -63,7 +63,7 @@ export function useTransactionConfirm() {
     isGaslessSupported,
     newTransactionMeta,
     selectedGasFeeToken,
-    transactionMeta.isGasFeeSponsored,
+    transactionMeta?.isGasFeeSponsored,
   ]);
 
   const handleGasless7702 = useCallback(() => {
@@ -73,7 +73,7 @@ export function useTransactionConfirm() {
   }, [
     isGaslessSupported,
     newTransactionMeta,
-    transactionMeta.isGasFeeSponsored,
+    transactionMeta?.isGasFeeSponsored,
   ]);
 
   const onTransactionConfirm = useCallback(async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

We always prioritise sponsored flows through STX over 7702. 
- if stx is disabled by the user or not available in the network, we fallback to 7702.
- if stx is disabled or not available and 7702 is not supported, we fallback to regular transaction submission, so we can't sponsor the flow.

This PR changes 3 parts of the codebase:
- `useTransactionConfirm` in the footer, we update the `isSponsored` flag to `false` if the sentinel API signalled the flow could be sponsored, but the conditions in the client weren't met. This makes it so that we can rely on the `isSponsored` flag for retroactive purposes, such as for the activity list.
- transaction controller init, to prioritise sponsored flows through STX over ones through 7702. We were previously sending these sponsored requests through 7702, but now we respect the existing logic that prioritises STX over 7702. It will only return `isSponsored` from the Sentinel API if it matches any of the sponsorship rules, including shield sponsorship and any others.
- UI code on the gas section so it uses `useGaslessSupported` to determine if the flow can be sponsored or not


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37117?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes STX over 7702 for sponsored submissions and ensures `isGasFeeSponsored`/UI reflect gasless support, with related hook and test updates.
> 
> - **Transactions/Controller**:
>   - Update `publishHook` to defer to 7702 only when `!isSmartTransaction` or `!sendBundleSupport`, prioritizing STX otherwise.
> - **UI (Confirm > Gas fees)**:
>   - `edit-gas-fees-row.tsx`: derive `isGasFeeSponsored` as `useIsGaslessSupported().isSupported && transactionMeta.isGasFeeSponsored` to avoid showing sponsorship when gasless is unsupported.
> - **Hooks**:
>   - `useTransactionConfirm`: set `newTransactionMeta.isGasFeeSponsored = isGaslessSupported && transactionMeta.isGasFeeSponsored`; mark `isExternalSign` for 7702 path.
> - **Tests**:
>   - `footer.test.tsx`: mock `useIsGaslessSupported` and gasless loading in scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d28fc4c9b68ef8d966b9bb589f3f3a2069375cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->