### PR TITLE
feat: new assets sort order for equal balances

### DIFF
--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -35,6 +35,7 @@ import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { SafeChain } from '../../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import { isGlobalNetworkSelectorRemoved } from '../../../../selectors/selectors';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
+import { sortAssetsWithPriority } from '../util/sortAssetsWithPriority';
 
 type TokenListProps = {
   onTokenClick: (chainId: string, address: string) => void;
@@ -102,34 +103,32 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
         }
 
         // Mapping necessary to comply with the type. Fields will be overriden with useTokenDisplayInfo
-        return assets
-          .filter((asset) => {
-            if (shouldHideZeroBalanceTokens && asset.balance === '0') {
-              return false;
-            }
-            return true;
-          })
-          .map((asset) => {
-            const token: TokenWithFiatAmount = {
-              ...asset,
-              tokenFiatAmount: asset.fiat?.balance,
-              secondary: null,
-              title: asset.name,
-              address:
-                'address' in asset ? asset.address : (asset.assetId as Hex),
-              chainId: asset.chainId as Hex,
-            };
-
-            return token;
-          });
+        return assets.filter((asset) => {
+          if (shouldHideZeroBalanceTokens && asset.balance === '0') {
+            return false;
+          }
+          return true;
+        });
       },
     );
-    const accountAssets = sortAssets(
-      [...accountAssetsPreSort],
+
+    const accountAssets = sortAssetsWithPriority(
+      accountAssetsPreSort,
       tokenSortConfig,
     );
 
-    return accountAssets;
+    return accountAssets.map((asset) => {
+      const token: TokenWithFiatAmount = {
+        ...asset,
+        tokenFiatAmount: asset.fiat?.balance,
+        secondary: null,
+        title: asset.name,
+        address: 'address' in asset ? asset.address : (asset.assetId as Hex),
+        chainId: asset.chainId as Hex,
+      };
+
+      return token;
+    });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
@@ -1,0 +1,190 @@
+import type { Asset } from '@metamask/assets-controllers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import {
+  compareFiatBalanceWithPriority,
+  sortAssetsWithPriority,
+} from './sortAssetsWithPriority';
+
+function createMockAsset({
+  name,
+  fiatBalance,
+  isNative = true,
+  chainId = CHAIN_IDS.MAINNET,
+}: {
+  name: string;
+  fiatBalance?: number;
+  isNative?: boolean;
+  chainId?: Hex | CaipChainId;
+}): Asset {
+  return {
+    name,
+    fiat: fiatBalance !== undefined ? { balance: fiatBalance } : undefined,
+    isNative,
+    chainId,
+  } as unknown as Asset;
+}
+
+describe('sortAssetsWithPriority', () => {
+  function extractAssetNames(assets: Asset[]): string[] {
+    return assets.map((asset) => asset.name);
+  }
+
+  it('sorts by name when key is "name"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'name',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset B',
+      'Asset Z',
+    ]);
+  });
+
+  it('sorts by fiat balance when key is "tokenFiatAmount"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'tokenFiatAmount',
+      order: 'dsc',
+      sortCallback: 'stringNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset Z',
+      'Asset B',
+    ]);
+  });
+});
+
+describe('compareFiatBalanceWithPriority', () => {
+  describe('fiat balance comparison', () => {
+    it('compares second value above first if the second asset has a fiat balance and the first asset does not', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        fiatBalance: undefined,
+      });
+      const assetB = createMockAsset({ name: 'Asset B', fiatBalance: 400 });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('compares second value above the first value if both assets have fiat balances and the second value is greater', () => {
+      const assetA = createMockAsset({ name: 'Asset A', fiatBalance: 300 });
+      const assetB = createMockAsset({ name: 'Asset B', fiatBalance: 400 });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+
+  describe('non-native asset comparison', () => {
+    it('returns -1 if the first asset is native and the second asset is not', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: true });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: false });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+
+    it('returns 1 if the second asset is native and the first asset is not', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: false });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: true });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('compares name values if neither asset is native', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: false });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: false });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+  });
+
+  describe('native asset comparison', () => {
+    it('compares name values if neither asset is in the defaultNativeAssetOrder', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: '0xeeeeeeeeeeeee1',
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: '0xeeeeeeeeeeeee2',
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+
+    it('compares second value above first if the second asset is in the defaultNativeAssetOrder and the first asset is not', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: '0xeeeeeeeeeeeee1',
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: CHAIN_IDS.BASE,
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('compares second value above first if both assets are in the defaultNativeAssetOrder and the second value has higher priority', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: CHAIN_IDS.ARBITRUM,
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('compares second value above first if both assets are in the defaultNativeAssetOrder and the second value has higher priority (both values have balances of zero)', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: CHAIN_IDS.ARBITRUM,
+        fiatBalance: 0,
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+        fiatBalance: 0,
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+});

--- a/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
@@ -19,7 +19,7 @@ function createMockAsset({
 }): Asset {
   return {
     name,
-    fiat: fiatBalance !== undefined ? { balance: fiatBalance } : undefined,
+    fiat: fiatBalance === undefined ? undefined : { balance: fiatBalance },
     isNative,
     chainId,
   } as unknown as Asset;

--- a/ui/components/app/assets/util/sortAssetsWithPriority.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.ts
@@ -7,10 +7,10 @@ import { sortAssets, type SortCriteria } from './sort';
 // These are the only two options for sorting assets
 // {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}
 // {"key": "tokenFiatAmount", "order": "dsc", "sortCallback": "stringNumeric"}
-export function sortAssetsWithPriority<T extends Asset>(
-  array: T[],
+export function sortAssetsWithPriority(
+  array: Asset[],
   criteria: SortCriteria,
-): T[] {
+): Asset[] {
   if (criteria.key === 'name') {
     return sortAssets(array, {
       key: 'name',

--- a/ui/components/app/assets/util/sortAssetsWithPriority.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.ts
@@ -1,13 +1,7 @@
 import type { Asset } from '@metamask/assets-controllers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import type { CaipChainId, Hex } from '@metamask/utils';
-import {
-  BtcScope,
-  SolScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { sortAssets, type SortCriteria } from './sort';
 
 // These are the only two options for sorting assets
@@ -25,49 +19,7 @@ export function sortAssetsWithPriority<T extends Asset>(
     });
   }
 
-  const xxx = [...array].sort((a, b) => {
-    const comparison = compareFiatBalanceWithPriority(a, b);
-
-    if (a.name === 'Solana' || b.name === 'Solana') {
-      // eslint-disable-next-line no-console
-      console.log('XXXXX', {
-        a: {
-          name: a.name,
-          chainId: a.chainId,
-          fiatBalance: a.fiat?.balance,
-          isNative: a.isNative,
-        },
-        b: {
-          name: b.name,
-          chainId: b.chainId,
-          fiatBalance: b.fiat?.balance,
-          isNative: b.isNative,
-        },
-        comparison,
-        balanceCheck: a.fiat?.balance && b.fiat?.balance,
-      });
-    }
-
-    return comparison;
-  });
-
-  // eslint-disable-next-line no-console
-  // console.log('ARRAY', {
-  //   unsorted: array.map((asset) => ({
-  //     name: asset.name,
-  //     fiatBalance: asset.fiat?.balance,
-  //     isNative: asset.isNative,
-  //     chainId: asset.chainId,
-  //   })),
-  //   sorted: xxx.map((asset) => ({
-  //     name: asset.name,
-  //     fiatBalance: asset.fiat?.balance,
-  //     isNative: asset.isNative,
-  //     chainId: asset.chainId,
-  //   })),
-  // });
-
-  return xxx;
+  return [...array].sort(compareFiatBalanceWithPriority);
 }
 
 // Higher priority assets are last in the array to facilitate sorting
@@ -77,9 +29,7 @@ const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
   CHAIN_IDS.BSC,
   CHAIN_IDS.ARBITRUM,
   CHAIN_IDS.BASE,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope.Mainnet,
-  ///: END:ONLY_INCLUDE_IF
   BtcScope.Mainnet,
   SolScope.Mainnet,
   CHAIN_IDS.LINEA_MAINNET,

--- a/ui/components/app/assets/util/sortAssetsWithPriority.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.ts
@@ -1,0 +1,132 @@
+import type { Asset } from '@metamask/assets-controllers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import {
+  BtcScope,
+  SolScope,
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  TrxScope,
+  ///: END:ONLY_INCLUDE_IF
+} from '@metamask/keyring-api';
+import { sortAssets, type SortCriteria } from './sort';
+
+// These are the only two options for sorting assets
+// {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}
+// {"key": "tokenFiatAmount", "order": "dsc", "sortCallback": "stringNumeric"}
+export function sortAssetsWithPriority<T extends Asset>(
+  array: T[],
+  criteria: SortCriteria,
+): T[] {
+  if (criteria.key === 'name') {
+    return sortAssets(array, {
+      key: 'name',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+  }
+
+  const xxx = [...array].sort((a, b) => {
+    const comparison = compareFiatBalanceWithPriority(a, b);
+
+    if (a.name === 'Solana' || b.name === 'Solana') {
+      // eslint-disable-next-line no-console
+      console.log('XXXXX', {
+        a: {
+          name: a.name,
+          chainId: a.chainId,
+          fiatBalance: a.fiat?.balance,
+          isNative: a.isNative,
+        },
+        b: {
+          name: b.name,
+          chainId: b.chainId,
+          fiatBalance: b.fiat?.balance,
+          isNative: b.isNative,
+        },
+        comparison,
+        balanceCheck: a.fiat?.balance && b.fiat?.balance,
+      });
+    }
+
+    return comparison;
+  });
+
+  // eslint-disable-next-line no-console
+  // console.log('ARRAY', {
+  //   unsorted: array.map((asset) => ({
+  //     name: asset.name,
+  //     fiatBalance: asset.fiat?.balance,
+  //     isNative: asset.isNative,
+  //     chainId: asset.chainId,
+  //   })),
+  //   sorted: xxx.map((asset) => ({
+  //     name: asset.name,
+  //     fiatBalance: asset.fiat?.balance,
+  //     isNative: asset.isNative,
+  //     chainId: asset.chainId,
+  //   })),
+  // });
+
+  return xxx;
+}
+
+// Higher priority assets are last in the array to facilitate sorting
+const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
+  CHAIN_IDS.POLYGON,
+  CHAIN_IDS.OPTIMISM,
+  CHAIN_IDS.BSC,
+  CHAIN_IDS.ARBITRUM,
+  CHAIN_IDS.BASE,
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  TrxScope.Mainnet,
+  ///: END:ONLY_INCLUDE_IF
+  BtcScope.Mainnet,
+  SolScope.Mainnet,
+  CHAIN_IDS.LINEA_MAINNET,
+  CHAIN_IDS.MAINNET,
+];
+
+/**
+ * Compares assets by fiat balance with priority sorting.
+ *
+ * @param a - The first asset to compare.
+ * @param b - The second asset to compare.
+ * @returns A negative number if the first asset should appear before the second, a positive number if the first asset should appear after the second, or 0 if they are equal.
+ */
+export function compareFiatBalanceWithPriority(a: Asset, b: Asset) {
+  // If one of the fiat balances is greater than the other, return the comparison
+  const fiatBalanceComparison = (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0);
+
+  // Only return comparison if it is not zero
+  if (fiatBalanceComparison) {
+    return fiatBalanceComparison;
+  }
+
+  // With equal fiat balances
+  // Always return native assets before token assets
+  // Apply the priority defined in defaultNativeAssetOrder if both are native assets
+  // If both assets are tokens or none is in the defaultNativeAssetOrder, compare by name
+  if (a.isNative && !b.isNative) {
+    return -1;
+  }
+
+  if (b.isNative && !a.isNative) {
+    return 1;
+  }
+
+  if (!a.isNative && !b.isNative) {
+    return a.name.localeCompare(b.name);
+  }
+
+  const nativeAssetOrderA = defaultNativeAssetOrder.indexOf(a.chainId);
+  const nativeAssetOrderB = defaultNativeAssetOrder.indexOf(b.chainId);
+
+  const nativeAssetOrderComparison = nativeAssetOrderB - nativeAssetOrderA;
+
+  if (nativeAssetOrderComparison) {
+    return nativeAssetOrderComparison;
+  }
+
+  // If neither asset is in the defaultNativeAssetOrder, compare by name
+  return a.name.localeCompare(b.name);
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use new asset sorting when balances are the same (or $0):
ETH Mainnet
ETH Linea
SOL Solana
BTC Bitcoin
TRX Tron
ETH Base
ETH Arbitrum
BNB Binance
ETH Optimism
POL Polygon

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37457?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed order of assets when their fiat balances are the same

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1259

## **Manual testing steps**

1. Open main wallet with a new wallet
2. Verify the order is correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1167" height="907" alt="image" src="https://github.com/user-attachments/assets/98a2f08c-e146-44f7-914a-6f15056827bc" />


### **After**

<!-- [screenshots/recordings] -->
<img width="1184" height="862" alt="image" src="https://github.com/user-attachments/assets/cef7c2d5-3ce0-48cc-ba78-d160731b1f91" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `sortAssetsWithPriority` to sort by fiat amount with native-chain priority on ties, updates `token-list` to use it, and adds unit tests.
> 
> - **Assets sorting**:
>   - Add `util/sortAssetsWithPriority` with `compareFiatBalanceWithPriority` to sort by `tokenFiatAmount` and break ties by native-asset priority, then name.
>   - Define default native asset priority list (e.g., main EVM and non-EVM chains) for tie-breaking.
> - **UI integration**:
>   - Update `assets/token-list/token-list.tsx` to use `sortAssetsWithPriority` and map to `TokenWithFiatAmount` after sorting.
> - **Tests**:
>   - Add `util/sortAssetsWithPriority.test.ts` covering name sort, fiat sort with priority, and tie-break scenarios (native vs token, chain priority).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed539b8825048f16c2745ca5a4c894a6b0193b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->