### PR TITLE
fix: Simulation Details - Display "No changes" in a single line

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
           </div>
         </div>
         <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          class="mm-box mm-text mm-text--body-md mm-text--text-align-right mm-box--width-11/12 mm-box--color-text-default"
         >
           No changes
         </p>

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
           </div>
         </div>
         <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          class="mm-box mm-text mm-text--body-md mm-text--text-align-right mm-box--width-11/12 mm-box--color-text-default"
         >
           No changes
         </p>

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          class="mm-box mm-text mm-text--body-md mm-text--text-align-right mm-box--width-11/12 mm-box--color-text-default"
         >
           No changes
         </p>

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          class="mm-box mm-text mm-text--body-md mm-text--text-align-right mm-box--width-11/12 mm-box--color-text-default"
         >
           No changes
         </p>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
           </div>
         </div>
         <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          class="mm-box mm-text mm-text--body-md mm-text--text-align-right mm-box--width-11/12 mm-box--color-text-default"
         >
           No changes
         </p>

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -149,10 +149,13 @@ describe('SimulationDetails', () => {
     expect(screen.getByText(/Unavailable/u)).toBeInTheDocument();
   });
 
-  it('renders empty content when there are no balance changes', () => {
+  it('renders empty content when there are no balance changes with proper alignment', () => {
     renderSimulationDetails({});
 
-    expect(screen.getByText(/No changes/u)).toBeInTheDocument();
+    const noChangesText = screen.getByText(/No changes/u);
+    expect(noChangesText).toBeInTheDocument();
+    expect(noChangesText).toHaveClass('mm-box--width-11/12');
+    expect(noChangesText).toHaveClass('mm-text--text-align-right');
   });
 
   it('passes the correct properties to BalanceChangeList components', () => {

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -35,6 +35,7 @@ import {
   FlexDirection,
   IconColor,
   JustifyContent,
+  TextAlign,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
@@ -115,7 +116,12 @@ const ErrorContent: React.FC<{ error: SimulationError }> = ({ error }) => {
 const EmptyContent: React.FC = () => {
   const t = useI18nContext();
   return (
-    <Text color={TextColor.textDefault} variant={TextVariant.bodyMd}>
+    <Text
+      color={TextColor.textDefault}
+      variant={TextVariant.bodyMd}
+      width={BlockSize.ElevenTwelfths}
+      textAlign={TextAlign.Right}
+    >
       {t('simulationDetailsNoChanges')}
     </Text>
   );


### PR DESCRIPTION
## **Description**
Simulation Details - Display "No changes" in a single line.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37464?quickstart=1)

## **Changelog**

CHANGELOG entry: Simulation Details - Displayed "No changes" in a single line

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34773

## **Manual testing steps**

1. Go to test dapp
2. Click on send
3. See the confirmation page with "No changes" on one line

## **Screenshots/Recordings**

Before:
<img width="390" height="304" alt="image" src="https://github.com/user-attachments/assets/54180b2e-069a-4ccb-8992-470ceb3e5213" />

After:
<img width="390" height="371" alt="image" src="https://github.com/user-attachments/assets/68d86f7a-8751-414d-bd56-9eb2fa762af5" />

After with longer text (e.g. if a translation in another language is longer than in English):
<img width="391" height="327" alt="image" src="https://github.com/user-attachments/assets/2f083ffc-7e4f-45f4-b190-d354635b0684" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Right-aligns and sets 11/12 width for the "No changes" message in Simulation Details and updates related tests/snapshots.
> 
> - **Simulation Details UI**:
>   - Aligns `"No changes"` text to the right and constrains width to `BlockSize.ElevenTwelfths` in `simulation-details.tsx` (`TextAlign.Right`, added `TextAlign` import).
> - **Tests**:
>   - Updates unit test to assert alignment/width classes and renames test for clarity in `simulation-details.test.tsx`.
>   - Refreshes snapshots to reflect new `"No changes"` layout across `info`, `base-transaction-info`, `native-transfer`, `nft-token-transfer`, and `token-transfer` components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31cc1d7806194dfd32dfccc420eb2799b40bd435. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->