### PR TITLE
fix: fix hidden/pinned actions cp-13.6.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2530,9 +2530,13 @@ export default class MetamaskController extends EventEmitter {
         );
       },
       setAccountGroupPinned:
-        this.accountTreeController.setAccountGroupPinned.bind(this.accountTreeController),
+        this.accountTreeController.setAccountGroupPinned.bind(
+          this.accountTreeController,
+        ),
       setAccountGroupHidden:
-        this.accountTreeController.setAccountGroupHidden.bind(this.accountTreeController),
+        this.accountTreeController.setAccountGroupHidden.bind(
+          this.accountTreeController,
+        ),
       syncAccountTreeWithUserStorage: async () => {
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         await this.getSnapKeyring();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2530,9 +2530,9 @@ export default class MetamaskController extends EventEmitter {
         );
       },
       setAccountGroupPinned:
-        this.accountTreeController.setAccountGroupPinned.bind(this),
+        this.accountTreeController.setAccountGroupPinned.bind(this.accountTreeController),
       setAccountGroupHidden:
-        this.accountTreeController.setAccountGroupHidden.bind(this),
+        this.accountTreeController.setAccountGroupHidden.bind(this.accountTreeController),
       syncAccountTreeWithUserStorage: async () => {
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         await this.getSnapKeyring();


### PR DESCRIPTION
## **Description**

The `.bind` was wrong for those actions, resulting in a runtime error.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37133?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37140

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bind `setAccountGroupPinned` and `setAccountGroupHidden` to `accountTreeController` to fix incorrect `this` context.
> 
> - **Accounts/Account Tree**:
>   - Fix bindings for `setAccountGroupPinned` and `setAccountGroupHidden` to use `this.accountTreeController` context in `app/scripts/metamask-controller.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9d030b3e9637c4da09ae5773ca298f81ba3cfde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->