### PR TITLE
fix: Vault Corruption flaky test `no such window: target window already closed` and `NoSuchAlertError: no such alert`

### DIFF
--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -166,7 +166,6 @@ describe('Vault Corruption', function () {
 
     // use the home page to destroy the vault
     await driver.executeAsyncScript(script);
-    await driver.delay(5000);
 
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -207,6 +207,7 @@ describe('Vault Corruption', function () {
 
     if (confirm) {
       // delay needed to mitigate a race condition where the tab is closed and re-opened after confirming, causing to window to become stale
+      await driver.delay(3000);
       try {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -122,7 +122,6 @@ describe('Vault Corruption', function () {
   async function waitForVaultRestorePage(driver: Driver) {
     await driver.waitUntil(
       async () => {
-        await driver.openNewPage('about:blank');
         await driver.navigate(PAGES.HOME, { waitForControllers: false });
         const title = await driver.driver.getTitle();
         // the browser will return an error message for our UI's HOME page until
@@ -170,6 +169,9 @@ describe('Vault Corruption', function () {
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)
     await driver.switchToWindow(initialWindow);
+
+    // get a new tab ready to use (required for Firefox)
+    await driver.openNewPage('about:blank');
 
     // wait for the background page to reload
     await waitForVaultRestorePage(driver);

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -165,6 +165,7 @@ describe('Vault Corruption', function () {
 
     // use the home page to destroy the vault
     await driver.executeAsyncScript(script);
+    await driver.delay(5000);
 
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -122,6 +122,7 @@ describe('Vault Corruption', function () {
   async function waitForVaultRestorePage(driver: Driver) {
     await driver.waitUntil(
       async () => {
+        await driver.openNewPage('about:blank');
         await driver.navigate(PAGES.HOME, { waitForControllers: false });
         const title = await driver.driver.getTitle();
         // the browser will return an error message for our UI's HOME page until
@@ -170,9 +171,6 @@ describe('Vault Corruption', function () {
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)
     await driver.switchToWindow(initialWindow);
-
-    // get a new tab ready to use (required for Firefox)
-    await driver.openNewPage('about:blank');
 
     // wait for the background page to reload
     await waitForVaultRestorePage(driver);

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -120,7 +120,6 @@ describe('Vault Corruption', function () {
    * @param driver - The WebDriver instance.
    */
   async function waitForVaultRestorePage(driver: Driver) {
-    await driver.delay(10000);
     await driver.waitUntil(
       async () => {
         await driver.navigate(PAGES.HOME, { waitForControllers: false });
@@ -207,7 +206,7 @@ describe('Vault Corruption', function () {
 
     if (confirm) {
       // delay needed to mitigate a race condition where the tab is closed and re-opened after confirming, causing to window to become stale
-      await driver.delay(3000);
+      await driver.delay(8000);
       try {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -120,17 +120,8 @@ describe('Vault Corruption', function () {
    * @param driver - The WebDriver instance.
    */
   async function waitForVaultRestorePage(driver: Driver) {
-    await driver.waitUntil(
-      async () => {
-        await driver.navigate(PAGES.HOME, { waitForControllers: false });
-        const title = await driver.driver.getTitle();
-        // the browser will return an error message for our UI's HOME page until
-        // the extension has restarted
-        return title === WINDOW_TITLES.ExtensionInFullScreenView;
-      },
-      // reload and check title as quickly a possible
-      { interval: 100, timeout: 10000 },
-    );
+    await driver.delay(10000)
+    await driver.navigate(PAGES.HOME, { waitForControllers: false });
     await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
   }
 

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -120,6 +120,7 @@ describe('Vault Corruption', function () {
    * @param driver - The WebDriver instance.
    */
   async function waitForVaultRestorePage(driver: Driver) {
+    await driver.delay(10000);
     await driver.waitUntil(
       async () => {
         await driver.navigate(PAGES.HOME, { waitForControllers: false });
@@ -168,7 +169,6 @@ describe('Vault Corruption', function () {
 
     // use the home page to destroy the vault
     await driver.executeAsyncScript(script);
-    await driver.delay(2000);
 
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)
@@ -177,12 +177,8 @@ describe('Vault Corruption', function () {
     // get a new tab ready to use (required for Firefox)
     await driver.openNewPage('about:blank');
 
-    await driver.delay(2000);
-
     // wait for the background page to reload
     await waitForVaultRestorePage(driver);
-
-    await driver.delay(2000);
 
     return firstAddress;
   }
@@ -202,24 +198,18 @@ describe('Vault Corruption', function () {
     confirm: boolean;
   }) {
     // click the Recovery/Reset button
-    await driver.delay(2000);
-
     await driver.clickElement('#critical-error-button');
 
     // Confirm we want to recover/reset.
     const prompt = await driver.driver.switchTo().alert();
     if (confirm) {
-      await driver.delay(2000);
-
       await prompt.accept();
     } else {
-      await driver.delay(2000);
       await prompt.dismiss();
     }
 
     if (confirm) {
       // delay needed to mitigate a race condition where the tab is closed and re-opened after confirming, causing to window to become stale
-      await driver.delay(3000);
       try {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -168,6 +168,7 @@ describe('Vault Corruption', function () {
 
     // use the home page to destroy the vault
     await driver.executeAsyncScript(script);
+    await driver.delay(2000);
 
     // the previous tab we were using is now closed, so we need to tell Selenium
     // to switch back to the other page (required for Chrome)
@@ -176,8 +177,12 @@ describe('Vault Corruption', function () {
     // get a new tab ready to use (required for Firefox)
     await driver.openNewPage('about:blank');
 
+    await driver.delay(2000);
+
     // wait for the background page to reload
     await waitForVaultRestorePage(driver);
+
+    await driver.delay(2000);
 
     return firstAddress;
   }
@@ -197,13 +202,18 @@ describe('Vault Corruption', function () {
     confirm: boolean;
   }) {
     // click the Recovery/Reset button
+    await driver.delay(2000);
+
     await driver.clickElement('#critical-error-button');
 
     // Confirm we want to recover/reset.
     const prompt = await driver.driver.switchTo().alert();
     if (confirm) {
+      await driver.delay(2000);
+
       await prompt.accept();
     } else {
+      await driver.delay(2000);
       await prompt.dismiss();
     }
 

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -132,10 +132,7 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible
       { interval: 100, timeout: 10000 },
     );
-    await driver.assertElementNotPresent('.loading-logo', {
-      timeout: 10000,
-      waitAtLeastGuard: 1000,
-    });
+    await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
   }
 
   /**

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -207,7 +207,7 @@ describe('Vault Corruption', function () {
 
     if (confirm) {
       // delay needed to mitigate a race condition where the tab is closed and re-opened after confirming, causing to window to become stale
-      await driver.delay(8000);
+      await driver.delay(3000);
       try {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -131,7 +131,10 @@ describe('Vault Corruption', function () {
       // reload and check title as quickly a possible
       { interval: 100, timeout: 10000 },
     );
-    await driver.assertElementNotPresent('.loading-logo', { timeout: 10000 });
+    await driver.assertElementNotPresent('.loading-logo', {
+      timeout: 10000,
+      waitAtLeastGuard: 1000,
+    });
   }
 
   /**

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -125,7 +125,12 @@ export class CriticalStartupErrorHandler {
         hasBackup: boolean;
         currentLocale?: string;
       };
-      displayStateCorruptionError(
+      // Cancel the liveness check since we're displaying a corruption error
+      clearTimeout(this.#livenessCheckTimeoutId);
+      if (this.#onLivenessCheckCompleted) {
+        this.#onLivenessCheckCompleted();
+      }
+      await displayStateCorruptionError(
         this.#container,
         this.#port,
         error,
@@ -145,6 +150,11 @@ export class CriticalStartupErrorHandler {
         error: ErrorLike;
         currentLocale?: string;
       };
+      // Cancel the liveness check since we're displaying a general error
+      clearTimeout(this.#livenessCheckTimeoutId);
+      if (this.#onLivenessCheckCompleted) {
+        this.#onLivenessCheckCompleted();
+      }
       await displayCriticalError(
         this.#container,
         CriticalErrorTranslationKey.TroubleStarting,

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -125,7 +125,7 @@ export class CriticalStartupErrorHandler {
         hasBackup: boolean;
         currentLocale?: string;
       };
-      displayStateCorruptionError(
+      await displayStateCorruptionError(
         this.#container,
         this.#port,
         error,

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -125,7 +125,7 @@ export class CriticalStartupErrorHandler {
         hasBackup: boolean;
         currentLocale?: string;
       };
-      await displayStateCorruptionError(
+      displayStateCorruptionError(
         this.#container,
         this.#port,
         error,

--- a/ui/helpers/utils/critical-startup-error-handler.ts
+++ b/ui/helpers/utils/critical-startup-error-handler.ts
@@ -34,6 +34,8 @@ export class CriticalStartupErrorHandler {
 
   #onLivenessCheckCompleted?: () => void;
 
+  #errorDisplayed = false;
+
   /**
    * Creates an instance of CriticalStartupErrorHandler.
    * This class listens for critical startup errors from the background script
@@ -66,13 +68,17 @@ export class CriticalStartupErrorHandler {
     try {
       await Promise.race([livenessCheck, timeoutPromise]);
     } catch (error) {
-      await displayCriticalError(
-        this.#container,
-        CriticalErrorTranslationKey.TroubleStarting,
-        // This cast is safe because `livenessCheck` can't throw, and `timeoutPromise` only throws an
-        // error.
-        error as ErrorLike,
-      );
+      // Only display error if we haven't already displayed one
+      if (!this.#errorDisplayed) {
+        this.#errorDisplayed = true;
+        await displayCriticalError(
+          this.#container,
+          CriticalErrorTranslationKey.TroubleStarting,
+          // This cast is safe because `livenessCheck` can't throw, and `timeoutPromise` only throws an
+          // error.
+          error as ErrorLike,
+        );
+      }
     } finally {
       clearTimeout(this.#livenessCheckTimeoutId);
     }
@@ -101,7 +107,9 @@ export class CriticalStartupErrorHandler {
     if (method === BACKGROUND_LIVENESS_METHOD) {
       if (this.#onLivenessCheckCompleted) {
         this.#onLivenessCheckCompleted();
-      } else {
+      } else if (!this.#errorDisplayed) {
+        // Only display error if we haven't already displayed one and liveness check wasn't initialized
+        this.#errorDisplayed = true;
         await displayCriticalError(
           this.#container,
           CriticalErrorTranslationKey.TroubleStarting,
@@ -125,18 +133,22 @@ export class CriticalStartupErrorHandler {
         hasBackup: boolean;
         currentLocale?: string;
       };
-      // Cancel the liveness check since we're displaying a corruption error
-      clearTimeout(this.#livenessCheckTimeoutId);
-      if (this.#onLivenessCheckCompleted) {
-        this.#onLivenessCheckCompleted();
+      // Only display error if we haven't already displayed one
+      if (!this.#errorDisplayed) {
+        this.#errorDisplayed = true;
+        // Cancel the liveness check since we're displaying a corruption error
+        clearTimeout(this.#livenessCheckTimeoutId);
+        if (this.#onLivenessCheckCompleted) {
+          this.#onLivenessCheckCompleted();
+        }
+        await displayStateCorruptionError(
+          this.#container,
+          this.#port,
+          error,
+          hasBackup,
+          currentLocale,
+        );
       }
-      await displayStateCorruptionError(
-        this.#container,
-        this.#port,
-        error,
-        hasBackup,
-        currentLocale,
-      );
     } else if (method === DISPLAY_GENERAL_STARTUP_ERROR) {
       if (!hasProperty(data, 'params') || !isObject(data.params)) {
         log.error(
@@ -150,17 +162,21 @@ export class CriticalStartupErrorHandler {
         error: ErrorLike;
         currentLocale?: string;
       };
-      // Cancel the liveness check since we're displaying a general error
-      clearTimeout(this.#livenessCheckTimeoutId);
-      if (this.#onLivenessCheckCompleted) {
-        this.#onLivenessCheckCompleted();
+      // Only display error if we haven't already displayed one
+      if (!this.#errorDisplayed) {
+        this.#errorDisplayed = true;
+        // Cancel the liveness check since we're displaying a general error
+        clearTimeout(this.#livenessCheckTimeoutId);
+        if (this.#onLivenessCheckCompleted) {
+          this.#onLivenessCheckCompleted();
+        }
+        await displayCriticalError(
+          this.#container,
+          CriticalErrorTranslationKey.TroubleStarting,
+          error as ErrorLike,
+          currentLocale,
+        );
       }
-      await displayCriticalError(
-        this.#container,
-        CriticalErrorTranslationKey.TroubleStarting,
-        error as ErrorLike,
-        currentLocale,
-      );
     }
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Vault Corruption is very flaky. The test fails after we have corrupted the vault and we click on the Critical Button error, as this causes to sometimes close the MM window completely, and then leading then to this error:

``` 
NoSuchWindowError: no such window: target window already closed from unknown error: web view not found   (Session info: chrome=126.0.6478.182)  
```

<img width="1149" height="445" alt="image" src="https://github.com/user-attachments/assets/696780a6-dbd5-49a4-9cd2-bcf18ce857eb" />


Or this one: `NoSuchAlertError: no such alert`





<img width="1133" height="532" alt="image" src="https://github.com/user-attachments/assets/d7d72c21-8faa-4c44-baf6-accbe4cb0273" />


It seems the issue might be in the button handler, so here I'm adding a flag to ensure the button handler cannot be overwritten: once #errorDisplayed is true, no subsequent calls to displayCriticalError or displayStateCorruptionError will execute.

I suspect this can happen because we are trying to open MM multiple times (with the waitUntil) and some previous call can overwrite that? ---to verify with @davidmurdoch @Gudahtt 

It might be better to fully understand what's hanging (if that's the case) that then overrides the handler, though I think  the change is safe/won't have unintended consequences

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37379?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/36916

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace polling-based wait with a fixed delay and loading check in the vault-corruption E2E test.
> 
> - **Tests (E2E)**
>   - **`test/e2e/tests/vault-corruption/vault-corruption.spec.ts`**
>     - Update `waitForVaultRestorePage`:
>       - Remove `waitUntil` loop that repeatedly navigated and checked window title.
>       - Add fixed 10s delay, navigate to `PAGES.HOME` with `waitForControllers: false`, then assert `.loading-logo` is not present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef934d2787e749cdb47f03695cde195adfc1802e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->