### PR TITLE
feat(ramps): fixes btc buy button deeplink bug

### DIFF
--- a/ui/ducks/ramps/constants.ts
+++ b/ui/ducks/ramps/constants.ts
@@ -1,3 +1,8 @@
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../shared/constants/bridge';
+import {
+  MULTICHAIN_NETWORK_TO_NICKNAME,
+  MultichainNetworks,
+} from '../../../shared/constants/multichain/networks';
 import {
   ARBITRUM_DISPLAY_NAME,
   AVALANCHE_DISPLAY_NAME,
@@ -13,6 +18,20 @@ import {
 import { AggregatorNetwork } from './types';
 
 export const defaultBuyableChains: AggregatorNetwork[] = [
+  {
+    active: true,
+    chainId: MultichainNetworks.BITCOIN,
+    chainName: MULTICHAIN_NETWORK_TO_NICKNAME[MultichainNetworks.BITCOIN],
+    shortName: NETWORK_TO_SHORT_NETWORK_NAME_MAP[MultichainNetworks.BITCOIN],
+    nativeTokenSupported: true,
+  },
+  {
+    active: true,
+    chainId: MultichainNetworks.SOLANA,
+    chainName: MULTICHAIN_NETWORK_TO_NICKNAME[MultichainNetworks.SOLANA],
+    shortName: NETWORK_TO_SHORT_NETWORK_NAME_MAP[MultichainNetworks.SOLANA],
+    nativeTokenSupported: true,
+  },
   {
     active: true,
     chainId: 1,

--- a/ui/ducks/ramps/ramps.test.ts
+++ b/ui/ducks/ramps/ramps.test.ts
@@ -292,7 +292,19 @@ describe('rampsSlice', () => {
   });
 
   describe('getIsBitcoinBuyable', () => {
-    it('should return false when Bitcoin is not in buyableChains', () => {
+    it('should return true when Bitcoin is in defaultBuyableChains', () => {
+      const state = store.getState();
+      expect(getIsBitcoinBuyable(state)).toBe(true);
+    });
+
+    it('should return false when Bitcoin is explicitly set to inactive', () => {
+      const mockBuyableChains = [
+        { chainId: MultichainNetworks.BITCOIN, active: false },
+      ];
+      store.dispatch({
+        type: 'ramps/setBuyableChains',
+        payload: mockBuyableChains,
+      });
       const state = store.getState();
       expect(getIsBitcoinBuyable(state)).toBe(false);
     });

--- a/ui/hooks/ramps/useRamps/useRamps.test.tsx
+++ b/ui/hooks/ramps/useRamps/useRamps.test.tsx
@@ -146,7 +146,7 @@ describe('useRamps', () => {
 
   it('should handle non-EVM chain IDs correctly (like Bitcoin)', () => {
     const metaMaskEntry = 'ext_buy_sell_button';
-    const bitcoinChainId = 'bitcoin:mainnet';
+    const bitcoinChainId = 'bip122:000000000019d6689c085ae165831e93';
     (isEvmChainId as jest.Mock).mockReturnValueOnce(false);
     mockStoreState = {
       ...mockStoreState,

--- a/ui/hooks/ramps/useRamps/useRamps.test.tsx
+++ b/ui/hooks/ramps/useRamps/useRamps.test.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react';
 import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
-import { isSolanaChainId } from '@metamask/bridge-controller';
+import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import configureStore from '../../../store/store';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import useRamps, { RampsMetaMaskEntry } from './useRamps';
 
-jest.mock('@metamask/bridge-controller', () => ({
-  ...jest.requireActual('@metamask/bridge-controller'),
-  isSolanaChainId: jest.fn(),
+jest.mock('../../../../shared/lib/asset-utils', () => ({
+  ...jest.requireActual('../../../../shared/lib/asset-utils'),
+  isEvmChainId: jest.fn(),
 }));
 
 const mockedMetametricsId = '0xtestMetaMetricsId';
@@ -41,6 +41,7 @@ describe('useRamps', () => {
     ];
 
     testCases.forEach(({ mockChainId, numericChainId }) => {
+      (isEvmChainId as jest.Mock).mockReturnValueOnce(true);
       mockStoreState = {
         ...mockStoreState,
         metamask: {
@@ -63,6 +64,7 @@ describe('useRamps', () => {
   it('should default the metamask entry param when opening the buy crypto URL', () => {
     const metaMaskEntry = 'ext_buy_sell_button';
     const mockChainId = '1';
+    (isEvmChainId as jest.Mock).mockReturnValueOnce(true);
 
     mockStoreState = {
       ...mockStoreState,
@@ -86,6 +88,7 @@ describe('useRamps', () => {
   it('should use the correct metamask entry param when opening the buy crypto URL', () => {
     const metaMaskEntry = 'ext_buy_banner_tokens';
     const mockChainId = '1';
+    (isEvmChainId as jest.Mock).mockReturnValueOnce(true);
 
     mockStoreState = {
       ...mockStoreState,
@@ -124,22 +127,39 @@ describe('useRamps', () => {
     jest.resetModules();
   });
 
-  it('should handle Solana chain IDs correctly', () => {
+  it('should handle EVM chain IDs correctly by converting to numeric format', () => {
     const metaMaskEntry = 'ext_buy_sell_button';
-    const solanaChainId = 'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ';
-    (isSolanaChainId as jest.Mock).mockReturnValueOnce(true);
+    const evmChainId = '0x1';
+    (isEvmChainId as jest.Mock).mockReturnValueOnce(true);
+    mockStoreState = {
+      ...mockStoreState,
+      metamask: {
+        ...mockStoreState.metamask,
+        ...mockNetworkState({ chainId: evmChainId }),
+      },
+    };
+    const mockBuyURI = `${process.env.PORTFOLIO_URL}/buy?metamaskEntry=${metaMaskEntry}&chainId=1&metametricsId=${mockedMetametricsId}&metricsEnabled=false`;
+    const { result } = renderHook(() => useRamps(), { wrapper });
+    const buyURI = result.current.getBuyURI(evmChainId);
+    expect(buyURI).toBe(mockBuyURI);
+  });
+
+  it('should handle non-EVM chain IDs correctly (like Bitcoin)', () => {
+    const metaMaskEntry = 'ext_buy_sell_button';
+    const bitcoinChainId = 'bitcoin:mainnet';
+    (isEvmChainId as jest.Mock).mockReturnValueOnce(false);
     mockStoreState = {
       ...mockStoreState,
       metamask: {
         ...mockStoreState.metamask,
         // @ts-expect-error ignore the 0xString interface check
-        ...mockNetworkState({ chainId: solanaChainId }),
+        ...mockNetworkState({ chainId: bitcoinChainId }),
       },
     };
-    const encodedChainId = encodeURIComponent(solanaChainId);
+    const encodedChainId = encodeURIComponent(bitcoinChainId);
     const mockBuyURI = `${process.env.PORTFOLIO_URL}/buy?metamaskEntry=${metaMaskEntry}&chainId=${encodedChainId}&metametricsId=${mockedMetametricsId}&metricsEnabled=false`;
     const { result } = renderHook(() => useRamps(), { wrapper });
-    const buyURI = result.current.getBuyURI(solanaChainId);
+    const buyURI = result.current.getBuyURI(bitcoinChainId);
     expect(buyURI).toBe(mockBuyURI);
   });
 });

--- a/ui/hooks/ramps/useRamps/useRamps.ts
+++ b/ui/hooks/ramps/useRamps/useRamps.ts
@@ -67,7 +67,6 @@ const useRamps = (
 
   const openBuyCryptoInPdapp = useCallback(
     (_chainId?: ChainId | CaipChainId) => {
-      console.log('openBuyCryptoInPdapp, _chainId', _chainId);
       const buyUrl = getBuyURI(_chainId || chainId);
       global.platform.openTab({
         url: buyUrl,

--- a/ui/hooks/ramps/useRamps/useRamps.ts
+++ b/ui/hooks/ramps/useRamps/useRamps.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { isSolanaChainId } from '@metamask/bridge-controller';
 import { CaipChainId, Hex, hexToNumber } from '@metamask/utils';
 import { ChainId } from '../../../../shared/constants/network';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
@@ -9,6 +8,9 @@ import {
   getMetaMetricsId,
   getParticipateInMetaMetrics,
 } from '../../../selectors';
+import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+
+const DEFAULT_PORTFOLIO_URL = 'https://app.metamask.io';
 
 type IUseRamps = {
   openBuyCryptoInPdapp: (chainId?: ChainId | CaipChainId) => void;
@@ -38,11 +40,12 @@ const useRamps = (
         params.set('metamaskEntry', metamaskEntry);
 
         let numericChainId = '';
-        if (isSolanaChainId(_chainId)) {
-          numericChainId = _chainId;
-        } else {
+        if (isEvmChainId(_chainId)) {
           numericChainId = hexToNumber(_chainId).toString();
+        } else {
+          numericChainId = _chainId;
         }
+
         params.set('chainId', numericChainId);
         if (metaMetricsId) {
           params.set('metametricsId', metaMetricsId);
@@ -51,12 +54,12 @@ const useRamps = (
         if (isMarketingEnabled) {
           params.set('marketingEnabled', String(isMarketingEnabled));
         }
-        const url = new URL(process.env.PORTFOLIO_URL || '');
+        const url = new URL(process.env.PORTFOLIO_URL || DEFAULT_PORTFOLIO_URL);
         url.pathname = 'buy';
         url.search = params.toString();
         return url.toString();
       } catch {
-        return 'https://app.metamask.io/buy';
+        return `${DEFAULT_PORTFOLIO_URL}/buy`;
       }
     },
     [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, metamaskEntry],
@@ -64,6 +67,7 @@ const useRamps = (
 
   const openBuyCryptoInPdapp = useCallback(
     (_chainId?: ChainId | CaipChainId) => {
+      console.log('openBuyCryptoInPdapp, _chainId', _chainId);
       const buyUrl = getBuyURI(_chainId || chainId);
       global.platform.openTab({
         url: buyUrl,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the useRamps hook to replace Solana-specific logic with a more generic EVM vs non-EVM chain detection approach, enabling support for Bitcoin and other non-EVM chains in the buy crypto flow.

It also adds BTC and SOL to the fallback list of buyable chains so that any ramp api network request issues will fall back to still enable BTC and SOL for buying.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37146?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for buying Bitcoin and other non-EVM cryptocurrencies through the MetaMask buy crypto flow

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/TRAM-2725

## **Manual testing steps**

1. Visit the BTC asset page
2. Click the buy button
3. Verify that query params are passed when visiting the portfolio

## **Screenshots/Recordings**
![btc-extension](https://github.com/user-attachments/assets/e9d2ec64-3d1b-49d1-b96a-dc7f4e177114)

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->



### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches buy URL logic to EVM vs non-EVM detection and adds Bitcoin/Solana to default buyable chains, with tests updated accordingly.
> 
> - **Ramps buy flow (`useRamps`)**:
>   - Replace Solana-specific check with `isEvmChainId` to detect EVM vs non-EVM.
>   - Convert EVM `chainId` from hex to numeric; pass non-EVM (e.g., CAIP-2 like Bitcoin) through unchanged.
>   - Add `DEFAULT_PORTFOLIO_URL` fallback and use it on URL parse failure.
> - **Defaults (`ui/ducks/ramps/constants.ts`)**:
>   - Add `BITCOIN` and `SOLANA` to `defaultBuyableChains` with display and short names; mark as `nativeTokenSupported`.
> - **Tests**:
>   - Update `useRamps` tests to mock `isEvmChainId`, verify EVM numeric conversion, non-EVM (Bitcoin) passthrough, and default URL fallback.
>   - Adjust `ramps` selectors tests to expect Bitcoin buyability by default and handle explicit inactive cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08abf035373b591a4a405a0de8c65c1add66df28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->