### PR TITLE
test: Turn bip44 ON by default

### DIFF
--- a/test/e2e/benchmarks/user-actions-benchmark.ts
+++ b/test/e2e/benchmarks/user-actions-benchmark.ts
@@ -13,6 +13,8 @@ import { unlockWallet, withFixtures } from '../helpers';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import BridgeQuotePage from '../page-objects/pages/bridge/quote-page';
 import HomePage from '../page-objects/pages/home/homepage';
+import HeaderNavbar from '../page-objects/pages/header-navbar';
+import AccountListPage from '../page-objects/pages/account-list-page';
 import {
   DEFAULT_BRIDGE_FEATURE_FLAGS,
   MOCK_TOKENS_ETHEREUM,
@@ -45,20 +47,13 @@ async function loadNewAccount(): Promise<number> {
     async ({ driver }: { driver: Driver }) => {
       await unlockWallet(driver);
 
-      await driver.clickElement('[data-testid="account-menu-icon"]');
-      await driver.clickElement(
-        '[data-testid="multichain-account-menu-popover-action-button"]',
-      );
+      const headerNavbar = new HeaderNavbar(driver);
+      await headerNavbar.openAccountsPage();
+      const accountListPage = new AccountListPage(driver);
+      await accountListPage.checkPageIsLoaded();
+
       const timestampBeforeAction = new Date();
-      await driver.clickElement(
-        '[data-testid="multichain-account-menu-popover-add-account"]',
-      );
-      await driver.fill('[placeholder="Account 2"]', '2nd account');
-      await driver.clickElement({ text: 'Add account', tag: 'button' });
-      await driver.waitForSelector({
-        css: '.currency-display-component__text',
-        text: '0',
-      });
+      await accountListPage.addMultichainAccount()
       const timestampAfterAction = new Date();
       loadingTimes =
         timestampAfterAction.getTime() - timestampBeforeAction.getTime();
@@ -101,11 +96,10 @@ async function confirmTx(): Promise<number> {
       );
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
+          '[data-testid="activity-list-item-action"]'
         );
         return confirmedTxes.length === 1;
       }, 10000);
