### PR TITLE
fix: Remove invalid `PreferencesController` metadata entry

### DIFF
--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -495,14 +495,6 @@ const controllerMetadata = {
     anonymous: false,
     usedInUi: true,
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
-  'preferences.useSidePanelAsDefault': {
-    includeInStateLogs: true,
-    persist: true,
-    anonymous: true,
-    usedInUi: true,
-  },
-  ///: END:ONLY_INCLUDE_IF
 };
 
 export class PreferencesController extends BaseController<


### PR DESCRIPTION
## **Description**

A recent PR added a metadata entry to `PreferencesController` for a second-level property. Metadata only applies to top-level state properties, so this entry is invalid.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37285?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

The entry was added in #36564

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the invalid metadata entry for `preferences.useSidePanelAsDefault` from `PreferencesController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638f33806c7fdbf9bbe1d50dece6e60f7ab2c9b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->