### PR TITLE
feat: Use `main-exp` Launch Darkly environment for experimental builds

### DIFF
--- a/app/scripts/controller-init/remote-feature-flag-controller-init.test.ts
+++ b/app/scripts/controller-init/remote-feature-flag-controller-init.test.ts
@@ -66,6 +66,21 @@ describe('getConfigForRemoteFeatureFlagRequest', () => {
       environment: 'rc',
     });
   });
+
+  // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
+  it.each(Object.keys(ENVIRONMENT))(
+    'returns main-exp for experimental build in "%s" environment',
+    async (environment: keyof typeof ENVIRONMENT) => {
+      process.env.METAMASK_BUILD_TYPE = 'experimental';
+      process.env.METAMASK_ENVIRONMENT = environment;
+
+      const result = getConfigForRemoteFeatureFlagRequest();
+      expect(result).toStrictEqual({
+        distribution: 'main',
+        environment: 'exp',
+      });
+    },
+  );
 });
 
 describe('RemoteFeatureFlagControllerInit', () => {

--- a/app/scripts/controller-init/remote-feature-flag-controller-init.test.ts
+++ b/app/scripts/controller-init/remote-feature-flag-controller-init.test.ts
@@ -68,7 +68,7 @@ describe('getConfigForRemoteFeatureFlagRequest', () => {
   });
 
   // @ts-expect-error ESLint is misconfigured and not applying Jest types to this file
-  it.each(Object.keys(ENVIRONMENT))(
+  it.each(Object.values(ENVIRONMENT))(
     'returns main-exp for experimental build in "%s" environment',
     async (environment: keyof typeof ENVIRONMENT) => {
       process.env.METAMASK_BUILD_TYPE = 'experimental';

--- a/app/scripts/controller-init/remote-feature-flag-controller-init.ts
+++ b/app/scripts/controller-init/remote-feature-flag-controller-init.ts
@@ -34,16 +34,20 @@ export function getConfigForRemoteFeatureFlagRequest() {
     process.env.METAMASK_ENVIRONMENT,
     'METAMASK_ENVIRONMENT is not defined',
   );
+  const buildType = process.env.METAMASK_BUILD_TYPE;
 
   const distribution =
-    BUILD_TYPE_MAPPING[
-      process.env.METAMASK_BUILD_TYPE as keyof typeof BUILD_TYPE_MAPPING
-    ] || DistributionType.Main;
+    BUILD_TYPE_MAPPING[buildType as keyof typeof BUILD_TYPE_MAPPING] ||
+    DistributionType.Main;
 
-  const environment =
+  let environment =
     ENVIRONMENT_MAPPING[
       process.env.METAMASK_ENVIRONMENT as keyof typeof ENVIRONMENT_MAPPING
     ] || EnvironmentType.Development;
+
+  if (buildType === 'experimental') {
+    environment = EnvironmentType.Exp;
+  }
 
   return { distribution, environment };
 }


### PR DESCRIPTION
## **Description**

The remote feature flag environment mapping has been updated to overwrite the environment used with `exp` for experimental builds. All experimental builds will now use the `main-exp` Launch Darkly environment, regardless where they are created from (i.e. regardless if they're from `main`, a pull request, a release candidate, a local build, etc.).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37145?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> For experimental builds, always use `environment: 'exp'` with `distribution: 'main'`, and add tests covering all environments.
> 
> - **Remote feature flag config**:
>   - Force `environment: 'exp'` when `METAMASK_BUILD_TYPE` is `experimental`, keeping `distribution: 'main'`.
>   - Minor refactor: cache `buildType` and make `environment` mutable to allow override.
> - **Tests**:
>   - Add parameterized test over all `ENVIRONMENT` values to assert experimental builds return `{ distribution: 'main', environment: 'exp' }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a426c901d8bc64a322ffdabafa51100d3da1b42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->