### PR TITLE
fix(snaps): Only trigger `onActive` and `onInactive` when client is unlocked (cp-13.7.0)

### DIFF
--- a/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
@@ -13,6 +13,7 @@ import {
   ErrorMessageEvent,
   OutboundRequest,
   OutboundResponse,
+  SetClientActive,
 } from '@metamask/snaps-controllers';
 import {
   GetEndowments,
@@ -36,6 +37,7 @@ import {
 import {
   KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerLockEvent,
+  KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
 import { SelectedNetworkControllerGetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
 import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
@@ -134,7 +136,10 @@ export function getSnapControllerMessenger(
 type InitActions =
   | KeyringControllerGetKeyringsByTypeAction
   | PreferencesControllerGetStateAction
-  | MetaMetricsControllerTrackEventAction;
+  | MetaMetricsControllerTrackEventAction
+  | SetClientActive;
+
+type InitEvents = KeyringControllerUnlockEvent;
 
 export type SnapControllerInitMessenger = ReturnType<
   typeof getSnapControllerInitMessenger
@@ -148,15 +153,16 @@ export type SnapControllerInitMessenger = ReturnType<
  * @returns The restricted messenger.
  */
 export function getSnapControllerInitMessenger(
-  messenger: Messenger<InitActions, never>,
+  messenger: Messenger<InitActions, InitEvents>,
 ) {
   return messenger.getRestricted({
     name: 'SnapControllerInit',
-    allowedEvents: [],
     allowedActions: [
       'KeyringController:getKeyringsByType',
       'PreferencesController:getState',
       'MetaMetricsController:trackEvent',
+      'SnapController:setClientActive',
     ],
+    allowedEvents: ['KeyringController:unlock'],
   });
 }

--- a/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/snaps/snap-controller-messenger.ts
@@ -139,7 +139,7 @@ type InitActions =
   | MetaMetricsControllerTrackEventAction
   | SetClientActive;
 
-type InitEvents = KeyringControllerUnlockEvent;
+type InitEvents = KeyringControllerUnlockEvent | KeyringControllerLockEvent;
 
 export type SnapControllerInitMessenger = ReturnType<
   typeof getSnapControllerInitMessenger
@@ -163,6 +163,6 @@ export function getSnapControllerInitMessenger(
       'MetaMetricsController:trackEvent',
       'SnapController:setClientActive',
     ],
-    allowedEvents: ['KeyringController:unlock'],
+    allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
   });
 }

--- a/app/scripts/controller-init/snaps/snap-controller-init.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.ts
@@ -137,6 +137,10 @@ export const SnapControllerInit: ControllerInitFunction<
     ) as unknown as TrackEventHook,
   });
 
+  initMessenger.subscribe('KeyringController:unlock', () => {
+    initMessenger.call('SnapController:setClientActive', true);
+  });
+
   return {
     controller,
   };

--- a/app/scripts/controller-init/snaps/snap-controller-init.ts
+++ b/app/scripts/controller-init/snaps/snap-controller-init.ts
@@ -137,6 +137,10 @@ export const SnapControllerInit: ControllerInitFunction<
     ) as unknown as TrackEventHook,
   });
 
+  initMessenger.subscribe('KeyringController:lock', () => {
+    initMessenger.call('SnapController:setClientActive', false);
+  });
+
   initMessenger.subscribe('KeyringController:unlock', () => {
     initMessenger.call('SnapController:setClientActive', true);
   });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7893,8 +7893,15 @@ export default class MetamaskController extends EventEmitter {
   set isClientOpen(open) {
     this._isClientOpen = open;
 
-    // Notify Snaps that the client is open or closed.
-    this.controllerMessenger.call('SnapController:setClientActive', open);
+    const { isUnlocked } = this.controllerMessenger.call(
+      'KeyringController:getState',
+    );
+
+    if (isUnlocked) {
+      // Notify Snaps that the client is open or closed when the client is
+      // unlocked.
+      this.controllerMessenger.call('SnapController:setClientActive', open);
+    }
 
     if (open) {
       this.controllerMessenger.call('BackendWebSocketService:connect');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes an issue where Snaps may try to call APIs that are only available when the client is unlocked in the `onActive` handler. After this change, `onActive` is only called when the client is being unlocked, or when the client is already in the unlocked state and is opened. `onInactive` is only called when the client is in the unlocked state and closed, or when the client is being locked.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37222?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Only trigger `onActive` and `onInactive` Snap lifecycle hooks when client is unlocked

## **Related issues**

Fixes #37179.

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate Snap lifecycle activation to the unlocked state and hook KeyringController lock/unlock to update Snap client activity.
> 
> - **Snaps Init/Messenger**:
>   - Allow `SnapController:setClientActive` action and subscribe to `KeyringController:lock`/`unlock` in `SnapControllerInit`, calling `setClientActive(false|true)` accordingly.
>   - Extend init messenger types/permissions to include `SetClientActive` and `KeyringControllerUnlockEvent`.
> - **MetaMask Controller**:
>   - In `isClientOpen` setter, call `SnapController:setClientActive` only if `KeyringController` is unlocked.
> - **Tests**:
>   - Add tests verifying `setClientActive` is called on lock/unlock events and refactor test setup to accept a base messenger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468cadd055dcdb4a5aa91ce0171703542715fde1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->