### PR TITLE
fix: flaky test `chrome-e2e-api-specs` with error `NoSuchWindowError: no such window: target window already closed`

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -87,12 +87,9 @@ jobs:
       test-command: yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.ts --browser chrome
 
   test-e2e-chrome-api-specs:
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     uses: ./.github/workflows/run-e2e.yml
     with:
-      test-suite-name: test-e2e-chrome-api-specs-run-${{ matrix.run }}
+      test-suite-name: test-e2e-chrome-api-specs
       build-artifact: build-test-browserify
       build-command: yarn build:test
       test-command: yarn test:api-specs

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -87,9 +87,12 @@ jobs:
       test-command: yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.ts --browser chrome
 
   test-e2e-chrome-api-specs:
+    strategy:
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     uses: ./.github/workflows/run-e2e.yml
     with:
-      test-suite-name: test-e2e-chrome-api-specs
+      test-suite-name: test-e2e-chrome-api-specs-run-${{ matrix.run }}
       build-artifact: build-test-browserify
       build-command: yarn build:test
       test-command: yarn test:api-specs

--- a/test/e2e/api-specs/ConfirmationRejectionRule.ts
+++ b/test/e2e/api-specs/ConfirmationRejectionRule.ts
@@ -8,7 +8,9 @@ import {
 } from '@open-rpc/meta-schema';
 import paramsToObj from '@open-rpc/test-coverage/build/utils/params-to-obj';
 import { Driver } from '../webdriver/driver';
+import { DEFAULT_FIXTURE_ACCOUNT_LOWERCASE } from '../constants';
 import { WINDOW_TITLES, switchToOrOpenDapp } from '../helpers';
+import TestDapp from '../page-objects/pages/test-dapp';
 import { addToQueue } from './helpers';
 
 type ConfirmationsRejectRuleOptions = {
@@ -54,6 +56,9 @@ export class ConfirmationsRejectRule implements Rule {
                 params: [{ eth_accounts: {} }],
               });
 
+              const testDapp = new TestDapp(this.driver);
+              await testDapp.checkPageIsLoaded();
+
               await this.driver.executeScript(
                 `window.ethereum.request(${requestPermissionsRequest})`,
               );
@@ -84,6 +89,10 @@ export class ConfirmationsRejectRule implements Rule {
 
               await switchToOrOpenDapp(this.driver);
 
+              await testDapp.checkConnectedAccounts(
+                DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+              );
+
               const switchEthereumChainRequest = JSON.stringify({
                 jsonrpc: '2.0',
                 method: 'wallet_switchEthereumChain',
@@ -97,6 +106,7 @@ export class ConfirmationsRejectRule implements Rule {
               await this.driver.executeScript(
                 `window.ethereum.request(${switchEthereumChainRequest})`,
               );
+              await testDapp.checkNetworkIsConnected('0x539');
             }
           } catch (e) {
             console.log(e);
@@ -135,6 +145,12 @@ export class ConfirmationsRejectRule implements Rule {
             });
             // make sure to switch back to the dapp or else the next test will fail on the wrong window
             await switchToOrOpenDapp(this.driver);
+            const testDapp = new TestDapp(this.driver);
+            await testDapp.checkPageIsLoaded();
+            await testDapp.checkConnectedAccounts(
+              DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+              false,
+            );
           } catch (e) {
             console.log(e);
           }
@@ -202,6 +218,13 @@ export class ConfirmationsRejectRule implements Rule {
 
               await this.driver.executeScript(
                 `window.ethereum.request(${revokePermissionsRequest})`,
+              );
+
+              const testDapp = new TestDapp(this.driver);
+              await testDapp.checkPageIsLoaded();
+              await testDapp.checkConnectedAccounts(
+                DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+                false,
               );
             }
           } catch (e) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition with windows after personal sign tests is done.

<img width="2056" height="1096" alt="image" src="https://github.com/user-attachments/assets/d8081bb0-3dbe-4147-8c3e-01cf6dd12ac4" />

To avoid this, I added checks between actions and it seems to effectively mitigate the failures. I've run this 10 times and success rate is 100% now

<img width="588" height="694" alt="image" src="https://github.com/user-attachments/assets/3082d4ae-1042-4e47-b0ad-4dac8a65b525" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37372?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. check ci  https://github.com/MetaMask/metamask-extension/actions/runs/18934479948/job/54057916990?pr=37372

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TestDapp-based page/account/network assertions and dapp switching to stabilize the confirmation rejection E2E flow and prevent window errors.
> 
> - **E2E tests (`test/e2e/api-specs/ConfirmationRejectionRule.ts`)**:
>   - Integrate `TestDapp` to assert page load and verify connected accounts using `DEFAULT_FIXTURE_ACCOUNT_LOWERCASE` before/after actions (connect/cancel/revoke).
>   - After connecting, validate network switch via `checkNetworkIsConnected('0x539')`.
>   - Ensure focus switches back to the dapp window after confirmations to avoid window mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bbe1dc3b466b64e057a5a57594062e9636e7536. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->