### PR TITLE
fix: flaky test `Update modal should disappear when closed`

### DIFF
--- a/test/e2e/page-objects/pages/dialog/update-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/update-modal.ts
@@ -1,4 +1,5 @@
 import { Driver } from '../../../webdriver/driver';
+import { regularDelayMs } from '../../../helpers';
 
 class UpdateModal {
   private driver: Driver;
@@ -31,10 +32,9 @@ class UpdateModal {
 
   async checkPageIsNotPresent() {
     console.log('Checking if update modal is not present');
-    const isPresent = await this.driver.isElementPresent(this.updateModal);
-    if (isPresent) {
-      throw new Error('Update modal should not be present');
-    }
+    await this.driver.assertElementNotPresent(this.updateModal, {
+      waitAtLeastGuard: regularDelayMs,
+    });
   }
 
   async confirm() {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -974,6 +974,9 @@ class Driver {
   /**
    * Checks if an element that matches the given locator is present on the page.
    *
+   * @deprecated This method should not be used because it can lead to race conditions
+   * when the element takes some ms to disappear. Instead use assertElementNotPresent
+   * which is a more robust method with customizable guard to avoid this problem.
    * @param {string | object} rawLocator - Element locator
    * @returns {Promise<boolean>} promise that resolves to a boolean indicating whether the element is present.
    */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Using `isElementPresent` can lead to race conditions, when the element takes some ms to disappear. 
Instead we can use `assertElementNotPresent` which is a more robust method, which has customizable guard, so we avoid this problem.

Eventually we should remove the usage of `isElementPresent` completely, to mitigate any flakyness. Very few tests use that, but I created a task for it here, so tackle it separately:


https://consensyssoftware.atlassian.net/browse/MMQA-1121


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37341?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a guarded `assertElementNotPresent` for the update modal and deprecate `isElementPresent` in the driver docs.
> 
> - **E2E tests**:
>   - `test/e2e/page-objects/pages/dialog/update-modal.ts`: Replace `isElementPresent` check with `driver.assertElementNotPresent(this.updateModal, { waitAtLeastGuard: regularDelayMs })`.
> - **Driver**:
>   - `test/e2e/webdriver/driver.js`: Mark `isElementPresent` as deprecated in JSDoc, advising `assertElementNotPresent` with guards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792f85fc8e4df9613ede217462e60eda0bb439e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->