### PR TITLE
chore: Bump Yarn to `4.10.3` and configure NPM age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -157,8 +157,19 @@ npmAuditIgnoreAdvisories:
   # Issue: @solana/web3.js version 2.0 is now @solana/kit! Remove @solana/web3.js@2 from your dependencies and replace it with @solana/kit.
   # As needed, upgrade all of your @solana-program/* dependencies to the latest versions that use Kit.
   - '@solana/web3.js (deprecation)'
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
-    spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
+    spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"
+
+# Configure the NPM minimal age gate to 3 days, meaning packages must be at
+# least 3 days old to be installed.
+npmMinimalAgeGate: 4320 # 3 days (in minutes)
+
+# Override the minimal age gate, allowing certain packages to be installed
+# regardless of their publish age.
+npmPreapprovedPackages:
+  - "@metamask/*"
+  - "@lavamoat/*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -160,9 +160,9 @@ npmAuditIgnoreAdvisories:
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
+    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
-    spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"
+    spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
 
 # Configure the NPM minimal age gate to 3 days, meaning packages must be at
 # least 3 days old to be installed.
@@ -171,5 +171,5 @@ npmMinimalAgeGate: 4320 # 3 days (in minutes)
 # Override the minimal age gate, allowing certain packages to be installed
 # regardless of their publish age.
 npmPreapprovedPackages:
-  - "@metamask/*"
-  - "@lavamoat/*"
+  - '@metamask/*'
+  - '@lavamoat/*'

--- a/package.json
+++ b/package.json
@@ -809,7 +809,7 @@
       "@metamask/streams": false
     }
   },
-  "packageManager": "yarn@4.9.4",
+  "packageManager": "yarn@4.10.3",
   "foundryup": {
     "binaries": [
       "anvil"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This bumps Yarn to the latest version (`4.10.3`), which includes support for setting an age gate for NPM packages. It's set to 3 days following the security recommendations, meaning that packages must be at least 3 days old to be installed.

From the [Yarn docs](https://yarnpkg.com/configuration/yarnrc):

> Minimum age of a package version according to the publish date on the npm registry in minutes to be considered for installation.
> 
> If a package version is newer than the minimal age gate, it will not be considered for installation. This can be used to reduce the likelihood of installing compromised packages.

See https://github.com/MetaMask/metamask-module-template/pull/270 for reference.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37119?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Yarn to 4.10.3 and adds a 3-day NPM package age gate with allowlist for MetaMask and LavaMoat packages.
> 
> - **Tooling**:
>   - Update `package.json` `packageManager` to `yarn@4.10.3`.
> - **Yarn config** (`.yarnrc.yml`):
>   - Add `npmMinimalAgeGate: 4320` (3 days).
>   - Add `npmPreapprovedPackages` allowlist: `@metamask/*`, `@lavamoat/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e3cc518aa0c4b68273938073b0a05d20a700f7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->