### PR TITLE
fix: correct trial days value

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2687,8 +2687,8 @@
   "form": {
     "message": "form"
   },
-  "freeSevenDayTrial": {
-    "message": "14 days free trial"
+  "freeTrailDays": {
+    "message": "$1 days free trial"
   },
   "from": {
     "message": "From"
@@ -5900,7 +5900,7 @@
     "message": "Plan details"
   },
   "shieldPlanDetails1": {
-    "message": "No charge now, try free for 14 days"
+    "message": "No charge now, try free for $1 days"
   },
   "shieldPlanDetails2": {
     "message": "Pre-approve membership (default 1 year), with fees charged only on a monthly basis"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2687,7 +2687,7 @@
   "form": {
     "message": "form"
   },
-  "freeTrailDays": {
+  "freeTrialDays": {
     "message": "$1 days free trial"
   },
   "from": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2687,8 +2687,8 @@
   "form": {
     "message": "form"
   },
-  "freeSevenDayTrial": {
-    "message": "14 days free trial"
+  "freeTrailDays": {
+    "message": "$1 days free trial"
   },
   "from": {
     "message": "From"
@@ -5900,7 +5900,7 @@
     "message": "Plan details"
   },
   "shieldPlanDetails1": {
-    "message": "No charge now, try free for 14 days"
+    "message": "No charge now, try free for $1 days"
   },
   "shieldPlanDetails2": {
     "message": "Pre-approve membership (default 1 year), with fees charged only on a monthly basis"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2687,7 +2687,7 @@
   "form": {
     "message": "form"
   },
-  "freeTrailDays": {
+  "freeTrialDays": {
     "message": "$1 days free trial"
   },
   "from": {

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -2600,7 +2600,7 @@
   "form": {
     "message": "foirm"
   },
-  "freeTrailDays": {
+  "freeTrialDays": {
     "message": "$1 days free trial"
   },
   "from": {

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -2600,8 +2600,8 @@
   "form": {
     "message": "foirm"
   },
-  "freeSevenDayTrial": {
-    "message": "Triail 7 lá saor in aisce"
+  "freeTrailDays": {
+    "message": "$1 days free trial"
   },
   "from": {
     "message": "Ó"
@@ -5738,7 +5738,7 @@
     "message": "Sonraí an phlean"
   },
   "shieldPlanDetails1": {
-    "message": "Gan aon táille anois, bain triail as saor in aisce ar feadh 14 lá"
+    "message": "Gan aon táille anois, bain triail as saor in aisce ar feadh $1 lá"
   },
   "shieldPlanDetails2": {
     "message": "Réamhcheadú ballraíochta (1 bhliain réamhshocraithe), agus táillí á ngearradh go míosúil amháin"

--- a/shared/constants/subscriptions.ts
+++ b/shared/constants/subscriptions.ts
@@ -11,3 +11,5 @@ export const PausedSubscriptionStatuses: string[] = [
   SUBSCRIPTION_STATUSES.pastDue,
   SUBSCRIPTION_STATUSES.unpaid,
 ];
+
+export const TRIAL_DAYS = 14;

--- a/shared/constants/subscriptions.ts
+++ b/shared/constants/subscriptions.ts
@@ -11,5 +11,3 @@ export const PausedSubscriptionStatuses: string[] = [
   SUBSCRIPTION_STATUSES.pastDue,
   SUBSCRIPTION_STATUSES.unpaid,
 ];
-
-export const TRIAL_DAYS = 14;

--- a/shared/constants/subscriptions.ts
+++ b/shared/constants/subscriptions.ts
@@ -11,3 +11,7 @@ export const PausedSubscriptionStatuses: string[] = [
   SUBSCRIPTION_STATUSES.pastDue,
   SUBSCRIPTION_STATUSES.unpaid,
 ];
+
+export const SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS = 14;
+
+export const SUBSCRIPTION_DEFAULT_PAYMENT_TOKEN = 'mUSD';

--- a/test/e2e/tests/shield/shield-entry-modal.spec.ts
+++ b/test/e2e/tests/shield/shield-entry-modal.spec.ts
@@ -107,7 +107,6 @@ describe('Shield Entry Modal', function () {
         testSpecificMock: mockSubscriptionApiCalls,
       },
       async ({ driver }) => {
-        await driver.delay(5_000);
         await loginWithBalanceValidation(driver);
 
         const homePage = new HomePage(driver);

--- a/test/lib/i18n-helpers.js
+++ b/test/lib/i18n-helpers.js
@@ -1,6 +1,6 @@
 import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 import * as en from '../../app/_locales/en/messages.json';
 
-export function tEn(key) {
-  return getMessage('en', en, key);
+export function tEn(key, substitutions = []) {
+  return getMessage('en', en, key, substitutions);
 }

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
@@ -75,7 +75,7 @@ describe('ShieldSubscriptionApproveInfo', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$8/month (Monthly)' as string)).toBeInTheDocument();
-    expect(getByText('14 days free trial')).toBeInTheDocument();
+    expect(getByText(tEn('freeTrialDays', [14]) as string)).toBeInTheDocument();
     expect(getByText(tEn('estimatedChanges') as string)).toBeInTheDocument();
     expect(getByText(tEn('youApprove') as string)).toBeInTheDocument();
     expect(getByText('96')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
@@ -4,7 +4,6 @@ import { ProductPrice } from '@metamask/subscription-controller';
 import { getMockApproveConfirmState } from '../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import { tEn } from '../../../../../../../test/lib/i18n-helpers';
-import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 import ShieldSubscriptionApproveInfo from './shield-subscription-approve';
 
 jest.mock('../hooks/useDecodedTransactionData', () => ({
@@ -55,7 +54,7 @@ jest.mock('../../../../../../hooks/subscription/useSubscriptionPricing', () => {
     unitAmount: 8000000,
     unitDecimals: 6,
     currency: 'usd',
-    trialPeriodDays: 7,
+    trialPeriodDays: 14,
   };
   return {
     useShieldSubscriptionPricingFromTokenApproval: jest.fn(() => ({
@@ -76,7 +75,7 @@ describe('ShieldSubscriptionApproveInfo', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$8/month (Monthly)' as string)).toBeInTheDocument();
-    expect(getByText(`${TRIAL_DAYS} days free trial`)).toBeInTheDocument();
+    expect(getByText('14 days free trial')).toBeInTheDocument();
     expect(getByText(tEn('estimatedChanges') as string)).toBeInTheDocument();
     expect(getByText(tEn('youApprove') as string)).toBeInTheDocument();
     expect(getByText('96')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx
@@ -4,6 +4,7 @@ import { ProductPrice } from '@metamask/subscription-controller';
 import { getMockApproveConfirmState } from '../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import { tEn } from '../../../../../../../test/lib/i18n-helpers';
+import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 import ShieldSubscriptionApproveInfo from './shield-subscription-approve';
 
 jest.mock('../hooks/useDecodedTransactionData', () => ({
@@ -75,7 +76,7 @@ describe('ShieldSubscriptionApproveInfo', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$8/month (Monthly)' as string)).toBeInTheDocument();
-    expect(getByText(tEn('freeSevenDayTrial') as string)).toBeInTheDocument();
+    expect(getByText(`${TRIAL_DAYS} days free trial`)).toBeInTheDocument();
     expect(getByText(tEn('estimatedChanges') as string)).toBeInTheDocument();
     expect(getByText(tEn('youApprove') as string)).toBeInTheDocument();
     expect(getByText('96')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
@@ -7,6 +7,7 @@ import {
 import { getMockConfirmState } from '../../../../../../../test/data/confirmations/helper';
 import { tEn } from '../../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers';
+import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 import { SubscriptionDetails } from './subscription-details';
 
 const mockProductPrice: ProductPrice = {
@@ -29,7 +30,7 @@ describe('SubscriptionDetails', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$80/year (Annual)' as string)).toBeInTheDocument();
-    expect(getByText(tEn('freeSevenDayTrial') as string)).toBeInTheDocument();
+    expect(getByText(`${TRIAL_DAYS} days free trial`)).toBeInTheDocument();
   });
 
   it('renders monthly plan without trial correctly', () => {

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
@@ -7,7 +7,6 @@ import {
 import { getMockConfirmState } from '../../../../../../../test/data/confirmations/helper';
 import { tEn } from '../../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers';
-import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 import { SubscriptionDetails } from './subscription-details';
 
 const mockProductPrice: ProductPrice = {
@@ -16,7 +15,7 @@ const mockProductPrice: ProductPrice = {
   unitAmount: 80000000,
   unitDecimals: 6,
   currency: 'usd',
-  trialPeriodDays: 7,
+  trialPeriodDays: 14,
 };
 
 describe('SubscriptionDetails', () => {
@@ -30,7 +29,7 @@ describe('SubscriptionDetails', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$80/year (Annual)' as string)).toBeInTheDocument();
-    expect(getByText(`${TRIAL_DAYS} days free trial`)).toBeInTheDocument();
+    expect(getByText('14 days free trial')).toBeInTheDocument();
   });
 
   it('renders monthly plan without trial correctly', () => {

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.test.tsx
@@ -29,7 +29,7 @@ describe('SubscriptionDetails', () => {
 
     expect(getByText(tEn('transactionShield') as string)).toBeInTheDocument();
     expect(getByText('$80/year (Annual)' as string)).toBeInTheDocument();
-    expect(getByText('14 days free trial')).toBeInTheDocument();
+    expect(getByText(tEn('freeTrialDays', [14]) as string)).toBeInTheDocument();
   });
 
   it('renders monthly plan without trial correctly', () => {

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -73,7 +73,7 @@ export const SubscriptionDetails = ({
             }}
           >
             <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
-              {t('freeTrialDays', [productPrice?.trialPeriodDays])}
+              {t('freeTrialDays', [productPrice?.trialPeriodDays ?? ''])}
             </Text>
           </Box>
         )}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { getProductPrice } from '../../../../../shield-plan/utils';
+import { SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS } from '../../../../../../../shared/constants/subscriptions';
 
 export const SubscriptionDetails = ({
   showTrial,
@@ -73,7 +74,10 @@ export const SubscriptionDetails = ({
             }}
           >
             <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
-              {t('freeTrialDays', [productPrice?.trialPeriodDays ?? ''])}
+              {t('freeTrialDays', [
+                productPrice?.trialPeriodDays ??
+                  SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS,
+              ])}
             </Text>
           </Box>
         )}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { getProductPrice } from '../../../../../shield-plan/utils';
+import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 
 export const SubscriptionDetails = ({
   showTrial,
@@ -73,7 +74,7 @@ export const SubscriptionDetails = ({
             }}
           >
             <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
-              {t('freeSevenDayTrial')}
+              {t('freeTrailDays', [TRIAL_DAYS])}
             </Text>
           </Box>
         )}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -74,7 +74,7 @@ export const SubscriptionDetails = ({
             }}
           >
             <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
-              {t('freeTrailDays', [TRIAL_DAYS])}
+              {t('freeTrialDays', [TRIAL_DAYS])}
             </Text>
           </Box>
         )}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -17,7 +17,6 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { getProductPrice } from '../../../../../shield-plan/utils';
-import { TRIAL_DAYS } from '../../../../../../../shared/constants/subscriptions';
 
 export const SubscriptionDetails = ({
   showTrial,
@@ -74,7 +73,7 @@ export const SubscriptionDetails = ({
             }}
           >
             <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
-              {t('freeTrialDays', [TRIAL_DAYS])}
+              {t('freeTrialDays', [productPrice?.trialPeriodDays])}
             </Text>
           </Box>
         )}

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -128,7 +128,7 @@ export const ShieldPaymentModal = ({
       ]);
     }
     // single token to display eg. Insufficient USDC
-    return t('shieldPlanNoFundsOneToken', [lastToken]);
+    return t('shieldPlanNoFundsOneToken', [lastToken ?? '']);
   }, [tokensSupported, t]);
 
   return (

--- a/ui/pages/shield-plan/shield-payment-modal.tsx
+++ b/ui/pages/shield-plan/shield-payment-modal.tsx
@@ -43,6 +43,7 @@ import {
   ERC20Asset,
   NativeAsset,
 } from '../../components/multichain/asset-picker-amount/asset-picker-modal/types';
+import { SUBSCRIPTION_DEFAULT_PAYMENT_TOKEN } from '../../../shared/constants/subscriptions';
 
 export const ShieldPaymentModal = ({
   isOpen,
@@ -128,7 +129,9 @@ export const ShieldPaymentModal = ({
       ]);
     }
     // single token to display eg. Insufficient USDC
-    return t('shieldPlanNoFundsOneToken', [lastToken ?? '']);
+    return t('shieldPlanNoFundsOneToken', [
+      lastToken ?? SUBSCRIPTION_DEFAULT_PAYMENT_TOKEN,
+    ]);
   }, [tokensSupported, t]);
 
   return (

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -285,7 +285,7 @@ const ShieldPlan = () => {
     const details = [];
     if (!isTrialed) {
       details.push(
-        t('shieldPlanDetails1', [selectedProductPrice?.trialPeriodDays]),
+        t('shieldPlanDetails1', [selectedProductPrice?.trialPeriodDays ?? '']),
       );
     }
     details.push(

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -79,7 +79,6 @@ import {
   selectNetworkConfigurationByChainId,
 } from '../../selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
-import { TRIAL_DAYS } from '../../../shared/constants/subscriptions';
 import { ShieldPaymentModal } from './shield-payment-modal';
 import { Plan } from './types';
 import { getProductPrice } from './utils';
@@ -285,7 +284,9 @@ const ShieldPlan = () => {
   const planDetails = useMemo(() => {
     const details = [];
     if (!isTrialed) {
-      details.push(t('shieldPlanDetails1', [TRIAL_DAYS]));
+      details.push(
+        t('shieldPlanDetails1', [selectedProductPrice?.trialPeriodDays]),
+      );
     }
     details.push(
       selectedPaymentMethod === PAYMENT_TYPES.byCrypto
@@ -294,7 +295,7 @@ const ShieldPlan = () => {
     );
     details.push(t('shieldPlanDetails3'));
     return details;
-  }, [t, selectedPaymentMethod, isTrialed]);
+  }, [t, selectedPaymentMethod, isTrialed, selectedProductPrice]);
 
   const [showPaymentModal, setShowPaymentModal] = useState(false);
 

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -79,6 +79,7 @@ import {
   selectNetworkConfigurationByChainId,
 } from '../../selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
+import { SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS } from '../../../shared/constants/subscriptions';
 import { ShieldPaymentModal } from './shield-payment-modal';
 import { Plan } from './types';
 import { getProductPrice } from './utils';
@@ -285,7 +286,10 @@ const ShieldPlan = () => {
     const details = [];
     if (!isTrialed) {
       details.push(
-        t('shieldPlanDetails1', [selectedProductPrice?.trialPeriodDays ?? '']),
+        t('shieldPlanDetails1', [
+          selectedProductPrice?.trialPeriodDays ??
+            SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS,
+        ]),
       );
     }
     details.push(

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -79,6 +79,7 @@ import {
   selectNetworkConfigurationByChainId,
 } from '../../selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
+import { TRIAL_DAYS } from '../../../shared/constants/subscriptions';
 import { ShieldPaymentModal } from './shield-payment-modal';
 import { Plan } from './types';
 import { getProductPrice } from './utils';
@@ -281,15 +282,19 @@ const ShieldPlan = () => {
   );
   const selectedPlanData = plans.find((plan) => plan.id === selectedPlan);
 
-  const planDetails = [
-    t('shieldPlanDetails1'),
-    t(
+  const planDetails = useMemo(() => {
+    const details = [];
+    if (!isTrialed) {
+      details.push(t('shieldPlanDetails1', [TRIAL_DAYS]));
+    }
+    details.push(
       selectedPaymentMethod === PAYMENT_TYPES.byCrypto
-        ? 'shieldPlanDetails2'
-        : 'shieldPlanDetails2Card',
-    ),
-    t('shieldPlanDetails3'),
-  ];
+        ? t('shieldPlanDetails2')
+        : t('shieldPlanDetails2Card'),
+    );
+    details.push(t('shieldPlanDetails3'));
+    return details;
+  }, [t, selectedPaymentMethod, isTrialed]);
 
   const [showPaymentModal, setShowPaymentModal] = useState(false);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Correct shield subscriptions trial days value in plan and crypto approval screen

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37295?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed shield subscription trial days value inconsistency

## **Related issues**

Fixes:

## **Manual testing steps**

1. shield plan page
2. trial days value should be the same as value in crypto approval screen

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parameterizes Shield trial days (default 14) across UI and locales, updates payment token fallback, and aligns tests with the new i18n and pricing behavior.
> 
> - **i18n/locales**:
>   - Replace `freeSevenDayTrial` with parameterized `freeTrialDays` and update `shieldPlanDetails1` to accept `$1` days in `app/_locales/en`, `en_GB`, and `ga`.
> - **Constants**:
>   - Add `SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS = 14` and `SUBSCRIPTION_DEFAULT_PAYMENT_TOKEN = 'mUSD'` in `shared/constants/subscriptions.ts`.
> - **UI (Shield)**:
>   - `subscription-details.tsx`: show trial badge via `t('freeTrialDays', [trialPeriodDays || SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS])`.
>   - `shield-plan.tsx`: build plan details with dynamic trial days (or default) and show only when not trialed.
>   - `shield-payment-modal.tsx`: fallback to `SUBSCRIPTION_DEFAULT_PAYMENT_TOKEN` in `shieldPlanNoFundsOneToken` when token missing.
> - **Tests**:
>   - Update unit tests to expect `freeTrialDays` with `[14]` and pricing `trialPeriodDays: 14`.
>   - Enhance `tEn` helper to support substitutions; remove unnecessary delay in e2e and mock pricing with 14-day trials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf645e1bcc47648cafdfe76143be0af5956ece78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->