### PR TITLE
feat: claims back button go to tx shield page

### DIFF
--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -103,6 +103,9 @@ const mapStateToProps = (state, ownProps) => {
     pathname.match(ADD_POPULAR_CUSTOM_NETWORK),
   );
   const isSnapSettingsRoute = Boolean(pathname.match(SNAP_SETTINGS_ROUTE));
+  const isShieldClaimPage = Boolean(
+    pathname.match(TRANSACTION_SHIELD_CLAIM_ROUTE),
+  );
 
   const environmentType = getEnvironmentType();
   const isPopup =
@@ -128,6 +131,8 @@ const mapStateToProps = (state, ownProps) => {
     backRoute = NETWORKS_ROUTE;
   } else if (isRevealSrpListPage || isPasswordChangePage) {
     backRoute = SECURITY_ROUTE;
+  } else if (isShieldClaimPage) {
+    backRoute = TRANSACTION_SHIELD_ROUTE;
   }
 
   let initialBreadCrumbRoute;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
On `Claims form` when user clicks on back button, page should redirect to `Transaction shield` page instead of `Settings` page

https://consensyssoftware.atlassian.net/browse/SUBS-654
https://consensyssoftware.atlassian.net/browse/SUBS-673

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37333?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Claims form back button redirect to Transaction shield page

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create or Login to account with shield subscription
2. Open metamask in popup mode
3. Go to Menu > Settings > Transaction Shield
4. Click on `Submit a claim`
5. While on Claims form, click on back button
6. App should redirect to `Transaction Shield`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/7b543233-8b1e-498d-beda-f66dee73c3b2

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/721aa9cf-2d8d-4d07-b1ec-be073b4d338a

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes the back button on the Transaction Shield claim page to `TRANSACTION_SHIELD_ROUTE` instead of `SETTINGS_ROUTE`.
> 
> - **Settings routing** (`ui/pages/settings/settings.container.js`):
>   - Add `isShieldClaimPage` detection via `TRANSACTION_SHIELD_CLAIM_ROUTE`.
>   - Set `backRoute` to `TRANSACTION_SHIELD_ROUTE` when on Shield Claim page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6839dd5b8b3ce1d61a063e4afe9ebd7c248aaff6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->