### PR TITLE
fix: added skip modal for create wallet using SRP

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6217,6 +6217,18 @@
   "siweURI": {
     "message": "URL"
   },
+  "skipAccountSecurity": {
+    "message": "Skip account security?"
+  },
+  "skipAccountSecurityDetails": {
+    "message": "If you lose this Secret Recovery Phrase, you won’t be able to access this wallet."
+  },
+  "skipAccountSecuritySecureNow": {
+    "message": "Secure now"
+  },
+  "skipAccountSecuritySkip": {
+    "message": "Skip"
+  },
   "skipDeepLinkInterstitial": {
     "message": "Don't show interstitial screen when opening deep links"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6217,6 +6217,18 @@
   "siweURI": {
     "message": "URL"
   },
+  "skipAccountSecurity": {
+    "message": "Skip account security?"
+  },
+  "skipAccountSecurityDetails": {
+    "message": "If you lose this Secret Recovery Phrase, you won’t be able to access this wallet."
+  },
+  "skipAccountSecuritySecureNow": {
+    "message": "Secure now"
+  },
+  "skipAccountSecuritySkip": {
+    "message": "Skip"
+  },
   "skipDeepLinkInterstitial": {
     "message": "Don't show interstitial screen when opening deep links"
   },

--- a/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
@@ -25,6 +25,17 @@ class SecureWalletPage {
   private readonly revealSecretRecoveryPhraseButton =
     '[data-testid="recovery-phrase-reveal"]';
 
+  private readonly skipAccountSecurityMessage = {
+    text: 'Skip account security?',
+    tag: 'h3',
+  };
+
+  private readonly skipSRPBackupCheckbox =
+    '[data-testid="skip-srp-backup-checkbox"]';
+
+  private readonly skipSRPBackupConfirmButton =
+    '[data-testid="skip-srp-backup-button"]';
+
   private readonly secureWalletRecommendedButton =
     '[data-testid="recovery-phrase-remind-later"]';
 
@@ -157,7 +168,11 @@ class SecureWalletPage {
 
   async skipSRPBackup(): Promise<void> {
     console.log('Skip SRP backup on Reveal SRP Onboarding page');
-    await this.driver.clickElement(this.secureWalletRecommendedButton);
+    await this.driver.waitForSelector(this.skipAccountSecurityMessage);
+    await this.driver.clickElement(this.skipSRPBackupCheckbox);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.skipSRPBackupConfirmButton,
+    );
   }
 }
 

--- a/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/secure-wallet-page.ts
@@ -168,6 +168,7 @@ class SecureWalletPage {
 
   async skipSRPBackup(): Promise<void> {
     console.log('Skip SRP backup on Reveal SRP Onboarding page');
+    await this.driver.clickElement(this.secureWalletRecommendedButton);
     await this.driver.waitForSelector(this.skipAccountSecurityMessage);
     await this.driver.clickElement(this.skipSRPBackupCheckbox);
     await this.driver.clickElementAndWaitToDisappear(

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/skip-srp-backup-popover.test.tsx.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/skip-srp-backup-popover.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SkipSRPBackup should match snapshot 1`] = `<div />`;

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.js
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -168,6 +168,32 @@ describe('Review Recovery Phrase Component', () => {
 
     expect(mockUseNavigate).toHaveBeenCalledWith(REVEAL_SRP_LIST_ROUTE, {
       replace: true,
+    });
+  });
+
+  it('should show skip srp backup popover when not from reminder and not from settings security', async () => {
+    const { getByTestId } = renderWithProvider(
+      <RecoveryPhrase {...props} />,
+      mockStore,
+    );
+
+    const remindLaterButton = getByTestId('recovery-phrase-remind-later');
+
+    fireEvent.click(remindLaterButton);
+
+    expect(getByTestId('skip-srp-backup-modal')).toBeInTheDocument();
+
+    const checkbox = getByTestId('skip-srp-backup-checkbox');
+    expect(checkbox).toBeInTheDocument();
+
+    const confirmSkip = getByTestId('skip-srp-backup-button');
+    expect(confirmSkip).toBeInTheDocument();
+    expect(confirmSkip).toBeDisabled();
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(confirmSkip).toBeEnabled();
     });
   });
 });

--- a/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.test.tsx
@@ -4,7 +4,6 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as browserRuntime from '../../../../shared/modules/browser-runtime.utils';
-import * as backgroundConnection from '../../../store/background-connection';
 import {
   PLATFORM_FIREFOX,
   PLATFORM_CHROME,

--- a/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import * as browserRuntime from '../../../../shared/modules/browser-runtime.utils';
+import * as backgroundConnection from '../../../store/background-connection';
+import {
+  PLATFORM_FIREFOX,
+  PLATFORM_CHROME,
+} from '../../../../shared/constants/app';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
+import {
+  ONBOARDING_COMPLETION_ROUTE,
+  ONBOARDING_METAMETRICS,
+} from '../../../helpers/constants/routes';
+import SkipSRPBackup from './skip-srp-backup-popover';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('SkipSRPBackup', () => {
+  const mockStore = {
+    metamask: {
+      firstTimeFlowType: FirstTimeFlowType.create,
+      networkConfigurationsByChainId: {
+        '0x1': {
+          chainId: '0x1',
+          name: 'Ethereum Mainnet',
+          nativeCurrency: 'ETH',
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              type: 'custom',
+              url: 'https://mainnet.infura.io',
+              networkClientId: 'mainnet',
+            },
+          ],
+          blockExplorerUrls: [],
+        },
+      },
+      selectedNetworkClientId: 'mainnet',
+      networksMetadata: {
+        mainnet: {
+          EIPS: { 1559: true },
+          status: 'available',
+        },
+      },
+      internalAccounts: {
+        accounts: {
+          accountId: {
+            address: '0x0000000000000000000000000000000000000000',
+            metadata: {
+              keyring: 'HD Key Tree',
+            },
+          },
+        },
+        selectedAccount: 'accountId',
+      },
+      keyrings: [
+        {
+          type: 'HD Key Tree',
+          accounts: ['0x0000000000000000000000000000000000000000'],
+        },
+      ],
+    },
+    localeMessages: {
+      currentLocale: 'en',
+    },
+  };
+
+  const store = configureMockStore([thunk])(mockStore);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should match snapshot', () => {
+    const { container } = renderWithProvider(
+      <SkipSRPBackup onClose={jest.fn()} secureYourWallet={jest.fn()} />,
+      store,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should navigate to onboarding metametrics when skip is confirmed on non-Firefox browser', async () => {
+    jest
+      .spyOn(browserRuntime, 'getBrowserName')
+      .mockReturnValue(PLATFORM_CHROME);
+
+    const { getByTestId } = renderWithProvider(
+      <SkipSRPBackup onClose={jest.fn()} secureYourWallet={jest.fn()} />,
+      store,
+    );
+
+    const checkbox = getByTestId('skip-srp-backup-checkbox');
+    expect(checkbox).toBeInTheDocument();
+
+    const confirmSkip = getByTestId('skip-srp-backup-button');
+    expect(confirmSkip).toBeInTheDocument();
+    expect(confirmSkip).toBeDisabled();
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(confirmSkip).toBeEnabled();
+    });
+
+    fireEvent.click(confirmSkip);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(ONBOARDING_METAMETRICS);
+    });
+  });
+
+  it('should navigate to onboarding completion when skip is confirmed on Firefox', async () => {
+    jest
+      .spyOn(browserRuntime, 'getBrowserName')
+      .mockReturnValue(PLATFORM_FIREFOX);
+
+    const { getByTestId } = renderWithProvider(
+      <SkipSRPBackup onClose={jest.fn()} secureYourWallet={jest.fn()} />,
+      store,
+    );
+
+    const checkbox = getByTestId('skip-srp-backup-checkbox');
+    expect(checkbox).toBeInTheDocument();
+
+    const confirmSkip = getByTestId('skip-srp-backup-button');
+    expect(confirmSkip).toBeInTheDocument();
+    expect(confirmSkip).toBeDisabled();
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(confirmSkip).toBeEnabled();
+    });
+
+    fireEvent.click(confirmSkip);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(ONBOARDING_COMPLETION_ROUTE);
+    });
+  });
+});

--- a/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.tsx
@@ -1,0 +1,165 @@
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { useDispatch, useSelector } from 'react-redux';
+import React, { useCallback, useContext, useState } from 'react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  AlignItems,
+  Display,
+  IconColor,
+  TextAlign,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import {
+  Box,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  ButtonSize,
+  Checkbox,
+  Button,
+  ButtonVariant,
+  Icon,
+  IconSize,
+  IconName,
+} from '../../../components/component-library';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { getHDEntropyIndex } from '../../../selectors/selectors';
+import { setSeedPhraseBackedUp } from '../../../store/actions';
+import {
+  ONBOARDING_COMPLETION_ROUTE,
+  ONBOARDING_METAMETRICS,
+} from '../../../helpers/constants/routes';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import { getFirstTimeFlowType } from '../../../selectors';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
+import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+import { TraceName } from '../../../../shared/lib/trace';
+
+type SkipSRPBackupProps = {
+  onClose: () => void;
+  secureYourWallet: () => void;
+};
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default function SkipSRPBackup({
+  onClose,
+  secureYourWallet,
+}: SkipSRPBackupProps) {
+  const [checked, setChecked] = useState(false);
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const hdEntropyIndex = useSelector(getHDEntropyIndex);
+  const firstTimeFlowType = useSelector(getFirstTimeFlowType);
+  const trackEvent = useContext(MetaMetricsContext);
+  const { bufferedEndTrace } = trackEvent;
+  const navigate = useNavigate();
+
+  const onSkipSrpBackup = useCallback(async () => {
+    await dispatch(setSeedPhraseBackedUp(false));
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.OnboardingWalletSecuritySkipConfirmed,
+      properties: {
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        hd_entropy_index: hdEntropyIndex,
+      },
+    });
+    bufferedEndTrace?.({ name: TraceName.OnboardingNewSrpCreateWallet });
+    bufferedEndTrace?.({ name: TraceName.OnboardingJourneyOverall });
+
+    if (
+      getBrowserName() === PLATFORM_FIREFOX ||
+      firstTimeFlowType === FirstTimeFlowType.restore
+    ) {
+      navigate(ONBOARDING_COMPLETION_ROUTE);
+    } else {
+      navigate(ONBOARDING_METAMETRICS);
+    }
+  }, [
+    dispatch,
+    firstTimeFlowType,
+    hdEntropyIndex,
+    navigate,
+    trackEvent,
+    bufferedEndTrace,
+  ]);
+
+  return (
+    <Modal isOpen onClose={onClose} data-testid="skip-srp-backup-modal">
+      <ModalOverlay />
+      <ModalContent alignItems={AlignItems.center}>
+        <ModalHeader onClose={onClose}>
+          <Box textAlign={TextAlign.Center}>
+            <Icon
+              name={IconName.Danger}
+              size={IconSize.Xl}
+              className="skip-srp-backup-popover__icon"
+              color={IconColor.errorDefault}
+            />
+            <Text
+              variant={TextVariant.headingMd}
+              textAlign={TextAlign.Center}
+              marginTop={4}
+              as="h3"
+            >
+              {t('skipAccountSecurity')}
+            </Text>
+          </Box>
+        </ModalHeader>
+        <Box paddingLeft={4} paddingRight={4}>
+          <Checkbox
+            id="skip-srp-backup__checkbox"
+            className="skip-srp-backup__checkbox"
+            data-testid="skip-srp-backup-checkbox"
+            isChecked={checked}
+            alignItems={AlignItems.flexStart}
+            onChange={() => {
+              setChecked(!checked);
+            }}
+            label={t('skipAccountSecurityDetails')}
+          />
+          <Box display={Display.Flex} marginTop={6} gap={4}>
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              onClick={() => {
+                trackEvent({
+                  category: MetaMetricsEventCategory.Onboarding,
+                  event:
+                    MetaMetricsEventName.OnboardingWalletSecuritySkipCanceled,
+                  properties: {
+                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    hd_entropy_index: hdEntropyIndex,
+                  },
+                });
+                secureYourWallet();
+              }}
+              block
+            >
+              {t('skipAccountSecuritySecureNow')}
+            </Button>
+            <Button
+              data-testid="skip-srp-backup-button"
+              size={ButtonSize.Lg}
+              disabled={!checked}
+              onClick={onSkipSrpBackup}
+              block
+              danger
+            >
+              {t('skipAccountSecuritySkip')}
+            </Button>
+          </Box>
+        </Box>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, I have added the Skip SRP backup popover. When the user clicks on the "Remind me later" button, the user will see the popover where they can continue with SRP, or the user can skip the backup.

Jira Link: https://consensyssoftware.atlassian.net/browse/SL-237

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37224?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added skip popover for SRP backup.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Extension
2. Create Wallet using SRP flow
3. In Import SRP click on "Remind me later" button and validate the changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/9e2c7e5f-a964-45e2-8fab-c03805593aab



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a confirmation popover when users choose “Remind me later” for SRP backup during onboarding, with updated telemetry, routing, locales, and tests.
> 
> - **Onboarding UI**:
>   - Introduces `SkipSRPBackup` popover (`ui/pages/onboarding-flow/recovery-phrase/skip-srp-backup-popover.tsx`) shown from `review-recovery-phrase.js` when clicking `recovery-phrase-remind-later`.
>   - Updates event flow: logs `OnboardingWalletSecuritySkipInitiated` from review page; confirms/cancels in popover with corresponding MetaMetrics and trace events.
>   - Adjusts navigation on skip: routes to `ONBOARDING_METAMETRICS` or `ONBOARDING_COMPLETION_ROUTE` based on browser/flow.
> - **Localization**:
>   - Adds strings `skipAccountSecurity*` in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Adds unit tests for the popover and review page interactions; snapshot added.
>   - Updates E2E page object (`test/e2e/.../secure-wallet-page.ts`) to handle the popover (checkbox + confirm).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f9e7fcf8d3655ca8aec1bb7ef95ca124753346. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->