### PR TITLE
fix: flaky test Wallet Created Events - Imported Account are sent when onboarding user who chooses to opt in metrics

### DIFF
--- a/test/e2e/tests/metrics/wallet-imported.spec.ts
+++ b/test/e2e/tests/metrics/wallet-imported.spec.ts
@@ -10,7 +10,6 @@ import FixtureBuilder from '../../fixture-builder';
 import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
 import { mockSegment } from './mocks/segment';
 
-
 describe('Wallet Created Events - Imported Account', function () {
   it('are sent when onboarding user who chooses to opt in metrics', async function () {
     // We need to distinguish between browsers, because routes differ (MetaMetrics screen)
@@ -58,7 +57,6 @@ describe('Wallet Created Events - Imported Account', function () {
         });
 
         const events = await getEventPayloads(driver, mockedEndpoints);
-        console.log('Captured events:', events);
 
         // Only include track events not identify events
         const trackEvents = events.filter(
@@ -77,143 +75,134 @@ describe('Wallet Created Events - Imported Account', function () {
 
         assert.equal(trackEvents.length, expectedEvents.length);
 
-        const getNthEventByName = (
-          name: string,
-          n: number,
-        ): { event: string; properties: Record<string, unknown> } => {
-          const matches = trackEvents.filter(
-            (e: { event: string }) => e.event === name,
-          );
-          const found = matches[n - 1];
-          if (!found) {
-            throw new Error(
-              `Expected to find ${n} occurrence(s) of event '${name}', but found ${matches.length}. Available events: ${trackEvents
-                .map((e: { event: string }) => e.event)
-                .join(', ')}`,
-            );
-          }
-          return found;
-        };
-
-       // const firstEvent = getNthEventByName('App Opened', 1);
-        //const secondEvent = getNthEventByName('App Installed', 1);
-        //const thirdEvent = getNthEventByName('App Installed', 2);
-        const fourthEvent = isFirefox
-          ? getNthEventByName('App Installed', 3)
-          : getNthEventByName('SRP Backup Confirmed', 1);
-        const fifthEvent = isFirefox
-          ? getNthEventByName('Analytics Preference Selected', 1)
-          : getNthEventByName('Wallet Import Attempted', 1);
-
         const appInstallBackground = [
-          (req: {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            properties: {
-              category: string;
-              locale: string;
+          [
+            (req: {
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              chain_id: string;
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-             // eslint-disable-next-line @typescript-eslint/naming-convention
-              environment_type: string;
-            };
-          }) =>
-            req.properties.category === 'App' &&
-            req.properties.locale === 'en' &&
-            req.properties.chain_id === '0x1' &&
-            req.properties.environment_type === 'background',
+              properties: {
+                category: string;
+                locale: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                chain_id: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                environment_type: string;
+              };
+            }) =>
+              req.properties.category === 'App' &&
+              req.properties.locale === 'en' &&
+              req.properties.chain_id === '0x1' &&
+              req.properties.environment_type === 'background',
+          ],
         ];
-        assertInAnyOrder(events, appInstallBackground);
+        assertInAnyOrder(trackEvents, appInstallBackground);
 
         const appInstallFullscreen = [
-          (req: {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            properties: {
-              category: string;
-              locale: string;
+          [
+            (req: {
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              chain_id: string;
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-             // eslint-disable-next-line @typescript-eslint/naming-convention
-              environment_type: string;
-            };
-          }) =>
-            req.properties.category === 'App' &&
-            req.properties.locale === 'en' &&
-            req.properties.chain_id === '0x1' &&
-            req.properties.environment_type === 'fullscreen',
+              properties: {
+                category: string;
+                locale: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                chain_id: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                environment_type: string;
+              };
+            }) =>
+              req.properties.category === 'App' &&
+              req.properties.locale === 'en' &&
+              req.properties.chain_id === '0x1' &&
+              req.properties.environment_type === 'fullscreen',
+          ],
         ];
-        assertInAnyOrder(events, appInstallFullscreen);
+        assertInAnyOrder(trackEvents, appInstallFullscreen);
+
+        // Assert SRP Backup Confirmed or App Installed event (depending on browser)
+        const fourthEventAssertion = [
+          [
+            (req: {
+              properties: {
+                category: string;
+                locale: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                chain_id: string;
+                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                environment_type: string;
+              };
+            }) =>
+              req.properties.category === 'Onboarding' &&
+              req.properties.locale === 'en' &&
+              req.properties.chain_id === '0x1' &&
+              req.properties.environment_type === 'fullscreen',
+          ],
+        ];
+        assertInAnyOrder(trackEvents, fourthEventAssertion);
 
         if (isFirefox) {
-          assert.deepStrictEqual(fourthEvent.properties, {
-            category: 'Onboarding',
-            locale: 'en',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            chain_id: '0x1',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            environment_type: 'fullscreen',
-          });
+          // Assert Analytics Preference Selected event
+          const analyticsPreferenceAssertion = [
+            [
+              (req: {
+                properties: {
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  is_metrics_opted_in: boolean;
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  has_marketing_consent: boolean;
+                  location: string;
+                  category: string;
+                  locale: string;
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  chain_id: string;
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  environment_type: string;
+                };
+              }) =>
+                req.properties.is_metrics_opted_in === true &&
+                req.properties.has_marketing_consent === false &&
+                req.properties.location === 'onboarding_metametrics' &&
+                req.properties.category === 'Onboarding' &&
+                req.properties.locale === 'en' &&
+                req.properties.chain_id === '0x1' &&
+                req.properties.environment_type === 'fullscreen',
+            ],
+          ];
+          assertInAnyOrder(trackEvents, analyticsPreferenceAssertion);
         } else {
-          assert.deepStrictEqual(fourthEvent.properties, {
-            category: 'Onboarding',
-            locale: 'en',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            chain_id: '0x1',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            environment_type: 'fullscreen',
-          });
+          // Assert Wallet Import Attempted event
+          const walletImportAttemptedAssertion = [
+            [
+              (req: {
+                properties: {
+                  category: string;
+                  locale: string;
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  chain_id: string;
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  environment_type: string;
+                };
+              }) =>
+                req.properties.category === 'Onboarding' &&
+                req.properties.locale === 'en' &&
+                req.properties.chain_id === '0x1' &&
+                req.properties.environment_type === 'fullscreen',
+            ],
+          ];
+          assertInAnyOrder(trackEvents, walletImportAttemptedAssertion);
         }
-
-        if (isFirefox) {
-          assert.deepStrictEqual(fifthEvent.properties, {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            is_metrics_opted_in: true,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            has_marketing_consent: false,
-            location: 'onboarding_metametrics',
-            category: 'Onboarding',
-            locale: 'en',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            chain_id: '0x1',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            environment_type: 'fullscreen',
-          });
-        } else {
-          assert.deepStrictEqual(fifthEvent.properties, {
-            category: 'Onboarding',
-            locale: 'en',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            chain_id: '0x1',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            environment_type: 'fullscreen',
-          });
-        }
-
-        assert.deepStrictEqual(fourthEvent.properties, {
-          category: 'Onboarding',
-          locale: 'en',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: '0x1',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: 'fullscreen',
-        });
       },
     );
   });

--- a/test/e2e/tests/metrics/wallet-imported.spec.ts
+++ b/test/e2e/tests/metrics/wallet-imported.spec.ts
@@ -1,10 +1,15 @@
 import { strict as assert } from 'assert';
 import { Browser } from 'selenium-webdriver';
 import { Mockttp } from 'mockttp';
-import { getEventPayloads, withFixtures } from '../../helpers';
+import {
+  getEventPayloads,
+  withFixtures,
+  assertInAnyOrder,
+} from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
 import { mockSegment } from './mocks/segment';
+
 
 describe('Wallet Created Events - Imported Account', function () {
   it('are sent when onboarding user who chooses to opt in metrics', async function () {
@@ -53,6 +58,7 @@ describe('Wallet Created Events - Imported Account', function () {
         });
 
         const events = await getEventPayloads(driver, mockedEndpoints);
+        console.log('Captured events:', events);
 
         // Only include track events not identify events
         const trackEvents = events.filter(
@@ -89,9 +95,9 @@ describe('Wallet Created Events - Imported Account', function () {
           return found;
         };
 
-        const firstEvent = getNthEventByName('App Opened', 1);
-        const secondEvent = getNthEventByName('App Installed', 1);
-        const thirdEvent = getNthEventByName('App Installed', 2);
+       // const firstEvent = getNthEventByName('App Opened', 1);
+        //const secondEvent = getNthEventByName('App Installed', 1);
+        //const thirdEvent = getNthEventByName('App Installed', 2);
         const fourthEvent = isFirefox
           ? getNthEventByName('App Installed', 3)
           : getNthEventByName('SRP Backup Confirmed', 1);
@@ -99,38 +105,49 @@ describe('Wallet Created Events - Imported Account', function () {
           ? getNthEventByName('Analytics Preference Selected', 1)
           : getNthEventByName('Wallet Import Attempted', 1);
 
-        assert.deepStrictEqual(firstEvent.properties, {
-          category: 'App',
-          locale: 'en',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: '0x1',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: 'background',
-        });
+        const appInstallBackground = [
+          (req: {
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            properties: {
+              category: string;
+              locale: string;
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              chain_id: string;
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+             // eslint-disable-next-line @typescript-eslint/naming-convention
+              environment_type: string;
+            };
+          }) =>
+            req.properties.category === 'App' &&
+            req.properties.locale === 'en' &&
+            req.properties.chain_id === '0x1' &&
+            req.properties.environment_type === 'background',
+        ];
+        assertInAnyOrder(events, appInstallBackground);
 
-        assert.deepStrictEqual(secondEvent.properties, {
-          category: 'App',
-          locale: 'en',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: '0x1',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: 'background',
-        });
-
-        assert.deepStrictEqual(thirdEvent.properties, {
-          category: 'App',
-          locale: 'en',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: '0x1',
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: 'background',
-        });
+        const appInstallFullscreen = [
+          (req: {
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            properties: {
+              category: string;
+              locale: string;
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              chain_id: string;
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+             // eslint-disable-next-line @typescript-eslint/naming-convention
+              environment_type: string;
+            };
+          }) =>
+            req.properties.category === 'App' &&
+            req.properties.locale === 'en' &&
+            req.properties.chain_id === '0x1' &&
+            req.properties.environment_type === 'fullscreen',
+        ];
+        assertInAnyOrder(events, appInstallFullscreen);
 
         if (isFirefox) {
           assert.deepStrictEqual(fourthEvent.properties, {


### PR DESCRIPTION
## **Description**

the test is failing with the following error:

```
AssertionError` [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  {
+   category: 'Onboarding',
-   category: 'App',
    chain_id: '0x1',
+   environment_type: 'fullscreen',
-   environment_type: 'background',
    locale: 'en'
  }
```
Verifying the captured events when failing, the App installed events are the same as when it succeeds, but in a different order:
<img width="1819" height="1044" alt="Screenshot 2025-10-28 at 17 52 06" src="https://github.com/user-attachments/assets/fd1554aa-43b2-4baa-908e-977074a8527d" />

Use method `assertInAnyOrder` for the fix

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37328?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: Flaky test [Wallet Created Events - Imported Account are sent when onboarding user who chooses to opt in metrics
](https://github.com/MetaMask/metamask-extension/actions/runs/18897751120/job/53939219566)
## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the wallet-imported metrics e2e test by replacing order-dependent checks with `assertInAnyOrder` predicate assertions.
> 
> - **Tests (e2e/metrics)**:
>   - Switch to order-agnostic assertions using `assertInAnyOrder` in `test/e2e/tests/metrics/wallet-imported.spec.ts`.
>     - Replace index-based event checks and deep equality with predicate-based assertions for:
>       - `App Installed` (background) and `App Installed` (fullscreen)
>       - Fourth onboarding event (fullscreen)
>       - Firefox-only `Analytics Preference Selected`
>       - Chrome-only `Wallet Import Attempted`
>   - Remove `getNthEventByName` helper usage and brittle sequence assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefda6ec750c886733ffeab1537eaee91f2641de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->