### PR TITLE
feat: Add non-navigable alert modals

### DIFF
--- a/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.test.tsx
+++ b/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.test.tsx
@@ -159,15 +159,20 @@ describe('MultipleAlertModal', () => {
     expect(onAcknowledgeClickMock).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the next alert when the "Got it" button is clicked', () => {
-    const { getByTestId, getByText } = renderWithProvider(
+  it('does not change the alert when the "Got it" button is clicked', () => {
+    onAcknowledgeClickMock.mockReset();
+    const { getByTestId, getByText, queryByText } = renderWithProvider(
       <MultipleAlertModal {...defaultProps} alertKey={DATA_ALERT_KEY_MOCK} />,
       mockStoreAcknowledgeAlerts,
     );
 
+    expect(getByText(alertsMock[1].message)).toBeInTheDocument();
+
     fireEvent.click(getByTestId('alert-modal-button'));
 
+    expect(onAcknowledgeClickMock).toHaveBeenCalledTimes(1);
     expect(getByText(alertsMock[1].message)).toBeInTheDocument();
+    expect(queryByText(alertsMock[2].message)).not.toBeInTheDocument();
   });
 
   it('closes modal when the "Got it" button is clicked', () => {
@@ -184,20 +189,6 @@ describe('MultipleAlertModal', () => {
     fireEvent.click(getByTestId('alert-modal-button'));
 
     expect(onAcknowledgeClickMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('resets to the first alert if there are unconfirmed alerts and the final alert is acknowledged', () => {
-    const { getByTestId, getByText } = renderWithProvider(
-      <MultipleAlertModal
-        {...defaultProps}
-        alertKey={CONTRACT_ALERT_KEY_MOCK}
-      />,
-      mockStore,
-    );
-
-    fireEvent.click(getByTestId('alert-modal-button'));
-
-    expect(getByText(alertsMock[0].message)).toBeInTheDocument();
   });
 
   describe('FieldAlerts not present', () => {
@@ -280,7 +271,7 @@ describe('MultipleAlertModal', () => {
 
       fireEvent.click(getByTestId('alert-modal-back-button'));
 
-      expect(getByText(alertsMock[1].message)).toBeInTheDocument();
+      expect(getByText(alertsMock[0].message)).toBeInTheDocument();
     });
   });
 

--- a/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.test.tsx
+++ b/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.test.tsx
@@ -23,6 +23,7 @@ describe('MultipleAlertModal', () => {
   const FROM_ALERT_KEY_MOCK = 'from';
   const CONTRACT_ALERT_KEY_MOCK = 'contract';
   const DATA_ALERT_KEY_MOCK = 'data';
+  const HIDDEN_ALERT_KEY_MOCK = 'hidden';
   const onAcknowledgeClickMock = jest.fn();
   const onCloseMock = jest.fn();
 
@@ -280,6 +281,100 @@ describe('MultipleAlertModal', () => {
       fireEvent.click(getByTestId('alert-modal-back-button'));
 
       expect(getByText(alertsMock[1].message)).toBeInTheDocument();
+    });
+  });
+
+  describe('Alerts hidden from navigation', () => {
+    const alertsWithHiddenNavigationMock = [
+      {
+        key: FROM_ALERT_KEY_MOCK,
+        field: FROM_ALERT_KEY_MOCK,
+        severity: Severity.Warning,
+        message: 'Alert 1',
+        reason: 'Reason 1',
+        alertDetails: ['Detail 1', 'Detail 2'],
+      },
+      {
+        key: HIDDEN_ALERT_KEY_MOCK,
+        field: HIDDEN_ALERT_KEY_MOCK,
+        severity: Severity.Danger,
+        message: 'Hidden Alert',
+        hideFromAlertNavigation: true,
+      },
+      {
+        key: CONTRACT_ALERT_KEY_MOCK,
+        field: CONTRACT_ALERT_KEY_MOCK,
+        severity: Severity.Info,
+        message: 'Alert 3',
+      },
+    ];
+
+    const mockStoreWithHiddenNavigation = configureMockStore([])({
+      ...STATE_MOCK,
+      confirmAlerts: {
+        alerts: { [OWNER_ID_MOCK]: alertsWithHiddenNavigationMock },
+        confirmed: {
+          [OWNER_ID_MOCK]: {
+            [FROM_ALERT_KEY_MOCK]: false,
+            [HIDDEN_ALERT_KEY_MOCK]: false,
+            [CONTRACT_ALERT_KEY_MOCK]: false,
+          },
+        },
+      },
+    });
+
+    const mockStoreWithHiddenNavigationConfirmed = configureMockStore([])({
+      ...STATE_MOCK,
+      confirmAlerts: {
+        alerts: { [OWNER_ID_MOCK]: alertsWithHiddenNavigationMock },
+        confirmed: {
+          [OWNER_ID_MOCK]: {
+            [FROM_ALERT_KEY_MOCK]: true,
+            [HIDDEN_ALERT_KEY_MOCK]: true,
+            [CONTRACT_ALERT_KEY_MOCK]: true,
+          },
+        },
+      },
+    });
+
+    it('does not render navigation controls when the selected alert hides navigation', () => {
+      const { queryByTestId } = renderWithProvider(
+        <MultipleAlertModal
+          {...defaultProps}
+          alertKey={HIDDEN_ALERT_KEY_MOCK}
+        />,
+        mockStoreWithHiddenNavigation,
+      );
+
+      expect(queryByTestId('alert-modal-next-button')).toBeNull();
+      expect(queryByTestId('alert-modal-back-button')).toBeNull();
+    });
+
+    it('skips alerts hidden from navigation when cycling forward', () => {
+      const { getByTestId, getByText, queryByText } = renderWithProvider(
+        <MultipleAlertModal {...defaultProps} />,
+        mockStoreWithHiddenNavigation,
+      );
+
+      fireEvent.click(getByTestId('alert-modal-next-button'));
+
+      expect(queryByText('Hidden Alert')).not.toBeInTheDocument();
+      expect(getByText('Alert 3')).toBeInTheDocument();
+    });
+
+    it('acknowledges an alert that hides navigation without cycling', () => {
+      onAcknowledgeClickMock.mockReset();
+      const { getByTestId } = renderWithProvider(
+        <MultipleAlertModal
+          {...defaultProps}
+          alertKey={HIDDEN_ALERT_KEY_MOCK}
+        />,
+        mockStoreWithHiddenNavigationConfirmed,
+      );
+
+      fireEvent.click(getByTestId('alert-modal-button'));
+
+      expect(onAcknowledgeClickMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.tsx
+++ b/ui/components/app/alert-system/multiple-alert-modal/multiple-alert-modal.tsx
@@ -1,11 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Box,
-  ButtonIcon,
-  ButtonIconSize,
-  IconName,
-  Text,
-} from '../../../component-library';
+import { Alert } from '../../../../ducks/confirm-alerts/confirm-alerts';
 import {
   AlignItems,
   BackgroundColor,
@@ -15,8 +9,15 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import useAlerts from '../../../../hooks/useAlerts';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+} from '../../../component-library';
 import { AlertModal } from '../alert-modal';
 
 export type MultipleAlertModalProps = {
@@ -251,8 +252,8 @@ export function MultipleAlertModal({
     }
 
     const fallbackKey =
-      (alertKeyExists && alertKey) ??
-      (pendingAlertExists && pendingAlertKey) ??
+      (alertKeyExists ? alertKey : undefined) ??
+      (pendingAlertExists ? pendingAlertKey : undefined) ??
       navigableAlertsToDisplay[0]?.key ??
       alertsToDisplay[0]?.key;
 

--- a/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
+++ b/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
@@ -54,12 +54,15 @@ export const ConfirmInfoAlertRow = ({
   const { getFieldAlerts } = useAlerts(ownerId);
   const fieldAlerts = getFieldAlerts(alertKey);
   const hasFieldAlert = fieldAlerts.length > 0;
-  const selectedAlertSeverity = fieldAlerts[0]?.severity;
-  const selectedAlertKey = fieldAlerts[0]?.key;
-  const selectedAlertShowArrow = fieldAlerts[0]?.showArrow;
-  const selectedAlertInlineAlertText = fieldAlerts[0]?.inlineAlertText;
+  const selectedAlert = fieldAlerts[0];
+  const selectedAlertSeverity = selectedAlert?.severity;
+  const selectedAlertKey = selectedAlert?.key;
+  const selectedAlertShowArrow = selectedAlert?.showArrow;
+  const selectedAlertInlineAlertText = selectedAlert?.inlineAlertText;
   const selectedAlertIsOpenModalOnClick =
-    fieldAlerts[0]?.isOpenModalOnClick ?? true;
+    selectedAlert?.isOpenModalOnClick ?? true;
+  const selectedAlertHideFromAlertNavigation =
+    selectedAlert?.hideFromAlertNavigation ?? false;
 
   const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false);
 
@@ -139,7 +142,7 @@ export const ConfirmInfoAlertRow = ({
           onFinalAcknowledgeClick={handleModalClose}
           onClose={handleModalClose}
           showCloseIcon={false}
-          skipAlertNavigation={true}
+          skipAlertNavigation={selectedAlertHideFromAlertNavigation}
         />
       )}
       {confirmInfoRow}

--- a/ui/ducks/confirm-alerts/confirm-alerts.ts
+++ b/ui/ducks/confirm-alerts/confirm-alerts.ts
@@ -69,6 +69,11 @@ export type Alert = {
   severity: AlertSeverity;
 
   /**
+   * Whether this alert should be excluded from navigation controls.
+   */
+  hideFromAlertNavigation?: boolean;
+
+  /**
    * Whether to show the arrow icon on the inline alert.
    */
   showArrow?: boolean;

--- a/ui/hooks/useAlerts.test.ts
+++ b/ui/hooks/useAlerts.test.ts
@@ -64,10 +64,24 @@ describe('useAlerts', () => {
     return renderHookUseAlert(ownerId, state).result;
   };
 
+  const sortBySeverityDesc = (alerts: Alert[]) => {
+    const severityOrder = {
+      [Severity.Danger]: 3,
+      [Severity.Warning]: 2,
+      [Severity.Info]: 1,
+      [Severity.Success]: 0,
+    };
+
+    return [...alerts].sort(
+      (a, b) => severityOrder[b.severity] - severityOrder[a.severity],
+    );
+  };
+
   describe('alerts', () => {
     it('returns all alerts', () => {
       const result = renderAndReturnResult();
-      expect(result.current.alerts).toEqual(alertsMock);
+      const expectedAlerts = sortBySeverityDesc(alertsMock);
+      expect(result.current.alerts).toEqual(expectedAlerts);
       expect(result.current.hasAlerts).toEqual(true);
       expect(result.current.hasDangerAlerts).toEqual(true);
       expect(result.current.hasUnconfirmedDangerAlerts).toEqual(false);
@@ -200,7 +214,10 @@ describe('useAlerts', () => {
         },
       });
 
-      expect(result.current.generalAlerts).toEqual(expectedGeneralAlerts);
+      const expectedSortedGeneralAlerts = sortBySeverityDesc(
+        expectedGeneralAlerts,
+      );
+      expect(result.current.generalAlerts).toEqual(expectedSortedGeneralAlerts);
     });
   });
 
@@ -229,10 +246,12 @@ describe('useAlerts', () => {
   describe('fieldAlerts', () => {
     it('returns all alerts with field property', () => {
       const result = renderAndReturnResult();
-      expect(result.current.fieldAlerts).toEqual([
-        alertsMock[0],
-        alertsMock[2],
-      ]);
+      const expectedFieldAlerts = sortBySeverityDesc(
+        [alertsMock[0], alertsMock[2]].filter(
+          (alert) => typeof alert !== 'undefined',
+        ) as Alert[],
+      );
+      expect(result.current.fieldAlerts).toEqual(expectedFieldAlerts);
     });
 
     it('returns empty array if no alerts with field property', () => {

--- a/ui/hooks/useAlerts.test.ts
+++ b/ui/hooks/useAlerts.test.ts
@@ -1,9 +1,10 @@
-import { Severity } from '../helpers/constants/design-system';
 import { renderHookWithProvider } from '../../test/lib/render-helpers';
 import {
-  ConfirmAlertsState,
+  Alert,
   AlertSeverity,
+  ConfirmAlertsState,
 } from '../ducks/confirm-alerts/confirm-alerts';
+import { Severity } from '../helpers/constants/design-system';
 import useAlerts from './useAlerts';
 
 describe('useAlerts', () => {
@@ -237,6 +238,71 @@ describe('useAlerts', () => {
     it('returns empty array if no alerts with field property', () => {
       const result = renderAndReturnResult('mockedOwnerId');
       expect(result.current.fieldAlerts).toEqual([]);
+    });
+  });
+
+  describe('navigable alerts', () => {
+    it('excludes alerts that hide from alert navigation', () => {
+      const hiddenFieldAlertKey = 'hidden-field';
+      const generalAlertKey = 'general';
+      const hiddenGeneralAlertKey = 'hidden-general';
+
+      const fieldVisibleAlert = {
+        key: fromAlertKeyMock,
+        field: fromAlertKeyMock,
+        severity: Severity.Danger as AlertSeverity,
+        message: 'Visible Field Alert',
+      };
+      const fieldHiddenAlert = {
+        key: hiddenFieldAlertKey,
+        field: fromAlertKeyMock,
+        severity: Severity.Warning as AlertSeverity,
+        message: 'Hidden Field Alert',
+        hideFromAlertNavigation: true,
+      };
+      const generalVisibleAlert = {
+        key: generalAlertKey,
+        severity: Severity.Info as AlertSeverity,
+        message: 'Visible General Alert',
+      };
+      const generalHiddenAlert = {
+        key: hiddenGeneralAlertKey,
+        severity: Severity.Success as AlertSeverity,
+        message: 'Hidden General Alert',
+        hideFromAlertNavigation: true,
+      };
+
+      const state = {
+        confirmAlerts: {
+          alerts: {
+            [ownerIdMock]: [
+              fieldVisibleAlert,
+              fieldHiddenAlert,
+              generalVisibleAlert,
+              generalHiddenAlert,
+            ],
+          },
+          confirmed: {},
+        },
+      };
+
+      const result = renderAndReturnResult(undefined, state);
+
+      expect(
+        result.current.navigableAlerts.map(({ key }: Alert) => key),
+      ).toEqual([fieldVisibleAlert.key, generalVisibleAlert.key]);
+      expect(
+        result.current.navigableFieldAlerts.map(({ key }: Alert) => key),
+      ).toEqual([fieldVisibleAlert.key]);
+      expect(
+        result.current.navigableGeneralAlerts.map(({ key }: Alert) => key),
+      ).toEqual([generalVisibleAlert.key]);
+      expect(
+        result.current
+          .getNavigableFieldAlerts(fromAlertKeyMock)
+          .map(({ key }: Alert) => key),
+      ).toEqual([fieldVisibleAlert.key]);
+      expect(result.current.getNavigableFieldAlerts('unknown')).toEqual([]);
     });
   });
 

--- a/ui/hooks/useAlerts.ts
+++ b/ui/hooks/useAlerts.ts
@@ -32,6 +32,18 @@ const useAlerts = (ownerId: string) => {
     useSelector((state) => selectFieldAlerts(state as AlertsState, ownerId)),
   );
 
+  const navigableAlerts = alerts.filter(
+    (alert) => !alert.hideFromAlertNavigation,
+  );
+
+  const navigableGeneralAlerts = generalAlerts.filter(
+    (alert) => !alert.hideFromAlertNavigation,
+  );
+
+  const navigableFieldAlerts = fieldAlerts.filter(
+    (alert) => !alert.hideFromAlertNavigation,
+  );
+
   const getFieldAlerts = useCallback(
     (field: string | undefined) => {
       if (!field) {
@@ -39,6 +51,19 @@ const useAlerts = (ownerId: string) => {
       }
 
       return alerts.filter((alert) => alert.field === field);
+    },
+    [alerts],
+  );
+
+  const getNavigableFieldAlerts = useCallback(
+    (field: string | undefined) => {
+      if (!field) {
+        return [];
+      }
+
+      return alerts.filter(
+        (alert) => alert.field === field && !alert.hideFromAlertNavigation,
+      );
     },
     [alerts],
   );
@@ -80,11 +105,15 @@ const useAlerts = (ownerId: string) => {
     fieldAlerts,
     generalAlerts,
     getFieldAlerts,
+    getNavigableFieldAlerts,
     hasAlerts,
     dangerAlerts,
     hasDangerAlerts: dangerAlerts?.length > 0,
     hasUnconfirmedDangerAlerts,
     isAlertConfirmed,
+    navigableAlerts,
+    navigableFieldAlerts,
+    navigableGeneralAlerts,
     setAlertConfirmed,
     unconfirmedDangerAlerts,
     unconfirmedFieldDangerAlerts,

--- a/ui/hooks/useAlerts.ts
+++ b/ui/hooks/useAlerts.ts
@@ -129,7 +129,7 @@ function sortAlertsBySeverity(alerts: Alert[]): Alert[] {
     [Severity.Success]: 0,
   };
 
-  return alerts.sort(
+  return [...alerts].sort(
     (a, b) => severityOrder[b.severity] - severityOrder[a.severity],
   );
 }

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -179,6 +179,7 @@ export function useShieldCoverageAlert(): Alert[] {
         inlineAlertText,
         showArrow: false,
         isOpenModalOnClick: true,
+        hideFromAlertNavigation: true,
       },
     ];
   }, [status, modalBodyStr, showAlert, t]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Introduces a new optional alert property to hide navigation for this alert.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37425?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/249abb46-f295-4035-b838-5e1843658410



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `hideFromAlertNavigation` to alerts and updates hooks/modal to skip these in navigation, with tests and usage updates.
> 
> - **Alert Model**:
>   - Add optional `hideFromAlertNavigation` to `Alert`.
> - **Hooks (`useAlerts`)**:
>   - Return `navigableAlerts`, `navigableFieldAlerts`, `navigableGeneralAlerts`, and `getNavigableFieldAlerts`, excluding alerts with `hideFromAlertNavigation`.
>   - Ensure severity sorting is non-mutating.
> - **UI – MultipleAlertModal**:
>   - Drive selection by `alertKey` with robust syncing/fallback logic.
>   - Navigate only through `navigable*` alerts; hide nav controls if current alert sets `hideFromAlertNavigation` or when skipping is requested.
>   - Acknowledge just triggers `onFinalAcknowledgeClick` (no cycling).
> - **UI – ConfirmInfoAlertRow**:
>   - Derive `selectedAlert` once; pass `skipAlertNavigation` based on `hideFromAlertNavigation`.
> - **Alerts – Shield Coverage**:
>   - Mark shield coverage alert with `hideFromAlertNavigation: true`.
> - **Tests**:
>   - Update/extend tests for severity ordering, navigable alert filtering, modal navigation hiding/skipping, and selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c72148d84fbb4501da58ca1ac2f9101cf94d76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->