### PR TITLE
fix: do not start subscription-polling when shield feature is disabled cp-13.8.0

### DIFF
--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -127,11 +127,24 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
   ]);
 
   useEffect(() => {
-    if (selectedAccount && isSignedIn && isUnlocked) {
+    if (
+      isMetaMaskShieldFeatureEnabled &&
+      isBasicFunctionalityEnabled &&
+      selectedAccount &&
+      isSignedIn &&
+      isUnlocked
+    ) {
       // start polling for the subscriptions
       dispatch(subscriptionsStartPolling());
     }
-  }, [isSignedIn, selectedAccount, dispatch, isUnlocked]);
+  }, [
+    isMetaMaskShieldFeatureEnabled,
+    isSignedIn,
+    selectedAccount,
+    dispatch,
+    isUnlocked,
+    isBasicFunctionalityEnabled,
+  ]);
 
   const resetShieldEntryModalShownStatus = useCallback(() => {
     if (!isShieldSubscriptionActive) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
fix: do not start subscription-polling when shield feature is disabled

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37476?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed subscription-polling when shield feature is disabled

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37485

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Start subscriptions polling only when Shield feature and basic functionality are enabled, alongside existing account/sign-in/unlock checks.
> 
> - **Shield subscription polling**:
>   - In `ui/contexts/shield/shield-subscription.tsx`, only dispatch `subscriptionsStartPolling()` when `isMetaMaskShieldFeatureEnabled` and `isBasicFunctionalityEnabled` are true (in addition to existing `selectedAccount`, `isSignedIn`, `isUnlocked`).
>   - Update the effect dependency array to include these flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c9334cf37beef5a106745768c6abf1f31e1b90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->