### PR TITLE
fix: update default pair for BTC

### DIFF
--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -555,6 +555,55 @@ describe('Bridge selectors', () => {
 
       expect(result).toStrictEqual(null);
     });
+
+    it('returns ETH as default token when bridging from Bitcoin', () => {
+      const state = createBridgeMockStore({
+        bridgeSliceOverrides: {
+          fromToken: {
+            address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', // Bitcoin native address
+            symbol: 'BTC',
+            chainId: MultichainNetworks.BITCOIN,
+            decimals: 8,
+          },
+          toChainId: formatChainIdToCaip(CHAIN_IDS.MAINNET),
+        },
+        featureFlagOverrides: {
+          extensionConfig: {
+            support: true,
+            chains: {
+              [toEvmCaipChainId(CHAIN_IDS.MAINNET)]: {
+                isActiveSrc: true,
+                isActiveDest: true,
+              },
+            },
+            bip44DefaultPairs: {
+              bip122: {
+                standard: {
+                  'bip122:000000000019d6689c085ae165831e93/slip44:0':
+                    'eip155:1/slip44:60',
+                },
+                other: {},
+              },
+            },
+          },
+        },
+      });
+      const result = getToToken(state as never);
+
+      // Should return ETH (native token) instead of mUSD for Bitcoin bridges
+      expect(result).toStrictEqual({
+        address: zeroAddress(),
+        assetId: 'eip155:1/slip44:60',
+        balance: '0',
+        chainId: 'eip155:1',
+        decimals: 18,
+        iconUrl: '',
+        image: './images/eth_logo.svg',
+        name: 'Ether',
+        string: '0',
+        symbol: 'ETH',
+      });
+    });
   });
 
   describe('getFromAmount', () => {

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -19,6 +19,7 @@ import {
   isNativeAddress,
   isNonEvmChainId,
   formatChainIdToHex,
+  isBitcoinChainId,
 } from '@metamask/bridge-controller';
 import { handleFetch } from '@metamask/controller-utils';
 import { decGWEIToHexWEI } from '../../../shared/modules/conversion.utils';
@@ -306,12 +307,20 @@ const createBridgeTokenPayload = (
 
 export const getDefaultToToken = (
   targetChainId: CaipChainId,
-  fromToken: Pick<NonNullable<TokenPayload['payload']>, 'address'>,
+  fromToken: Pick<NonNullable<TokenPayload['payload']>, 'address' | 'chainId'>,
 ) => {
   const commonPair = BRIDGE_CHAINID_COMMON_TOKEN_PAIR[targetChainId];
 
   if (commonPair) {
-    // If source is native token, default to USDC on same chain
+    // If bridging from Bitcoin, default to native mainnet token (ETH) instead of common pair token
+    if (fromToken.chainId && isBitcoinChainId(fromToken.chainId)) {
+      const nativeAsset = getNativeAssetForChainId(targetChainId);
+      if (nativeAsset) {
+        return createBridgeTokenPayload(nativeAsset, targetChainId);
+      }
+    }
+
+    // If source is native token, default to common pair token on destination chain
     if (isNativeAddress(fromToken.address)) {
       return createBridgeTokenPayload(commonPair, targetChainId);
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update default token pair when user selects BTC as src asset to mainnet's `ETH` instead of `mUSD`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37512?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated default pair for BTC

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3354

## **Manual testing steps**

1. Go to swaps page
2. Select BTC as src token
3. Verify that ETH on mainnet is auto-selected as destination token

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="476" height="755" alt="Screenshot 2025-11-04 at 14 53 31" src="https://github.com/user-attachments/assets/b075dfc4-5f13-4193-999a-fd7bda5cf388" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defaults the destination token to native ETH on mainnet when the source asset is BTC, updating `getDefaultToToken` logic and adding a unit test.
> 
> - **Bridge logic**:
>   - Update `getDefaultToToken` in `ui/ducks/bridge/utils.ts` to:
>     - Accept `fromToken` with `chainId` and use `isBitcoinChainId`.
>     - When source is Bitcoin, return destination chain's native token (e.g., ETH on mainnet) instead of common pair (`mUSD`).
> - **Tests**:
>   - Add test in `ui/ducks/bridge/selectors.test.ts` asserting ETH is selected by default when bridging from BTC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 374b8a5a0f06fc5e2dafaf553d6e369ace0ce274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->