### PR TITLE
fix: gator permission persistence

### DIFF
--- a/app/scripts/constants/snaps.ts
+++ b/app/scripts/constants/snaps.ts
@@ -1,5 +1,17 @@
 // Needed for webpack to analyze the preinstalled snaps
 export const PREINSTALLED_SNAPS_URLS = [
+  ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
+  new URL(
+    '@metamask/permissions-kernel-snap/dist/preinstalled-snap.json',
+    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
+    import.meta.url,
+  ),
+  new URL(
+    '@metamask/gator-permissions-snap/dist/preinstalled-snap.json',
+    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
+    import.meta.url,
+  ),
+  ///: END:ONLY_INCLUDE_IF
   new URL(
     '@metamask/message-signing-snap/dist/preinstalled-snap.json',
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
@@ -41,16 +53,4 @@ export const PREINSTALLED_SNAPS_URLS = [
     // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
     import.meta.url,
   ),
-  ///: BEGIN:ONLY_INCLUDE_IF(gator-permissions)
-  new URL(
-    '@metamask/permissions-kernel-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
-    import.meta.url,
-  ),
-  new URL(
-    '@metamask/gator-permissions-snap/dist/preinstalled-snap.json',
-    // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
-    import.meta.url,
-  ),
-  ///: END:ONLY_INCLUDE_IF
 ];

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "@metamask/etherscan-link": "^3.0.0",
     "@metamask/gas-fee-controller": "^24.0.0",
     "@metamask/gator-permissions-controller": "^0.2.0",
-    "@metamask/gator-permissions-snap": "^0.4.1",
+    "@metamask/gator-permissions-snap": "0.4.0",
     "@metamask/institutional-wallet-snap": "1.3.4",
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
     "@metamask/json-rpc-engine": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6436,9 +6436,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gator-permissions-snap@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@metamask/gator-permissions-snap@npm:0.4.1"
+"@metamask/gator-permissions-snap@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@metamask/gator-permissions-snap@npm:0.4.0"
   dependencies:
     "@metamask/abi-utils": "npm:3.0.0"
     "@metamask/delegation-core": "npm:0.2.0"
@@ -6446,7 +6446,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:8.1.0"
     "@metamask/utils": "npm:11.4.2"
     zod: "npm:3.25.76"
-  checksum: 10/23f8aacbb87847f9e9f0c56afbbf527e6cd2ffaf82a696e9becf26c835925ab67853b002b938e916a6f17228e376b1ca37612e40bcb93e7969eaee4eb4486925
+  checksum: 10/259564e96f3d8c035482c780e180fbd303ea7fc2f641ac3d0da7cfdf258a540190c70a4467485aec581f11a744cc16867e211693bcd6c0e247091c5d9d32e817
   languageName: node
   linkType: hard
 
@@ -31862,7 +31862,7 @@ __metadata:
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/gas-fee-controller": "npm:^24.0.0"
     "@metamask/gator-permissions-controller": "npm:^0.2.0"
-    "@metamask/gator-permissions-snap": "npm:^0.4.1"
+    "@metamask/gator-permissions-snap": "npm:0.4.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.4"
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
     "@metamask/json-rpc-engine": "npm:^10.0.0"


### PR DESCRIPTION
## **Description**

@metamask/gator-permissions-snap@0.4.0 enabled storing granted permissions to profile sync.

This surfaced a bug where the request to @metamask/message-signing-snap was declined, even though @metamask/gator-permissions-snap was included in the initial-connections of the message signing snap. @metamask/gator-permissions-snap@0.4.1 was rolled out with persistence disabled (the only change).

The issue was the install order of the preinstalled snaps. Because @metamask/message-signing-snap was installed before @metamask/gator-permissions-snap, when registering permissions, no entry was found to assign the permission, so it was dropped.

This PR resolves that problem, but reordering the preinstalled snaps so that @metamask/gator-permissions-snap is installed _first_. It also reverts the version of @metamask/gator-permissions-snap to 0.4.0.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37158?quickstart=1)

## **Changelog**

CHANGELOG entry: Enables storing EIP-7715 permissions granted by the user

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders preinstalled snaps to install gator-permissions first and pins @metamask/gator-permissions-snap to 0.4.0.
> 
> - **Snaps installation order**:
>   - Move `ONLY_INCLUDE_IF(gator-permissions)` block (kernel + gator snaps) to the top of `PREINSTALLED_SNAPS_URLS` in `app/scripts/constants/snaps.ts` so these install before others.
> - **Dependencies**:
>   - Pin `@metamask/gator-permissions-snap` to `0.4.0` in `package.json` and update `yarn.lock` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71f498ea0cd73c56d9b77c8069841e8dfbbe5f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->