### PR TITLE
fix: toast avatar icon

### DIFF
--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -245,7 +245,7 @@ function ConnectAccountGroupToast() {
   const seedAddress = useSelector((state) =>
     getIconSeedAddressByAccountGroupId(
       state,
-      selectedAccountGroupInternalAccounts.id,
+      selectedAccountGroupInternalAccounts?.id,
     ),
   );
 

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -250,7 +250,7 @@ function ConnectAccountGroupToast() {
   );
 
   // Early return if selectedAccountGroupInternalAccounts is undefined
-  if (!selectedAccountGroupInternalAccounts) {
+  if (!selectedAccountGroupInternalAccounts || !seedAddress) {
     return null;
   }
 

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -58,6 +58,7 @@ import {
 import { getDappActiveNetwork } from '../../../selectors/dapp';
 import {
   getAccountGroupWithInternalAccounts,
+  getIconSeedAddressByAccountGroupId,
   getSelectedAccountGroup,
 } from '../../../selectors/multichain-accounts/account-tree';
 import { hasChainIdSupport } from '../../../../shared/lib/multichain/scope-utils';
@@ -241,6 +242,13 @@ function ConnectAccountGroupToast() {
       .map((account) => account.address);
   }, [existingChainIds, selectedAccountGroupInternalAccounts?.accounts]);
 
+  const seedAddress = useSelector((state) =>
+    getIconSeedAddressByAccountGroupId(
+      state,
+      selectedAccountGroupInternalAccounts.id,
+    ),
+  );
+
   // Early return if selectedAccountGroupInternalAccounts is undefined
   if (!selectedAccountGroupInternalAccounts) {
     return null;
@@ -252,10 +260,7 @@ function ConnectAccountGroupToast() {
         dataTestId="connect-account-toast"
         key="connect-account-toast"
         startAdornment={
-          <PreferredAvatar
-            address={selectedAccountGroupInternalAccounts.id}
-            className="self-center"
-          />
+          <PreferredAvatar address={seedAddress} className="self-center" />
         }
         text={t('accountIsntConnectedToastText', [
           selectedAccountGroupInternalAccounts.metadata?.name,

--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -1335,15 +1335,13 @@ describe('Multichain Accounts Selectors', () => {
       expect(result).toBe(ACCOUNT_3_ADDRESS);
     });
 
-    it('throws error when no group ID is found', () => {
-      expect(() =>
-        getIconSeedAddressByAccountGroupId(
-          typedMockState,
-          'nonExistentGroupId' as AccountGroupId,
-        ),
-      ).toThrow(
-        'Error in getIconSeedAddressByAccountGroupId: No accounts found in the specified group',
+    it('returns empty when no group ID is found', () => {
+      const result = getIconSeedAddressByAccountGroupId(
+        typedMockState,
+        'nonExistentGroupId' as AccountGroupId,
       );
+
+      expect(result).toBe('');
     });
   });
 

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -858,9 +858,7 @@ export const getIconSeedAddressByAccountGroupId = createDeepEqualSelector(
   [getInternalAccountsFromGroupById],
   (accounts: InternalAccount[]): string => {
     if (!accounts || accounts.length === 0) {
-      throw new Error(
-        'Error in getIconSeedAddressByAccountGroupId: No accounts found in the specified group',
-      );
+      return '';
     }
 
     for (const account of accounts) {


### PR DESCRIPTION
## **Description**

Fixes #37049

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: toast avatar icon

## **Related issues**

Fixes:

## **Manual testing steps**

1. Connect to a dapp
2. Switch to a different account that isn't connected
3. Observe toast

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Connect account group toast now uses a seed address for the avatar and the icon seed selector returns an empty string when no accounts exist, with tests updated accordingly.
> 
> - **UI**:
>   - `ConnectAccountGroupToast` in `ui/components/app/toast-master/toast-master.js` now derives `seedAddress` via `getIconSeedAddressByAccountGroupId` and uses it for `PreferredAvatar`; early-returns if missing.
> - **Selectors**:
>   - `getIconSeedAddressByAccountGroupId` in `ui/selectors/multichain-accounts/account-tree.ts` returns `''` when no accounts are found (instead of throwing).
> - **Tests**:
>   - Update `getIconSeedAddressByAccountGroupId` tests to expect empty string for non-existent group IDs; keep existing seed address expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1cd56400266f38867de3be87f41b165f2f5e775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->