### PR TITLE
fix: Fix `navigateNext` logic on multiple confirmations

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -502,6 +502,9 @@ describe('ConfirmFooter', () => {
 
           // It will navigate to transaction confirmation
           expect(navigateNextMock).toHaveBeenCalledTimes(1);
+          expect(navigateNextMock).toHaveBeenCalledWith(
+            addEthereumChainApproval.id,
+          );
         },
       );
     });

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -250,7 +250,7 @@ const Footer = () => {
     onCancel({ location: MetaMetricsEventLocation.Confirmation });
 
     navigateNext(currentConfirmation.id);
-  }, [navigateNext, onCancel, shouldThrottleOrigin, currentConfirmation.id]);
+  }, [navigateNext, onCancel, shouldThrottleOrigin, currentConfirmation]);
 
   const isShowShieldFooterCoverageIndicator = useEnableShieldCoverageChecks();
 

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -231,7 +231,7 @@ const Footer = () => {
       dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
     }
 
-    navigateNext();
+    navigateNext(currentConfirmation.id);
     resetTransactionState();
   }, [
     currentConfirmation,
@@ -249,8 +249,8 @@ const Footer = () => {
     }
     onCancel({ location: MetaMetricsEventLocation.Confirmation });
 
-    navigateNext();
-  }, [navigateNext, onCancel, shouldThrottleOrigin]);
+    navigateNext(currentConfirmation.id);
+  }, [navigateNext, onCancel, shouldThrottleOrigin, currentConfirmation.id]);
 
   const isShowShieldFooterCoverageIndicator = useEnableShieldCoverageChecks();
 

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.test.ts
@@ -320,7 +320,7 @@ describe('useConfirmationNavigation', () => {
   describe('navigateNext', () => {
     it('navigates to the next confirmation', () => {
       const result = renderHook(ApprovalType.Transaction);
-      result.navigateNext();
+      result.navigateNext(APPROVAL_ID_MOCK);
       expect(history.replace).toHaveBeenCalledTimes(1);
       expect(history.replace).toHaveBeenCalledWith(
         `${CONFIRM_TRANSACTION_ROUTE}/${APPROVAL_ID_2_MOCK}`,

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -69,11 +69,18 @@ export function useConfirmationNavigation() {
     [confirmations, navigateToId],
   );
 
-  const navigateNext = useCallback(() => {
-    if (count > 1) {
-      navigateToIndex(1);
-    }
-  }, [count, navigateToIndex]);
+  const navigateNext = useCallback(
+    (confirmationId: string) => {
+      const pendingConfirmations = confirmations.filter(
+        (confirmation) => confirmation.id !== confirmationId,
+      );
+      if (pendingConfirmations.length >= 1) {
+        const index = getIndex(pendingConfirmations[0].id);
+        navigateToIndex(index);
+      }
+    },
+    [confirmations, getIndex, navigateToIndex],
+  );
 
   return {
     confirmations,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to strengthen `navigateNext` logic in confirmation navigation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37121?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36989

## **Manual testing steps**

1. Multiple confirmations on https://github.com/MetaMask/metamask-extension/pull/36640 should work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines confirmation navigation by passing the current confirmation ID to `navigateNext` and updating logic to route to the next pending item; updates footer and tests accordingly.
> 
> - **Hooks**:
>   - Update `useConfirmationNavigation.navigateNext` to accept `confirmationId` and navigate to the next pending confirmation excluding the given ID.
>   - Adjust navigation flow to compute next index via `getIndex` and `navigateToIndex`.
> - **UI**:
>   - In `confirm/footer`, pass `currentConfirmation.id` to `navigateNext` on both confirm and cancel actions.
> - **Tests**:
>   - Update tests to call `navigateNext` with the current approval ID and assert correct routing.
>   - Add assertion that footer passes the correct ID to `navigateNext` (e.g., `addEthereumChainApproval.id`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2554fefd3bb89af3cab3caf5b193ddf533e17617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->