### PR TITLE
fix: flaky test `Vault Decryptor Page is able to decrypt the vault uploading the log file in the vault-decryptor webapp`

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -81,15 +81,10 @@ jobs:
     # This if statement is equivalent to IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
-    strategy:
-      matrix:
-        index: [0, 1, 2, 3, 4, 5]
     with:
       test-suite-name: test-e2e-chrome-vault-decryption
       build-artifact: build-dist-browserify
       test-command: yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.ts --browser chrome
-      matrix-index: ${{ matrix.index }}
-      matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-api-specs:
     uses: ./.github/workflows/run-e2e.yml

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -81,10 +81,15 @@ jobs:
     # This if statement is equivalent to IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
+    strategy:
+      matrix:
+        index: [0, 1, 2, 3, 4, 5]
     with:
       test-suite-name: test-e2e-chrome-vault-decryption
       build-artifact: build-dist-browserify
       test-command: yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.ts --browser chrome
+      matrix-index: ${{ matrix.index }}
+      matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-api-specs:
     uses: ./.github/workflows/run-e2e.yml

--- a/test/e2e/vault-decryption-chrome.spec.ts
+++ b/test/e2e/vault-decryption-chrome.spec.ts
@@ -120,8 +120,8 @@ async function waitUntilFileIsWritten({
     }
     console.log(`File size is too small (${fileSize} bytes)`);
     if (attempt < maxRetries - 1) {
-      console.log(`Waiting for 5 seconds before retrying...`);
-      await driver.delay(5000);
+      console.log(`Waiting for 8 seconds before retrying...`);
+      await driver.delay(8000);
     }
   }
   // If the loop completes without success, throw an error


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as we can see in the logs, the time it took for the file to be ready was not enough.
We can see how the file was being written (the size was growing), so nothing was frozen on the app/file system side. It just means it needed more time. It might correlate with other things we are seeing in ci lately, where everything takes a bit longer than before:

<img width="1093" height="521" alt="image" src="https://github.com/user-attachments/assets/9597952e-03de-49e7-aadc-0ffa2466213b" />


<img width="305" height="204" alt="image" src="https://github.com/user-attachments/assets/275fc4f3-8557-4179-8d64-829e213b4e44" />



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37509?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check multiple ci runs above to verify fix

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies dapp swap comparison UI/logic and parsing, removes priority sorting util and unused i18n/metrics, updates domain/name lookup and tests, and tweaks e2e timing to reduce flakiness.
> 
> - **Confirmations**:
>   - Simplify `DappSwapComparisonBanner` to tab toggle only; rely on `selectedQuote` and remove callout UI/styles and related i18n keys/tests.
>   - Update swap parsing utils: rename Seaport byte to Permit2Permit and add unwrap WETH support; adjust metrics hook to return `selectedQuote` only and refine metrics; update tests/snapshots.
>   - Simulation details: simplify “No changes” header layout; update snapshots/tests.
> - **Assets**:
>   - Refactor `TokenList` to map token fields before sorting and use `sortAssets`; remove `sortAssetsWithPriority` util and its tests.
> - **Domains/Send**:
>   - Change `lookupDomainName(domainName)` to always use current chain; `useNameValidation` no longer dispatches lookup; update tests.
> - **Metrics/Unlock**:
>   - Remove `UseDifferentLoginMethodClicked` event and tracking from unlock flow.
> - **E2E**:
>   - Refactor gas limit specs to use `unlockWallet` and direct selectors.
>   - Increase vault-decryptor file write wait from 5s to 8s to reduce flakiness.
> - **Locales**:
>   - Remove unused Dapp Swap comparison strings in `en` and `en_GB`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d04ae91eee2536935ccf3b3109138be151022c16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->