### PR TITLE
release: Bump main version to 13.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.8.0",
+  "version": "13.9.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 13.8.0 to 13.9.0 after cutting the release branch.

### Why this is needed:
- **Nightly builds**: Each nightly build needs to be one minor version ahead of the current release candidate
- **Version conflicts**: Prevents conflicts between nightlies and release candidates
- **Platform alignment**: Maintains version alignment between MetaMask mobile and extension
- **Update systems**: Ensures nightlies are accepted by app stores and browser update systems

### What changed:
- Version bumped from `13.8.0` to `13.9.0`
- Platform: `extension`
- Files updated by `set-semvar-version.sh` script

### Next steps:
This PR should be **manually reviewed and merged by the release manager** to maintain proper version flow.

### Related:
- Release version: 13.8.0
- Release branch: release/13.8.0
- Platform: extension
- Test mode: false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `package.json` version from 13.8.0 to 13.9.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c08fa0986648e6fe231c87f54936d334cd749d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->