### PR TITLE
feat: Hide insufficient funds alert on sponsored stx

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,24 +1,25 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { TransactionMeta } from '@metamask/transaction-controller';
 
 import { sumHexes } from '../../../../../../shared/modules/conversion.utils';
+import {
+  AlertActionKey,
+  RowAlertKey,
+} from '../../../../../components/app/confirm/info/row/constants';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   getMultichainNetworkConfigurationsByChainId,
   getUseTransactionSimulations,
   selectTransactionAvailableBalance,
   selectTransactionFeeById,
 } from '../../../../../selectors';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { Severity } from '../../../../../helpers/constants/design-system';
-import {
-  AlertActionKey,
-  RowAlertKey,
-} from '../../../../../components/app/confirm/info/row/constants';
-import { isBalanceSufficient } from '../../../send-legacy/send.utils';
 import { useConfirmContext } from '../../../context/confirm';
+import { isBalanceSufficient } from '../../../send-legacy/send.utils';
+import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 
 export function useInsufficientBalanceAlerts({
   ignoreGasFeeToken,
@@ -66,6 +67,10 @@ export function useInsufficientBalanceAlerts({
     balance,
   });
 
+  const isSponsored = currentConfirmation?.isGasFeeSponsored;
+  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
+  const isSponsoredTransaction = isSponsored && isGaslessSupported;
+
   const canSkipSimulationChecks = ignoreGasFeeToken || !isSimulationEnabled;
   const hasGaslessSimulationFinished =
     canSkipSimulationChecks || Boolean(gasFeeTokens);
@@ -73,7 +78,8 @@ export function useInsufficientBalanceAlerts({
   const showAlert =
     insufficientBalance &&
     hasGaslessSimulationFinished &&
-    (ignoreGasFeeToken || !selectedGasFeeToken);
+    (ignoreGasFeeToken || !selectedGasFeeToken) &&
+    !isSponsoredTransaction;
 
   return useMemo(() => {
     if (!showAlert) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37300?quickstart=1)

In https://github.com/MetaMask/metamask-extension/pull/37117 we added support for sponsored smart transactions but forgot to relax the conditions to show the insufficient funds alert so this case is taken into account. This PR fixes this.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses the insufficient balance alert when gas fees are sponsored and gasless transactions are supported, with accompanying tests.
> 
> - **Confirmations Hooks**:
>   - Update `useInsufficientBalanceAlerts` to detect sponsored transactions via `currentConfirmation.isGasFeeSponsored` and `useIsGaslessSupported()`.
>   - Gate `showAlert` to exclude alerts for sponsored transactions when gasless is supported.
> - **Tests**:
>   - Mock `useIsGaslessSupported` and add a test ensuring no alert for sponsored transactions when supported.
>   - Maintain existing coverage for balance, batch transactions, gas fee token, and chain mismatch cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b337735ea443426cf941f1969c2a35d0205420c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->