### PR TITLE
refactor: migrated `ui/components/app/assets` to react-router-dom-v5-compat

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/nft-details.test.js
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.test.js
@@ -1,12 +1,11 @@
 import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import copyToClipboard from 'copy-to-clipboard';
 import { toHex } from '@metamask/controller-utils';
 import { startNewDraftTransaction } from '../../../../../ducks/send';
-import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../../test/data/mock-state.json';
 import { DEFAULT_ROUTE } from '../../../../../helpers/constants/routes';
 import { COPY_OPTIONS } from '../../../../../../shared/constants/copy';
@@ -30,15 +29,13 @@ jest.mock('../../../../../helpers/utils/util', () => ({
 
 jest.mock('copy-to-clipboard');
 
-const mockHistoryPush = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(() => ({ search: '' })),
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-  useParams: jest.fn(),
-}));
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockUseNavigate,
+  };
+});
 
 jest.mock('../../../../../ducks/send/index.js', () => ({
   ...jest.requireActual('../../../../../ducks/send/index.js'),
@@ -64,6 +61,7 @@ describe('NFT Details', () => {
 
   const props = {
     nft: nfts[5],
+    nftChainId: CHAIN_IDS.MAINNET,
   };
 
   beforeEach(() => {
@@ -71,14 +69,13 @@ describe('NFT Details', () => {
   });
 
   it('should match minimal props and state snapshot', async () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.GOERLI });
     getAssetImageURL.mockResolvedValue(
       'https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link',
     );
     shortenAddress.mockReturnValue('0xDc738...06414');
 
     const { container } = renderWithProvider(
-      <NftDetails {...props} />,
+      <NftDetails {...props} nftChainId={CHAIN_IDS.GOERLI} />,
       mockStore,
     );
 
@@ -88,7 +85,6 @@ describe('NFT Details', () => {
   });
 
   it(`should route to '/' route when the back button is clicked`, () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const { queryByTestId } = renderWithProvider(
       <NftDetails {...props} />,
       mockStore,
@@ -98,11 +94,10 @@ describe('NFT Details', () => {
 
     fireEvent.click(backButton);
 
-    expect(mockHistoryPush).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
   it(`should call removeAndIgnoreNFT with proper nft details and route to '/' when removing nft`, async () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const { queryByTestId } = renderWithProvider(
       <NftDetails {...props} />,
       mockStore,
@@ -121,11 +116,10 @@ describe('NFT Details', () => {
       'testNetworkConfigurationId',
     );
     expect(setRemoveNftMessage).toHaveBeenCalledWith('success');
-    expect(mockHistoryPush).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
   it(`should call setRemoveNftMessage with error when removeAndIgnoreNft fails and route to '/'`, async () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const { queryByTestId } = renderWithProvider(
       <NftDetails {...props} />,
       mockStore,
@@ -146,11 +140,10 @@ describe('NFT Details', () => {
       'testNetworkConfigurationId',
     );
     expect(setRemoveNftMessage).toHaveBeenCalledWith('error');
-    expect(mockHistoryPush).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
   it('should copy nft address', async () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const { queryByTestId } = renderWithProvider(
       <NftDetails {...props} />,
       mockStore,
@@ -163,9 +156,9 @@ describe('NFT Details', () => {
   });
 
   it('should navigate to draft transaction send route with ERC721 data', async () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const nftProps = {
       nft: nfts[5],
+      nftChainId: CHAIN_IDS.MAINNET,
     };
     nfts[5].isCurrentlyOwned = true;
     const { queryByTestId } = renderWithProvider(
@@ -182,16 +175,16 @@ describe('NFT Details', () => {
         details: { ...nfts[5], tokenId: '1' },
       });
 
-      expect(mockHistoryPush).toHaveBeenCalledWith(
+      expect(mockUseNavigate).toHaveBeenCalledWith(
         '/send/amount-recipient?asset=0xDc7382Eb0Bc9C352A4CbA23c909bDA01e0206414&chainId=0x1',
       );
     });
   });
 
   it('should not render send button if isCurrentlyOwned is false', () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const sixthNftProps = {
       nft: nfts[6],
+      nftChainId: CHAIN_IDS.MAINNET,
     };
     nfts[6].isCurrentlyOwned = false;
 
@@ -205,9 +198,9 @@ describe('NFT Details', () => {
   });
 
   it('should render send button if it is an ERC1155', () => {
-    useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
     const nftProps = {
       nft: nfts[1],
+      nftChainId: CHAIN_IDS.MAINNET,
     };
     nfts[1].isCurrentlyOwned = true;
     const { queryByTestId } = renderWithProvider(
@@ -235,7 +228,7 @@ describe('NFT Details', () => {
     );
 
     const { findByTestId } = renderWithProvider(
-      <NftDetails nft={mockNft} />,
+      <NftDetails nftChainId={CHAIN_IDS.MAINNET} nft={mockNft} />,
       mockStore,
     );
 
@@ -253,11 +246,10 @@ describe('NFT Details', () => {
 
   describe(`Alternative Networks' OpenSea Links`, () => {
     it('should open opeasea link with goeli testnet chainId', async () => {
-      useParams.mockReturnValue({ chainId: CHAIN_IDS.GOERLI });
       global.platform = { openTab: jest.fn() };
 
       const { queryByTestId } = renderWithProvider(
-        <NftDetails {...props} />,
+        <NftDetails {...props} nftChainId={CHAIN_IDS.GOERLI} />,
         mockStore,
       );
 
@@ -277,7 +269,6 @@ describe('NFT Details', () => {
     });
 
     it('should open tab to mainnet opensea url with nft info', async () => {
-      useParams.mockReturnValue({ chainId: CHAIN_IDS.MAINNET });
       global.platform = { openTab: jest.fn() };
 
       const mainnetState = {
@@ -310,7 +301,6 @@ describe('NFT Details', () => {
     });
 
     it('should open tab to polygon opensea url with nft info', async () => {
-      useParams.mockReturnValue({ chainId: CHAIN_IDS.POLYGON });
       const polygonState = {
         ...mockState,
         metamask: {
@@ -326,7 +316,7 @@ describe('NFT Details', () => {
       const openTabSpy = jest.spyOn(global.platform, 'openTab');
 
       const { queryByTestId } = renderWithProvider(
-        <NftDetails {...props} />,
+        <NftDetails {...props} nftChainId={CHAIN_IDS.POLYGON} />,
         polygonMockStore,
       );
 
@@ -344,7 +334,6 @@ describe('NFT Details', () => {
     });
 
     it('should open tab to sepolia opensea url with nft info', async () => {
-      useParams.mockReturnValue({ chainId: CHAIN_IDS.SEPOLIA });
       const sepoliaState = {
         ...mockState,
         metamask: {
@@ -360,7 +349,7 @@ describe('NFT Details', () => {
       const openTabSpy = jest.spyOn(global.platform, 'openTab');
 
       const { queryByTestId } = renderWithProvider(
-        <NftDetails {...props} />,
+        <NftDetails {...props} nftChainId={CHAIN_IDS.SEPOLIA} />,
         sepoliaMockStore,
       );
 
@@ -378,7 +367,6 @@ describe('NFT Details', () => {
     });
 
     it('should not render opensea redirect button', async () => {
-      useParams.mockReturnValue({ chainId: '0x99' });
       const randomNetworkState = {
         ...mockState,
         metamask: {
@@ -391,7 +379,7 @@ describe('NFT Details', () => {
       );
 
       const { queryByTestId } = renderWithProvider(
-        <NftDetails {...props} />,
+        <NftDetails {...props} nftChainId="0x99" />,
         randomNetworkMockStore,
       );
 

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { isEqual } from 'lodash';
 import { getTokenTrackerLink, getAccountLink } from '@metamask/etherscan-link';
 import { Nft } from '@metamask/assets-controllers';
@@ -122,7 +122,7 @@ export function NftDetailsComponent({
   } = nft;
 
   const t = useI18nContext();
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const ipfsGateway = useSelector(getIpfsGateway);
   const currentNetwork = useSelector(getCurrentChainId);
@@ -133,6 +133,7 @@ export function NftDetailsComponent({
   const { enabled: isSendRedesignEnabled } = useRedesignedSendFlow();
 
   const nftNetworkConfigs = useSelector(getNetworkConfigurationsByChainId);
+
   const nftChainNetwork = nftNetworkConfigs[nftChainId as Hex];
   const { defaultRpcEndpointIndex } = nftChainNetwork;
   const { networkClientId: nftNetworkClientId } =
@@ -264,7 +265,7 @@ export function NftDetailsComponent({
           isSuccessful: isSuccessfulEvent,
         },
       });
-      history.push(DEFAULT_ROUTE);
+      navigate(DEFAULT_ROUTE);
     }
   };
 
@@ -337,7 +338,7 @@ export function NftDetailsComponent({
       }),
     );
     // We only allow sending one NFT at a time
-    navigateToSendRoute(history, isSendRedesignEnabled, {
+    navigateToSendRoute(navigate, isSendRedesignEnabled, {
       address: nft.address,
       chainId: nftChainId,
     });
@@ -376,7 +377,7 @@ export function NftDetailsComponent({
   };
 
   const handleImageClick = () => {
-    return history.push(`${ASSET_ROUTE}/image/${address}/${tokenId}`);
+    return navigate(`${ASSET_ROUTE}/image/${address}/${tokenId}`);
   };
 
   const getValueInFormattedCurrency = (
@@ -412,7 +413,7 @@ export function NftDetailsComponent({
             size={ButtonIconSize.Sm}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
-            onClick={() => history.push(DEFAULT_ROUTE)}
+            onClick={() => navigate(DEFAULT_ROUTE)}
             data-testid="nft__back"
           />
           <NftOptions
@@ -985,10 +986,8 @@ export function NftDetailsComponent({
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function NftDetails({ nft }: { nft: Nft }) {
-  const { chainId } = useParams();
-
-  return <NftDetailsComponent nft={nft} nftChainId={chainId ?? ''} />;
+function NftDetails({ nft, nftChainId }: { nft: Nft; nftChainId?: string }) {
+  return <NftDetailsComponent nft={nft} nftChainId={nftChainId ?? ''} />;
 }
 
 export default NftDetails;

--- a/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory, useParams } from 'react-router-dom';
+import { useNavigate, useNavigationType } from 'react-router-dom-v5-compat';
 import { Nft } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { getNftImage, getNftImageAlt } from '../../../../../helpers/utils/nfts';
@@ -23,7 +23,6 @@ import {
   JustifyContent,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { ASSET_ROUTE } from '../../../../../helpers/constants/routes';
 import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDetailsFromTokenURI';
 // TODO: Remove restricted import
@@ -31,12 +30,26 @@ import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDeta
 import { isWebUrl } from '../../../../../../app/scripts/lib/util';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
 import { getImageForChainId } from '../../../../../selectors/multichain';
+import { ASSET_ROUTE } from '../../../../../helpers/constants/routes';
 
+type NftFullImageProps = {
+  params?: {
+    asset?: string;
+    id?: string;
+  };
+};
+
+/**
+ * Component displaying full NFT image
+ *
+ * @param options0 - Component props
+ * @param options0.params - Route parameters including asset and id
+ */
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export default function NftFullImage() {
+export default function NftFullImage({ params }: NftFullImageProps) {
   const t = useI18nContext();
-  const { asset, id } = useParams<{ asset: string; id: string }>();
+  const { asset, id } = params ?? {};
   const allNfts = useSelector(getAllNfts);
   const nfts = Object.values(allNfts).flat() as Nft[];
   const nft = nfts.find(
@@ -77,7 +90,8 @@ export default function NftFullImage() {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (image && isWebUrl(image)) ||
     (imageFromTokenURI && isWebUrl(imageFromTokenURI));
-  const history = useHistory();
+  const navigationType = useNavigationType();
+  const navigate = useNavigate();
 
   const [visible, setVisible] = useState(false);
 
@@ -86,14 +100,16 @@ export default function NftFullImage() {
   }, []);
 
   const onClose = useCallback(() => {
-    if (history.action === 'PUSH') {
-      // Previous action was a PUSH, so we can navigate back
-      history.goBack();
+    if (navigationType === 'PUSH') {
+      // Previous navigation was a PUSH, so safe to go back
+      navigate(-1);
     } else {
-      // Previous action was a POP or something else, safer to navigate back to asset details
-      history.push(`${ASSET_ROUTE}/${hexChainId}/${asset}/${id}`);
+      // Fallback: go to the asset details route explicitly
+      navigate(`${ASSET_ROUTE}/${hexChainId}/${asset}/${id}`, {
+        replace: true,
+      });
     }
-  }, [asset, hexChainId, history, id]);
+  }, [asset, hexChainId, id, navigate, navigationType]);
 
   return (
     <Box className="main-container asset__container">

--- a/ui/components/app/assets/nfts/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.tsx
+++ b/ui/components/app/assets/nfts/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { BannerAlert } from '../../../../component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { SECURITY_ROUTE } from '../../../../../helpers/constants/routes';
@@ -15,7 +15,7 @@ export default function NftsDetectionNoticeImportNFTs({
   onActionButtonClick,
 }: NftsDetectionNoticeImportNFTsProps) {
   const t = useI18nContext();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return (
     <BannerAlert
@@ -23,7 +23,7 @@ export default function NftsDetectionNoticeImportNFTs({
       actionButtonLabel={t('selectEnableDisplayMediaPrivacyPreference')}
       actionButtonOnClick={(e) => {
         e.preventDefault();
-        history.push(`${SECURITY_ROUTE}#display-nft-media`);
+        navigate(`${SECURITY_ROUTE}#display-nft-media`);
         onActionButtonClick?.();
       }}
     >

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { toHex } from '@metamask/controller-utils';
 import {
   AlignItems,
@@ -37,7 +37,7 @@ import { NftEmptyState } from '../nft-empty-state';
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function NftsTab() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const useNftDetection = useSelector(getUseNftDetection);
   const isMainnet = useSelector(getIsMainnet);
   const { privacyMode } = useSelector(getPreferences);
@@ -87,7 +87,7 @@ export default function NftsTab() {
   }, [nftsLoading, nftsStillFetchingIndication]);
 
   const handleNftClick = (nft: NFT) => {
-    history.push(
+    navigate(
       `${ASSET_ROUTE}/${toHex(nft.chainId)}/${nft.address}/${nft.tokenId}`,
     );
   };

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -4,7 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
-import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { useTokenFiatAmount } from '../../../../hooks/useTokenFiatAmount';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
@@ -45,6 +45,14 @@ jest.mock('../../../../hooks/useTokenFiatAmount', () => {
 jest.mock('../../../../hooks/useIsOriginalTokenSymbol', () => {
   return {
     useIsOriginalTokenSymbol: jest.fn(),
+  };
+});
+
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockUseNavigate,
   };
 });
 

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useTokenDisplayInfo } from '../hooks';
 import {
   ButtonSecondary,
@@ -49,7 +49,7 @@ export default function TokenCell({
   safeChains,
 }: TokenCellProps) {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const t = useI18nContext();
   const isEvm = isEvmChainId(token.chainId);
   const nativeCurrencySymbol = useMemo(
@@ -119,7 +119,7 @@ export default function TokenCell({
               <ButtonSecondary
                 onClick={() => {
                   dispatch(setEditedNetwork({ chainId: token.chainId }));
-                  history.push(NETWORKS_ROUTE);
+                  navigate(NETWORKS_ROUTE);
                 }}
                 block
               >

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { toHex } from '@metamask/controller-utils';
 import {
   isCaipChainId,
@@ -95,7 +95,7 @@ const CoinButtons = ({
   const [showReceiveModal, setShowReceiveModal] = useState(false);
 
   const { address: selectedAddress } = account;
-  const history = useHistory();
+  const navigate = useNavigate();
   const networks = useSelector(getNetworkConfigurationIdByChainId) as Record<
     string,
     string
@@ -280,7 +280,7 @@ const CoinButtons = ({
     if (trackingLocation !== 'home') {
       params = { chainId: chainId.toString() };
     }
-    navigateToSendRoute(history, isSendRedesignEnabled, params);
+    navigateToSendRoute(navigate, isSendRedesignEnabled, params);
   }, [
     chainId,
     account,
@@ -349,7 +349,7 @@ const CoinButtons = ({
 
     if (isMultichainAccountsState2Enabled && selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
-      history.push(
+      navigate(
         `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedAccountGroup)}?${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
       );
     } else {
@@ -359,7 +359,7 @@ const CoinButtons = ({
   }, [
     isMultichainAccountsState2Enabled,
     selectedAccountGroup,
-    history,
+    navigate,
     trackEvent,
     trackingLocation,
     chainId,

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -5,7 +5,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { EthAccountType, EthMethod, BtcScope } from '@metamask/keyring-api';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { KeyringType } from '../../../../shared/constants/keyring';
 import { useIsOriginalNativeTokenSymbol } from '../../../hooks/useIsOriginalNativeTokenSymbol';
 import useMultiPolling from '../../../hooks/useMultiPolling';

--- a/ui/components/app/wallet-overview/non-evm-overview.test.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.test.tsx
@@ -7,7 +7,7 @@ import { BtcAccountType, BtcMethod, BtcScope } from '@metamask/keyring-api';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { MultichainNativeAssets } from '../../../../shared/constants/multichain/assets';
 import mockState from '../../../../test/data/mock-state.json';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import { defaultBuyableChains } from '../../../ducks/ramps/constants';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -49,6 +49,13 @@ jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
   default: jest.fn(() => ({
     openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp,
   })),
+  RampsMetaMaskEntry: {
+    BuySellButton: 'ext_buy_sell_button',
+    NftBanner: 'ext_buy_banner_nfts',
+    TokensBanner: 'ext_buy_banner_tokens',
+    ActivityBanner: 'ext_buy_banner_activity',
+    BtcBanner: 'ext_buy_banner_btc',
+  },
 }));
 
 const BUY_BUTTON = 'coin-overview-buy';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.test.tsx
@@ -3,7 +3,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import nock from 'nock';
-import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import { AssetPickerModalNftTab } from './asset-picker-modal-nft-tab';

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-nft-tab.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Box } from '../../../component-library';
 import Spinner from '../../../ui/spinner';
 import {
@@ -46,7 +46,7 @@ export function AssetPickerModalNftTab({
   renderSearch,
 }: AssetPickerModalNftTabProps) {
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const useNftDetection = useSelector(getUseNftDetection);
   const isMainnet = useSelector(getIsMainnet);
   const nftsStillFetchingIndication = useSelector(
@@ -114,7 +114,7 @@ export function AssetPickerModalNftTab({
         skipComputeEstimatedGasLimit: false,
       }),
     );
-    navigateToSendRoute(history, isSendRedesignEnabled, {
+    navigateToSendRoute(navigate, isSendRedesignEnabled, {
       address: nft.address,
       chainId: nft.chainId,
     });

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -11,7 +11,7 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useNftsCollections } from '../../../../hooks/useNftsCollections';
 import { useTokenTracker } from '../../../../hooks/useTokenTracker';
-import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-send-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {

--- a/ui/pages/asset/asset.tsx
+++ b/ui/pages/asset/asset.tsx
@@ -2,7 +2,7 @@ import { Nft } from '@metamask/assets-controllers';
 import { CaipChainId, Hex } from '@metamask/utils';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Redirect, useParams } from 'react-router-dom';
+import { Navigate } from 'react-router-dom-v5-compat';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import NftDetails from '../../components/app/assets/nfts/nft-details/nft-details';
 import { getNFTsByChainId } from '../../ducks/metamask/metamask';
@@ -11,14 +11,21 @@ import { getTokenByAccountAndAddressAndChainId } from '../../selectors/assets';
 import NativeAsset from './components/native-asset';
 import TokenAsset from './components/token-asset';
 
-/** A page representing a native, token, or NFT asset */
-const Asset = () => {
-  const params = useParams<{
-    chainId: Hex;
-    asset: string;
-    id: string;
-  }>();
+type AssetProps = {
+  params: {
+    chainId?: Hex;
+    asset?: string;
+    id?: string;
+  };
+};
 
+/**
+ * A page representing a native, token, or NFT asset
+ *
+ * @param options0 - Component props
+ * @param options0.params - Route parameters including chainId, asset, and id
+ */
+const Asset = ({ params }: AssetProps) => {
   const { chainId, asset, id } = params;
   const decodedAsset = asset ? decodeURIComponent(asset) : undefined;
 
@@ -47,12 +54,12 @@ const Asset = () => {
 
   const content = (() => {
     if (nft) {
-      return <NftDetails nft={nft} />;
+      return <NftDetails nft={nft} nftChainId={chainId} />;
     }
 
     const isInvalid = !token || !chainId;
     if (isInvalid) {
-      return <Redirect to={{ pathname: DEFAULT_ROUTE }} />;
+      return <Navigate to={DEFAULT_ROUTE} />;
     }
 
     const shouldShowToken = !token.isNative && token.address;

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -8,7 +8,7 @@ import {
   CHAIN_IDS,
   MAINNET_DISPLAY_NAME,
 } from '../../../../shared/constants/network';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { KeyringType } from '../../../../shared/constants/keyring';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { ETH_EOA_METHODS } from '../../../../shared/constants/eth-methods';
@@ -404,7 +404,7 @@ describe('AssetPage', () => {
     const { container } = renderWithProvider(
       <AssetPage asset={native} optionsButton={null} />,
       store,
-      ['/0x1'],
+      '/0x1',
     );
     const dynamicImages = container.querySelectorAll('img[alt*="logo"]');
     dynamicImages.forEach((img) => {
@@ -484,7 +484,7 @@ describe('AssetPage', () => {
           },
         },
       }),
-      ['/0x1/0xe4246B1Ac0Ba6839d9efA41a8A30AE3007185f55'],
+      '/0x1/0xe4246B1Ac0Ba6839d9efA41a8A30AE3007185f55',
     );
 
     // Verify chart is rendered

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@metamask/utils';
 import React, { ReactNode, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
@@ -92,7 +92,7 @@ const AssetPage = ({
   optionsButton: React.ReactNode;
 }) => {
   const t = useI18nContext();
-  const history = useHistory();
+  const navigate = useNavigate();
   const currency = useSelector(getCurrentCurrency);
   const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const isEvm = isEvmChainId(asset.chainId);
@@ -324,7 +324,7 @@ const AssetPage = ({
             size={ButtonIconSize.Sm}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
-            onClick={() => history.push(DEFAULT_ROUTE)}
+            onClick={() => navigate(DEFAULT_ROUTE)}
           />
         </Box>
         {optionsButton}
@@ -391,7 +391,7 @@ const AssetPage = ({
           borderColor={BorderColor.borderMuted}
           marginInline={4}
           style={{ height: '1px', borderBottomWidth: 0 }}
-        ></Box>
+        />
         <Box
           marginTop={2}
           display={Display.Flex}

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 ///: BEGIN:ONLY_INCLUDE_IF(multichain)
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { CaipAssetType } from '@metamask/utils';
@@ -60,7 +60,7 @@ const TokenButtons = ({
   const dispatch = useDispatch();
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
   const isEvm = isEvmChainId(token.chainId);
   const isMultichainAccountsState2Enabled = useSelector(
@@ -189,7 +189,7 @@ const TokenButtons = ({
           details: token,
         }),
       );
-      navigateToSendRoute(history, isSendRedesignEnabled, {
+      navigateToSendRoute(navigate, isSendRedesignEnabled, {
         address: token.address,
         chainId: token.chainId,
       });
@@ -204,7 +204,7 @@ const TokenButtons = ({
   }, [
     trackEvent,
     dispatch,
-    history,
+    navigate,
     token,
     setCorrectChain,
     account,

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -4,8 +4,6 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
-
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
 import { AssetType } from '../../../../../../shared/constants/transaction';
@@ -40,7 +38,6 @@ import { AdvancedDetailsButton } from './advanced-details-button';
 export const WalletInitiatedHeader = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const history = useHistory();
   const { enabled: isSendRedesignEnabled } = useRedesignedSendFlow();
   const { onCancel } = useConfirmActions();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -90,11 +87,10 @@ export const WalletInitiatedHeader = () => {
     await dispatch(editExistingTransaction(assetType, id.toString()));
     dispatch(clearConfirmTransaction());
     dispatch(showSendTokenPage());
-    navigateToSendRoute(history, isSendRedesignEnabled);
+    navigateToSendRoute(navigate, isSendRedesignEnabled);
   }, [
     currentConfirmation,
     dispatch,
-    history,
     isSendRedesignEnabled,
     navigate,
     onCancel,

--- a/ui/pages/confirmations/utils/send.test.ts
+++ b/ui/pages/confirmations/utils/send.test.ts
@@ -185,14 +185,9 @@ describe('Send - utils', () => {
 
   describe('navigateToSendRoute', () => {
     it('call history.push with send route', () => {
-      const mockHistoryPush = jest.fn();
-      navigateToSendRoute(
-        {
-          push: mockHistoryPush,
-        },
-        false,
-      );
-      expect(mockHistoryPush).toHaveBeenCalled();
+      const mockUseNavigate = jest.fn();
+      navigateToSendRoute(mockUseNavigate, false);
+      expect(mockUseNavigate).toHaveBeenCalled();
     });
   });
 

--- a/ui/pages/confirmations/utils/send.ts
+++ b/ui/pages/confirmations/utils/send.ts
@@ -5,7 +5,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { addHexPrefix } from 'ethereumjs-util';
-import { useHistory } from 'react-router-dom';
+import { NavigateFunction } from 'react-router-dom-v5-compat';
 
 import { Numeric, NumericBase } from '../../../../shared/modules/Numeric';
 import {
@@ -277,7 +277,7 @@ export function convertedCurrency(
 }
 
 export const navigateToSendRoute = (
-  history: ReturnType<typeof useHistory>,
+  navigate: NavigateFunction,
   isSendRedesignEnabled: boolean,
   params?: {
     address?: string;
@@ -294,12 +294,12 @@ export const navigateToSendRoute = (
       if (chainId) {
         queryParams.append('chainId', chainId);
       }
-      history.push(`${SEND_ROUTE}/amount-recipient?${queryParams.toString()}`);
+      navigate(`${SEND_ROUTE}/amount-recipient?${queryParams.toString()}`);
     } else {
-      history.push(`${SEND_ROUTE}/asset`);
+      navigate(`${SEND_ROUTE}/asset`);
     }
   } else {
-    history.push(SEND_ROUTE);
+    navigate(SEND_ROUTE);
   }
 };
 

--- a/ui/pages/defi/components/defi-details-list.test.tsx
+++ b/ui/pages/defi/components/defi-details-list.test.tsx
@@ -2,24 +2,22 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
 import DefiDetailsList from './defi-details-list';
-
-const mockHistoryPush = jest.fn();
 
 const mockUseParams = jest
   .fn()
   .mockReturnValue({ chainId: CHAIN_IDS.MAINNET, protocolId: 'aave' });
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(() => ({ search: '' })),
-  useHistory: () => ({
-    push: mockHistoryPush,
-  }),
-  useParams: () => mockUseParams(),
-}));
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockUseNavigate,
+    useParams: () => mockUseParams(),
+  };
+});
 
 describe('DeFiDetailsPage', () => {
   const store = configureMockStore([thunk])(mockState);

--- a/ui/pages/defi/components/defi-details-page.test.tsx
+++ b/ui/pages/defi/components/defi-details-page.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import { renderWithProvider } from '../../../../test/jest/rendering';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
 import DeFiPage from './defi-details-page';
 
@@ -10,10 +10,12 @@ const mockUseParams = jest
   .fn()
   .mockReturnValue({ chainId: CHAIN_IDS.MAINNET, protocolId: 'aave' });
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => mockUseParams(),
-}));
+jest.mock('react-router-dom', () => {
+  return {
+    ...jest.requireActual('react-router-dom'),
+    useParams: () => mockUseParams(),
+  };
+});
 
 describe('DeFiDetailsPage', () => {
   const mockStore = {

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -656,19 +656,61 @@ export default function Routes() {
               );
             }}
           </Route>
-          <Authenticated
-            path={`${ASSET_ROUTE}/image/:asset/:id`}
-            component={NftFullImage}
-          />
-          <Authenticated
-            path={`${ASSET_ROUTE}/:chainId/:asset/:id`}
-            component={Asset}
-          />
-          <Authenticated
-            path={`${ASSET_ROUTE}/:chainId/:asset/`}
-            component={Asset}
-          />
-          <Authenticated path={`${ASSET_ROUTE}/:chainId`} component={Asset} />
+          <Route path={`${ASSET_ROUTE}/image/:asset/:id`}>
+            {(props: RouteComponentProps<{ asset: string; id: string }>) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const NftFullImageComponent = NftFullImage as any;
+              return (
+                <AuthenticatedV5Compat>
+                  <NftFullImageComponent params={props.match.params} />
+                </AuthenticatedV5Compat>
+              );
+            }}
+          </Route>
+          <Route path={`${ASSET_ROUTE}/:chainId/:asset/:id`}>
+            {(
+              props: RouteComponentProps<{
+                chainId: string;
+                asset: string;
+                id: string;
+              }>,
+            ) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const AssetComponent = Asset as any;
+              return (
+                <AuthenticatedV5Compat>
+                  <AssetComponent params={props.match.params} />
+                </AuthenticatedV5Compat>
+              );
+            }}
+          </Route>
+          <Route path={`${ASSET_ROUTE}/:chainId/:asset/`}>
+            {(
+              props: RouteComponentProps<{
+                chainId: string;
+                asset: string;
+              }>,
+            ) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const AssetComponent = Asset as any;
+              return (
+                <AuthenticatedV5Compat>
+                  <AssetComponent params={props.match.params} />
+                </AuthenticatedV5Compat>
+              );
+            }}
+          </Route>
+          <Route path={`${ASSET_ROUTE}/:chainId`}>
+            {(props: RouteComponentProps<{ chainId: string }>) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const AssetComponent = Asset as any;
+              return (
+                <AuthenticatedV5Compat>
+                  <AssetComponent params={props.match.params} />
+                </AuthenticatedV5Compat>
+              );
+            }}
+          </Route>
           <Authenticated
             path={`${DEFI_ROUTE}/:chainId/:protocolId`}
             component={DeFiPage}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR completes the migration of asset-related components in `ui/components/app/assets` and `ui/pages/asset` from `react-router-dom` (v5) to `react-router-dom-v5-compat` while maintaining compatibility with the existing v5 routing infrastructure.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37157?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: Part of https://github.com/MetaMask/MetaMask-planning/issues/3261

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces history/params usage with v5-compat navigation, refactors asset/NFT routes and navigation utils, and updates tests accordingly.
> 
> - **Routing/NAV migration**
>   - Replace `useHistory`/`useParams` with `react-router-dom-v5-compat` (`useNavigate`, `useNavigationType`) across `ui/components/app/assets/*`, wallet overview buttons, confirmations header, and token/NFT flows.
>   - Update `navigateToSendRoute` to accept a `navigate` function and replace all `history.push` usages.
>   - Refactor components to accept route params via props and/or explicit props (e.g., `NftDetails` now accepts `nftChainId`; `NftFullImage` and `Asset` accept `params`).
>   - Rework asset/NFT routes in `routes.component.tsx` to use render props with `AuthenticatedV5Compat`, passing `match.params` into components.
> - **Tests**
>   - Switch to `render-helpers-navigate` and mock `react-router-dom-v5-compat` hooks; update expectations from `history.push` to `useNavigate` and adjust snapshots.
>   - Update tests for NFT details/full image, token cell, asset picker modal, asset page, wallet overview, and DeFi pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0780068d9b4e62a1ced4b7de1a0df445c9772ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->