### PR TITLE
ci: skip build-lavamoat-viz if no policy changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,7 +371,7 @@ jobs:
       - name: See if policy.json files have changed
         id: policy-changed
         run: |
-          # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json
+          # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json or policy-override.json
           if [ -f "changed-files/changed-files.json" ]; then
             if grep -q -e 'policy.json' -e 'policy-override.json' changed-files/changed-files.json; then
               echo "Lavamoat policy.json file changes detected."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,7 +346,8 @@ jobs:
       APPLE_EXPERIMENTAL_CLIENT_ID: 00000000000
       GOOGLE_FLASK_CLIENT_ID: 00000000000
       APPLE_FLASK_CLIENT_ID: 00000000000
-
+    outputs:
+      changed: ${{ steps.policy-changed.outputs.changed }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -374,14 +375,14 @@ jobs:
           # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json or policy-override.json
           if [ -f "changed-files/changed-files.json" ]; then
             if grep -q -e 'policy.json' -e 'policy-override.json' changed-files/changed-files.json; then
-              echo "Lavamoat policy.json file changes detected."
+              echo "Lavamoat policy file changes detected."
               echo "changed=true" >> "$GITHUB_OUTPUT"
             else
-              echo "No Lavamoat policy.json file changes detected."
+              echo "No Lavamoat policy file changes detected."
               echo "changed=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "Cannot find 'changed-files.json', assuming that Lavamoat policy.json files have changed."
+            echo "Cannot find 'changed-files.json', assuming that Lavamoat policy files have changed."
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -423,6 +424,8 @@ jobs:
       - build-source-map-explorer
       - build-lavamoat-viz
     uses: ./.github/workflows/publish-prerelease.yml
+    with:
+      changed: ${{ needs.build-lavamoat-viz.outputs.changed == 'true' }}
     secrets:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -347,7 +347,7 @@ jobs:
       GOOGLE_FLASK_CLIENT_ID: 00000000000
       APPLE_FLASK_CLIENT_ID: 00000000000
     outputs:
-      changed: ${{ steps.policy-changed.outputs.changed }}
+      lavamoat-policy-changed: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -369,34 +369,34 @@ jobs:
       - run: yarn tsx .github/scripts/git-diff-default-branch.ts
         if: ${{ steps.download-changed-files.outcome == 'failure' }}
 
-      - name: See if policy.json files have changed
-        id: policy-changed
+      - name: See if lavamoat policy files have changed
+        id: lavamoat-policy-changed
         run: |
           # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json or policy-override.json
           if [ -f "changed-files/changed-files.json" ]; then
             if grep -q -e 'policy.json' -e 'policy-override.json' changed-files/changed-files.json; then
               echo "Lavamoat policy file changes detected."
-              echo "changed=true" >> "$GITHUB_OUTPUT"
+              echo "lavamoat-policy-changed=true" >> "$GITHUB_OUTPUT"
             else
               echo "No Lavamoat policy file changes detected."
-              echo "changed=false" >> "$GITHUB_OUTPUT"
+              echo "lavamoat-policy-changed=false" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "Cannot find 'changed-files.json', assuming that Lavamoat policy files have changed."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "lavamoat-policy-changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download artifact 'build-dist-browserify'
-        if: ${{ steps.policy-changed.outputs.changed == 'true' }}
+        if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: build-dist-browserify
 
       - run: ./.github/scripts/create-lavamoat-viz.sh
-        if: ${{ steps.policy-changed.outputs.changed == 'true' }}
+        if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' }}
 
       - name: Upload 'build-viz' to S3
-        if: ${{ steps.policy-changed.outputs.changed == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
         uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
         with:
           aws-region: ${{ vars.AWS_REGION }}
@@ -425,7 +425,7 @@ jobs:
       - build-lavamoat-viz
     uses: ./.github/workflows/publish-prerelease.yml
     with:
-      changed: ${{ needs.build-lavamoat-viz.outputs.changed == 'true' }}
+      lavamoat-policy-changed: ${{ needs.build-lavamoat-viz.outputs.lavamoat-policy-changed == 'true' }}
     secrets:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,6 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       GOOGLE_PROD_CLIENT_ID: 00000000000
       APPLE_PROD_CLIENT_ID: 00000000000
@@ -354,15 +355,47 @@ jobs:
           skip-allow-scripts: true
           use-yarn-hydrate: true
 
+      - name: Download changed-files artifact
+        if: ${{ env.BRANCH != 'main' }}
+        id: download-changed-files
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: changed-files
+          path: ./changed-files/
+
+      # if the changed-files artifact does not exist, we get the diff
+      - run: yarn tsx .github/scripts/git-diff-default-branch.ts
+        if: ${{ steps.download-changed-files.outcome == 'failure' }}
+
+      - name: See if policy.json files have changed
+        id: policy-changed
+        run: |
+          # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json
+          if [ -f "changed-files/changed-files.json" ]; then
+            if grep -q 'policy.json' changed-files/changed-files.json; then
+              echo "Lavamoat policy.json file changes detected."
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "No Lavamoat policy.json file changes detected."
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Cannot find 'changed-files.json', assuming that Lavamoat policy.json files have changed."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download artifact 'build-dist-browserify'
+        if: ${{ steps.policy-changed.outputs.changed == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: build-dist-browserify
 
       - run: ./.github/scripts/create-lavamoat-viz.sh
+        if: ${{ steps.policy-changed.outputs.changed == 'true' }}
 
       - name: Upload 'build-viz' to S3
-        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        if: ${{ steps.policy-changed.outputs.changed == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
         uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,7 +373,7 @@ jobs:
         run: |
           # if 'changed-files/changed-files.json' exists, check if it contains any files named policy.json
           if [ -f "changed-files/changed-files.json" ]; then
-            if grep -q 'policy.json' changed-files/changed-files.json; then
+            if grep -q -e 'policy.json' -e 'policy-override.json' changed-files/changed-files.json; then
               echo "Lavamoat policy.json file changes detected."
               echo "changed=true" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -6,7 +6,7 @@ on:
       PR_COMMENT_TOKEN:
         required: true
     inputs:
-      changed:
+      lavamoat-policy-changed:
         description: 'Whether the Lavamoat policy files have changed'
         required: true
         type: boolean
@@ -30,7 +30,7 @@ jobs:
       MERGE_BASE_COMMIT_HASH: '' # placeholder so that we have autocomplete and logs
       CLOUDFRONT_REPO_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
       HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
-      CHANGED: ${{ inputs.changed }}
+      LAVAMOAT_POLICY_CHANGED: ${{ inputs.lavamoat-policy-changed }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -5,6 +5,11 @@ on:
     secrets:
       PR_COMMENT_TOKEN:
         required: true
+    inputs:
+      changed:
+        description: 'Whether the Lavamoat policy files have changed'
+        required: true
+        type: boolean
 
 jobs:
   publish-prerelease:
@@ -25,6 +30,7 @@ jobs:
       MERGE_BASE_COMMIT_HASH: '' # placeholder so that we have autocomplete and logs
       CLOUDFRONT_REPO_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
       HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
+      CHANGED: ${{ inputs.changed }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -155,9 +155,14 @@ async function start(): Promise<void> {
 
   const allArtifactsUrl = `https://github.com/${OWNER}/${REPOSITORY}/actions/runs/${RUN_ID}#artifacts`;
 
-  const contentRows = [
-    ...buildContentRows,
-    `build viz (only exists if policy files have changed): ${depVizLink}`,
+  const contentRows = [...buildContentRows];
+
+  // Only show build viz link if the policy files changed
+  if (process.env.CHANGED === 'true') {
+    contentRows.push(`build viz: ${depVizLink}`);
+  }
+
+  contentRows.push(
     `bundle size: ${bundleSizeStatsLink}`,
     `user-actions-benchmark: ${userActionsStatsLink}`,
     `storybook: ${storybookLink}`,
@@ -167,7 +172,8 @@ async function start(): Promise<void> {
        <summary>bundle viz:</summary>
        ${bundleMarkup}
      </details>`,
-  ];
+  );
+
   const hiddenContent = `<ul>${contentRows
     .map((row) => `<li>${row}</li>`)
     .join('\n')}</ul>`;

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -157,7 +157,7 @@ async function start(): Promise<void> {
 
   const contentRows = [
     ...buildContentRows,
-    `build viz: ${depVizLink}`,
+    `build viz (only exists if policy files have changed): ${depVizLink}`,
     `bundle size: ${bundleSizeStatsLink}`,
     `user-actions-benchmark: ${userActionsStatsLink}`,
     `storybook: ${storybookLink}`,

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -60,6 +60,7 @@ async function start(): Promise<void> {
     HEAD_COMMIT_HASH,
     MERGE_BASE_COMMIT_HASH,
     HOST_URL,
+    LAVAMOAT_POLICY_CHANGED,
   } = process.env as Record<string, string>;
 
   if (!PR_NUMBER) {
@@ -157,9 +158,9 @@ async function start(): Promise<void> {
 
   const contentRows = [...buildContentRows];
 
-  // Only show build viz link if the policy files changed
-  if (process.env.CHANGED === 'true') {
-    contentRows.push(`build viz: ${depVizLink}`);
+  // Only show lavamoat build viz link if the policy files changed
+  if (LAVAMOAT_POLICY_CHANGED === 'true') {
+    contentRows.push(`lavamoat build viz: ${depVizLink}`);
   }
 
   contentRows.push(


### PR DESCRIPTION
## **Description**

We only need to `build-lavamoat-viz` if one of the `policy.json` or `policy-override.json` files changed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#5948

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build and publish LavaMoat viz only when policy files change, propagate the flag to prerelease workflow and PR comment content.
> 
> - **CI workflows**
>   - `./.github/workflows/main.yml`:
>     - `build-lavamoat-viz`: add `GITHUB_TOKEN`; detect changes to `policy.json`/`policy-override.json` via `changed-files` artifact or fallback diff; expose `lavamoat-policy-changed` job output; conditionally run artifact download, `create-lavamoat-viz.sh`, and S3 upload when flag is `true`.
>     - `publish-prerelease`: pass `lavamoat-policy-changed` from `build-lavamoat-viz` into called workflow inputs.
>   - `./.github/workflows/publish-prerelease.yml`:
>     - Add boolean input `lavamoat-policy-changed`; export to env as `LAVAMOAT_POLICY_CHANGED`.
> - **PR comment bot** (`development/metamaskbot-build-announce.ts`):
>   - Read `LAVAMOAT_POLICY_CHANGED`; only include `lavamoat build viz` link when `true`; refactor content rows accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea1e020d3807ef2d2b84c77636adc689c41a696c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->