### PR TITLE
fix: flaky test `Update modal should disappear when closed`

### DIFF
--- a/test/e2e/tests/update-modal/update-modal.spec.ts
+++ b/test/e2e/tests/update-modal/update-modal.spec.ts
@@ -7,7 +7,7 @@ import UpdateModal from '../../page-objects/pages/dialog/update-modal';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import { version } from '../../../../package.json';
 
-describe('Update modal test', function (this: Suite) {
+describe('Update modal', function (this: Suite) {
   it('should not be shown by default', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/update-modal/update-modal.spec.ts
+++ b/test/e2e/tests/update-modal/update-modal.spec.ts
@@ -7,7 +7,7 @@ import UpdateModal from '../../page-objects/pages/dialog/update-modal';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import { version } from '../../../../package.json';
 
-describe('Update modal', function (this: Suite) {
+describe('Update modal test', function (this: Suite) {
   it('should not be shown by default', async function () {
     await withFixtures(
       {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -806,7 +806,7 @@ class Driver {
    * @param rawLocator - The locator used to identify the element to be clicked
    * @param timeout - The maximum time in ms to wait for the element to disappear after clicking.
    */
-  async clickElementAndWaitToDisappear(rawLocator, timeout = 2000) {
+  async clickElementAndWaitToDisappear(rawLocator, timeout = 3000) {
     const element = await this.findClickableElement(rawLocator);
     await element.click();
     await element.waitForElementState('hidden', timeout);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The timeout in clickElementAndWaitToDisappear has a default max value of 2seconds. This is insufficient in the update modal test, where sometimes the spec fails as the element didn't disappear yet:

<img width="951" height="146" alt="image" src="https://github.com/user-attachments/assets/47433113-1793-4c83-ad0e-316bfabeedf0" />

This increases the default timeout to 3 seconds at the driver method level. This won't mean that we will always wait until the full 3 seconds but that now, we have a bigger window to wait.
I chose to change this at the driver method, to help stabilize all ci in general, not just for that case, as 3 seconds still seams a reasonable amount of time (in the case we need to fully wait for them).


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37465?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci. I edited the spec file to trigger the quality gate and run the Update Modal spec 5 more times x4 (each build), so it was run 20+4 times and it passed (other specs failed due to existing flakiness, being fixed in different PRs)

https://github.com/MetaMask/metamask-extension/pull/37465/commits/0b857c08c0048d53b61ea809e3d24c8bb40550b6


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase default timeout from 2s to 3s in `clickElementAndWaitToDisappear` to improve reliability of disappearing elements.
> 
> - **Tests (E2E)**:
>   - `test/e2e/webdriver/driver.js`:
>     - `clickElementAndWaitToDisappear`: default timeout increased `2000ms` → `3000ms`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 919feab8d63df2cfd2795a7377c2b8f29edc127f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->