### PR TITLE
fix: normalize basePath trailing slash in getRelativeLocationForNestedRoutes

### DIFF
--- a/ui/pages/routes/utils.js
+++ b/ui/pages/routes/utils.js
@@ -356,16 +356,17 @@ export function showAppHeader(props) {
  * When using v5-compat <Routes> and <Route> components inside a parent route,
  * the child Routes need to match against paths relative to the parent route,
  * not the full pathname. This function strips the base path prefix from the
- * location to create a relative location.
+ * location to create a relative location. The resulting pathname is guaranteed
+ * to start with '/', as required by React Router Route matching.
  *
  * @param {object} location - The full location object from react-router
  * @param {string} location.pathname - The full pathname (e.g., '/connect/id/snap-install')
- * @param {string} basePath - The base path to remove (e.g., '/connect/id')
+ * @param {string} basePath - The base path to remove (e.g., '/connect/id' or '/connect/id/')
  * @returns {object} A new location object with pathname set to the relative path
  * (e.g., '/snap-install' or '/') and all other location properties preserved
  * @example
  * // Full pathname: '/connect/abc123/snaps-connect'
- * // Base path: '/connect/abc123'
+ * // Base path: '/connect/abc123' or '/connect/abc123/'
  * const relativeLocation = getRelativeLocationForNestedRoutes(
  *   location,
  *   '/connect/abc123'
@@ -379,8 +380,12 @@ export function showAppHeader(props) {
  * </Routes>
  */
 export function getRelativeLocationForNestedRoutes(location, basePath) {
-  const relativePathname = location.pathname.startsWith(basePath)
-    ? location.pathname.slice(basePath.length) || '/'
+  const normalizedBasePath = basePath.endsWith('/')
+    ? basePath.slice(0, -1)
+    : basePath;
+
+  const relativePathname = location.pathname.startsWith(normalizedBasePath)
+    ? location.pathname.slice(normalizedBasePath.length) || '/'
     : location.pathname;
 
   return {

--- a/ui/pages/routes/utils.test.ts
+++ b/ui/pages/routes/utils.test.ts
@@ -130,7 +130,7 @@ describe('getRelativeLocationForNestedRoutes', () => {
       basePath,
     ) as typeof location;
 
-    expect(result.pathname).toBe('snaps-connect');
+    expect(result.pathname).toBe('/snaps-connect');
   });
 
   it('should return "/" when pathname is basePath with trailing slash', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes a bug introduced in https://github.com/MetaMask/metamask-extension/pull/37019/files#r2450271792, where in `getRelativeLocationForNestedRoutes` where basePaths ending with a trailing slash would produce relative pathnames without a leading slash, causing React Router Route matching to fail.

When using nested v5-compat Routes with a basePath that includes a trailing slash:
- **Input:** `pathname: '/connect/abc123/snaps-connect'`, `basePath: '/connect/abc123/'`
- **Bug output:** `'snaps-connect'`  (it is missing leading slash)
- **Expected:** `'/snaps-connect'` 

This violated React Router's requirement that paths start with `/`, breaking Route matching.

The solution is to normalize the basePath by removing any trailing slash **before** extracting the relative pathname. This ensures consistent behavior and guarantees all relative pathnames start with `/`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37161?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: normalize basePath trailing slash in getRelativeLocationForNestedRoutes

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/37019/files#r2450271792

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes basePath by trimming trailing slashes so relative pathnames always start with '/', and updates tests accordingly.
> 
> - **Routing utils (`ui/pages/routes/utils.js`)**:
>   - Normalize `basePath` by removing a trailing slash before computing the relative path.
>   - Guarantee resulting `pathname` begins with `/` for React Router matching.
>   - Update JSDoc to reflect handling of trailing slashes and clarify examples.
> - **Tests (`ui/pages/routes/utils.test.ts`)**:
>   - Adjust expectation for trailing-slash `basePath` to assert leading `/` in the relative pathname.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38440bb11c9c91ab0a382378b5c177a4620deb71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->