### PR TITLE
fix: improve integrations tests ci reliability

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,7 +73,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: test:integration:coverage
-        run: yarn test:integration:coverage
+        run: yarn test:integration:coverage --silent
 
       - name: Rename coverage
         run: mv coverage/integration/coverage-final.json coverage/integration/coverage-integration.json

--- a/test/integration/confirmations/transactions/alerts.test.tsx
+++ b/test/integration/confirmations/transactions/alerts.test.tsx
@@ -5,7 +5,6 @@ import nock from 'nock';
 import { SimulationTokenStandard } from '@metamask/transaction-controller';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import {
@@ -262,14 +261,12 @@ const addTokenBalanceChangesToTransaction = (
 
 describe('Contract Interaction Confirmation Alerts', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/confirmations/transactions/contract-interaction.test.tsx
+++ b/test/integration/confirmations/transactions/contract-interaction.test.tsx
@@ -23,7 +23,7 @@ import {
   getUnapprovedContractInteractionTransaction,
 } from './transactionDataHelpers';
 
-jest.setTimeout(20_000);
+jest.setTimeout(30_000);
 
 jest.mock('../../../../ui/store/background-connection', () => ({
   ...jest.requireActual('../../../../ui/store/background-connection'),
@@ -515,19 +515,21 @@ describe('Contract Interaction Confirmation', () => {
 
     fireEvent.click(await screen.findByTestId('confirm-footer-cancel-button'));
 
-    expect(
-      mockedBackgroundConnection.submitRequestToBackground,
-    ).toHaveBeenCalledWith(
-      'updateEventFragment',
-      expect.arrayContaining([
-        expect.objectContaining({
-          properties: expect.objectContaining({
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            external_link_clicked: 'security_alert_support_link',
+    await waitFor(() => {
+      expect(
+        mockedBackgroundConnection.submitRequestToBackground,
+      ).toHaveBeenCalledWith(
+        'updateEventFragment',
+        expect.arrayContaining([
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              external_link_clicked: 'security_alert_support_link',
+            }),
           }),
-        }),
-      ]),
-    );
+        ]),
+      );
+    });
   });
 });

--- a/test/integration/confirmations/transactions/erc20-approve.test.tsx
+++ b/test/integration/confirmations/transactions/erc20-approve.test.tsx
@@ -6,7 +6,6 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { tEn } from '../../../lib/i18n-helpers';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { ENVIRONMENT } from '../../../../development/build/constants';
@@ -123,14 +122,12 @@ const setupSubmitRequestToBackgroundMocks = (
 
 describe('ERC20 Approve Confirmation', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/confirmations/transactions/erc721-approve.test.tsx
+++ b/test/integration/confirmations/transactions/erc721-approve.test.tsx
@@ -6,7 +6,6 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { tEn } from '../../../lib/i18n-helpers';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { getUnapprovedApproveTransaction } from './transactionDataHelpers';
@@ -122,14 +121,12 @@ const setupSubmitRequestToBackgroundMocks = (
 
 describe('ERC721 Approve Confirmation', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/confirmations/transactions/increase-allowance.test.tsx
+++ b/test/integration/confirmations/transactions/increase-allowance.test.tsx
@@ -6,7 +6,6 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { tEn } from '../../../lib/i18n-helpers';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { getUnapprovedIncreaseAllowanceTransaction } from './transactionDataHelpers';
@@ -122,14 +121,12 @@ const setupSubmitRequestToBackgroundMocks = (
 
 describe('ERC20 increaseAllowance Confirmation', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/confirmations/transactions/set-approval-for-all-revoke.test.tsx
+++ b/test/integration/confirmations/transactions/set-approval-for-all-revoke.test.tsx
@@ -5,7 +5,6 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { tEn } from '../../../lib/i18n-helpers';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { getUnapprovedSetApprovalForAllTransaction } from './transactionDataHelpers';
@@ -122,14 +121,12 @@ const setupSubmitRequestToBackgroundMocks = (
 
 describe('ERC721 setApprovalForAll - Revoke Confirmation', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/confirmations/transactions/set-approval-for-all.test.tsx
+++ b/test/integration/confirmations/transactions/set-approval-for-all.test.tsx
@@ -6,7 +6,6 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as backgroundConnection from '../../../../ui/store/background-connection';
 import { tEn } from '../../../lib/i18n-helpers';
 import { integrationTestRender } from '../../../lib/render-helpers';
-import { createTestProviderTools } from '../../../stub/provider';
 import mockMetaMaskState from '../../data/integration-init-state.json';
 import { createMockImplementation, mock4byte } from '../../helpers';
 import { getUnapprovedSetApprovalForAllTransaction } from './transactionDataHelpers';
@@ -122,14 +121,12 @@ const setupSubmitRequestToBackgroundMocks = (
 
 describe('ERC721 setApprovalForAll Confirmation', () => {
   beforeAll(() => {
-    const { provider } = createTestProviderTools({
-      networkId: 'sepolia',
-      chainId: '0xaa36a7',
-    });
+    global.ethereumProvider = {
+      request: jest.fn(),
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ethereumProvider = provider as any;
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
   });
 
   beforeEach(() => {

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -58,6 +58,7 @@
       "balance": "0x0"
     }
   },
+  "accountsAssets": {},
   "accountsByChainId": {
     "0xaa36a7": {
       "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc": {

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -9,9 +9,7 @@
           "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0": {
             "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
             "type": "multichain-account",
-            "accounts": [
-              "51737ecb-beb4-4a2b-bcab-c99d0f587a33"
-            ],
+            "accounts": ["51737ecb-beb4-4a2b-bcab-c99d0f587a33"],
             "metadata": {
               "name": "Account 1",
               "entropy": {

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -10,8 +10,7 @@
             "id": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
             "type": "multichain-account",
             "accounts": [
-              "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3",
-              "07c2cfec-36c9-46c4-8115-3836d3ac9047"
+              "51737ecb-beb4-4a2b-bcab-c99d0f587a33"
             ],
             "metadata": {
               "name": "Account 1",
@@ -33,6 +32,7 @@
     }
   },
   "accounts": { "0x03cf1158b58ccdfc04dd518f11f85c3ee7fa0189": {} },
+  "accountsAssets": {},
   "accountsByChainId": {},
   "addSnapAccountEnabled": false,
   "addressBook": {
@@ -247,6 +247,9 @@
       "name": "Sepolia",
       "nativeCurrency": "SepoliaETH"
     }
+  },
+  "networkConnectionBanner": {
+    "status": "unknown"
   },
   "networksMetadata": { "sepolia": { "status": "unknown", "EIPS": {} } },
   "networksWithTransactionActivity": {

--- a/test/integration/defi/defi-positions.test.tsx
+++ b/test/integration/defi/defi-positions.test.tsx
@@ -378,7 +378,6 @@ describe('Defi positions list', () => {
               MetaMetricsEventName.DeFiDetailsOpened,
         );
 
-      console.log(JSON.stringify(metricsEvents));
       expect(metricsEvents).toHaveLength(2);
     });
 

--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -89,11 +89,9 @@ export default function NftGrid({
   return (
     <Box style={{ margin: 16 }}>
       <Box display={Display.Grid} gap={4} className="nft-items__wrapper">
-        {nfts.map((nft: NFT) => {
-          const { tokenURI } = nft;
-
+        {nfts.map((nft: NFT, index: number) => {
           return (
-            <NFTGridItemErrorBoundary key={tokenURI} fallback={() => null}>
+            <NFTGridItemErrorBoundary key={index} fallback={() => null}>
               <Box
                 data-testid="nft-wrapper"
                 className="nft-items__image-wrapper"

--- a/ui/pages/confirmations/hooks/alerts/transactions/PendingTransactionAlertMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/PendingTransactionAlertMessage.tsx
@@ -5,11 +5,10 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import ZENDESK_URLS from '../../../../../helpers/constants/zendesk-url';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
 
-export const PendingTransactionAlertMessage = () => {
-  const t = useI18nContext();
-
+export const PendingTransactionAlertMessage = (
+  t: (key: string, ...args: unknown[]) => string,
+) => {
   return (
     <Text
       variant={TextVariant.bodyMd}

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.test.ts
@@ -9,11 +9,12 @@ import { getMockConfirmState } from '../../../../../../test/data/confirmations/h
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
-import { PendingTransactionAlertMessage } from './PendingTransactionAlertMessage';
 import { usePendingTransactionAlerts } from './usePendingTransactionAlerts';
 
 jest.mock('./PendingTransactionAlertMessage', () => ({
-  PendingTransactionAlertMessage: () => 'PendingTransactionAlertMessage',
+  PendingTransactionAlertMessage: (
+    _t: (key: string, ...args: unknown[]) => string,
+  ) => 'PendingTransactionAlertMessage',
 }));
 
 const ACCOUNT_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
@@ -137,7 +138,7 @@ describe('usePendingTransactionAlerts', () => {
       {
         field: RowAlertKey.Speed,
         key: 'pendingTransactions',
-        content: PendingTransactionAlertMessage(),
+        content: 'PendingTransactionAlertMessage',
         reason: 'Pending transaction',
         severity: Severity.Warning,
       },

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.ts
@@ -30,10 +30,12 @@ export function usePendingTransactionAlerts(): Alert[] {
       {
         field: RowAlertKey.Speed,
         key: 'pendingTransactions',
-        content: PendingTransactionAlertMessage(),
+        content: PendingTransactionAlertMessage(
+          t as (key: string, ...args: unknown[]) => string,
+        ),
         reason: t('alertReasonPendingTransactions'),
         severity: Severity.Warning,
       },
     ];
-  }, [hasPendingTransactions]);
+  }, [hasPendingTransactions, t]);
 }

--- a/ui/pages/settings/networks-tab/networks-form/use-safe-chains.ts
+++ b/ui/pages/settings/networks-tab/networks-form/use-safe-chains.ts
@@ -26,6 +26,7 @@ export const useSafeChains = () => {
   }>({ safeChains: [] });
 
   useEffect(() => {
+    let isMounted = true;
     if (useSafeChainsListValidation) {
       fetchWithCache({
         url: CHAIN_SPEC_URL,
@@ -34,12 +35,20 @@ export const useSafeChains = () => {
         cacheOptions: { cacheRefreshTime: DAY },
       })
         .then((response) => {
-          setSafeChains({ safeChains: response });
+          if (isMounted) {
+            setSafeChains({ safeChains: response });
+          }
         })
         .catch((error) => {
-          setSafeChains({ error });
+          if (isMounted) {
+            setSafeChains({ error });
+          }
         });
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [useSafeChainsListValidation]);
 
   return safeChains;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Improve integrations tests reliability. Recently we have noticed that the tests started to fail more frequently with timeouts. We are not able to repro it locally though. Our suspicions are that running the tests with instrumented code and the amount of messages being printed to the console is making the tests significantly slower. The reason for a lot of the messages being printed are legit React errors that need to be fixed by developers (attempted to fix some on this PR).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37330?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Silences integration test run, stubs ethereum provider and increases timeouts, refactors pending-transaction alert to accept i18n, tweaks NFT grid keys and safe-chains hook, and updates test fixtures.
> 
> - **CI**:
>   - Run `yarn test:integration:coverage --silent` to reduce console noise.
> - **Tests (integration)**:
>   - Replace `createTestProviderTools` with `global.ethereumProvider` stubs across transaction confirmation tests.
>   - Increase Jest timeout to `30_000` in `contract-interaction` tests.
>   - Use `waitFor` when asserting metrics updates; remove stray `console.log`.
>   - Update fixtures in `integration-init-state.json` and `onboarding-completion-route.json`.
> - **Confirmations Alerts**:
>   - Refactor `PendingTransactionAlertMessage` to accept `t` and remove hook usage.
>   - Update `usePendingTransactionAlerts` to pass `t` and include it in memo deps; adjust tests accordingly.
> - **UI**:
>   - Use array index as key in `ui/components/.../nft-grid.tsx` `NFTGridItemErrorBoundary` mapping.
> - **Hooks**:
>   - `useSafeChains`: add mounted guard to avoid state updates after unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c9732228e99f393936151313bb4300114b23066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->