### PR TITLE
fix: Use account group address in `SnapUIAvatar` when applicable

### DIFF
--- a/ui/components/app/snaps/snap-ui-avatar/snap-ui-avatar.tsx
+++ b/ui/components/app/snaps/snap-ui-avatar/snap-ui-avatar.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { AvatarAccountSize } from '@metamask/design-system-react';
+import { CaipAccountId, parseCaipAccountId } from '@metamask/utils';
+import { isEvmAccountType } from '@metamask/keyring-api';
 import { PreferredAvatar } from '../../preferred-avatar';
+import { getIsMultichainAccountsState2Enabled } from '../../../../selectors/multichain-accounts';
+import { getAccountGroupsByAddress } from '../../../../selectors/multichain-accounts/account-tree';
+import { MultichainAccountsState } from '../../../../selectors/multichain-accounts/account-tree.types';
 
 type SnapUIAvatarProps = {
   // The address must be a CAIP-10 string.
@@ -9,8 +15,26 @@ type SnapUIAvatarProps = {
 };
 
 export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
-  address,
+  address: caipAddress,
   size,
 }) => {
-  return <PreferredAvatar address={address} size={size} />;
+  const { address } = useMemo(() => {
+    return parseCaipAccountId(caipAddress as CaipAccountId);
+  }, [caipAddress]);
+
+  const useAccountGroups = useSelector(getIsMultichainAccountsState2Enabled);
+
+  const accountGroups = useSelector((state: MultichainAccountsState) =>
+    getAccountGroupsByAddress(state, [address]),
+  );
+
+  const accountGroupAddress = accountGroups[0]?.accounts.find((account) =>
+    isEvmAccountType(account.type),
+  )?.address;
+
+  // Display the account group address if it exists as the default.
+  const displayAddress =
+    useAccountGroups && accountGroupAddress ? accountGroupAddress : caipAddress;
+
+  return <PreferredAvatar address={displayAddress} size={size} />;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adjusts `SnapUIAvatar` to use the account group address when it is available and the feature flag is enabled. If no address is found it falls back to the default behavior.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37173?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where some avatars would be out of sync

## **Manual testing steps**

1. Initiate a Solana send
2. Notice that the account avatar on the confirmation matches the account list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="422" height="629" alt="Screenshot 2025-10-24 at 12 19 00" src="https://github.com/user-attachments/assets/da237138-6544-4f17-a5cf-208feea42c83" />

### **After**

<img width="419" height="637" alt="Screenshot 2025-10-24 at 12 17 20" src="https://github.com/user-attachments/assets/97fb9ad6-95d4-4701-9bf7-93227b452b39" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `SnapUIAvatar` now prefers the EVM account group address (behind feature flag) parsed from a CAIP-10 input, falling back to the original address.
> 
> - **Snap UI**:
>   - Update `ui/components/app/snaps/snap-ui-avatar/snap-ui-avatar.tsx` to prefer an account group EVM address for `PreferredAvatar` when `getIsMultichainAccountsState2Enabled` is true; otherwise fall back to the provided CAIP-10 address.
>   - Parse the CAIP-10 input via `parseCaipAccountId` and derive the display address using Redux selectors `getAccountGroupsByAddress` and `getIsMultichainAccountsState2Enabled`.
>   - Add `useMemo` for address parsing and filter group accounts by `isEvmAccountType`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b445d24877a77f0917a1dbb4db7b725bb22cb55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->