### PR TITLE
fix: skip calling getFees for sponsored transactions

### DIFF
--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -273,11 +273,13 @@ describe('submitSmartTransactionHook', () => {
     });
   });
 
-  it('skips getting fees if the transaction is sponsored', async () => {
+  it('skips getting fees if the transaction is signed and sponsored', async () => {
     withRequest(async ({ request }) => {
       request.transactionMeta.isGasFeeSponsored = true;
       request.featureFlags.smartTransactions.extensionReturnTxHashAsap = true;
+
       const result = await submitSmartTransactionHook(request);
+
       expect(
         request.smartTransactionsController.getFees,
       ).not.toHaveBeenCalled();

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -173,8 +173,11 @@ class SmartTransactionHook {
     }
 
     let getFeesResponse;
-    // Skip getting fees if the tx is sponsored
-    if (!this.#transactionMeta.isGasFeeSponsored) {
+    // Skip getting fees if the tx is signed and sponsored
+    if (
+      !this.#signedTransactionInHex ||
+      !this.#transactionMeta.isGasFeeSponsored
+    ) {
       try {
         getFeesResponse = await this.#smartTransactionsController.getFees(
           { ...this.#txParams, chainId: this.#chainId },

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -171,20 +171,23 @@ class SmartTransactionHook {
     if (this.#shouldShowStatusPage) {
       await this.#startApprovalFlow();
     }
+
     let getFeesResponse;
-    try {
-      getFeesResponse = await this.#smartTransactionsController.getFees(
-        { ...this.#txParams, chainId: this.#chainId },
-        undefined,
-        { networkClientId: this.#transactionMeta.networkClientId },
-      );
-    } catch (error) {
-      log.error(
-        'Error in smart transaction publish hook, falling back to regular transaction submission',
-        error,
-      );
-      this.#onApproveOrReject();
-      return useRegularTransactionSubmit; // Fallback to regular transaction submission.
+    if (!this.#signedTransactionInHex) {
+      try {
+        getFeesResponse = await this.#smartTransactionsController.getFees(
+          { ...this.#txParams, chainId: this.#chainId },
+          undefined,
+          { networkClientId: this.#transactionMeta.networkClientId },
+        );
+      } catch (error) {
+        log.error(
+          'Error in smart transaction publish hook, falling back to regular transaction submission',
+          error,
+        );
+        this.#onApproveOrReject();
+        return useRegularTransactionSubmit; // Fallback to regular transaction submission.
+      }
     }
     try {
       const submitTransactionResponse = await this.#signAndSubmitTransactions({

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -173,7 +173,8 @@ class SmartTransactionHook {
     }
 
     let getFeesResponse;
-    if (!this.#signedTransactionInHex) {
+    // Skip getting fees if the tx is sponsored
+    if (!this.#transactionMeta.isGasFeeSponsored) {
       try {
         getFeesResponse = await this.#smartTransactionsController.getFees(
           { ...this.#txParams, chainId: this.#chainId },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
1. There is a bug in smart transaction hook that when submitting signed transaction, it still call `getFees` even though it's not needed. This leads to sponsored transactions to fail to submit due to `getFees` call throw errors when users have insufficient funds.
2. To solve this, we'll skip calling `getFees` if transaction is already signed or it's a batch

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37355?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally bypasses getFees for pre-signed sponsored smart transactions and updates tests to cover the new behavior and error handling.
> 
> - **Smart Transactions Logic**:
>   - Skip calling `getFees` when `signedTransactionInHex` is present and `transactionMeta.isGasFeeSponsored` is true.
>   - Retain `getFees` try/catch with fallback to regular submission on error.
>   - Continue normal sign-and-submit flow and status page handling.
> - **Tests**:
>   - Add test verifying fees are not fetched for signed, sponsored transactions and that `submitSignedTransactions` is called.
>   - Strengthen error-path test to assert `getFees` was invoked before fallback.
>   - Ensure ASAP tx-hash return behavior remains validated via feature flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06aeccda5ad2a99f03259de77ba246f3b53e1ef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->