### PR TITLE
refactor: Refactor integration between UserOperationController and TransactionController

### DIFF
--- a/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/user-operation-controller-init.test.ts
@@ -1,5 +1,9 @@
 import { Messenger } from '@metamask/base-controller';
 import { UserOperationController } from '@metamask/user-operation-controller';
+import type {
+  TransactionControllerEmulateNewTransaction,
+  TransactionControllerEmulateTransactionUpdate,
+} from '@metamask/transaction-controller';
 import { ControllerInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
@@ -9,10 +13,6 @@ import {
   UserOperationControllerInitMessenger,
 } from '../messengers';
 import { UserOperationControllerInit } from './user-operation-controller-init';
-import {
-  TransactionControllerEmulateNewTransaction,
-  TransactionControllerEmulateTransactionUpdate,
-} from '@metamask/transaction-controller';
 
 jest.mock('@metamask/user-operation-controller', () => ({
   UserOperationController: jest.fn().mockImplementation(() => ({

--- a/app/scripts/controller-init/messengers/index.ts
+++ b/app/scripts/controller-init/messengers/index.ts
@@ -186,7 +186,10 @@ import {
   getSignatureControllerInitMessenger,
   getSignatureControllerMessenger,
 } from './signature-controller-messenger';
-import { getUserOperationControllerMessenger } from './user-operation-controller-messenger';
+import {
+  getUserOperationControllerInitMessenger,
+  getUserOperationControllerMessenger,
+} from './user-operation-controller-messenger';
 
 export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
@@ -373,8 +376,14 @@ export {
   getTokensControllerMessenger,
   getTokensControllerInitMessenger,
 } from './tokens-controller-messenger';
-export type { UserOperationControllerMessenger } from './user-operation-controller-messenger';
-export { getUserOperationControllerMessenger } from './user-operation-controller-messenger';
+export type {
+  UserOperationControllerMessenger,
+  UserOperationControllerInitMessenger,
+} from './user-operation-controller-messenger';
+export {
+  getUserOperationControllerMessenger,
+  getUserOperationControllerInitMessenger,
+} from './user-operation-controller-messenger';
 
 export const CONTROLLER_MESSENGERS = {
   AccountOrderController: {
@@ -657,7 +666,7 @@ export const CONTROLLER_MESSENGERS = {
   },
   UserOperationController: {
     getMessenger: getUserOperationControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getUserOperationControllerInitMessenger,
   },
   UserStorageController: {
     getMessenger: getUserStorageControllerMessenger,

--- a/app/scripts/controller-init/messengers/user-operation-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/user-operation-controller-messenger.ts
@@ -6,16 +6,26 @@ import {
   KeyringControllerPrepareUserOperationAction,
   KeyringControllerSignUserOperationAction,
 } from '@metamask/keyring-controller';
+import type {
+  TransactionControllerEmulateNewTransaction,
+  TransactionControllerEmulateTransactionUpdate,
+} from '@metamask/transaction-controller';
 
 type AllowedActions =
   | AddApprovalRequest
   | KeyringControllerPatchUserOperationAction
   | KeyringControllerPrepareUserOperationAction
   | KeyringControllerSignUserOperationAction
-  | NetworkControllerGetNetworkClientByIdAction;
+  | NetworkControllerGetNetworkClientByIdAction
+  | TransactionControllerEmulateNewTransaction
+  | TransactionControllerEmulateTransactionUpdate;
 
 export type UserOperationControllerMessenger = ReturnType<
   typeof getUserOperationControllerMessenger
+>;
+
+export type UserOperationControllerInitMessenger = ReturnType<
+  typeof getUserOperationControllerInitMessenger
 >;
 
 /**
@@ -36,6 +46,26 @@ export function getUserOperationControllerMessenger(
       'KeyringController:prepareUserOperation',
       'KeyringController:patchUserOperation',
       'KeyringController:signUserOperation',
+    ],
+    allowedEvents: [],
+  });
+}
+
+/**
+ * Create a messenger restricted to the actions/events required to initialize
+ * the user operation controller.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getUserOperationControllerInitMessenger(
+  messenger: Messenger<AllowedActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'UserOperationControllerInit',
+    allowedActions: [
+      'TransactionController:emulateNewTransaction',
+      'TransactionController:emulateTransactionUpdate',
     ],
     allowedEvents: [],
   });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -758,16 +758,6 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
-    this.userOperationController.hub.on(
-      'user-operation-added',
-      this._onUserOperationAdded.bind(this),
-    );
-
-    this.userOperationController.hub.on(
-      'transaction-updated',
-      this._onUserOperationTransactionUpdated.bind(this),
-    );
-
     // on/off shield controller based on shield subscription
     this.controllerMessenger.subscribe(
       'SubscriptionController:stateChange',
@@ -8519,58 +8509,6 @@ export default class MetamaskController extends EventEmitter {
       {
         matomoEvent: true,
       },
-    );
-  }
-
-  _onUserOperationAdded(userOperationMeta) {
-    const transactionMeta = this.txController.state.transactions.find(
-      (tx) => tx.id === userOperationMeta.id,
-    );
-
-    if (!transactionMeta) {
-      return;
-    }
-
-    if (transactionMeta.type === TransactionType.swap) {
-      this.controllerMessenger.publish(
-        'TransactionController:transactionNewSwap',
-        { transactionMeta },
-      );
-    } else if (transactionMeta.type === TransactionType.swapApproval) {
-      this.controllerMessenger.publish(
-        'TransactionController:transactionNewSwapApproval',
-        { transactionMeta },
-      );
-    }
-  }
-
-  _onUserOperationTransactionUpdated(transactionMeta) {
-    const updatedTransactionMeta = {
-      ...transactionMeta,
-      txParams: {
-        ...transactionMeta.txParams,
-        from: this.accountsController.getSelectedAccount().address,
-      },
-    };
-
-    const transactionExists = this.txController.state.transactions.some(
-      (tx) => tx.id === updatedTransactionMeta.id,
-    );
-
-    if (!transactionExists) {
-      this.txController.update((state) => {
-        state.transactions.push(updatedTransactionMeta);
-      });
-    }
-
-    this.txController.updateTransaction(
-      updatedTransactionMeta,
-      'Generated from user operation',
-    );
-
-    this.controllerMessenger.publish(
-      'TransactionController:transactionStatusUpdated',
-      { transactionMeta: updatedTransactionMeta },
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/streams": "^0.4.0",
     "@metamask/subscription-controller": "^2.0.0",
-    "@metamask/transaction-controller": "^60.7.0",
+    "@metamask/transaction-controller": "^60.10.0",
     "@metamask/user-operation-controller": "^39.0.0",
     "@metamask/utils": "^11.4.2",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7954,9 +7954,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.7.0":
-  version: 60.7.0
-  resolution: "@metamask/transaction-controller@npm:60.7.0"
+"@metamask/transaction-controller@npm:^60.10.0, @metamask/transaction-controller@npm:^60.7.0":
+  version: 60.10.0
+  resolution: "@metamask/transaction-controller@npm:60.10.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -7965,7 +7965,7 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/base-controller": "npm:^8.4.1"
+    "@metamask/base-controller": "npm:^8.4.2"
     "@metamask/controller-utils": "npm:^11.14.1"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
@@ -7986,7 +7986,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^24.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: 10/5aa7b5479094f9e12813b3b18c13513ef2e68519afe753657ab23c594b88c7e3d42c740621d7e952cd966efea797dd6de3e15f127578b02c275084ed6ada48fe
+  checksum: 10/e2b088d71ac7777ec6827c6c5ab75ebf9d2ab894cb6320d66472c534a9d376df11cd70e64d6e88ccf7b4e2f14a414b9b43f4769acedc0051c4aba13ee231f89c
   languageName: node
   linkType: hard
 
@@ -31931,7 +31931,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.3.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
-    "@metamask/transaction-controller": "npm:^60.7.0"
+    "@metamask/transaction-controller": "npm:^60.10.0"
     "@metamask/user-operation-controller": "npm:^39.0.0"
     "@metamask/utils": "npm:^11.4.2"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
## **Description**

The UserOperationController now triggers transaction added/updated events in the TransactionController by using the new `emulateNewTransaction` and `emulateTransactionUpdate` added in v60.10.0 of
`@metamask/transaction-controller`. These event handlers have also been migrated out of `metamask-controller.js` and into the init module, which is where these sort of integrations belong.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37199?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This helps unblock #31843. The old integration was incompatible with the new messenger, which does not allow publishing an event outside of its namespace.

## **Manual testing steps**

N/A

## **Screenshots/Recordings**
N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes UserOperationController events to TransactionController using new emulate* actions through an init messenger; removes legacy handlers, adds tests, and bumps transaction-controller to v60.10.0.
> 
> - **Controller Init**:
>   - Wire `UserOperationController` hub events in `controller-init/confirmations/user-operation-controller-init.ts` to `TransactionController` via `initMessenger.call` using `TransactionController:emulateNewTransaction` and `TransactionController:emulateTransactionUpdate`.
> - **Messengers**:
>   - Add `getUserOperationControllerInitMessenger` exposing `emulateNewTransaction` and `emulateTransactionUpdate` actions.
>   - Export/init in `messengers/index.ts` and update `CONTROLLER_MESSENGERS.UserOperationController.getInitMessenger`.
> - **Cleanup**:
>   - Remove legacy `user-operation-added` and `transaction-updated` handlers from `app/scripts/metamask-controller.js`.
> - **Tests**:
>   - Update `user-operation-controller-init.test.ts` to validate messenger wiring and emulate calls.
> - **Dependencies**:
>   - Bump `@metamask/transaction-controller` to `^60.10.0` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f45a7fe1d57421b961f956d3c4d9a5ba8112436d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->