### PR TITLE
chore: improve initial rendering for setting pages

### DIFF
--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -52,7 +52,6 @@ import {
   useUnCancelSubscription,
   useUpdateSubscriptionCardPaymentMethod,
   useUserSubscriptionByProduct,
-  useUserSubscriptions,
 } from '../../../hooks/subscription/useSubscription';
 import { getShortDateFormatterV2 } from '../../asset/util';
 import {
@@ -67,7 +66,7 @@ import LoadingScreen from '../../../components/ui/loading-screen';
 import AddFundsModal from '../../../components/app/modals/add-funds-modal/add-funds-modal';
 import {
   useSubscriptionPaymentMethods,
-  useSubscriptionPricing,
+  useUseSubscriptionsWithPricing,
 } from '../../../hooks/subscription/useSubscriptionPricing';
 import {
   getSubscriptionCryptoApprovalAmount,
@@ -108,21 +107,16 @@ const TransactionShield = () => {
   const dispatch = useDispatch();
 
   const {
-    customerId,
+    subscriptionPricing,
     subscriptions,
-    loading: subscriptionsLoading,
-  } = useUserSubscriptions({
-    refetch: true, // always fetch latest subscriptions state in settings screen
-  });
+    customerId,
+    loading: subscriptionsAndPricingRequestLoading,
+  } = useUseSubscriptionsWithPricing();
+
   const shieldSubscription = useUserSubscriptionByProduct(
     PRODUCT_TYPES.SHIELD,
     subscriptions,
   );
-
-  const { subscriptionPricing, loading: subscriptionPricingLoading } =
-    useSubscriptionPricing({
-      refetch: true, // need to refetch here in case user already subscribed and doesn't go through shield plan screen
-    });
   const cryptoPaymentMethod = useSubscriptionPaymentMethods(
     PAYMENT_TYPES.byCrypto,
     subscriptionPricing,
@@ -177,7 +171,7 @@ const TransactionShield = () => {
     openGetSubscriptionBillingPortalResult.pending ||
     updateSubscriptionCardPaymentMethodResult.pending;
 
-  const showSkeletonLoader = subscriptionsLoading || subscriptionPricingLoading;
+  const showSkeletonLoader = subscriptionsAndPricingRequestLoading;
 
   useEffect(() => {
     if (shieldSubscription) {

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -60,14 +60,13 @@ import {
   TokenWithApprovalAmount,
   useAvailableTokenBalances,
   useSubscriptionPaymentMethods,
-  useSubscriptionPricing,
   useSubscriptionProductPlans,
+  useUseSubscriptionsWithPricing,
 } from '../../hooks/subscription/useSubscriptionPricing';
 import { startSubscriptionWithCard } from '../../store/actions';
 import {
   useSubscriptionCryptoApprovalTransaction,
   useUserSubscriptionByProduct,
-  useUserSubscriptions,
 } from '../../hooks/subscription/useSubscription';
 import { useAsyncCallback } from '../../hooks/useAsync';
 import { useI18nContext } from '../../hooks/useI18nContext';
@@ -87,13 +86,13 @@ const ShieldPlan = () => {
     getInternalAccountBySelectedAccountGroupAndCaip(state, 'eip155:1'),
   );
   const {
+    subscriptionPricing,
     subscriptions,
     trialedProducts,
-    loading: subscriptionsLoading,
-    error: subscriptionsError,
-  } = useUserSubscriptions({
-    refetch: true, // always fetch latest subscriptions state in shield plan screen
-  });
+    loading: subscriptionsAndPricingRequestLoading,
+    error: subscriptionsAndPricingRequestError,
+  } = useUseSubscriptionsWithPricing();
+
   const shieldSubscription = useUserSubscriptionByProduct(
     PRODUCT_TYPES.SHIELD,
     subscriptions,
@@ -110,14 +109,6 @@ const ShieldPlan = () => {
   const [selectedPlan, setSelectedPlan] = useState<RecurringInterval>(
     RECURRING_INTERVALS.year,
   );
-
-  const {
-    subscriptionPricing,
-    loading: subscriptionPricingLoading,
-    error: subscriptionPricingError,
-  } = useSubscriptionPricing({
-    refetch: true, // always fetch latest price
-  });
 
   const pricingPlans = useSubscriptionProductPlans(
     PRODUCT_TYPES.SHIELD,
@@ -193,11 +184,8 @@ const ShieldPlan = () => {
     ]);
 
   const loading =
-    subscriptionsLoading ||
-    subscriptionPricingLoading ||
-    subscriptionResult.pending;
-  const error =
-    subscriptionsError || subscriptionPricingError || subscriptionResult.error;
+    subscriptionsAndPricingRequestLoading || subscriptionResult.pending;
+  const error = subscriptionsAndPricingRequestError || subscriptionResult.error;
 
   const plans: Plan[] = useMemo(
     () =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR improves the initial rendering times for shield setting pages by making concurrent requests (subscriptions + pricing) instead of waiting for one by one.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37132?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: improve initial rendering for shield setting pages

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
