### PR TITLE
chore: update balance empty state design and add funding modal

### DIFF
--- a/ui/components/app/balance-empty-state/balance-empty-state.test.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.test.tsx
@@ -8,21 +8,6 @@ import {
   BalanceEmptyStateProps,
 } from './balance-empty-state';
 
-// Mock useRamps hook
-const mockOpenBuyCryptoInPdapp = jest.fn();
-jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: jest.fn(() => ({
-    openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp,
-  })),
-  RampsMetaMaskEntry: {
-    TokensBanner: 'tokens-banner',
-    ActivityBanner: 'activity-banner',
-    BtcBanner: 'btc-banner',
-  },
-}));
-
 const store = configureStore({
   metamask: {
     ...mockState.metamask,
@@ -43,12 +28,14 @@ describe('BalanceEmptyState', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
-  it('should call openBuyCryptoInPdapp when button is clicked', () => {
+  it('should open the funding method modal when button is clicked', () => {
     renderComponent();
 
     const button = screen.getByRole('button');
     fireEvent.click(button);
 
-    expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByTestId('balance-empty-state-funding-modal'),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -16,7 +16,6 @@ import {
   ButtonSize,
   twMerge,
 } from '@metamask/design-system-react';
-import { CaipChainId } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import { getMultichainCurrentNetwork } from '../../../selectors/multichain';
@@ -30,7 +29,8 @@ import useRamps, {
 } from '../../../hooks/ramps/useRamps/useRamps';
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 import { getCurrentLocale } from '../../../ducks/locale/locale';
-import { ChainId } from '../../../../shared/constants/network';
+
+import { FundingMethodModal } from '../../multichain/funding-method-modal/funding-method-modal';
 
 export type BalanceEmptyStateProps = {
   /**
@@ -41,14 +41,23 @@ export type BalanceEmptyStateProps = {
    * Additional className to apply to the component
    */
   className?: string;
+  /**
+   * Callback function to handle receive crypto action
+   */
+  onClickReceive?: () => void;
 };
 
-export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = (props) => {
+export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
+  onClickReceive,
+  ...props
+}) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
   const currentLocale = useSelector(getCurrentLocale);
   const chainId = useSelector(getCurrentChainId);
   const { nickname } = useSelector(getMultichainCurrentNetwork);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { openBuyCryptoInPdapp } = useRamps(RampsMetaMaskEntry.TokensBanner);
 
@@ -79,8 +88,21 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = (props) => {
       },
     });
 
-    openBuyCryptoInPdapp(chainId as ChainId | CaipChainId);
-  }, [chainId, openBuyCryptoInPdapp, trackEvent]);
+    setIsModalOpen(true);
+  }, [chainId, trackEvent]);
+
+  // Handle modal close
+  const handleModalClose = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
+  // Handle receive crypto option
+  const handleReceive = useCallback(() => {
+    // Close modal and handle receive flow
+    setIsModalOpen(false);
+    // Always call the onClickReceive callback
+    onClickReceive?.();
+  }, [onClickReceive]);
 
   return (
     <Box
@@ -88,38 +110,44 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = (props) => {
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Center}
       padding={6}
-      margin={4}
       backgroundColor={BoxBackgroundColor.BackgroundSection}
-      gap={4}
+      gap={5}
       {...props}
       className={twMerge('rounded-lg', props.className)}
     >
       <Box
+        flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
+        gap={1}
       >
-        <img
-          src="./images/bank-transfer.png"
-          alt={t('fundYourWallet')}
-          width="100"
-          height="100"
-        />
+        <Box
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+        >
+          <img
+            src="./images/bank-transfer.png"
+            alt={t('fundYourWallet')}
+            width="100"
+            height="100"
+          />
+        </Box>
+        <Text
+          variant={TextVariant.HeadingLg}
+          color={TextColor.TextDefault}
+          fontWeight={FontWeight.Bold}
+          textAlign={TextAlign.Center}
+        >
+          {t('fundYourWallet')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          textAlign={TextAlign.Center}
+        >
+          {t('getYourWalletReadyToUseWeb3')}
+        </Text>
       </Box>
-      <Text
-        variant={TextVariant.HeadingMd}
-        color={TextColor.TextDefault}
-        fontWeight={FontWeight.Bold}
-        textAlign={TextAlign.Center}
-      >
-        {t('fundYourWallet')}
-      </Text>
-      <Text
-        variant={TextVariant.BodyMd}
-        color={TextColor.TextAlternative}
-        textAlign={TextAlign.Center}
-      >
-        {t('getYourWalletReadyToUseWeb3')}
-      </Text>
       <Button
         variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
@@ -128,6 +156,12 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = (props) => {
       >
         {t('addFunds')}
       </Button>
+      <FundingMethodModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        title={t('addFunds')}
+        onClickReceive={handleReceive}
+      />
     </Box>
   );
 };

--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -24,9 +24,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import useRamps, {
-  RampsMetaMaskEntry,
-} from '../../../hooks/ramps/useRamps/useRamps';
+
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 import { getCurrentLocale } from '../../../ducks/locale/locale';
 
@@ -58,8 +56,6 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
   const { nickname } = useSelector(getMultichainCurrentNetwork);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const { openBuyCryptoInPdapp } = useRamps(RampsMetaMaskEntry.TokensBanner);
 
   // Track when component is displayed
   useEffect(() => {

--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -111,15 +111,10 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
       {...props}
       className={twMerge('rounded-lg', props.className)}
     >
-      <Box
-        flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
-        gap={1}
-      >
+      <Box flexDirection={BoxFlexDirection.Column} gap={1}>
         <Box
+          flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
-          justifyContent={BoxJustifyContent.Center}
         >
           <img
             src="./images/bank-transfer.png"

--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -157,6 +157,7 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
         onClose={handleModalClose}
         title={t('addFunds')}
         onClickReceive={handleReceive}
+        data-testid="balance-empty-state-funding-modal"
       />
     </Box>
   );

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
@@ -37,6 +37,7 @@ describe('FundingMethodModal', () => {
         onClose={jest.fn()}
         title="Test Modal"
         onClickReceive={jest.fn()}
+        data-testid="funding-method-modal"
       />,
       store,
     );
@@ -52,6 +53,7 @@ describe('FundingMethodModal', () => {
         onClose={jest.fn()}
         title="Test Modal"
         onClickReceive={jest.fn()}
+        data-testid="funding-method-modal"
       />,
       store,
     );
@@ -66,6 +68,7 @@ describe('FundingMethodModal', () => {
         onClose={jest.fn()}
         title="Test Modal"
         onClickReceive={jest.fn()}
+        data-testid="funding-method-modal"
       />,
       store,
     );
@@ -82,6 +85,7 @@ describe('FundingMethodModal', () => {
         onClose={jest.fn()}
         title="Test Modal"
         onClickReceive={onClickReceive}
+        data-testid="funding-method-modal"
       />,
       store,
     );
@@ -99,6 +103,7 @@ describe('FundingMethodModal', () => {
         onClose={jest.fn()}
         title="Test Modal"
         onClickReceive={jest.fn()}
+        data-testid="funding-method-modal"
       />,
       store,
     );

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -8,6 +8,7 @@ import {
   ModalHeader,
   Text,
   IconName,
+  type ModalProps,
 } from '../../component-library';
 import {
   TextVariant,
@@ -36,7 +37,7 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import FundingMethodItem from './funding-method-item';
 
-type FundingMethodModalProps = {
+type FundingMethodModalProps = Omit<ModalProps, 'children'> & {
   isOpen: boolean;
   onClose: () => void;
   title: string;
@@ -48,6 +49,7 @@ export const FundingMethodModal: React.FC<FundingMethodModalProps> = ({
   onClose,
   title,
   onClickReceive,
+  ...props
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
@@ -113,7 +115,7 @@ export const FundingMethodModal: React.FC<FundingMethodModalProps> = ({
   }, [chainId, symbol]);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} data-testid="funding-method-modal">
+    <Modal isOpen={isOpen} onClose={onClose} {...props}>
       <ModalOverlay />
       <ModalContent modalDialogProps={{ padding: 0 }}>
         <ModalHeader paddingBottom={2} onClose={onClose}>


### PR DESCRIPTION
## **Description**

This PR updates the balance empty state component with design improvements and adds a funding modal when cta is clicked instead of routing to buy

- Updated layout and spacing
- Added `FundingMethodModal` component to provide users with funding options when they click "Add Funds" 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37366?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: https://consensyssoftware.atlassian.net/browse/DSYS-161

## **Manual testing steps**

1. Navigate to Storybook and locate the Balance Empty State component
2. Verify the updated design displays correctly with proper spacing and typography
3. Click the "Add Funds" button to test the funding modal functionality
4. Verify the modal opens with funding options

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Previous balance empty state with basic layout and direct ramps integration

https://github.com/user-attachments/assets/c16fc29c-ae6f-4460-b6fc-49503b4105bc

### **After**

Updated balance empty state with improved design and integrated funding modal

https://github.com/user-attachments/assets/3c5b0d2a-ba5e-40a8-a2bc-38901e396cb8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> BalanceEmptyState now opens a funding options modal (with buy/receive/transfer) instead of direct buy, with design tweaks and corresponding tests.
> 
> - **UI**:
>   - `BalanceEmptyState`:
>     - Opens `FundingMethodModal` on “Add funds” instead of calling `useRamps` directly; adds `onClickReceive` prop and local open/close state.
>     - Layout/typography tweaks (container structure, spacing, heading variant).
>   - `FundingMethodModal`:
>     - Accepts and forwards `ModalProps` (e.g., `data-testid`), renders funding options.
>     - Handlers: buy via `openBuyCryptoInPdapp`, receive via callback, transfer via `portfolio` URL in new tab; emits MetaMetrics events.
> - **Tests**:
>   - Update `balance-empty-state` test to assert modal opens on button click.
>   - Add/expand `funding-method-modal` tests for open/closed rendering and click handlers (buy, receive, transfer).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 307a783b26421576ad5daec6ea3866c43a72c133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->