### PR TITLE
fix: excess home component re-render

### DIFF
--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -250,7 +251,14 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
+// Strip unused 'match' prop from withRouter
+// It causes cascading, unnecessary re-renders
+// eslint-disable-next-line react/prop-types
+const HomeWithRouter = ({ match: _match, ...props }) => {
+  return <Home {...props} />;
+};
+
 export default compose(
   withRouter,
   connect(mapStateToProps, mapDispatchToProps),
-)(Home);
+)(HomeWithRouter);


### PR DESCRIPTION
## **Description**

The Home component has excessive re-renders, and this cascades down to the child components.

One cause is the `match` object from `withRouter`. It’s an object and receives a new reference on each render. It isn’t used within the Home component so this PR removes it from props

Later on we should migrate the Home component to a function component and use React Router hooks instead of withRouter

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: reduce excess re-renders

## **Related issues**

Fixes:

## **Manual testing steps**

Use React profile to observe re-renders


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/743b098d-e5b7-40b7-9b63-8266b1a4fc0d



<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8925a29a-263a-4f67-b661-9a5bc8c7dc02


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps Home with a component that strips the unused `match` prop from `withRouter` to reduce unnecessary re-renders.
> 
> - **Home container (`ui/pages/home/home.container.js`)**:
>   - Introduces `HomeWithRouter` wrapper that strips the unused `match` prop from `withRouter` to avoid cascading re-renders.
>   - Updates export to compose `withRouter` and `connect` with `HomeWithRouter` instead of `Home`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5070c95cd846cd92bdfbed5a5382779b4131c0de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->