### PR TITLE
feat: confirm screen fix styles

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2678,7 +2678,7 @@
     "message": "form"
   },
   "freeSevenDayTrial": {
-    "message": "Free 7-day trial"
+    "message": "14 days free trial"
   },
   "from": {
     "message": "From"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2678,7 +2678,7 @@
     "message": "form"
   },
   "freeSevenDayTrial": {
-    "message": "Free 7-day trial"
+    "message": "14 days free trial"
   },
   "from": {
     "message": "From"

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Display,
   FlexDirection,
+  JustifyContent,
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
@@ -30,12 +31,16 @@ const ShieldFooterAgreement = () => {
   }
 
   return (
-    <Box display={Display.Flex} flexDirection={FlexDirection.Row} gap={4}>
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.center}
+      gap={4}
+    >
       <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
         {t('shieldFooterAgreement', [
           <ButtonLink
             href={SHIELD_TERMS_OF_USE_URL}
-            color={TextColor.textAlternative}
             size={ButtonLinkSize.Inherit}
             externalLink
             key="shield-footer-agreement-button"

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve-loader.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve-loader.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@metamask/design-system-react';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import React from 'react';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
 import { Skeleton } from '../../../../../../components/component-library/skeleton';
@@ -8,35 +8,47 @@ const ShieldSubscriptionApproveLoader = () => {
     <Box paddingTop={4}>
       {/* Subscription Details */}
       <ConfirmInfoSection>
-        <Box paddingBottom={4}>
-          <Skeleton height={12} width={150} />
-        </Box>
-        <Box>
-          <Skeleton height={12} width={150} />
+        <Box flexDirection={BoxFlexDirection.Column} padding={2} gap={2}>
+          <Box>
+            <Skeleton height={24} width="100%" />
+          </Box>
+          <Box>
+            <Skeleton height={24} width="50%" />
+          </Box>
         </Box>
       </ConfirmInfoSection>
       {/* Estimated Changes */}
       <ConfirmInfoSection>
-        <Box paddingBottom={4}>
-          <Skeleton height={12} width={175} />
-        </Box>
-        <Box>
-          <Skeleton height={12} width={100} />
+        <Box flexDirection={BoxFlexDirection.Column} padding={2} gap={2}>
+          <Box>
+            <Skeleton height={24} width="50%" />
+          </Box>
+          <Box>
+            <Skeleton height={24} width="100%" />
+          </Box>
         </Box>
       </ConfirmInfoSection>
       {/* Account Details */}
       <ConfirmInfoSection>
-        <Box>
-          <Skeleton height={12} width={75} />
+        <Box padding={2}>
+          <Skeleton height={24} width="100%" />
+        </Box>
+      </ConfirmInfoSection>
+      {/* Billing Details */}
+      <ConfirmInfoSection>
+        <Box padding={2}>
+          <Skeleton height={24} width="100%" />
         </Box>
       </ConfirmInfoSection>
       {/* Gas Fees */}
       <ConfirmInfoSection>
-        <Box paddingBottom={4}>
-          <Skeleton height={12} width={75} />
-        </Box>
-        <Box>
-          <Skeleton height={12} width={75} />
+        <Box flexDirection={BoxFlexDirection.Column} padding={2} gap={2}>
+          <Box>
+            <Skeleton height={24} width="100%" />
+          </Box>
+          <Box>
+            <Skeleton height={24} width="100%" />
+          </Box>
         </Box>
       </ConfirmInfoSection>
     </Box>

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -63,9 +63,10 @@ export const SubscriptionDetails = ({
         {showTrial && (
           <Box
             data-testid="free-seven-day-trial"
+            className="rounded-lg"
             alignItems={BoxAlignItems.Center}
-            paddingLeft={1}
-            paddingRight={1}
+            paddingLeft={2}
+            paddingRight={2}
             style={{
               color: 'var(--color-primary-default)',
               backgroundColor: 'var(--color-primary-muted-hover)',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Updated shield confirmation skeleton loader
- Updated Free trial tag border radius
- Update footer note style 

https://consensyssoftware.atlassian.net/browse/SUBS-566
https://consensyssoftware.atlassian.net/browse/SUBS-580
https://consensyssoftware.atlassian.net/browse/SUBS-596
https://consensyssoftware.atlassian.net/browse/SUBS-600
https://consensyssoftware.atlassian.net/browse/SUBS-602

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37159?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated UI and copywriting on Shield Plan Confirm page

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create an account with enough USDC, USDT or mUSD for shield subscription
2. Go to Menu > Settings > Transaction Shield
3. Should redirect to Shield Plan page
4. Select Payment via Crypto
5. Continue Subscription
6. Check changes: New skeleton loader, 14-day trial tag copy and UI, footer color and alignment

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
**Skeleton Loader**
<img width="424" height="809" alt="Screenshot 2025-10-24 at 3 05 04 PM" src="https://github.com/user-attachments/assets/293b819f-1f5e-4539-b5f0-9f68838b855c" />


**Confirm page**
<img width="416" height="793" alt="Screenshot 2025-10-24 at 3 05 09 PM" src="https://github.com/user-attachments/assets/11eb67b5-c11c-455a-b679-44cb210cf22a" />

<!-- [screenshots/recordings] -->


### **After**
**Skeleton Loader**
<img width="414" height="796" alt="Screenshot 2025-10-24 at 2 56 29 PM" src="https://github.com/user-attachments/assets/c5782f54-04d4-4ce8-b45e-986eef433419" />



**Confirm page**
<img width="417" height="793" alt="Screenshot 2025-10-24 at 2 57 14 PM" src="https://github.com/user-attachments/assets/648380aa-2675-4d8d-9766-f3b2eb898a1c" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Shield subscription confirmation UI (skeleton layout, centered footer, trial tag styling) and changes trial copy to “14 days free trial” in en and en_GB.
> 
> - **UI (Shield Subscription Confirm)**:
>   - **Skeleton Loader**: Reworks layout using column stacks, padding/gaps; adds distinct sections for Billing Details and Gas Fees.
>   - **Footer Note**: Centers agreement row by adding `justifyContent={JustifyContent.center}`; cleans up `ButtonLink` props.
>   - **Trial Tag**: Adds `rounded-lg` and increases horizontal padding in `subscription-details`.
> - **i18n**:
>   - Updates `freeSevenDayTrial` message to `"14 days free trial"` in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d4589aa08b106a200fad9798e692f056337eabb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->