### PR TITLE
fix: flaky test `Deep Link handles the skipDeepLinkInterstitial flag correctly`

### DIFF
--- a/test/e2e/page-objects/pages/deep-link-page.ts
+++ b/test/e2e/page-objects/pages/deep-link-page.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { By } from 'selenium-webdriver';
 import { Driver } from '../../webdriver/driver';
+import { regularDelayMs } from '../../helpers';
 
 export default class DeepLink {
   protected readonly driver: Driver;
@@ -23,7 +24,9 @@ export default class DeepLink {
     try {
       await this.driver.waitForSelector(this.descriptionBox);
       // loading indicator should not be present when the page is loaded
-      await this.driver.assertElementNotPresent(this.loadingIndicator);
+      await this.driver.assertElementNotPresent(this.loadingIndicator, {
+        waitAtLeastGuard: regularDelayMs,
+      });
     } catch (e) {
       console.log('Timeout while waiting for Deep Link page to be loaded', e);
       throw e;

--- a/test/e2e/page-objects/pages/deep-link-page.ts
+++ b/test/e2e/page-objects/pages/deep-link-page.ts
@@ -23,14 +23,7 @@ export default class DeepLink {
     try {
       await this.driver.waitForSelector(this.descriptionBox);
       // loading indicator should not be present when the page is loaded
-      const element = await this.driver.driver.findElements(
-        By.css(this.loadingIndicator),
-      );
-      assert.equal(
-        element.length,
-        0,
-        'Loading indicator should not be present',
-      );
+      await this.driver.assertElementNotPresent(this.loadingIndicator);
     } catch (e) {
       console.log('Timeout while waiting for Deep Link page to be loaded', e);
       throw e;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The spec fails sometimes as the element is briefly present, though just some ms, as it's not even captured by the screenshot. Adding a guard stabilizes the spec:

<img width="1076" height="290" alt="image" src="https://github.com/user-attachments/assets/d848320b-d7ca-47ea-9102-1d4d12e8f3fa" />

<img width="1152" height="785" alt="image" src="https://github.com/user-attachments/assets/a1114338-a29a-4a45-9d35-0972f190668d" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37500?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace manual loading-indicator absence check with `driver.assertElementNotPresent` in `DeepLink.checkPageIsLoaded`.
> 
> - **E2E Tests**:
>   - **`test/e2e/page-objects/pages/deep-link-page.ts`**:
>     - In `checkPageIsLoaded`, replace manual `findElements` + length assertion with `driver.assertElementNotPresent(this.loadingIndicator)` to verify the loading indicator is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4f32d44681fc5803157b808f050c032ff5ae94b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->