### PR TITLE
feat: make all two-tab components use full-width layout

### DIFF
--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -118,14 +118,11 @@ export const AccountDetailsDisplay = ({
         </Box>
       )}
       {!pending && networkSupporting7702Present && (
-        <Tabs
-          onTabClick={() => undefined}
-          style={{ width: '100%', marginTop: '8px' }}
-        >
-          <Tab name="Type" tabKey="Type" style={{ width: '50%' }}>
+        <Tabs onTabClick={() => undefined} className="mt-2">
+          <Tab name="Type" tabKey="Type" className="flex-1">
             <SmartAccountTab address={address} />
           </Tab>
-          <Tab name="Details" tabKey="Details" style={{ width: '50%' }}>
+          <Tab name="Details" tabKey="Details" className="flex-1">
             <AccountDetailsSection
               address={address}
               onExportClick={onExportClick}

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -105,7 +105,7 @@ export const AccountDetailsDisplay = ({
           data-testid="address-copy-button-text"
         />
       </Box>
-      {pending && (
+      {false && (
         <Box
           paddingTop={12}
           paddingBottom={12}
@@ -117,19 +117,19 @@ export const AccountDetailsDisplay = ({
           <Preloader size={18} />
         </Box>
       )}
-      {!pending && networkSupporting7702Present && (
-        <Tabs onTabClick={() => undefined} className="mt-2">
-          <Tab name="Type" tabKey="Type" className="flex-1">
-            <SmartAccountTab address={address} />
-          </Tab>
-          <Tab name="Details" tabKey="Details" className="flex-1">
-            <AccountDetailsSection
-              address={address}
-              onExportClick={onExportClick}
-            />
-          </Tab>
-        </Tabs>
-      )}
+      {/* {!pending && networkSupporting7702Present && ( */}
+      <Tabs onTabClick={() => undefined} className="mt-2">
+        <Tab name="Type" tabKey="Type" className="flex-1">
+          <SmartAccountTab address={address} />
+        </Tab>
+        <Tab name="Details" tabKey="Details" className="flex-1">
+          <AccountDetailsSection
+            address={address}
+            onExportClick={onExportClick}
+          />
+        </Tab>
+      </Tabs>
+      {/* )} */}
       {!pending && !networkSupporting7702Present && (
         <AccountDetailsSection
           address={address}

--- a/ui/components/multichain/account-details/account-details-display.js
+++ b/ui/components/multichain/account-details/account-details-display.js
@@ -105,7 +105,7 @@ export const AccountDetailsDisplay = ({
           data-testid="address-copy-button-text"
         />
       </Box>
-      {false && (
+      {pending && (
         <Box
           paddingTop={12}
           paddingBottom={12}
@@ -117,19 +117,19 @@ export const AccountDetailsDisplay = ({
           <Preloader size={18} />
         </Box>
       )}
-      {/* {!pending && networkSupporting7702Present && ( */}
-      <Tabs onTabClick={() => undefined} className="mt-2">
-        <Tab name="Type" tabKey="Type" className="flex-1">
-          <SmartAccountTab address={address} />
-        </Tab>
-        <Tab name="Details" tabKey="Details" className="flex-1">
-          <AccountDetailsSection
-            address={address}
-            onExportClick={onExportClick}
-          />
-        </Tab>
-      </Tabs>
-      {/* )} */}
+      {!pending && networkSupporting7702Present && (
+        <Tabs onTabClick={() => undefined} className="mt-2">
+          <Tab name="Type" tabKey="Type" className="flex-1">
+            <SmartAccountTab address={address} />
+          </Tab>
+          <Tab name="Details" tabKey="Details" className="flex-1">
+            <AccountDetailsSection
+              address={address}
+              onExportClick={onExportClick}
+            />
+          </Tab>
+        </Tabs>
+      )}
       {!pending && !networkSupporting7702Present && (
         <AccountDetailsSection
           address={address}

--- a/ui/components/multichain/account-details/account-details.tsx
+++ b/ui/components/multichain/account-details/account-details.tsx
@@ -13,6 +13,7 @@ import {
   AlignItems,
   Display,
   FlexDirection,
+  JustifyContent,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -108,7 +109,7 @@ export const AccountDetails = ({ address }: AccountDetailsProps) => {
     <PreferredAvatar
       address={address}
       size={AvatarAccountSize.Lg}
-      style={{ margin: '0 auto' }}
+      className="mx-auto"
     />
   );
 
@@ -132,6 +133,10 @@ export const AccountDetails = ({ address }: AccountDetailsProps) => {
               } else if (attemptingExport === AttemptExportState.None) {
                 onClose();
               }
+            }}
+            childrenWrapperProps={{
+              display: Display.Flex,
+              justifyContent: JustifyContent.center,
             }}
           >
             {attemptingExport === AttemptExportState.PrivateKey

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-tabs.tsx
@@ -36,7 +36,12 @@ export const AssetPickerModalTabs = ({
       >
         {visibleTabs.map((tabName) => {
           return (
-            <Tab key={tabName} name={t(tabName)} tabKey={tabName}>
+            <Tab
+              key={tabName}
+              name={t(tabName)}
+              tabKey={tabName}
+              className="flex-1"
+            >
               {children.find(({ key }) => key === tabName)}
             </Tab>
           );

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -748,6 +748,7 @@ export const ImportTokensModal = ({ onClose }) => {
                   tabKey={TAB_NAMES.SEARCH}
                   name={t('search')}
                   onClick={() => setDefaultActiveTabKey(TAB_NAMES.SEARCH)}
+                  className="flex-1"
                 >
                   <Box paddingTop={4}>
                     {useTokenDetection ? null : (
@@ -836,6 +837,7 @@ export const ImportTokensModal = ({ onClose }) => {
                 name={t('customToken')}
                 onClick={() => setDefaultActiveTabKey(TAB_NAMES.CUSTOM_TOKEN)}
                 data-testid="import-tokens-modal-custom-token-tab"
+                className="flex-1"
               >
                 {isConfirming ? (
                   <ImportTokensModalConfirm networkFilter={networkFilter} />

--- a/ui/components/multichain/network-manager/network-tabs.tsx
+++ b/ui/components/multichain/network-manager/network-tabs.tsx
@@ -35,12 +35,17 @@ export const NetworkTabs = ({ initialTab }: { initialTab: string }) => {
             className: 'network-manager__tab-content',
           }}
         >
-          <Tab tabKey="networks" name={t('networkTabPopular') ?? 'Popular'}>
+          <Tab
+            tabKey="networks"
+            name={t('networkTabPopular') ?? 'Popular'}
+            className="flex-1"
+          >
             <DefaultNetworks />
           </Tab>
           <Tab
             tabKey="custom-networks"
             name={t('networkTabCustom') ?? 'Custom'}
+            className="flex-1"
           >
             <CustomNetworks />
           </Tab>

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -181,7 +181,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                 <button
                   aria-disabled="false"
                   aria-selected="true"
-                  class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default"
+                  class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default flex-1"
                   role="tab"
                   tabindex="0"
                 >
@@ -190,7 +190,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                 <button
                   aria-disabled="false"
                   aria-selected="false"
-                  class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default"
+                  class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default flex-1"
                   data-testid="send-contacts-tab"
                   role="tab"
                   tabindex="-1"

--- a/ui/components/multichain/pages/send/components/recipient.tsx
+++ b/ui/components/multichain/pages/send/components/recipient.tsx
@@ -130,7 +130,11 @@ export const SendPageRecipient = () => {
         {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          <Tab tabKey={ACCOUNTS_TAB_KEY} name={t('yourAccounts')}>
+          <Tab
+            tabKey={ACCOUNTS_TAB_KEY}
+            name={t('yourAccounts')}
+            className="flex-1"
+          >
             <SendPageYourAccounts />
           </Tab>
         }
@@ -141,6 +145,7 @@ export const SendPageRecipient = () => {
             tabKey={CONTACTS_TAB_KEY}
             name={t('contacts')}
             data-testid="send-contacts-tab"
+            className="flex-1"
           >
             <SendPageAddressBook />
           </Tab>

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -215,11 +215,15 @@ export default function RevealSeedPage() {
             }
           }}
         >
-          <Tab name={t('revealSeedWordsText')} tabKey="text-seed">
+          <Tab
+            name={t('revealSeedWordsText')}
+            tabKey="text-seed"
+            className="flex-1"
+          >
             <Label marginTop={4}>{t('yourPrivateSeedPhrase')}</Label>
             <ExportTextContainer text={seedWords} onClickCopy={onClickCopy} />
           </Tab>
-          <Tab name={t('revealSeedWordsQR')} tabKey="qr-srp">
+          <Tab name={t('revealSeedWordsQR')} tabKey="qr-srp" className="flex-1">
             <Box
               display={Display.Flex}
               justifyContent={JustifyContent.center}

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/__snapshots__/multichain-accounts-connect-page.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`MultichainConnectPage renders correctly 1`] = `
             <button
               aria-disabled="false"
               aria-selected="true"
-              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab"
+              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab flex-1"
               data-testid="accounts-tab"
               role="tab"
               tabindex="0"
@@ -93,7 +93,7 @@ exports[`MultichainConnectPage renders correctly 1`] = `
             <button
               aria-disabled="false"
               aria-selected="false"
-              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab flex-1"
               data-testid="permissions-tab"
               role="tab"
               tabindex="-1"
@@ -330,7 +330,7 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
             <button
               aria-disabled="false"
               aria-selected="true"
-              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab"
+              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab flex-1"
               data-testid="accounts-tab"
               role="tab"
               tabindex="0"
@@ -340,7 +340,7 @@ exports[`MultichainConnectPage renders with existing permissions correctly 1`] =
             <button
               aria-disabled="false"
               aria-selected="false"
-              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab flex-1"
               data-testid="permissions-tab"
               role="tab"
               tabindex="-1"
@@ -577,7 +577,7 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
             <button
               aria-disabled="false"
               aria-selected="true"
-              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab"
+              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default multichain-connect-page__tab flex-1"
               data-testid="accounts-tab"
               role="tab"
               tabindex="0"
@@ -587,7 +587,7 @@ exports[`MultichainConnectPage renders with multichain origin request correctly 
             <button
               aria-disabled="false"
               aria-selected="false"
-              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default multichain-connect-page__tab flex-1"
               data-testid="permissions-tab"
               role="tab"
               tabindex="-1"

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
@@ -605,7 +605,7 @@ export const MultichainAccountsConnectPage: React.FC<
       >
         <Tabs onTabClick={() => null} defaultActiveTabKey="accounts">
           <Tab
-            className="multichain-connect-page__tab"
+            className="multichain-connect-page__tab flex-1"
             name={t('accounts')}
             tabKey="accounts"
             data-testid="accounts-tab"
@@ -669,7 +669,7 @@ export const MultichainAccountsConnectPage: React.FC<
           </Tab>
           <Tab
             name={t('permissions')}
-            className="multichain-connect-page__tab"
+            className="multichain-connect-page__tab flex-1"
             tabKey="permissions"
             data-testid="permissions-tab"
             disabled={selectedAccountGroupIds.length === 0}

--- a/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
+++ b/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`ConnectPage should render correctly 1`] = `
             <button
               aria-disabled="false"
               aria-selected="true"
-              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default"
+              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default flex-1"
               data-testid="accounts-tab"
               role="tab"
               tabindex="0"
@@ -93,7 +93,7 @@ exports[`ConnectPage should render correctly 1`] = `
             <button
               aria-disabled="false"
               aria-selected="false"
-              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default flex-1"
               data-testid="permissions-tab"
               role="tab"
               tabindex="-1"
@@ -504,7 +504,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
             <button
               aria-disabled="false"
               aria-selected="true"
-              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default"
+              class="text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default text-default border-b-text-default flex-1"
               data-testid="accounts-tab"
               role="tab"
               tabindex="0"
@@ -514,7 +514,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
             <button
               aria-disabled="false"
               aria-selected="false"
-              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default text-center flex align-middle justify-center border-b-2 border-transparent px-0 py-1 transition-all duration-200 cubic-bezier(0.7, 0, 0.15, 1) hover:enabled:text-default flex-1"
               data-testid="permissions-tab"
               role="tab"
               tabindex="-1"

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -548,6 +548,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
             name={t('accounts')}
             tabKey="accounts"
             data-testid="accounts-tab"
+            className="flex-1"
           >
             <Box marginTop={4}>
               <Box
@@ -652,6 +653,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
               !solanaAccountExistsInWallet &&
               selectedAccounts.length === 0
             }
+            className="flex-1"
           >
             <Box marginTop={4}>
               <SiteCell


### PR DESCRIPTION
## **Description**

Update all Tab components with two tabs to use full-width layout instead of left-aligned layout. This improves the visual balance and utilization of available space in the UI.

The changes add `className="flex-1"` to Tab components in various parts of the application to make each tab take up equal width (50% each) when there are two tabs.

<img width="984" height="512" alt="Screenshot 2025-10-23 at 10 47 30 AM" src="https://github.com/user-attachments/assets/a7d6573f-92cd-4f8d-aa39-a3df4a04ba39" />

## **Changelog**

CHANGELOG entry: Updated two-tab components to use full-width layout for better visual balance

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-244

## **Manual testing steps**

0. Rely on screenshots in code comments or:
1. Go to Account Details page with EIP-7702 network support
2. Verify the "Type" and "Details" tabs are full width
3. Go to Import Tokens modal
4. Verify the "Search" and "Custom Token" tabs are full width  
5. Go to Network Manager
6. Verify the "Popular" and "Custom" tabs are full width
7. Go to Send page recipient selection
8. Verify the "Your Accounts" and "Contacts" tabs are full width
9. Go to Reveal Seed page
10. Verify the "Text" and "QR" tabs are full width

## **Screenshots/Recordings**

### **After**

Added after screenshots to code comments for easier review and visual regression testing

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies full-width (flex-1) tab styling to all two-tab UIs and minor layout tweaks (utility classes, centered modal header).
> 
> - **UI/Layout**:
>   - **Tabs**: Make two-tab layouts full-width by adding `className="flex-1"` to `Tab` in:
>     - `account-details-display`, `asset-picker-modal-tabs`, `import-tokens-modal`, `network-tabs`, `send/components/recipient`, `reveal-seed`, `multichain-accounts-connect-page`, `permissions-connect/connect-page`.
>   - **Styling cleanups**: Replace inline styles with utility classes (e.g., `mx-auto`, `mt-2`) and center modal header content via `childrenWrapperProps` in `account-details.tsx`.
> - **Tests**:
>   - Update snapshots to reflect full-width tabs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 475824a1b45fdd3a8c407b08e326eaad324bd9c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->