### PR TITLE
ci: added NFTs to Power User persona

### DIFF
--- a/app/scripts/fixtures/generate-wallet-state.js
+++ b/app/scripts/fixtures/generate-wallet-state.js
@@ -9,6 +9,7 @@ import { E2E_SRP, defaultFixture } from '../../../test/e2e/default-fixture';
 import FixtureBuilder from '../../../test/e2e/fixture-builder';
 import { encryptorFactory } from '../lib/encryptor-factory';
 import { normalizeSafeAddress } from '../lib/multichain/address';
+import { CHAIN_IDS } from '../../../shared/constants/network';
 import { withAddressBook } from './with-address-book';
 import { FIXTURES_APP_STATE } from './with-app-state';
 import { withConfirmedTransactions } from './with-confirmed-transactions';
@@ -51,7 +52,8 @@ export async function generateWalletState(withState, fromTest) {
     .withPreferencesController(generatePreferencesControllerState(accounts))
     .withTokensController(generateTokensControllerState(accounts[0]))
     .withTransactionController(generateTransactionControllerState(accounts[0]))
-    .withEnabledNetworks(ALL_POPULAR_NETWORKS);
+    .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+    .withNftController(generateNftControllerState(accounts));
 
   return fixtureBuilder;
 }
@@ -339,4 +341,76 @@ function generateTransactionControllerState(account) {
   }
 
   return transactions;
+}
+
+/**
+ * Generates the state for the NftController.
+ *
+ * @param {Array<string>} accounts - The account addresses to associate NFT data with.
+ * @returns {object} The generated NftController state.
+ */
+function generateNftControllerState(accounts) {
+  console.log('Generating NftController state');
+
+  if (FIXTURES_CONFIG.withNfts === 0) {
+    return {};
+  }
+
+  const state = { allNfts: {} };
+
+  for (const [index, accountString] of accounts.entries()) {
+    state.allNfts[accountString] = {};
+    const account = state.allNfts[accountString];
+
+    // Initialize empty arrays for ALL_POPULAR_NETWORKS
+    for (const chainId of Object.keys(ALL_POPULAR_NETWORKS.eip155)) {
+      account[chainId] = [];
+    }
+
+    const startIndex = index * FIXTURES_CONFIG.withNfts + 1;
+
+    for (let i = startIndex; i < startIndex + FIXTURES_CONFIG.withNfts; i++) {
+      // These particular NFT collections were chosen because:
+      // -- predictable image URLs
+      // -- every image is different
+      // -- reliably loaded when tested
+
+      // Pudgy Penguins on Mainnet
+      account[CHAIN_IDS.MAINNET].push({
+        address: '0xBd3531dA5CF5857e7CfAA92426877b022e612cf8',
+        tokenId: i.toString(),
+        image: `ipfs://QmNf1UsmdGaMbpatQ6toXSkzDpizaGmC9zfunCyoz1enD5/penguin/${i}.png`,
+      });
+
+      // OptiPunks on Optimism
+      account[CHAIN_IDS.OPTIMISM].push({
+        address: '0xb8df6cc3050cc02f967db1ee48330ba23276a492',
+        tokenId: i.toString(),
+        image: `ipfs://QmbAhtqQqiSQqwCwQgrRB6urGc3umTskiuVpgX7FvHhutU/${i}.png`,
+      });
+
+      // Based Kongz on Base
+      account[CHAIN_IDS.BASE].push({
+        address: '0xa7f18e5046a94c376df1c769a6ad3001f2be3a7b',
+        tokenId: i.toString(),
+        image: `ipfs://bafybeia5p5qwrmatw4efdo2khhecaopxpjm32k67vhdnihsnybiavidogq/${i}.png`,
+      });
+
+      // Snout Zoo 2025 on Polygon
+      account[CHAIN_IDS.POLYGON].push({
+        address: '0xd3a40a9810cf9eb9431c885e7a13161118d253dd',
+        tokenId: i.toString(),
+        image: `ipfs://bafybeihcba5cbsu4huts6obpenjhjnqpm43gboutnfibrjycv47pu27gky/${i}.jpeg`,
+      });
+
+      // Pancake Squad NFTs on BSC
+      account[CHAIN_IDS.BSC].push({
+        address: '0x0a8901b0e25deb55a87524f0cc164e9644020eba',
+        tokenId: i.toString(),
+        image: `ipfs://QmaYTLuEoP35NcBKLsyPMzwDpebbZWukdEkzeGV9fVcUCt/pancakesquad${i}.png`,
+      });
+    }
+  }
+
+  return state;
 }

--- a/app/scripts/start-with-wallet-state.mjs
+++ b/app/scripts/start-with-wallet-state.mjs
@@ -28,6 +28,12 @@ const FIXTURES_FLAGS = {
     defaultValue: true,
     explanation: 'Specify whether to load suggested networks.',
   },
+  '--withNfts': {
+    type: 'number',
+    defaultValue: 20,
+    explanation:
+      'Specify the number of NFTs to import per network per account.',
+  },
   '--withPreferences': {
     type: 'boolean',
     defaultValue: true,

--- a/test/e2e/benchmarks/constants.ts
+++ b/test/e2e/benchmarks/constants.ts
@@ -21,6 +21,7 @@ export const WITH_STATE_POWER_USER = {
   withContacts: 40,
   withErc20Tokens: true,
   withNetworks: true,
+  withNfts: 20,
   withPreferences: true,
   withUnreadNotifications: 15,
 };


### PR DESCRIPTION
## **Description**

20 NFTs imported for each account in each of these 5 collections:
- Pudgy Penguins on Mainnet
- OptiPunks on Optimism
- Based Kongz on Base
- Snout Zoo 2025 on Polygon
- Pancake Squad NFTs on BSC

These particular NFT collections were chosen because:
- predictable image URLs
- every image is different
- reliably loaded when tested

These changes probably do not have any effect on the benchmarks as is, because they do not open the NFT page.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#5859

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable NFT fixtures and populates `NftController` state across multiple networks; exposes a `--withNfts` flag and updates the Power User persona.
> 
> - **Fixtures**:
>   - Add `NftController` state generation in `app/scripts/fixtures/generate-wallet-state.js` via `withNftController(generateNftControllerState(accounts))`.
>   - Implement `generateNftControllerState` to prefill `allNfts` per account for `MAINNET`, `OPTIMISM`, `BASE`, `POLYGON`, and `BSC` using `CHAIN_IDS` and `ALL_POPULAR_NETWORKS`.
> - **CLI**:
>   - Introduce `--withNfts` flag in `app/scripts/start-with-wallet-state.mjs` (number, default `20`) to control NFTs per network per account.
> - **Benchmarks**:
>   - Update `test/e2e/benchmarks/constants.ts` Power User config to include `withNfts: 20`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8faaa2b083117b7abcb881a5cdd416a7b0431ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->