### PR TITLE
fix: flaky test `Change assets changes to native currency when switching accounts during a NFT send`

### DIFF
--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -388,16 +388,10 @@ class SendTokenPage {
     tokenId?: string,
   ): Promise<void> {
     console.log(`Checking if token symbol "${tokenSymbol}" is displayed`);
-    const assetPickerSymbol = await this.driver.waitForSelector(
-      this.assetPickerSymbol,
-    );
-    this.driver.waitForNonEmptyElement(assetPickerSymbol);
-    const text = await assetPickerSymbol.getText();
-    assert.equal(
-      text,
-      tokenSymbol,
-      `Expected token symbol to be ${tokenSymbol}, got ${text}`,
-    );
+    await this.driver.waitForSelector({
+      css: this.assetPickerSymbol,
+      text: tokenSymbol,
+    });
 
     if (tokenId) {
       const id = `#${tokenId}`;

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -215,6 +215,7 @@ describe('Change assets', function () {
 
         // Choose the nft
         await homePage.goToNftTab();
+        await headerNavbar.checkAccountLabel('Account 1');
         await nftListPage.clickNFTFromList();
         await nftDetailsPage.checkPageIsLoaded();
         await nftDetailsPage.clickNFTSendButton();

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -215,7 +215,6 @@ describe('Change assets', function () {
 
         // Choose the nft
         await homePage.goToNftTab();
-        await headerNavbar.checkAccountLabel('Account 1');
         await nftListPage.clickNFTFromList();
         await nftDetailsPage.checkPageIsLoaded();
         await nftDetailsPage.clickNFTSendButton();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test is flaky as we are trying to assert an element has the correct text. This can lead to a race condition when we do the assert, and the element hasn't yet being updated:

<img width="1004" height="318" alt="image" src="https://github.com/user-attachments/assets/ff98d6ae-16c3-4630-a834-edaf184a2c7c" />

And you see in the screenshot the asset is correct:

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/ab1875dd-6f09-4eda-838b-616b9a6c4954" />

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/46bce31a-c474-47db-b567-45564584df1a" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37460?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes e2e token symbol verification by waiting for the selector with matching text in the send token asset picker.
> 
> - **Tests (e2e)**:
>   - **Send token page object (`test/e2e/page-objects/pages/send/send-token-page.ts`)**:
>     - Update `checkTokenSymbolInAssetPicker` to use `waitForSelector({ css: asset symbol, text })` instead of reading text and asserting directly, improving synchronization when verifying the token symbol.
>     - Retain optional token ID check via `waitForSelector` on `p` with `#<id>` text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12dee59d7093b8687f6594b6e100dbe2fed9a6f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->