### PR TITLE
fix: flaky test `dApp Request Gas Limit should update the gas limit in the activity list after submitting a request with custom gas (above estimated gas limit)`

### DIFF
--- a/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 import { createDappTransaction } from '../../../page-objects/flows/transaction';
+import ActivityListPage from '../../../page-objects/pages/home/activity-list';
+import HomePage from '../../../page-objects/pages/home/homepage';
 import TestDapp from '../../../page-objects/pages/test-dapp';
 import { Driver } from '../../../webdriver/driver';
 
 const { strict: assert } = require('assert');
 const FixtureBuilder = require('../../../fixture-builder');
-const {
-  withFixtures,
-  unlockWallet,
-  WINDOW_TITLES,
-} = require('../../../helpers');
+const { withFixtures, WINDOW_TITLES } = require('../../../helpers');
 
 describe('dApp Request Gas Limit', function () {
   it('should update the gas limit in the activity list after submitting a request with custom gas (lower than 21000)', async function () {
@@ -29,7 +28,7 @@ describe('dApp Request Gas Limit', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
@@ -52,12 +51,13 @@ describe('dApp Request Gas Limit', function () {
         );
 
         // Click on Activity tab
-        await driver.clickElement(
-          '[data-testid="account-overview__activity-tab"]',
-        );
+        const homePage = new HomePage(driver);
+        await homePage.goToActivityList();
 
         // Wait for the transaction to appear and click on it
-        await driver.clickElement('[data-testid="activity-list-item"]');
+        const activityList = new ActivityListPage(driver);
+        await activityList.checkFailedTxNumberDisplayedInActivity(1);
+        await activityList.clickTransactionListItem();
 
         // Now on transaction details page, find and verify the gas limit
         const rows = await driver.findElements(
@@ -91,7 +91,7 @@ describe('dApp Request Gas Limit', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
@@ -114,12 +114,13 @@ describe('dApp Request Gas Limit', function () {
         );
 
         // Click on Activity tab
-        await driver.clickElement(
-          '[data-testid="account-overview__activity-tab"]',
-        );
+        const homePage = new HomePage(driver);
+        await homePage.goToActivityList();
 
         // Wait for the transaction to appear and click on it
-        await driver.clickElement('[data-testid="activity-list-item"]');
+        const activityList = new ActivityListPage(driver);
+        await activityList.checkFailedTxNumberDisplayedInActivity(1);
+        await activityList.clickTransactionListItem();
 
         // Now on transaction details page, find and verify the gas limit
         const rows = await driver.findElements(
@@ -153,7 +154,7 @@ describe('dApp Request Gas Limit', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
@@ -175,13 +176,14 @@ describe('dApp Request Gas Limit', function () {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
 
-        // Click on Activity tab
-        await driver.clickElement(
-          '[data-testid="account-overview__activity-tab"]',
-        );
+       // Click on Activity tab
+        const homePage = new HomePage(driver);
+        await homePage.goToActivityList();
 
         // Wait for the transaction to appear and click on it
-        await driver.clickElement('[data-testid="activity-list-item"]');
+        const activityList = new ActivityListPage(driver);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.clickTransactionListItem();
 
         // Now on transaction details page, find and verify the gas limit
         const rows = await driver.findElements(
@@ -215,7 +217,7 @@ describe('dApp Request Gas Limit', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        await unlockWallet(driver);
+        await loginWithBalanceValidation(driver);
 
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
@@ -238,12 +240,13 @@ describe('dApp Request Gas Limit', function () {
         );
 
         // Click on Activity tab
-        await driver.clickElement(
-          '[data-testid="account-overview__activity-tab"]',
-        );
+        const homePage = new HomePage(driver);
+        await homePage.goToActivityList();
 
         // Wait for the transaction to appear and click on it
-        await driver.clickElement('[data-testid="activity-list-item"]');
+        const activityList = new ActivityListPage(driver);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.clickTransactionListItem();
 
         // Now on transaction details page, find and verify the gas limit
         const rows = await driver.findElements(

--- a/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts
@@ -176,7 +176,7 @@ describe('dApp Request Gas Limit', function () {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
 
-       // Click on Activity tab
+        // Click on Activity tab
         const homePage = new HomePage(driver);
         await homePage.goToActivityList();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky because after we go to the Activity List and click on the Transaction to open the tx details, the tx details is not there. The problem is that we click on the tx when sometimes is not yet confirmed, causing that if we click just when the tx confirms (updates) the component re-renders and the modal is closed/not open.

To avoid re-renders when we click, we'll always wait until the tx is confirmed/failed, then we click to open the details.

Extra note: this spec is not following page objects. I leave out of the scope of this PR to migrate all the test, as this only intends to fix the flakiness, but we should migrate the test in a separate PR.

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/d50586b2-7636-4819-9d9d-72ee81aa7bfd" />

<img width="961" height="537" alt="image" src="https://github.com/user-attachments/assets/4c5c8ace-8c7e-4799-a25b-239e3063b9ba" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37488?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the dApp Request Gas Limit e2e tests by using the new login flow and Activity/Home page objects to verify and open transactions.
> 
> - **Tests (`test/e2e/tests/confirmations/transactions/request-gas-limit.spec.ts`)**:
>   - Replace `unlockWallet` with `loginWithBalanceValidation`.
>   - Use `HomePage.goToActivityList()` instead of direct selector clicks.
>   - Use `ActivityListPage` to assert tx count/status (`checkFailedTxNumberDisplayedInActivity`, `checkConfirmedTxNumberDisplayedInActivity`) and open items (`clickTransactionListItem`).
>   - Maintain gas parameters and assert displayed gas limit in transaction details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c523733125ef2b74d9c679511dba4a9c46132001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->