### PR TITLE
fix: use chainId-based native currency in transaction display hooks

### DIFF
--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -102,6 +102,7 @@ export function useTokenFiatAmount(
       currentCurrency,
       tokenAmount,
       tokenSymbol,
+      formatted,
       hideCurrencySymbol,
     ],
   );

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -241,12 +241,15 @@ export function useTransactionDisplayData(transactionGroup) {
     ).toString(10);
   }
 
+  const txChainId = transactionGroup?.initialTransaction?.chainId;
+
   const tokenFiatAmount = useTokenFiatAmount(
     token?.address,
     tokenDisplayValue,
     token?.symbol,
     undefined,
     true,
+    txChainId,
   );
 
   // used to append to the primary display value. initialized to either token.symbol or undefined
@@ -395,9 +398,13 @@ export function useTransactionDisplayData(transactionGroup) {
   const primaryCurrencyPreferences = useUserPreferencedCurrency(
     PRIMARY,
     {},
-    transactionGroup?.initialTransaction?.chainId,
+    txChainId,
   );
-  const secondaryCurrencyPreferences = useUserPreferencedCurrency(SECONDARY);
+  const secondaryCurrencyPreferences = useUserPreferencedCurrency(
+    SECONDARY,
+    {},
+    txChainId,
+  );
 
   const [primaryCurrency] = useCurrencyDisplay(
     primaryValue,
@@ -407,7 +414,7 @@ export function useTransactionDisplayData(transactionGroup) {
       suffix: primarySuffix,
       ...primaryCurrencyPreferences,
     },
-    transactionGroup?.initialTransaction?.chainId,
+    txChainId,
   );
 
   const [secondaryCurrency] = useCurrencyDisplay(
@@ -420,7 +427,7 @@ export function useTransactionDisplayData(transactionGroup) {
       hideLabel: isTokenCategory || Boolean(swapTokenValue),
       ...secondaryCurrencyPreferences,
     },
-    transactionGroup?.initialTransaction?.chainId,
+    txChainId,
   );
 
   if (!recipientAddress && transferInformation) {


### PR DESCRIPTION
## **Description**

This PR fixes currency display issues in multi-chain environments by implementing proper chainId-based native currency handling in transaction display hooks.

**Reason for the change:**
The current implementation was not correctly handling native currency display and conversion rates when dealing with transactions across different chains, leading to incorrect currency values being shown to users.

**Improvement/solution:**
- Enhanced `useCurrencyDisplay` to use chainId-specific native currency and conversion rates
- Updated `useTransactionDisplayData` to consistently pass chainId throughout the currency display flow
- Improved `useTokenFiatAmount` dependency tracking for better re-rendering behavior

## **Changelog**

CHANGELOG entry: Fixed currency display and conversion rates for multi-chain transactions

## **Related issues**

Fixes: [Add issue number if applicable]

## **Manual testing steps**

1. Switch to a non-Ethereum network (e.g., Polygon, BSC)
2. Initiate a transaction on that network
3. Verify that the transaction display shows correct native currency symbols and fiat conversion rates
4. Check transaction history to ensure past transactions display correct currency information

### **Before**

<img width="814" height="1178" alt="image" src="https://github.com/user-attachments/assets/5b8ca878-b3f8-4e94-9f6d-960ce7800ad7" />

### **After**

<img width="816" height="1202" alt="image" src="https://github.com/user-attachments/assets/0cd5a7e2-b7b2-4978-90f8-6440aacecd62" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use chainId-scoped native currency and conversion rates across transaction display hooks, and fix a memo dependency in token fiat amount.
> 
> - **Hooks**:
>   - **`useCurrencyDisplay`**:
>     - Use chainId-derived native currency (`effectiveNativeCurrency`) and chainId-scoped `conversionRate` when available.
>     - Update `isNativeCurrency` logic and pass `effectiveNativeCurrency` to formatters/conversion.
>     - Add related dependencies to `useMemo`.
>   - **`useTransactionDisplayData`**:
>     - Derive `txChainId` and pass it to `useTokenFiatAmount`, `useUserPreferencedCurrency` (PRIMARY/SECONDARY), and `useCurrencyDisplay` for consistent chain-scoped formatting.
>   - **`useTokenFiatAmount`**:
>     - Include `formatted` in `useMemo` dependency array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d842a5ba16ff38ae868728bd2455199d3d167e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->