### PR TITLE
ci: count network requests made during benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -406,6 +406,7 @@ jobs:
 
   publish-prerelease:
     name: Publish prerelease
+    if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     needs:
       - build-dist-browserify
       - build-dist-mv2-browserify

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   benchmarks:
+    if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:

--- a/test/e2e/benchmarks/constants.ts
+++ b/test/e2e/benchmarks/constants.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_NUM_BROWSER_LOADS = 10;
 export const DEFAULT_NUM_PAGE_LOADS = 10;
 
-export const ALL_TRACES = {
+export const ALL_METRICS = {
   uiStartup: 'UI Startup',
   load: 'navigation[0].load',
   domContentLoaded: 'navigation[0].domContentLoaded',
@@ -13,6 +13,7 @@ export const ALL_TRACES = {
   initialActions: 'Initial Actions',
   loadScripts: 'Load Scripts',
   setupStore: 'Setup Store',
+  numNetworkReqs: 'numNetworkReqs',
 } as const;
 
 export const WITH_STATE_POWER_USER = {

--- a/test/e2e/benchmarks/types-generated.ts
+++ b/test/e2e/benchmarks/types-generated.ts
@@ -17,6 +17,7 @@ export type Metrics = {
   'Initial Actions': number;
   'Load Scripts': number;
   'Setup Store': number;
+  numNetworkReqs: number;
 };
 
 export type StatisticalResult = {
@@ -39,4 +40,8 @@ export type BenchmarkArguments = {
   out?: string;
   retries: number;
   persona: 'standard' | 'powerUser';
+};
+
+export type NetworkReport = {
+  numNetworkReqs: number;
 };

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -357,15 +357,16 @@ async function withFixtures(options, testSuite) {
       : setupMocking;
 
     // Use the mockingSetupFunction we just chose
-    const { mockedEndpoint, getPrivacyReport } = await mockingSetupFunction(
-      mockServer,
-      testSpecificMock,
-      {
-        chainId: localNodeOptsNormalized[0]?.options.chainId || 1337,
-        ethConversionInUsd,
-        monConversionInUsd,
-      },
-    );
+    const {
+      mockedEndpoint,
+      getPrivacyReport,
+      getNetworkReport,
+      clearNetworkReport,
+    } = await mockingSetupFunction(mockServer, testSpecificMock, {
+      chainId: localNodeOptsNormalized[0]?.options.chainId || 1337,
+      ethConversionInUsd,
+      monConversionInUsd,
+    });
 
     if ((await detectPort(8000)) !== 8000) {
       throw new Error(
@@ -419,6 +420,8 @@ async function withFixtures(options, testSuite) {
       mockedEndpoint,
       mockServer,
       extensionId,
+      getNetworkReport,
+      clearNetworkReport,
     });
 
     const errorsAndExceptions = driver.summarizeErrorsAndExceptions();

--- a/test/e2e/mock-e2e-pass-through.ts
+++ b/test/e2e/mock-e2e-pass-through.ts
@@ -1,8 +1,11 @@
-import type { Mockttp, MockedEndpoint } from 'mockttp';
+import type { MockedEndpoint, Mockttp } from 'mockttp';
+import { NetworkReport } from './benchmarks/types-generated';
 
 type SetupMockReturn = {
   mockedEndpoint: MockedEndpoint[];
   getPrivacyReport: () => string[];
+  getNetworkReport: () => NetworkReport;
+  clearNetworkReport: () => void;
 };
 
 /**
@@ -20,16 +23,32 @@ export async function setupMockingPassThrough(
   _options = undefined,
   _withSolanaWebSocket = undefined,
 ): Promise<SetupMockReturn> {
+  let numNetworkReqs = 0;
+
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
       console.log('Request going to a live server ============', req.url);
+      numNetworkReqs += 1;
       return {};
     },
   });
 
   const mockedEndpoint = await testSpecificMock(server);
 
-  return { mockedEndpoint, getPrivacyReport };
+  function getNetworkReport(): NetworkReport {
+    return { numNetworkReqs };
+  }
+
+  function clearNetworkReport() {
+    numNetworkReqs = 0;
+  }
+
+  return {
+    mockedEndpoint,
+    getPrivacyReport,
+    getNetworkReport,
+    clearNetworkReport,
+  };
 }
 
 /**

--- a/test/e2e/mock-e2e-pass-through.ts
+++ b/test/e2e/mock-e2e-pass-through.ts
@@ -28,12 +28,15 @@ export async function setupMockingPassThrough(
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
       console.log('Request going to a live server ============', req.url);
-      numNetworkReqs += 1;
       return {};
     },
   });
 
   const mockedEndpoint = await testSpecificMock(server);
+
+  server.on('request-initiated', () => {
+    numNetworkReqs += 1;
+  });
 
   function getNetworkReport(): NetworkReport {
     return { numNetworkReqs };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -150,7 +150,9 @@ async function setupMocking(
   testSpecificMock,
   { chainId, ethConversionInUsd = 1700 },
 ) {
+  let numNetworkReqs = 0;
   const privacyReport = new Set();
+
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: ({ headers: { host }, url }) => {
       if (blocklistedHosts.includes(host)) {
@@ -164,13 +166,21 @@ async function setupMocking(
       }
       console.log('Request redirected to the catch all mock ============', url);
       return {
-        // If the URL or the host is not in the allowlsit nor blocklisted, we return a 200.
+        // If the URL or the host is not in the allowlist nor blocklisted, we return a 200.
         response: {
           statusCode: 200,
         },
       };
     },
   });
+
+  function getNetworkReport() {
+    return { numNetworkReqs };
+  }
+
+  function clearNetworkReport() {
+    numNetworkReqs = 0;
+  }
 
   const mockedEndpoint = await testSpecificMock(server);
   // Mocks below this line can be overridden by test-specific mocks
@@ -1254,6 +1264,8 @@ async function setupMocking(
    * operation. See the browserAPIRequestDomains regex above.
    */
   server.on('request-initiated', (request) => {
+    numNetworkReqs += 1;
+
     const privateHosts = matchPrivateHosts(request);
     if (privateHosts.size) {
       for (const privateHost of privateHosts) {
@@ -1272,7 +1284,12 @@ async function setupMocking(
     }
   });
 
-  return { mockedEndpoint, getPrivacyReport };
+  return {
+    mockedEndpoint,
+    getPrivacyReport,
+    getNetworkReport,
+    clearNetworkReport,
+  };
 }
 
 async function mockLensNameProvider(server) {


### PR DESCRIPTION
## **Description**

Measures and adds a `numNetworkReqs` line to the `UI Startup Metrics` table.  More detailed info on the network requests is coming in a later PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: MetaMask/metamask-planning#6123

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds numNetworkReqs to page-load benchmarks by counting network requests via mocks and wiring through helpers, and skips certain CI jobs for merge queue runs.
> 
> - **Benchmarks**:
>   - Add `numNetworkReqs` to collected `Metrics`; include in `ALL_METRICS` used for stats output.
>   - Capture network requests in mocks (`test/e2e/mock-e2e.js`, `test/e2e/mock-e2e-pass-through.ts`) and expose `getNetworkReport`/`clearNetworkReport`.
>   - Wire through helpers (`withFixtures`) to benchmark runners; reset network counters per page load and record counts.
>   - Update generated types to include `numNetworkReqs` and define `NetworkReport`; rename `ALL_TRACES` to `ALL_METRICS`; add browser-load start logging.
> - **CI**:
>   - Skip `publish-prerelease` and `run-benchmarks` jobs on `merge_group` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6a123549a59066eed05591303f31879a94f4be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->