### PR TITLE
chore: simplify useTransactionDisplay

### DIFF
--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -35,14 +35,8 @@ export default function SmartTransactionListItem({
   const dispatch = useDispatch();
   const [cancelSwapLinkClicked, setCancelSwapLinkClicked] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
-  const {
-    title,
-    category,
-    primaryCurrency,
-    recipientAddress,
-    isPending,
-    senderAddress,
-  } = useTransactionDisplayData(transactionGroup);
+  const { title, category, primaryCurrency, recipientAddress, isPending } =
+    useTransactionDisplayData(transactionGroup);
   const currentChain = useSelector(getCurrentNetwork);
 
   const { time, status } = smartTransaction;
@@ -59,6 +53,8 @@ export default function SmartTransactionListItem({
   const toggleShowDetails = useCallback(() => {
     setShowDetails((prev) => !prev);
   }, []);
+  const senderAddress = transactionGroup.initialTransaction.txParams?.from;
+
   return (
     <>
       <ActivityListItem

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -36,6 +36,7 @@ import {
   Text,
 } from '../../component-library';
 
+import { getStatusKey } from '../../../helpers/utils/transactions.util';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -192,13 +193,12 @@ function TransactionListItemInner({
     primaryCurrency,
     recipientAddress,
     secondaryCurrency,
-    displayedStatusKey: displayedStatusKeyFromSrcTransaction,
     isPending,
   } = useTransactionDisplayData(transactionGroup);
   const displayedStatusKey =
     isBridgeTx && isBridgeFailed
       ? TransactionStatus.failed
-      : displayedStatusKeyFromSrcTransaction;
+      : getStatusKey(transactionGroup.primaryTransaction);
   const date = formatDateWithYearContext(
     transactionGroup.primaryTransaction.time,
     'MMM d, y',

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -194,7 +194,6 @@ function TransactionListItemInner({
     isPending,
     senderAddress,
     detailsTitle,
-    remoteSignerAddress,
   } = useTransactionDisplayData(transactionGroup);
   const displayedStatusKey =
     isBridgeTx && isBridgeFailed
@@ -417,7 +416,6 @@ function TransactionListItemInner({
             />
           )}
           chainId={chainId}
-          remoteSignerAddress={remoteSignerAddress}
         />
       )}
       {!supportsEIP1559 && showRetryEditGasPopover && (

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -118,9 +118,11 @@ function TransactionListItemInner({
   };
 
   const {
-    initialTransaction: { id },
+    initialTransaction: { id, txParams },
     primaryTransaction: { error, status },
   } = transactionGroup;
+
+  const senderAddress = txParams?.from;
 
   const trackEvent = useContext(MetaMetricsContext);
 
@@ -192,8 +194,6 @@ function TransactionListItemInner({
     secondaryCurrency,
     displayedStatusKey: displayedStatusKeyFromSrcTransaction,
     isPending,
-    senderAddress,
-    detailsTitle,
   } = useTransactionDisplayData(transactionGroup);
   const displayedStatusKey =
     isBridgeTx && isBridgeFailed
@@ -394,7 +394,7 @@ function TransactionListItemInner({
       </ActivityListItem>
       {showDetails && (
         <TransactionListItemDetails
-          title={detailsTitle}
+          title={title}
           onClose={toggleShowDetails}
           transactionGroup={transactionGroup}
           primaryCurrency={primaryCurrency}

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -73,11 +73,8 @@ const signatureTypes = [
  * @typedef {object} TransactionDisplayData
  * @property {string} primaryCurrency - the currency string to display in the primary position
  * @property {string} recipientAddress - the Ethereum address of the recipient
- * @property {string} senderAddress - the Ethereum address of the sender
- * @property {string} status - the status of the transaction
  * @property {string} title - the primary title of the tx that will be displayed in the activity list
  * @property {string} [secondaryCurrency] - the currency string to display in the secondary position
- * @property {string} displayedStatusKey - the key representing the displayed status of the transaction
  * @property {boolean} isPending - indicates if the transaction is pending
  */
 
@@ -443,7 +440,6 @@ export function useTransactionDisplayData(transactionGroup) {
       (isUnifiedSwapTx && !secondaryCurrency)
         ? undefined
         : secondaryCurrency,
-    displayedStatusKey,
     isPending,
   };
 }

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -121,7 +121,7 @@ export function useTransactionDisplayData(transactionGroup) {
   const { initialTransaction, primaryTransaction } = transactionGroup;
   // initialTransaction contains the data we need to derive the primary purpose of this transaction group
   const { transferInformation, type } = initialTransaction;
-  const { from, to } = initialTransaction.txParams || {};
+  const { from: senderAddress, to } = initialTransaction.txParams || {};
 
   const isUnifiedSwapTx =
     [TransactionType.swap, TransactionType.bridge].includes(type) &&
@@ -141,7 +141,6 @@ export function useTransactionDisplayData(transactionGroup) {
 
   let prefix = '-';
   let recipientAddress = to;
-  const senderAddress = from;
   const transactionData = initialTransaction?.txParams?.data;
 
   // This value is used to determine whether we should look inside txParams.data
@@ -396,8 +395,6 @@ export function useTransactionDisplayData(transactionGroup) {
     );
   }
 
-  const detailsTitle = title;
-
   const primaryCurrencyPreferences = useUserPreferencedCurrency(
     PRIMARY,
     {},
@@ -437,7 +434,6 @@ export function useTransactionDisplayData(transactionGroup) {
     title,
     primaryCurrency:
       type === TransactionType.swap && isPending ? '' : primaryCurrency,
-    senderAddress,
     recipientAddress,
     secondaryCurrency:
       (isTokenCategory && !tokenFiatAmount) ||
@@ -449,6 +445,5 @@ export function useTransactionDisplayData(transactionGroup) {
         : secondaryCurrency,
     displayedStatusKey,
     isPending,
-    detailsTitle,
   };
 }

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
 import { MemoryRouter } from 'react-router-dom';
-import { TransactionStatus } from '@metamask/transaction-controller';
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import transactions from '../../test/data/transaction-data.json';
@@ -25,128 +24,99 @@ const expectedResults = [
   {
     title: 'Sent',
     primaryCurrency: '-1 ETH',
-    senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
     secondaryCurrency: '-1 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
-    detailsTitle: 'Sent',
   },
   {
     title: 'Sent',
     primaryCurrency: '-2 ETH',
-    senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x0ccc8aeeaf5ce790f3b448325981a143fdef8848',
     secondaryCurrency: '-2 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Sent',
     primaryCurrency: '-2 ETH',
-    senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',
     secondaryCurrency: '-2 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Received',
     primaryCurrency: '18.75 ETH',
-    senderAddress: '0x31b98d14007bdee637298086988a0bbd31184523',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     secondaryCurrency: '18.75 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Received',
     primaryCurrency: '0 ETH',
-    senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     secondaryCurrency: '0 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Received',
     primaryCurrency: '1 ETH',
-    senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     secondaryCurrency: '1 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Swap ETH to ABC',
     primaryCurrency: '+1 ABC',
-    senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Contract deployment',
     primaryCurrency: '-0 ETH',
-    senderAddress: '0xee014609ef9e09776ac5fe00bdbfef57bcdefebb',
     recipientAddress: undefined,
     secondaryCurrency: '-0 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Safe transfer from',
     primaryCurrency: '-0 ETH',
-    senderAddress: '0x806627172af48bd5b0765d3449a7def80d6576ff',
     recipientAddress: '0xe7d522230eff653bb0a9b4385f0be0815420dd98',
     secondaryCurrency: '-0 ETH',
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Approve ABC spending cap',
     primaryCurrency: '0.00000000000005 ABC',
-    senderAddress: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
     secondaryCurrency: undefined,
-    displayedStatusKey: TransactionStatus.confirmed,
     isPending: false,
   },
   {
     title: 'Sent BAT as ETH',
     primaryCurrency: '-33.425656732428330864 BAT',
-    senderAddress: '0x0a985a957b490f4d05bef05bc7ec556dd8535946',
     recipientAddress: '0xc6f6ca03d790168758285264bcbf7fb30d27322b',
     secondaryCurrency: undefined,
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Sent USDC as DAI',
     primaryCurrency: '-5 USDC',
-    senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     secondaryCurrency: undefined,
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Sent BNB as USDC',
     primaryCurrency: '-0.05 BNB',
-    senderAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     recipientAddress: '0x141d32a89a1e0a5ef360034a2f60a4b917c18838',
     secondaryCurrency: undefined,
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
   {
     title: 'Sent ABC',
     primaryCurrency: '-1.234 ABC',
-    senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
     secondaryCurrency: undefined,
     isPending: false,
-    displayedStatusKey: TransactionStatus.confirmed,
   },
 ];
 
@@ -282,16 +252,6 @@ describe('useTransactionDisplayData', () => {
         );
       });
 
-      it(`should return a displayedStatusKey of ${expected.displayedStatusKey}`, () => {
-        const { result } = renderHookWithRouter(
-          () => useTransactionDisplayData(transactionGroup),
-          tokenAddress,
-        );
-        expect(result.current.displayedStatusKey).toStrictEqual(
-          expected.displayedStatusKey,
-        );
-      });
-
       it(`should return a recipientAddress of ${expected.recipientAddress}`, () => {
         const { result } = renderHookWithRouter(
           () => useTransactionDisplayData(transactionGroup),
@@ -299,16 +259,6 @@ describe('useTransactionDisplayData', () => {
         );
         expect(result.current.recipientAddress).toStrictEqual(
           expected.recipientAddress,
-        );
-      });
-
-      it(`should return a senderAddress of ${expected.senderAddress}`, () => {
-        const { result } = renderHookWithRouter(
-          () => useTransactionDisplayData(transactionGroup),
-          tokenAddress,
-        );
-        expect(result.current.senderAddress).toStrictEqual(
-          expected.senderAddress,
         );
       });
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removing redundant exports of useTransactionDisplayData. Also, there is no such remoteSignerAddress 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37368?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies useTransactionDisplayData by removing extra fields and moving sender/status logic to components, updating list items and tests accordingly.
> 
> - **Hooks**:
>   - **useTransactionDisplayData**: Removes `senderAddress`, `displayedStatusKey`, `detailsTitle` from returned data; derives `senderAddress` internally only for computations; retains `isPending`; minor refactor of address extraction.
> - **Components**:
>   - **transaction-list-item.component**:
>     - Use `getStatusKey` for `displayedStatusKey` instead of hook-provided value.
>     - Compute `senderAddress` from `txParams?.from` and pass to details.
>     - Pass `title` to `TransactionListItemDetails` and remove `remoteSignerAddress` prop.
>   - **smart-transaction-list-item.component**:
>     - Stop relying on `senderAddress` from hook; compute from `transactionGroup.initialTransaction.txParams?.from`.
>     - Keep status handling for smart tx and pass `title` to details.
> - **Tests**:
>   - Update `useTransactionDisplayData.test` to drop expectations for `displayedStatusKey`, `senderAddress`, and `detailsTitle`; keep assertions for `title`, currencies, and `recipientAddress`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e4732996028522649ab97bee312ebde23b54b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->