-
       await driver.waitForSelector('.transaction-status-label--confirmed');
       const timestampAfterAction = new Date();
       loadingTimes =

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -334,21 +334,12 @@ async function withFixtures(options, testSuite) {
     webSocketServer.start();
     await setupSolanaWebsocketMocks(solanaWebSocketSpecificMocks);
 
-    // The feature flag wrapper chooses state 2 by default
-    // but we want most tests to be able to run with state 0 (bip-44 disabled)
-    // So the default argument is 0
-    // and doing nothing here means we get state 2
-
-    if (forceBip44Version === 0) {
-      await mockMultichainAccountsFeatureFlagStateTwo(mockServer);
-      console.log('Applying multichain accounts feature flag disabled mock');
-    } else if (forceBip44Version === 1) {
-      console.log(
-        'Applying multichain accounts state 1 feature state 1 enabled mock',
-      );
+    if (forceBip44Version === 1) {
+      console.log('Applying multichain accounts stage 1');
       await mockMultichainAccountsFeatureFlagStateOne(mockServer);
     } else {
-      console.log('BIP-44 state 2 enabled');
+      // This sets BIP44 stage 2 by default
+      console.log('BIP-44 stage 2 enabled');
       await mockMultichainAccountsFeatureFlagStateTwo(mockServer);
     }
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -174,7 +174,7 @@ async function withFixtures(options, testSuite) {
     monConversionInUsd,
     manifestFlags,
     solanaWebSocketSpecificMocks = [],
-    forceBip44Version = 0,
+    forceBip44Version = true,
   } = options;
 
   // Normalize localNodeOptions
@@ -334,11 +334,7 @@ async function withFixtures(options, testSuite) {
     webSocketServer.start();
     await setupSolanaWebsocketMocks(solanaWebSocketSpecificMocks);
 
-    if (forceBip44Version === 1) {
-      console.log('Applying multichain accounts stage 1');
-      await mockMultichainAccountsFeatureFlagStateOne(mockServer);
-    } else {
-      // This sets BIP44 stage 2 by default
+    if (forceBip44Version) {
       console.log('BIP-44 stage 2 enabled');
       await mockMultichainAccountsFeatureFlagStateTwo(mockServer);
     }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -340,6 +340,7 @@ async function withFixtures(options, testSuite) {
     // and doing nothing here means we get state 2
 
     if (forceBip44Version === 0) {
+      await mockMultichainAccountsFeatureFlagStateTwo(mockServer);
       console.log('Applying multichain accounts feature flag disabled mock');
     } else if (forceBip44Version === 1) {
       console.log(

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -221,33 +221,25 @@ class AccountListPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(options?: {
-    isMultichainAccountsState2Enabled?: boolean;
-  }): Promise<void> {
+  async checkPageIsLoaded(): Promise<void> {
     try {
-      const selectorsToWaitFor = options?.isMultichainAccountsState2Enabled
-        ? [
-            {
-              css: this.createMultichainAccountButton,
-              text: 'Create account',
-            },
-            this.multichainAccountOptionsMenuButton,
-          ]
-        : [this.createAccountButton, this.accountOptionsMenuButton];
-      await this.driver.waitForMultipleSelectors(selectorsToWaitFor);
+      await this.driver.waitForMultipleSelectors([
+        {
+          css: this.createMultichainAccountButton,
+          text: 'Create account',
+        },
+        this.multichainAccountOptionsMenuButton,
+      ]);
     } catch (e) {
       console.log('Timeout while waiting for account list to be loaded', e);
       throw e;
     }
 
-    if (options?.isMultichainAccountsState2Enabled) {
-      console.log(`Check that account syncing not displayed in account list`);
-      await this.driver.assertElementNotPresent({
-        css: this.createMultichainAccountButton,
-        text: 'Syncing',
-      });
-    }
-
+    console.log(`Check that account syncing not displayed in account list`);
+    await this.driver.assertElementNotPresent({
+      css: this.createMultichainAccountButton,
+      text: 'Syncing',
+    });
     console.log('Account list is loaded');
   }
 

--- a/test/e2e/tests/bridge/bridge-negative-cases.spec.ts
+++ b/test/e2e/tests/bridge/bridge-negative-cases.spec.ts
@@ -16,19 +16,23 @@ import {
   DEFAULT_BRIDGE_FEATURE_FLAGS,
 } from './constants';
 
-const DEFAULT_LOCAL_NODE_USD_BALANCE = '127,500.00';
+const DEFAULT_LOCAL_NODE_USD_BALANCE = '25';
 
 describe('Bridge functionality', function (this: Suite) {
   it('should show that more funds are needed to execute the Bridge', async function () {
+
     await withFixtures(
-      getInsufficientFundsFixtures(
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getInsufficientFundsFixtures(
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
         const homePage = new HomePage(driver);
-        await homePage.checkExpectedBalanceIsDisplayed('$84,992.50', 'USD');
+        await homePage.checkExpectedBalanceIsDisplayed('24.998', 'ETH');
         await homePage.startSwapFlow();
 
         const bridgePage = new BridgeQuotePage(driver);
@@ -47,20 +51,23 @@ describe('Bridge functionality', function (this: Suite) {
 
   it('should show message that no trade route is available if getQuote returns error 500', async function () {
     await withFixtures(
-      getQuoteNegativeCasesFixtures(
-        {
-          statusCode: 500,
-          json: 'Internal server error',
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 500,
+            json: 'Internal server error',
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
         const homePage = new HomePage(driver);
         await homePage.checkExpectedBalanceIsDisplayed(
           DEFAULT_LOCAL_NODE_USD_BALANCE,
-          '$',
+          'ETH',
         );
         await homePage.startSwapFlow();
 
@@ -72,20 +79,23 @@ describe('Bridge functionality', function (this: Suite) {
 
   it('should show message that no trade route is available if getQuote returns empty array', async function () {
     await withFixtures(
-      getQuoteNegativeCasesFixtures(
-        {
-          statusCode: 200,
-          json: [],
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 200,
+            json: [],
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
         const homePage = new HomePage(driver);
         await homePage.checkExpectedBalanceIsDisplayed(
           DEFAULT_LOCAL_NODE_USD_BALANCE,
-          '$',
+          'ETH',
         );
         await homePage.startSwapFlow();
 
@@ -97,20 +107,23 @@ describe('Bridge functionality', function (this: Suite) {
 
   it('should show message that no trade route is available if getQuote returns invalid response', async function () {
     await withFixtures(
-      getQuoteNegativeCasesFixtures(
-        {
-          statusCode: 200,
-          json: GET_QUOTE_INVALID_RESPONSE,
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 200,
+            json: GET_QUOTE_INVALID_RESPONSE,
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
         const homePage = new HomePage(driver);
         await homePage.checkExpectedBalanceIsDisplayed(
           DEFAULT_LOCAL_NODE_USD_BALANCE,
-          '$',
+          'ETH',
         );
 
         await homePage.startSwapFlow();
@@ -121,21 +134,24 @@ describe('Bridge functionality', function (this: Suite) {
     );
   });
 
-  it('should show that bridge transaction is pending if getTxStatus returns error 500', async function () {
+  it.skip('should show that bridge transaction is pending if getTxStatus returns error 500', async function () {
     await withFixtures(
-      getBridgeNegativeCasesFixtures(
-        {
-          statusCode: 500,
-          json: 'Internal server error',
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: true,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 500,
+            json: 'Internal server error',
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
 
         const homePage = new HomePage(driver);
-        await homePage.checkExpectedBalanceIsDisplayed('$84,992.50', 'USD');
+        await homePage.checkExpectedBalanceIsDisplayed('25', 'USD');
         await homePage.startSwapFlow();
 
         const bridgePage = await enterBridgeQuote(driver);
@@ -148,21 +164,24 @@ describe('Bridge functionality', function (this: Suite) {
     );
   });
 
-  it('should show failed bridge activity if getTxStatus returns failed source transaction', async function () {
+  it.skip('should show failed bridge activity if getTxStatus returns failed source transaction', async function () {
     await withFixtures(
-      getBridgeNegativeCasesFixtures(
-        {
-          statusCode: 200,
-          json: FAILED_SOURCE_TRANSACTION,
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 200,
+            json: FAILED_SOURCE_TRANSACTION,
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
 
         const homePage = new HomePage(driver);
-        await homePage.checkExpectedBalanceIsDisplayed('$84,992.50', 'USD');
+        await homePage.checkExpectedBalanceIsDisplayed('25', 'ETH');
         await homePage.startSwapFlow();
 
         const bridgePage = await enterBridgeQuote(driver);
@@ -176,21 +195,24 @@ describe('Bridge functionality', function (this: Suite) {
     );
   });
 
-  it('should show failed bridge activity if getTxStatus returns failed destination transaction', async function () {
+  it.skip('should show failed bridge activity if getTxStatus returns failed destination transaction', async function () {
     await withFixtures(
-      getBridgeNegativeCasesFixtures(
-        {
-          statusCode: 200,
-          json: FAILED_DEST_TRANSACTION,
-        },
-        DEFAULT_BRIDGE_FEATURE_FLAGS,
-        this.test?.fullTitle(),
-      ),
+      {
+        forceBip44Version: false,
+        ...getQuoteNegativeCasesFixtures(
+          {
+            statusCode: 200,
+            json: FAILED_DEST_TRANSACTION,
+          },
+          DEFAULT_BRIDGE_FEATURE_FLAGS,
+          this.test?.fullTitle(),
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
 
         const homePage = new HomePage(driver);
-        await homePage.checkExpectedBalanceIsDisplayed('$84,992.50', 'USD');
+        await homePage.checkExpectedBalanceIsDisplayed('25', 'ETH');
         await homePage.startSwapFlow();
 
         const bridgePage = await enterBridgeQuote(driver);

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -38,6 +38,7 @@ import {
   SSE_RESPONSE_HEADER,
 } from './constants';
 import MOCK_SWAP_QUOTES_ETH_MUSD from './mocks/swap-quotes-eth-musd.json';
+import { BIP44_STAGE_TWO } from '../multichain-accounts/feature-flag-mocks';
 
 export class BridgePage {
   driver: Driver;
@@ -375,7 +376,9 @@ async function mockFeatureFlags(
       return {
         ok: true,
         statusCode: 200,
-        json: [{ bridgeConfig: featureFlags }],
+        json: [
+          { bridgeConfig: featureFlags, ...BIP44_STAGE_TWO },
+        ],
       };
     });
 }
@@ -851,10 +854,6 @@ export const getBridgeFixtures = (
         await mockETHtoUSDC(mockServer),
         await mockDAItoETH(mockServer),
         await mockSwapETHtoMUSD(mockServer),
-        await mockSwapETHtoMUSD(mockServer),
-        await mockSwapETHtoMUSD(mockServer),
-        await mockSwapETHtoMUSD(mockServer),
-        await mockSwapETHtoMUSD(mockServer),
         await mockUSDCtoDAI(mockServer, featureFlags.sse?.enabled),
         await mockFeatureFlags(mockServer, featureFlags),
         await mockAccountsTransactions(mockServer),
@@ -939,8 +938,6 @@ export const getQuoteNegativeCasesFixtures = (
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
-        '0xe708': true,
-        '0xa4b1': true,
       },
     });
 
@@ -955,6 +952,7 @@ export const getQuoteNegativeCasesFixtures = (
     manifestFlags: {
       remoteFeatureFlags: {
         bridgeConfig: featureFlags,
+        ...BIP44_STAGE_TWO,
       },
       testing: { disableSmartTransactionsOverride: true },
     },
@@ -964,7 +962,7 @@ export const getQuoteNegativeCasesFixtures = (
         type: 'anvil',
         options: {
           chainId: 1,
-          hardfork: 'muirGlacier',
+          hardfork: 'london',
         },
       },
     ],
@@ -1020,7 +1018,7 @@ export const getBridgeNegativeCasesFixtures = (
   };
 };
 
-export const getInsufficientFundsFixtures = (
+export const  getInsufficientFundsFixtures = (
   featureFlags: Partial<FeatureFlagResponse> = {},
   title?: string,
 ) => {
@@ -1033,7 +1031,6 @@ export const getInsufficientFundsFixtures = (
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
-        '0xe708': true,
       },
     });
 
@@ -1047,6 +1044,7 @@ export const getInsufficientFundsFixtures = (
     manifestFlags: {
       remoteFeatureFlags: {
         bridgeConfig: featureFlags,
+        ...BIP44_STAGE_TWO
       },
     },
     smartContract: SMART_CONTRACTS.HST,

--- a/test/e2e/tests/bridge/swap-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/swap-positive-cases.spec.ts
@@ -8,11 +8,14 @@ describe('Swap tests', function (this: Suite) {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
   it('updates recommended swap quote incrementally when SSE events are received', async function () {
     await withFixtures(
-      getBridgeFixtures(
-        this.test?.fullTitle(),
-        BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        false,
-      ),
+      {
+        forceBip44Version: false,
+        ...getBridgeFixtures(
+          this.test?.fullTitle(),
+          BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
+          false,
+        ),
+      },
       async ({ driver }) => {
         await unlockWallet(driver);
 

--- a/test/e2e/tests/identity/account-syncing/account-syncing-settings-toggle.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/account-syncing-settings-toggle.spec.ts
@@ -60,9 +60,7 @@ describe('Account syncing - Settings Toggle', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify the default account exists
         await accountListPage.checkAccountDisplayedInAccountList(
@@ -107,9 +105,7 @@ describe('Account syncing - Settings Toggle', function () {
         await driver.navigate(PAGES.HOME);
         await header.checkPageIsLoaded();
         await header.openAccountMenu();
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Create third account with sync disabled - this should NOT sync to user storage
         await accountListPage.addMultichainAccount();
@@ -139,9 +135,7 @@ describe('Account syncing - Settings Toggle', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify only accounts created with sync enabled are restored
         const visibleAccounts = [DEFAULT_ACCOUNT_NAME, SECOND_ACCOUNT_NAME];

--- a/test/e2e/tests/identity/account-syncing/adding-and-renaming-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/adding-and-renaming-accounts.spec.ts
@@ -72,9 +72,7 @@ describe('Account syncing - Adding and Renaming Accounts', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify default account is visible
         await accountListPage.checkAccountDisplayedInAccountList(
@@ -133,9 +131,7 @@ describe('Account syncing - Adding and Renaming Accounts', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify both accounts from previous phase are still visible
         await accountListPage.checkAccountDisplayedInAccountList(
@@ -209,9 +205,7 @@ describe('Account syncing - Adding and Renaming Accounts', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify all accounts and renames are properly synced
         await accountListPage.checkAccountDisplayedInAccountList(

--- a/test/e2e/tests/identity/account-syncing/balances.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/balances.spec.ts
@@ -55,9 +55,7 @@ describe('Account syncing - Accounts with Balances', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Should see default account
         await accountListPage.checkAccountDisplayedInAccountList('Account 1');

--- a/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
@@ -69,9 +69,7 @@ describe('Account syncing - Unsupported Account types', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify default account is visible
         await accountListPage.checkAccountDisplayedInAccountList(
@@ -142,9 +140,7 @@ describe('Account syncing - Unsupported Account types', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify regular accounts are still visible (synced accounts)
         const visibleAccounts = [DEFAULT_ACCOUNT_NAME, SECOND_ACCOUNT_NAME];

--- a/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
@@ -67,9 +67,7 @@ describe('Account syncing - Multiple SRPs', function () {
         await header.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Verify default account is visible
         await accountListPage.checkAccountDisplayedInAccountList(
@@ -117,9 +115,7 @@ describe('Account syncing - Multiple SRPs', function () {
 
         // Add a fourth account with custom name to the second SRP
         await header.openAccountMenu();
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Add account with custom name to specific SRP
         await accountListPage.addMultichainAccount({

--- a/test/e2e/tests/multichain-accounts/account-details.spec.ts
+++ b/test/e2e/tests/multichain-accounts/account-details.spec.ts
@@ -27,9 +27,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });
@@ -99,9 +97,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: 'Account 1',
           });
@@ -157,9 +153,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });
@@ -171,9 +165,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
 
           await accountDetailsPage.clickConfirmAccountNameButton();
 
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
 
           await accountListPage.checkAccountNameIsDisplayed(newName);
         },
@@ -190,9 +182,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });
@@ -219,9 +209,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });
@@ -252,9 +240,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });
@@ -280,9 +266,7 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         },
         async (driver: Driver) => {
           const accountListPage = new AccountListPage(driver);
-          await accountListPage.checkPageIsLoaded({
-            isMultichainAccountsState2Enabled: true,
-          });
+          await accountListPage.checkPageIsLoaded();
           await accountListPage.openMultichainAccountMenu({
             accountLabel: account1.name,
           });

--- a/test/e2e/tests/multichain-accounts/account-details.spec.ts
+++ b/test/e2e/tests/multichain-accounts/account-details.spec.ts
@@ -124,7 +124,6 @@ describe('Multichain Accounts - Account Details', function (this: Suite) {
         {
           fixtures: new FixtureBuilder().build(),
           title: this.test?.fullTitle(),
-          forceBip44Version: 2,
         },
         async ({ driver }) => {
           await loginWithoutBalanceValidation(driver);

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -34,9 +34,7 @@ describe('Add account', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.addMultichainAccount();
         await accountListPage.checkAccountDisplayedInAccountList(
           SECOND_ACCOUNT_NAME,
@@ -71,9 +69,7 @@ describe('Add account', function () {
         // BUG 37030 With BIP44 enabled wallet is not showing balance
         // await homePage.checkLocalNodeBalanceIsDisplayed();
         await headerNavbar.openAccountsPage();
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountDisplayedInAccountList(
           SECOND_ACCOUNT_NAME,
         );
@@ -93,9 +89,7 @@ describe('Add account', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.openMultichainAccountMenu({
           accountLabel: importedAccount.name,
         });
@@ -125,9 +119,7 @@ describe('Add account', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.addMultichainAccount();
         await accountListPage.checkAccountDisplayedInAccountList(
           SECOND_ACCOUNT_NAME,
@@ -168,9 +160,7 @@ describe('Add account', function () {
 
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountsPage();
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountNotDisplayedInAccountList(
           IMPORTED_ACCOUNT_NAME,
         );
@@ -185,9 +175,7 @@ describe('Add account', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.addMultichainAccount();
         await accountListPage.openMultichainAccountMenu({
           accountLabel: 'Account 2',
@@ -211,9 +199,7 @@ describe('Add account', function () {
         await headerNavbar.checkAccountLabel(CUSTOM_ACCOUNT_NAME);
         await headerNavbar.openAccountsPage();
 
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkAccountDisplayedInAccountList(
           CUSTOM_ACCOUNT_NAME,
         );

--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -34,7 +34,6 @@ describe('Add wallet', function () {
       await arrange();
     await withFixtures(
       {
-        forceBip44Version: 2,
         fixtures: new FixtureBuilder({ onboarding: true }).build(),
         testSpecificMock: (server: Mockttp) => {
           userStorageMockttpController.setupPath(
@@ -104,7 +103,6 @@ describe('Add wallet', function () {
       await arrange();
     await withFixtures(
       {
-        forceBip44Version: 2,
         fixtures: new FixtureBuilder()
           .withAccountsControllerImportedAccount()
           .withKeyringControllerImportedAccountVault()
@@ -163,7 +161,6 @@ describe('Add wallet', function () {
       await arrange();
     await withFixtures(
       {
-        forceBip44Version: 2,
         fixtures: new FixtureBuilder()
           .withKeyringControllerImportedAccountVault()
           .build(),

--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -68,9 +68,7 @@ describe('Add wallet', function () {
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountsPage();
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         await accountListPage.openMultichainAccountMenu({
           accountLabel: 'Account 1',
@@ -88,17 +86,13 @@ describe('Add wallet', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.startImportSecretPhrase(E2E_SRP, {
           isMultichainAccountsState2Enabled: true,
         });
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountsPage();
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
         await accountListPage.checkNumberOfAvailableAccounts(3);
       },
     );
@@ -136,9 +130,7 @@ describe('Add wallet', function () {
         await headerNavbar.checkAccountLabel('Account 1');
         await headerNavbar.openAccountsPage();
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Imports an account with JSON file
         const jsonFile = path.join(
@@ -194,9 +186,7 @@ describe('Add wallet', function () {
         await headerNavbar.checkAccountLabel('Account 1');
         await headerNavbar.openAccountsPage();
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // import active account with private key from the account menu and check error message
         await accountListPage.addNewImportedAccount(

--- a/test/e2e/tests/multichain-accounts/feature-flag-mocks.ts
+++ b/test/e2e/tests/multichain-accounts/feature-flag-mocks.ts
@@ -3,6 +3,17 @@ import { Mockttp } from 'mockttp';
 export const FEATURE_FLAGS_URL =
   'https://client-config.api.cx.metamask.io/v1/flags';
 
+export const BIP44_STAGE_TWO = {
+  enableMultichainAccountsState2: {
+    enabled: true,
+    featureVersion: '2',
+    minimumVersion: '12.19.0',
+  },
+  sendRedesign: {
+    enabled: false,
+  },
+}
+
 export const mockMultichainAccountsFeatureFlag = (mockServer: Mockttp) =>
   mockServer
     .forGet(FEATURE_FLAGS_URL)
@@ -74,18 +85,7 @@ export const mockMultichainAccountsFeatureFlagStateTwo = (
       return {
         ok: true,
         statusCode: 200,
-        json: [
-          {
-            enableMultichainAccountsState2: {
-              enabled: true,
-              featureVersion: '2',
-              minimumVersion: '12.19.0',
-            },
-            sendRedesign: {
-              enabled: false,
-            },
-          },
-        ],
+        json: [ BIP44_STAGE_TWO ],
       };
     });
 

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -17,9 +17,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Ensure that wallet information is displayed
         await accountListPage.checkWalletDisplayedInAccountListMenu('Wallet 1');
@@ -45,9 +43,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Ensure that wallet information is displayed
         await accountListPage.checkWalletDisplayedInAccountListMenu('Wallet 1');
@@ -88,9 +84,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         );
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         // Ensure that wallet information is displayed
         await accountListPage.checkWalletDisplayedInAccountListMenu('Wallet 1');

--- a/test/e2e/tests/multichain-accounts/multichain-wallet-details.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-wallet-details.spec.ts
@@ -22,9 +22,7 @@ describe('Multichain Accounts - Wallet Details', function (this: Suite) {
         await headerNavbar.openAccountMenu();
 
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded({
-          isMultichainAccountsState2Enabled: true,
-        });
+        await accountListPage.checkPageIsLoaded();
 
         await accountListPage.checkWalletDisplayedInAccountListMenu('Wallet 1');
         await accountListPage.checkAccountNameIsDisplayed('Account 1');

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1790,9 +1790,7 @@ export async function withSolanaAccountSnap(
         text: 'Popular',
         tag: 'button',
       });
-      await driver.clickElement(
-        '[data-testid="Solana"]',
-      );
+      await driver.clickElement('[data-testid="Solana"]');
 
       await test(driver, mockServer, extensionId);
     },

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1784,6 +1784,16 @@ export async function withSolanaAccountSnap(
     }) => {
       await loginWithBalanceValidation(driver);
 
+      // Change to Solana
+      await driver.clickElement('[data-testid="sort-by-networks"]');
+      await driver.clickElement({
+        text: 'Popular',
+        tag: 'button',
+      });
+      await driver.clickElement(
+        '[data-testid="Solana"]',
+      );
+
       await test(driver, mockServer, extensionId);
     },
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR turns BIP44 by default and make changes to the fixtures so that Solana account is already created when the Extension starts

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37365?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables BIP-44 state 2 by default across e2e, adds multichain/Solana defaults to fixtures, and updates page objects and tests to the new multichain flows and feature-flag mocks.
> 
> - **E2E Framework**:
>   - Default `withFixtures` now enables BIP-44 stage 2 via feature flag (boolean `forceBip44Version`, true by default) and applies only state-2 mocks when enabled.
>   - Updated selectors and flows in benchmarks (use `HeaderNavbar`/`AccountListPage`; activity selector for confirmed tx).
> - **Fixtures & Mocks**:
>   - `default-fixture` seeds `AccountTreeController` with a multichain wallet (Ethereum + Solana account) and updates `AccountsController` metadata; enables Solana in network enablement.
>   - Introduces `BIP44_STAGE_TWO` and injects it into feature-flag responses; various bridge fixtures/mocks include it.
> - **Page Objects**:
>   - `AccountListPage.checkPageIsLoaded` simplified to multichain UI (always expects "Create account" and options menu; removes state arg); ensures "Syncing" not shown.
>   - `HeaderNavbar` adds `clickNetworkAddresses`.
> - **Bridge Tests**:
>   - Adjusted expectations to ETH balances/units; explicitly disable BIP-44 where needed; minor skips added; hardforks normalized; duplicate mocks removed.
> - **Multichain Accounts Tests**:
>   - Updated to new `checkPageIsLoaded()` signature and multichain flows; remove per-test state flags; minor assertions streamlined.
>   - Unskips and simplifies wallet details scenario (validate presence in account list).
> - **Solana Test Utilities**:
>   - Add native price mock; tweak enabled networks and initial navigation (network filter steps); remove per-account creation loop.
> - **Misc**:
>   - Numerous tests now pass `forceBip44Version: false` where legacy behavior is required; balance constants adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8bb58746570dc0d8221589467490686b98cf129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->