### PR TITLE
test: fix flaky test " Multichain API Calling wallet_invokeMethod "

### DIFF
--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -205,7 +205,7 @@ describe('Multichain API', function () {
               await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
             } else {
               await confirmation.checkNetworkIsDisplayed('Localhost 7777');
-              await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+              await confirmation.clickFooterConfirmButton();
 
               // third confirmation page should display Account 2 as sender account
               await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -236,7 +236,7 @@ class TransactionConfirmation extends Confirmation {
         css: this.senderAccount,
         text: account,
       },
-      2000,
+      5000,
     );
   }
 

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -231,13 +231,18 @@ class TransactionConfirmation extends Confirmation {
     console.log(
       `Checking sender account ${account} on transaction confirmation page.`,
     );
-    return await this.driver.isElementPresentAndVisible(
-      {
+    try {
+      await this.driver.waitForSelector({
         css: this.senderAccount,
         text: account,
-      },
-      5000,
-    );
+      });
+      return true;
+    } catch (err) {
+      console.log(
+        `Sender account ${account} is not displayed on transaction confirmation page.`,
+      );
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The reason for the test failure is that when calling `clickFooterConfirmButtonAndAndWaitForWindowToClose`, the window does not close after clicking the confirm button. This behavior is correct, because multiple confirmation windows are open, the next test step checks the display of the next confirmation screen. Therefore, we should not use `clickFooterConfirmButtonAndAndWaitForWindowToClose`. The fix is to use `clickFooterConfirmButton` instead.

Why the test was flaky instead of consistently failing? Because in the test spec, we use `if` conditions to check and confirm the confirmation screens. Since the send calls are triggered at the same time, the order in which the confirmation screens appear can vary. The test verifies the displayed information on confirmation screen regardless the screen order.
If the flow goes into a different `if` block, the test passes; however, if it follows this particular `if` block, the test fails.

I also improved the function `checkIsSenderAccountDisplayed` to use `waitForSelector` to be more stable.

I ran this test 10 times and they all passed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37390?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. test should be stable and pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes multichain E2E by avoiding window-close waits during sequential confirmations and making sender-account checks wait-based.
> 
> - **E2E Tests (`test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts`)**
>   - For the second confirmation flow, replace `clickFooterConfirmButtonAndAndWaitForWindowToClose` with `clickFooterConfirmButton` to proceed without waiting for the window to close when multiple dialogs are pending.
> - **Page Object (`test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts`)**
>   - Make `checkIsSenderAccountDisplayed` more robust by using `waitForSelector` with try/catch, returning a boolean after waiting for the sender account element.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c92f5cbf645d4744f44167cb44e65e0e4cf3bcba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->