### PR TITLE
fix: add missing shield links

### DIFF
--- a/ui/components/app/shield-entry-modal/shield-entry-modal.tsx
+++ b/ui/components/app/shield-entry-modal/shield-entry-modal.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { SubscriptionUserEvent } from '@metamask/subscription-controller';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { TRANSACTION_SHIELD_LINK } from '../../../helpers/constants/common';
 import {
   AlignItems,
   Display,
@@ -95,7 +96,7 @@ export default function ShieldEntryModal() {
                 size={ButtonLinkSize.Inherit}
                 target="_blank"
                 rel="noopener noreferrer"
-                href="#"
+                href={TRANSACTION_SHIELD_LINK}
               >
                 {t('learnMoreUpperCase')}
               </ButtonLink>,

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -4,6 +4,8 @@ export const SECONDARY = 'SECONDARY';
 const _contractAddressLink =
   'https://support.metamask.io/managing-my-tokens/moving-your-tokens/why-am-i-being-warned-about-sending-tokens-to-a-contract/';
 
+export const TRANSACTION_SHIELD_LINK = 'https://metamask.io/transaction-shield';
+
 // eslint-disable-next-line prefer-destructuring
 export const METAMETRICS_SETTINGS_LINK =
   'https://support.metamask.io/privacy-and-security/how-to-manage-your-metametrics-settings';

--- a/ui/pages/settings/transaction-shield-tab/submit-claim-form/submit-claim-form.tsx
+++ b/ui/pages/settings/transaction-shield-tab/submit-claim-form/submit-claim-form.tsx
@@ -34,11 +34,18 @@ import { useClaimState } from '../../../../hooks/claims/useClaimState';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { isValidEmail } from '../../../../../app/scripts/lib/util';
-import { submitShieldClaim } from '../../../../store/actions';
+import {
+  submitShieldClaim,
+  setDefaultHomeActiveTabName,
+} from '../../../../store/actions';
 import LoadingScreen from '../../../../components/ui/loading-screen';
 import { setShowClaimSubmitToast } from '../../../../components/app/toast-master/utils';
 import { ClaimSubmitToastType } from '../../../../../shared/constants/app-state';
-import { TRANSACTION_SHIELD_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  TRANSACTION_SHIELD_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { TRANSACTION_SHIELD_LINK } from '../../../../helpers/constants/common';
 import { FileUploader } from '../../../../components/component-library/file-uploader';
 import { isSafeChainId } from '../../../../../shared/modules/network.utils';
 
@@ -227,6 +234,11 @@ const SubmitClaimForm = () => {
     }));
   }, [caseDescription, t]);
 
+  const handleOpenActivityTab = useCallback(async () => {
+    dispatch(setDefaultHomeActiveTabName('activity'));
+    navigate(DEFAULT_ROUTE);
+  }, [dispatch, navigate]);
+
   const handleSubmitClaim = useCallback(async () => {
     if (isInvalidData) {
       return;
@@ -292,7 +304,13 @@ const SubmitClaimForm = () => {
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
         {t('shieldClaimDetails', [
           <TextButton key="here-link" className="min-w-0" asChild>
-            <a href="#">{t('here')}</a>
+            <a
+              href={TRANSACTION_SHIELD_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('here')}
+            </a>
           </TextButton>,
         ])}
       </Text>
@@ -374,9 +392,9 @@ const SubmitClaimForm = () => {
               <TextButton
                 size={TextButtonSize.BodySm}
                 className="min-w-0"
-                asChild
+                onClick={handleOpenActivityTab}
               >
-                <a href="#">{t('shieldClaimImpactedTxHashHelpTextLink')}</a>
+                {t('shieldClaimImpactedTxHashHelpTextLink')}
               </TextButton>
             </Text>
           ) : (
@@ -388,9 +406,9 @@ const SubmitClaimForm = () => {
               <TextButton
                 size={TextButtonSize.BodySm}
                 className="min-w-0"
-                asChild
+                onClick={handleOpenActivityTab}
               >
-                <a href="#">{t('shieldClaimImpactedTxHashHelpTextLink')}</a>
+                {t('shieldClaimImpactedTxHashHelpTextLink')}
               </TextButton>
             </Text>
           )

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -60,6 +60,7 @@ import {
   SHIELD_PLAN_ROUTE,
   TRANSACTION_SHIELD_CLAIM_ROUTE,
 } from '../../../helpers/constants/routes';
+import { TRANSACTION_SHIELD_LINK } from '../../../helpers/constants/common';
 import { getProductPrice } from '../../shield-plan/utils';
 import Tooltip from '../../../components/ui/tooltip';
 import { ThemeType } from '../../../../shared/constants/preferences';
@@ -725,7 +726,11 @@ const TransactionShield = () => {
         {buttonRow(
           t('shieldTxMembershipViewFullBenefits'),
           () => {
-            // todo: link to benefits page
+            window.open(
+              TRANSACTION_SHIELD_LINK,
+              '_blank',
+              'noopener noreferrer',
+            );
           },
           'shield-detail-view-benefits-button',
         )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
1. References of Transaction Shield are missing in many places in Shield screens. 
2. Update them
- add links in "View full benefits" in Shield settings
- add links in Shield claims
- add links in Shield entry modal

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37380?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `TRANSACTION_SHIELD_LINK` and updates Shield UI to open external learn/benefits pages and navigate users to Activity for TX hash help.
> 
> - **UI/Links**:
>   - Add `TRANSACTION_SHIELD_LINK` in `ui/helpers/constants/common.ts`.
>   - `ui/components/app/shield-entry-modal/shield-entry-modal.tsx`: Replace placeholder learn-more href with `TRANSACTION_SHIELD_LINK`.
>   - `ui/pages/settings/transaction-shield-tab/transaction-shield.tsx`: View benefits opens `TRANSACTION_SHIELD_LINK` in new tab.
> - **Claims form UX**:
>   - `ui/pages/settings/transaction-shield-tab/submit-claim-form/submit-claim-form.tsx`:
>     - Update "here" link to `TRANSACTION_SHIELD_LINK` (opens in new tab).
>     - Change impacted TX hash help from dummy link to action: dispatch `setDefaultHomeActiveTabName('activity')` and navigate to `DEFAULT_ROUTE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cc6db54c5a04ea072cc4da2ec7ff6388af663cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->