### PR TITLE
fix: cp-13.8.0 Fix unknown token issue when nonEVM selected in network manager

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { genUnapprovedTokenTransferConfirmation } from '../../../../../../../test/data/confirmations/token-transfer';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../../../test/lib/render-helpers';
-import { getTokenList } from '../../../../../../selectors';
+import { selectERC20TokensByChain } from '../../../../../../selectors';
 import { useTokenDetails } from './useTokenDetails';
 
 jest.mock('react-redux', () => ({
@@ -14,15 +14,19 @@ jest.mock('react-redux', () => ({
 const ICON_SYMBOL = 'FROG';
 const ICON_URL =
   'https://static.cx.metamask.io/api/v1/tokenIcons/1/0x0a2c375553e6965b42c135bb8b15a8914b08de0c.png';
-const MOCK_TOKEN_LIST = (transactionMeta: TransactionMeta) => ({
-  [transactionMeta.txParams.to as string]: {
-    address: transactionMeta.txParams.to,
-    aggregators: ['CoinGecko', 'Socket', 'Coinmarketcap'],
-    decimals: 9,
-    iconUrl: ICON_URL,
-    name: 'Frog on ETH',
-    occurrences: 3,
-    symbol: ICON_SYMBOL,
+const MOCK_TOKEN_LIST_BY_CHAIN = (transactionMeta: TransactionMeta) => ({
+  [transactionMeta.chainId]: {
+    data: {
+      [(transactionMeta.txParams.to as string).toLowerCase()]: {
+        address: transactionMeta.txParams.to,
+        aggregators: ['CoinGecko', 'Socket', 'Coinmarketcap'],
+        decimals: 9,
+        iconUrl: ICON_URL,
+        name: 'Frog on ETH',
+        occurrences: 3,
+        symbol: ICON_SYMBOL,
+      },
+    },
   },
 });
 
@@ -33,56 +37,15 @@ describe('useTokenDetails', () => {
     jest.resetAllMocks();
   });
 
-  it('returns token details from selected token if it exists', () => {
-    const transactionMeta = genUnapprovedTokenTransferConfirmation(
-      {},
-    ) as TransactionMeta;
-
-    const TEST_SELECTED_TOKEN = {
-      address: 'address',
-      decimals: 18,
-      symbol: 'symbol',
-      iconUrl: 'iconUrl',
-      image: 'image',
-    };
-
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === getTokenList) {
-        return MOCK_TOKEN_LIST(transactionMeta);
-      } else if (selector?.toString().includes('getWatchedToken')) {
-        return TEST_SELECTED_TOKEN;
-      }
-      return undefined;
-    });
-
-    const { result } = renderHookWithProvider(
-      () => useTokenDetails(transactionMeta),
-      mockState,
-    );
-
-    expect(result.current).toEqual({
-      tokenImage: 'iconUrl',
-      tokenSymbol: 'symbol',
-    });
-  });
-
   it('returns token details from the token list if it exists', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    const TEST_SELECTED_TOKEN = {
-      address: 'address',
-      decimals: 18,
-    };
-
     useSelectorMock.mockImplementation((selector) => {
-      if (selector === getTokenList) {
-        return MOCK_TOKEN_LIST(transactionMeta);
-      } else if (selector?.toString().includes('getWatchedToken')) {
-        return TEST_SELECTED_TOKEN;
+      if (selector === selectERC20TokensByChain) {
+        return MOCK_TOKEN_LIST_BY_CHAIN(transactionMeta);
       }
-
       return undefined;
     });
 
@@ -97,85 +60,14 @@ describe('useTokenDetails', () => {
     });
   });
 
-  it('returns selected token image if no iconUrl is included', () => {
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token is not found', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    const TEST_SELECTED_TOKEN = {
-      address: 'address',
-      decimals: 18,
-      symbol: 'symbol',
-      image: 'image',
-    };
-
     useSelectorMock.mockImplementation((selector) => {
-      if (selector === getTokenList) {
-        return MOCK_TOKEN_LIST(transactionMeta);
-      } else if (selector?.toString().includes('getWatchedToken')) {
-        return TEST_SELECTED_TOKEN;
-      }
-      return undefined;
-    });
-
-    const { result } = renderHookWithProvider(
-      () => useTokenDetails(transactionMeta),
-      mockState,
-    );
-
-    expect(result.current).toEqual({
-      tokenImage: 'image',
-      tokenSymbol: 'symbol',
-    });
-  });
-
-  it('returns token list icon url if no image is included in the token', () => {
-    const transactionMeta = genUnapprovedTokenTransferConfirmation(
-      {},
-    ) as TransactionMeta;
-
-    const TEST_SELECTED_TOKEN = {
-      address: 'address',
-      decimals: 18,
-      symbol: 'symbol',
-    };
-
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === getTokenList) {
-        return MOCK_TOKEN_LIST(transactionMeta);
-      } else if (selector?.toString().includes('getWatchedToken')) {
-        return TEST_SELECTED_TOKEN;
-      }
-      return undefined;
-    });
-
-    const { result } = renderHookWithProvider(
-      () => useTokenDetails(transactionMeta),
-      mockState,
-    );
-
-    expect(result.current).toEqual({
-      tokenImage: ICON_URL,
-      tokenSymbol: 'symbol',
-    });
-  });
-
-  it('returns undefined if no image is found', () => {
-    const transactionMeta = genUnapprovedTokenTransferConfirmation(
-      {},
-    ) as TransactionMeta;
-
-    const TEST_SELECTED_TOKEN = {
-      address: 'address',
-      decimals: 18,
-      symbol: 'symbol',
-    };
-
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === getTokenList) {
+      if (selector === selectERC20TokensByChain) {
         return {};
-      } else if (selector?.toString().includes('getWatchedToken')) {
-        return TEST_SELECTED_TOKEN;
       }
       return undefined;
     });
@@ -187,7 +79,71 @@ describe('useTokenDetails', () => {
 
     expect(result.current).toEqual({
       tokenImage: undefined,
-      tokenSymbol: 'symbol',
+      tokenSymbol: 'Unknown',
+    });
+  });
+
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if chainId is not in token list', () => {
+    const transactionMeta = genUnapprovedTokenTransferConfirmation(
+      {},
+    ) as TransactionMeta;
+
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectERC20TokensByChain) {
+        return {
+          '0x999': {
+            data: {
+              '0xsomeotheraddress': {
+                iconUrl: ICON_URL,
+                symbol: ICON_SYMBOL,
+              },
+            },
+          },
+        };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useTokenDetails(transactionMeta),
+      mockState,
+    );
+
+    expect(result.current).toEqual({
+      tokenImage: undefined,
+      tokenSymbol: 'Unknown',
+    });
+  });
+
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token address is not in chain data', () => {
+    const transactionMeta = genUnapprovedTokenTransferConfirmation(
+      {},
+    ) as TransactionMeta;
+
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectERC20TokensByChain) {
+        return {
+          [transactionMeta.chainId]: {
+            data: {
+              '0xdifferentaddress': {
+                iconUrl: ICON_URL,
+                symbol: ICON_SYMBOL,
+              },
+            },
+          },
+        };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useTokenDetails(transactionMeta),
+      mockState,
+    );
+
+    expect(result.current).toEqual({
+      tokenImage: undefined,
+      tokenSymbol: 'Unknown',
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -1,20 +1,32 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { selectERC20TokensByChain } from '../../../../../../selectors';
+import {
+  getAllTokens,
+  selectERC20TokensByChain,
+} from '../../../../../../selectors';
+import { Token } from '../../../../../../components/app/assets/types';
 
 export const useTokenDetails = (transactionMeta: TransactionMeta) => {
   const t = useI18nContext();
   const {
     chainId,
-    txParams: { to },
+    txParams: { to, from },
   } = transactionMeta ?? { txParams: {} };
-  const tokenListByChain = useSelector(selectERC20TokensByChain);
-  const { iconUrl: tokenImage, symbol: tokenSymbol } = tokenListByChain[chainId]
-    ?.data?.[to?.toLowerCase() as string] ?? {
-    iconUrl: undefined,
-    symbol: t('unknown'),
-  };
+  const erc20TokensByChain = useSelector(selectERC20TokensByChain);
+  const allTokens = useSelector(getAllTokens);
+
+  const erc20Token =
+    erc20TokensByChain[chainId]?.data?.[to?.toLowerCase() as string];
+  const tokenListToken = allTokens?.[chainId]?.[from as string].find(
+    (token: Token) =>
+      token.address?.toLowerCase() === (to?.toLowerCase() as string),
+  );
+
+  const tokenImage =
+    erc20Token?.iconUrl || tokenListToken?.iconUrl || undefined;
+  const tokenSymbol =
+    erc20Token?.symbol || tokenListToken?.symbol || t('unknown');
 
   return { tokenImage, tokenSymbol };
 };

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -18,7 +18,7 @@ export const useTokenDetails = (transactionMeta: TransactionMeta) => {
 
   const erc20Token =
     erc20TokensByChain[chainId]?.data?.[to?.toLowerCase() as string];
-  const tokenListToken = allTokens?.[chainId]?.[from as string].find(
+  const tokenListToken = allTokens?.[chainId]?.[from as string]?.find(
     (token: Token) =>
       token.address?.toLowerCase() === (to?.toLowerCase() as string),
   );

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -1,26 +1,20 @@
-import { TokenListMap } from '@metamask/assets-controllers';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { getTokenList, getWatchedToken } from '../../../../../../selectors';
-import { MultichainState } from '../../../../../../selectors/multichain';
+import { selectERC20TokensByChain } from '../../../../../../selectors';
 
 export const useTokenDetails = (transactionMeta: TransactionMeta) => {
   const t = useI18nContext();
-  const selectedToken = useSelector((state: MultichainState) =>
-    getWatchedToken(transactionMeta)(state),
-  );
-  const tokenList = useSelector(getTokenList) as TokenListMap;
-
-  const tokenImage =
-    selectedToken?.iconUrl ||
-    selectedToken?.image ||
-    tokenList[transactionMeta?.txParams?.to as string]?.iconUrl;
-
-  const tokenSymbol =
-    selectedToken?.symbol ||
-    tokenList[transactionMeta?.txParams?.to as string]?.symbol ||
-    t('unknown');
+  const {
+    chainId,
+    txParams: { to },
+  } = transactionMeta ?? { txParams: {} };
+  const tokenListByChain = useSelector(selectERC20TokensByChain);
+  const { iconUrl: tokenImage, symbol: tokenSymbol } = tokenListByChain[chainId]
+    ?.data?.[to?.toLowerCase() as string] ?? {
+    iconUrl: undefined,
+    symbol: t('unknown'),
+  };
 
   return { tokenImage, tokenSymbol };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix a bug where token shows as unknown when network manager is selected nonEVM network.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37491?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix token image and symbol in confirmation for EVM transactions when nonEVM network is selected at wallet view

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37428

## **Manual testing steps**

1. Select nonEVM network (Solana / BTC)
2. Go to send flow 
3. Pick an ERC20 token (especially not on mainnet)
4. Proceed send
5. You should be able to see token name and image in confirmation

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/979ed59b-cd45-4534-9e4f-ac58c509f2e3



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors token resolution in confirmations to use chain-scoped selectors with fallbacks and updates tests for presence/absence cases.
> 
> - **Confirmations UI**:
>   - **Hook `useTokenDetails`**:
>     - Switches to chain-scoped selectors `selectERC20TokensByChain` and `getAllTokens` to resolve token details.
>     - Derives `erc20Token` from `erc20TokensByChain[chainId].data[to]`; falls back to `allTokens[chainId][from]` lookup; returns `t('unknown')` when absent.
>     - Removes reliance on `getWatchedToken`/`getTokenList`.
>   - **Tests `useTokenDetails.test.ts`**:
>     - Updated mocks to new chain-scoped token map shape.
>     - Adds/updates cases for token present and for missing token/chain/address returning `{ tokenImage: undefined, tokenSymbol: 'Unknown' }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e634c49a8f9d9e9a31a766e93faacccf623e3f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->