### PR TITLE
fix: flaky test `Account syncing - Multiple SRPs adds accounts across multiple SRPs and sync them`

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -71,6 +71,11 @@ class AccountListPage {
   private readonly addImportedAccountButton =
     '[data-testid="multichain-account-menu-popover-add-imported-account"]';
 
+  private readonly addingAccountMessage = {
+    text: 'Adding account...',
+    tag: 'p',
+  };
+
   private readonly addSnapAccountButton = {
     text: 'Add account Snap',
     tag: 'button',
@@ -86,11 +91,6 @@ class AccountListPage {
 
   private readonly closeMultichainAccountsPageButton =
     '.multichain-page-header button[aria-label="Back"]';
-
-  private readonly creatingAccountMessage = {
-    text: 'Creating account...',
-    tag: 'p',
-  };
 
   private readonly addMultichainWalletButton =
     '[data-testid="account-list-add-wallet-button"]';
@@ -548,7 +548,7 @@ class AccountListPage {
       `Open multichain account menu in account list for account ${options.accountLabel}`,
     );
     // To ensure no pending Create Account action is in progress
-    await this.driver.assertElementNotPresent(this.creatingAccountMessage, {
+    await this.driver.assertElementNotPresent(this.addingAccountMessage, {
       waitAtLeastGuard: largeDelayMs,
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A PR which changes the text from Create Account to Add Account was merged yesterday: 
https://github.com/MetaMask/metamask-extension/pull/37288

This introduces flakiness in our e2e, as we had a condition to mitigate flakiness, which relied on Creating Account message which now has changed.

This PR updates the copy, so we mitigate the flakiness again.

See in the logs how we waited for Creating account .. and since this message is never there anymore, we jump into the next step causing the spec to fail. We should wait until the account creating has completed, by using the new copy.

<img width="1018" height="195" alt="image" src="https://github.com/user-attachments/assets/982a32ef-79b7-4d12-8caf-6545f60f0100" />

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/718bac6e-5fe9-412c-b47f-b3bb475e1a3b" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37410?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates e2e selector to check for `Adding account...` instead of `Creating account...` before opening the multichain account menu.
> 
> - **Tests (e2e)**
>   - In `test/e2e/page-objects/pages/account-list-page.ts`:
>     - Replace `creatingAccountMessage` with `addingAccountMessage` (`'Creating account...'` -> `'Adding account...'`).
>     - Update `openMultichainAccountMenu` to assert absence of `addingAccountMessage` before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a8f8510c3e30fe21e7ba6d46fa29e5ad31068d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->