### PR TITLE
chore: INFRA-3041-Added github-tools to .gitignore

### DIFF
--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -36,11 +36,11 @@ jobs:
   run-stable-sync:
     name: Run Stable branch sync
     needs: get-next-version
-    uses: metamask/github-tools/.github/workflows/stable-sync.yml@486f5d113c5524eaab9a058abe76097f83a4c33e
+    uses: metamask/github-tools/.github/workflows/stable-sync.yml@79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b
     secrets:
       github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
     with:
       semver-version: ${{ needs.get-next-version.outputs.next-version }}
       repo-type: 'extension' # Accepts 'mobile' or 'extension'
-      github-tools-version: '486f5d113c5524eaab9a058abe76097f83a4c33e'
+      github-tools-version: '79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b'
       stable-branch-name: 'stable' # Defaults to `stable`

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ development/generate-attributions/.yarn/*
 
 # MetaMask
 .metamask/*
+github-tools/
 
 # Playwright
 public/playwright


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-3041
Github-tools PR: https://github.com/MetaMask/github-tools/pull/154

Summary of Changes

Prevented github-tools from appearing in PRs
File: github-tools/.github/workflows/stable-sync.yml
What: Added explicit cleanup commands to unstage and remove github-tools directory before pushing
Impact: The sync PR will no longer include a github-tools/ submodule or directory
Disabled package.json version bump for Extension
File: github-tools/.github/scripts/stable-sync.js
What: Removed the yarn version logic that bumped package.json version
Before: Extension ran yarn version to update the version
After: Extension now preserves package.json from stable branch (same as mobile)
Impact: No version bump will occur in the sync PR for either mobile or extension
Verified PR title format
File: github-tools/.github/workflows/stable-sync.yml (line 147)
What: Confirmed it already uses release: prefix (no change needed)
Format: "release: sync stable to main for version X.Y.Z"
Testing in Extension: https://github.com/consensys-test/metamask-extension-test-workflow2/pull/209, https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18951817173
Testing in Mobile: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/30, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18951842114

Testing Post CR comments: https://github.com/consensys-test/metamask-extension-test-workflow2/pull/212

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: None

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps stable-branch sync workflow to a new github-tools ref and ignores the `github-tools/` directory.
> 
> - **CI/Workflows**:
>   - Update `.github/workflows/stable-branch-sync.yml` to use `metamask/github-tools/.github/workflows/stable-sync.yml@79ce6e3` and set `github-tools-version` to `79ce6e3`.
> - **Repo hygiene**:
>   - Add `github-tools/` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8418e545b13f3e389d6b71f8f5cb71ab096c10a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->