### PR TITLE
refactor: extract transaction type to category mapping

### DIFF
--- a/ui/components/app/transaction-list-item/helpers.test.ts
+++ b/ui/components/app/transaction-list-item/helpers.test.ts
@@ -1,7 +1,7 @@
 import { TransactionType } from '@metamask/transaction-controller';
 import { TransactionGroupCategory } from '../../../../shared/constants/transaction';
-import { mapTransactionTypeToCategory } from './helpers';
 import transactions from '../../../../test/data/transaction-data.json';
+import { mapTransactionTypeToCategory } from './helpers';
 
 const expectedResults = [
   {

--- a/ui/components/app/transaction-list-item/helpers.test.ts
+++ b/ui/components/app/transaction-list-item/helpers.test.ts
@@ -1,0 +1,75 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { TransactionGroupCategory } from '../../../../shared/constants/transaction';
+import { mapTransactionTypeToCategory } from './helpers';
+import transactions from '../../../../test/data/transaction-data.json';
+
+const expectedResults = [
+  {
+    title: 'Sent',
+    category: TransactionGroupCategory.send,
+  },
+  {
+    title: 'Sent',
+    category: TransactionGroupCategory.send,
+  },
+  {
+    title: 'Sent',
+    category: TransactionGroupCategory.send,
+  },
+  {
+    title: 'Received',
+    category: TransactionGroupCategory.receive,
+  },
+  {
+    title: 'Received',
+    category: TransactionGroupCategory.receive,
+  },
+  {
+    title: 'Received',
+    category: TransactionGroupCategory.receive,
+  },
+  {
+    title: 'Swap ETH to ABC',
+    category: TransactionType.swap,
+  },
+  {
+    title: 'Contract deployment',
+    category: TransactionGroupCategory.interaction,
+  },
+  {
+    title: 'Safe transfer from',
+    category: TransactionGroupCategory.send,
+  },
+  {
+    title: 'Approve ABC spending cap',
+    category: TransactionGroupCategory.approval,
+  },
+  {
+    title: 'Sent BAT as ETH',
+    category: TransactionType.swapAndSend,
+  },
+  {
+    title: 'Sent USDC as DAI',
+    category: TransactionType.swapAndSend,
+  },
+  {
+    title: 'Sent BNB as USDC',
+    category: TransactionType.swapAndSend,
+  },
+  {
+    title: 'Sent ABC',
+    category: TransactionGroupCategory.send,
+  },
+];
+
+describe('mapTransactionTypeToCategory', () => {
+  it('returns correct categories for transaction types', () => {
+    transactions.forEach(({ primaryTransaction }, index) => {
+      const transactionType = primaryTransaction.type as TransactionType;
+
+      const result = mapTransactionTypeToCategory(transactionType);
+
+      expect(result).toBe(expectedResults[index].category);
+    });
+  });
+});

--- a/ui/components/app/transaction-list-item/helpers.ts
+++ b/ui/components/app/transaction-list-item/helpers.ts
@@ -3,6 +3,9 @@ import { TransactionGroupCategory as GroupCategory } from '../../../../shared/co
 
 export function mapTransactionTypeToCategory(transactionType: TransactionType) {
   switch (transactionType) {
+    // Ported from useTransactionDisplayData
+    case null:
+    case undefined:
     case TransactionType.personalSign:
     case TransactionType.signTypedData:
     case TransactionType.ethDecrypt:

--- a/ui/components/app/transaction-list-item/helpers.ts
+++ b/ui/components/app/transaction-list-item/helpers.ts
@@ -1,0 +1,46 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { TransactionGroupCategory as GroupCategory } from '../../../../shared/constants/transaction';
+
+export function mapTransactionTypeToCategory(transactionType: TransactionType) {
+  switch (transactionType) {
+    case TransactionType.personalSign:
+    case TransactionType.signTypedData:
+    case TransactionType.ethDecrypt:
+    case TransactionType.ethGetEncryptionPublicKey: {
+      return GroupCategory.signatureRequest;
+    }
+    case TransactionType.swapApproval:
+    case TransactionType.tokenMethodApprove:
+    case TransactionType.tokenMethodSetApprovalForAll:
+    case TransactionType.tokenMethodIncreaseAllowance:
+    case TransactionType.bridgeApproval: {
+      return GroupCategory.approval;
+    }
+    case TransactionType.contractInteraction:
+    case TransactionType.batch:
+    case TransactionType.revokeDelegation:
+    case TransactionType.deployContract: {
+      return GroupCategory.interaction;
+    }
+    case TransactionType.tokenMethodTransferFrom:
+    case TransactionType.tokenMethodTransfer:
+    case TransactionType.tokenMethodSafeTransferFrom:
+    case TransactionType.simpleSend: {
+      return GroupCategory.send;
+    }
+    case TransactionType.swap: {
+      return GroupCategory.swap;
+    }
+    case TransactionType.swapAndSend: {
+      return GroupCategory.swapAndSend;
+    }
+    case TransactionType.bridge: {
+      return GroupCategory.bridge;
+    }
+    case TransactionType.incoming: {
+      return GroupCategory.receive;
+    }
+    default:
+      return undefined;
+  }
+}

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -70,6 +70,7 @@ import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
   NETWORK_TO_NAME_MAP,
 } from '../../../../shared/constants/network';
+import { mapTransactionTypeToCategory } from './helpers';
 
 function TransactionListItemInner({
   transactionGroup,
@@ -180,9 +181,12 @@ function TransactionListItemInner({
     isEarliestNonce,
   );
 
+  const category = mapTransactionTypeToCategory(
+    transactionGroup.initialTransaction.type,
+  );
+
   const {
     title,
-    category,
     primaryCurrency,
     recipientAddress,
     secondaryCurrency,

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -26,7 +26,6 @@ import {
   TOKEN_CATEGORY_HASH,
 } from '../helpers/constants/transactions';
 import { getNfts } from '../ducks/metamask/metamask';
-import { TransactionGroupCategory } from '../../shared/constants/transaction';
 import { captureSingleException } from '../store/actions';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { getTokenValueParam } from '../../shared/lib/metamask-controller-utils';
@@ -72,7 +71,6 @@ const signatureTypes = [
 
 /**
  * @typedef {object} TransactionDisplayData
- * @property {string} category - the transaction category that will be used for rendering the icon in the activity list
  * @property {string} primaryCurrency - the currency string to display in the primary position
  * @property {string} recipientAddress - the Ethereum address of the recipient
  * @property {string} senderAddress - the Ethereum address of the sender
@@ -265,7 +263,6 @@ export function useTransactionDisplayData(transactionGroup) {
   // but can later be modified if dealing with a swap
   let secondaryDisplayValue = isTokenCategory ? tokenFiatAmount : undefined;
 
-  let category;
   let title;
 
   const {
@@ -278,10 +275,8 @@ export function useTransactionDisplayData(transactionGroup) {
   const bridgeTokenDisplayData = useBridgeTokenDisplayData(transactionGroup);
 
   if (signatureTypes.includes(type)) {
-    category = TransactionGroupCategory.signatureRequest;
     title = t('signatureRequest');
   } else if (type === TransactionType.swap) {
-    category = TransactionGroupCategory.swap;
     title = t('swapTokenToToken', [
       bridgeTokenDisplayData.sourceTokenSymbol ??
         initialTransaction.sourceTokenSymbol,
@@ -314,7 +309,6 @@ export function useTransactionDisplayData(transactionGroup) {
 
     recipientAddress = initialTransaction.swapAndSendRecipient;
 
-    category = TransactionGroupCategory.swapAndSend;
     title = t('sentTokenAsToken', [
       initialTransaction.sourceTokenSymbol,
       initialTransaction.destinationTokenSymbol,
@@ -334,7 +328,6 @@ export function useTransactionDisplayData(transactionGroup) {
       prefix = '-';
     }
   } else if (type === TransactionType.swapApproval) {
-    category = TransactionGroupCategory.approval;
     title = t('swapApproval', [
       bridgeTokenDisplayData.sourceTokenSymbol ??
         primaryTransaction.sourceTokenSymbol,
@@ -343,7 +336,6 @@ export function useTransactionDisplayData(transactionGroup) {
       bridgeTokenDisplayData.sourceTokenSymbol ??
       primaryTransaction.sourceTokenSymbol;
   } else if (type === TransactionType.tokenMethodApprove) {
-    category = TransactionGroupCategory.approval;
     prefix = '';
     title = t('approveSpendingCap', [
       token?.symbol || t('token').toLowerCase(),
@@ -351,13 +343,11 @@ export function useTransactionDisplayData(transactionGroup) {
   } else if (type === TransactionType.tokenMethodSetApprovalForAll) {
     const isRevoke = !tokenData?.args?.[1];
 
-    category = TransactionGroupCategory.approval;
     prefix = '';
     title = isRevoke
       ? t('revokePermissionTitle', [token?.symbol || nft?.name || t('token')])
       : t('setApprovalForAllTitle', [token?.symbol || t('token')]);
   } else if (type === TransactionType.tokenMethodIncreaseAllowance) {
-    category = TransactionGroupCategory.approval;
     prefix = '';
     title = t('approveIncreaseAllowance', [token?.symbol || t('token')]);
   } else if (
@@ -365,42 +355,33 @@ export function useTransactionDisplayData(transactionGroup) {
     type === TransactionType.batch ||
     type === TransactionType.revokeDelegation
   ) {
-    category = TransactionGroupCategory.interaction;
     const transactionTypeTitle = getTransactionTypeTitle(t, type);
     title =
       (methodData?.name && camelCaseToCapitalize(methodData.name)) ||
       transactionTypeTitle;
   } else if (type === TransactionType.deployContract) {
-    // @todo Should perhaps be a separate group?
-    category = TransactionGroupCategory.interaction;
     title = getTransactionTypeTitle(t, type);
   } else if (type === TransactionType.incoming) {
-    category = TransactionGroupCategory.receive;
     title = t('received');
     prefix = '';
   } else if (
     type === TransactionType.tokenMethodTransferFrom ||
     type === TransactionType.tokenMethodTransfer
   ) {
-    category = TransactionGroupCategory.send;
     title = t('sentSpecifiedTokens', [
       token?.symbol || nft?.name || t('token'),
     ]);
     recipientAddress = getTokenAddressParam(tokenData);
   } else if (type === TransactionType.tokenMethodSafeTransferFrom) {
-    category = TransactionGroupCategory.send;
     title = t('safeTransferFrom');
     recipientAddress = getTokenAddressParam(tokenData);
   } else if (type === TransactionType.simpleSend) {
-    category = TransactionGroupCategory.send;
     title = t('sent');
   } else if (type === TransactionType.bridgeApproval) {
-    category = TransactionGroupCategory.approval;
     title = t('bridgeApproval', [bridgeTokenDisplayData.sourceTokenSymbol]);
     primarySuffix = bridgeTokenDisplayData.sourceTokenSymbol;
   } else if (type === TransactionType.bridge) {
     title = destChainName ? t('bridgedToChain', [destChainName]) : t('bridged');
-    category = bridgeTokenDisplayData.category;
     primarySuffix = bridgeTokenDisplayData.sourceTokenSymbol;
     primaryDisplayValue = formatAmount(
       locale,
@@ -454,7 +435,6 @@ export function useTransactionDisplayData(transactionGroup) {
 
   return {
     title,
-    category,
     primaryCurrency:
       type === TransactionType.swap && isPending ? '' : primaryCurrency,
     senderAddress,

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -4,10 +4,7 @@ import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 import { MemoryRouter } from 'react-router-dom';
-import {
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import transactions from '../../test/data/transaction-data.json';
@@ -15,7 +12,6 @@ import transactions from '../../test/data/transaction-data.json';
 // eslint-disable-next-line import/no-restricted-paths
 import messages from '../../app/_locales/en/messages.json';
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../helpers/constants/routes';
-import { TransactionGroupCategory } from '../../shared/constants/transaction';
 import { KeyringType } from '../../shared/constants/keyring';
 import { createMockInternalAccount } from '../../test/jest/mocks';
 import { getMessage } from '../helpers/utils/i18n-helper';
@@ -28,7 +24,6 @@ import { useTransactionDisplayData } from './useTransactionDisplayData';
 const expectedResults = [
   {
     title: 'Sent',
-    category: TransactionGroupCategory.send,
     primaryCurrency: '-1 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
@@ -39,7 +34,6 @@ const expectedResults = [
   },
   {
     title: 'Sent',
-    category: TransactionGroupCategory.send,
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x0ccc8aeeaf5ce790f3b448325981a143fdef8848',
@@ -49,7 +43,6 @@ const expectedResults = [
   },
   {
     title: 'Sent',
-    category: TransactionGroupCategory.send,
     primaryCurrency: '-2 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
@@ -59,7 +52,6 @@ const expectedResults = [
   },
   {
     title: 'Received',
-    category: TransactionGroupCategory.receive,
     primaryCurrency: '18.75 ETH',
     senderAddress: '0x31b98d14007bdee637298086988a0bbd31184523',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -69,7 +61,6 @@ const expectedResults = [
   },
   {
     title: 'Received',
-    category: TransactionGroupCategory.receive,
     primaryCurrency: '0 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -79,7 +70,6 @@ const expectedResults = [
   },
   {
     title: 'Received',
-    category: TransactionGroupCategory.receive,
     primaryCurrency: '1 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
@@ -89,7 +79,6 @@ const expectedResults = [
   },
   {
     title: 'Swap ETH to ABC',
-    category: TransactionType.swap,
     primaryCurrency: '+1 ABC',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
@@ -98,7 +87,6 @@ const expectedResults = [
   },
   {
     title: 'Contract deployment',
-    category: TransactionGroupCategory.interaction,
     primaryCurrency: '-0 ETH',
     senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: undefined,
@@ -108,7 +96,6 @@ const expectedResults = [
   },
   {
     title: 'Safe transfer from',
-    category: TransactionGroupCategory.send,
     primaryCurrency: '-0 ETH',
     senderAddress: '0x806627172af48bd5b0765d3449a7def80d6576ff',
     recipientAddress: '0xe7d522230eff653bb0a9b4385f0be0815420dd98',
@@ -118,7 +105,6 @@ const expectedResults = [
   },
   {
     title: 'Approve ABC spending cap',
-    category: TransactionGroupCategory.approval,
     primaryCurrency: '0.00000000000005 ABC',
     senderAddress: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
@@ -128,7 +114,6 @@ const expectedResults = [
   },
   {
     title: 'Sent BAT as ETH',
-    category: TransactionType.swapAndSend,
     primaryCurrency: '-33.425656732428330864 BAT',
     senderAddress: '0x0a985a957b490f4d05bef05bc7ec556dd8535946',
     recipientAddress: '0xc6f6ca03d790168758285264bcbf7fb30d27322b',
@@ -138,7 +123,6 @@ const expectedResults = [
   },
   {
     title: 'Sent USDC as DAI',
-    category: TransactionType.swapAndSend,
     primaryCurrency: '-5 USDC',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -148,7 +132,6 @@ const expectedResults = [
   },
   {
     title: 'Sent BNB as USDC',
-    category: TransactionType.swapAndSend,
     primaryCurrency: '-0.05 BNB',
     senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
@@ -158,7 +141,6 @@ const expectedResults = [
   },
   {
     title: 'Sent ABC',
-    category: TransactionGroupCategory.send,
     primaryCurrency: '-1.234 ABC',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
@@ -278,14 +260,6 @@ describe('useTransactionDisplayData', () => {
           tokenAddress,
         );
         expect(result.current.title).toStrictEqual(expected.title);
-      });
-
-      it(`should return a category of ${expected.category}`, () => {
-        const { result } = renderHookWithRouter(
-          () => useTransactionDisplayData(transactionGroup),
-          tokenAddress,
-        );
-        expect(result.current.category).toStrictEqual(expected.category);
       });
 
       it(`should return a primaryCurrency of ${expected.primaryCurrency}`, () => {


### PR DESCRIPTION
## **Description**

`useTransactionDisplayData` was overloaded doing too many different responsibilities

- This extracts the category mapping, part of deconstructing the hook
- It surfaced that there was no such `TransctionType.sign` enum
- Also makes it easier to see the mapping at a glance

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37160?quickstart=1)

## **Changelog**


CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves transaction type-to-category mapping into a new helper, updates TransactionListItem to use it, and removes category logic from useTransactionDisplayData with tests adjusted accordingly.
> 
> - **UI**:
>   - **Transaction category mapping**: Extracts type→category mapping to `ui/components/app/transaction-list-item/helpers.ts` (`mapTransactionTypeToCategory`).
>   - **TransactionListItem**: Uses `mapTransactionTypeToCategory(transactionGroup.initialTransaction.type)`; stops relying on `useTransactionDisplayData` for `category`.
> - **Hook**:
>   - `useTransactionDisplayData`: Removes `category` import, computation, and return value; updates typedef accordingly.
> - **Tests**:
>   - Adds `helpers.test.ts` covering mapping outputs.
>   - Updates `useTransactionDisplayData.test.js` to remove `category` assertions and related imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55e26241e96bc68565e755de8173cb4e9537a43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->