### PR TITLE
feat: Allow Danger alerts with acknowledgeBypass to skip acknowledgement

### DIFF
--- a/ui/components/app/alert-system/alert-modal/alert-modal.test.tsx
+++ b/ui/components/app/alert-system/alert-modal/alert-modal.test.tsx
@@ -206,6 +206,42 @@ describe('AlertModal', () => {
     useAlertsSpy.mockRestore();
   });
 
+  it('allows bypassing acknowledgement for danger alerts when acknowledgeBypass is true', () => {
+    const dangerAlert = alertsMock.find(
+      (alert) => alert.key === DATA_ALERT_KEY_MOCK,
+    ) as Alert;
+
+    const dangerAlertWithBypass = {
+      ...dangerAlert,
+      acknowledgeBypass: true,
+    };
+
+    const bypassStore = configureMockStore([])({
+      ...STATE_MOCK,
+      confirmAlerts: {
+        alerts: { [OWNER_ID_MOCK]: [dangerAlertWithBypass] },
+        confirmed: {
+          [OWNER_ID_MOCK]: {
+            [DATA_ALERT_KEY_MOCK]: false,
+          },
+        },
+      },
+    });
+
+    const { queryByTestId, getByTestId } = renderWithProvider(
+      <AlertModal
+        ownerId={OWNER_ID_MOCK}
+        onAcknowledgeClick={onAcknowledgeClickMock}
+        onClose={onCloseMock}
+        alertKey={DATA_ALERT_KEY_MOCK}
+      />,
+      bypassStore,
+    );
+
+    expect(queryByTestId('alert-modal-acknowledge-checkbox')).toBeNull();
+    expect(getByTestId('alert-modal-button')).toBeEnabled();
+  });
+
   it('calls onClose when the button is clicked', () => {
     const { getByLabelText } = renderWithProvider(
       <AlertModal

--- a/ui/components/app/alert-system/alert-modal/alert-modal.tsx
+++ b/ui/components/app/alert-system/alert-modal/alert-modal.tsx
@@ -104,6 +104,16 @@ function getSeverityStyle(severity?: Severity) {
   }
 }
 
+function requiresAcknowledgement(alert: Alert) {
+  return (
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    alert.severity === Severity.Danger &&
+    !alert.isBlocking &&
+    !alert.acknowledgeBypass
+  );
+}
+
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function AlertHeader({
@@ -247,13 +257,12 @@ export function AcknowledgeCheckboxBase({
   isConfirmed: boolean;
   label?: string;
 }) {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  if (selectedAlert.isBlocking || selectedAlert.severity !== Severity.Danger) {
+  const t = useI18nContext();
+
+  if (!requiresAcknowledgement(selectedAlert)) {
     return null;
   }
 
-  const t = useI18nContext();
   const severityStyle = getSeverityStyle(selectedAlert.severity);
   return (
     <Box
@@ -385,8 +394,8 @@ export function AlertModal({
   const isConfirmed = selectedAlert
     ? isAlertConfirmed(selectedAlert.key)
     : false;
-  const isAlertDanger = selectedAlert
-    ? selectedAlert.severity === Severity.Danger
+  const acknowledgementRequired = selectedAlert
+    ? requiresAcknowledgement(selectedAlert)
     : false;
 
   const handleCheckboxClick = useCallback(() => {
@@ -448,7 +457,7 @@ export function AlertModal({
               <>
                 <AcknowledgeButton
                   onAcknowledgeClick={onAcknowledgeClick}
-                  isConfirmed={!isAlertDanger || isConfirmed}
+                  isConfirmed={acknowledgementRequired ? isConfirmed : true}
                   hasActions={Boolean(selectedAlert.actions)}
                   isBlocking={selectedAlert.isBlocking}
                 />

--- a/ui/components/app/alert-system/confirm-alert-modal/confirm-alert-modal.test.tsx
+++ b/ui/components/app/alert-system/confirm-alert-modal/confirm-alert-modal.test.tsx
@@ -111,6 +111,39 @@ describe('ConfirmAlertModal', () => {
     expect(getByTestId('alert-modal-button')).toBeInTheDocument();
   });
 
+  it('enables submit button when danger alert has acknowledgeBypass flag', () => {
+    const bypassState = {
+      confirmAlerts: {
+        alerts: {
+          [OWNER_ID_MOCK]: [
+            {
+              key: DATA_ALERT_KEY_MOCK,
+              field: DATA_ALERT_KEY_MOCK,
+              severity: Severity.Danger,
+              message: DATA_ALERT_MESSAGE_MOCK,
+              acknowledgeBypass: true,
+            },
+          ],
+        },
+        confirmed: {
+          [OWNER_ID_MOCK]: {
+            [DATA_ALERT_KEY_MOCK]: false,
+          },
+        },
+      },
+    };
+
+    const bypassStore = configureMockStore([])(bypassState);
+
+    const { queryByTestId, getByTestId } = renderWithProvider(
+      <ConfirmAlertModal {...defaultProps} />,
+      bypassStore,
+    );
+
+    expect(queryByTestId('alert-modal-acknowledge-checkbox')).toBeNull();
+    expect(getByTestId('confirm-alert-modal-submit-button')).toBeEnabled();
+  });
+
   describe('when there are multiple alerts', () => {
     it('renders the next alert when the "Got it" button is clicked', () => {
       const mockStoreAcknowledgeAlerts = configureMockStore([])({

--- a/ui/components/app/alert-system/confirm-alert-modal/confirm-alert-modal.tsx
+++ b/ui/components/app/alert-system/confirm-alert-modal/confirm-alert-modal.tsx
@@ -178,6 +178,11 @@ export function ConfirmAlertModal({
     return null;
   }
 
+  const acknowledgementRequired =
+    selectedAlert.severity === Severity.Danger &&
+    !selectedAlert.isBlocking &&
+    !selectedAlert.acknowledgeBypass;
+
   return (
     <AlertModal
       ownerId={ownerId}
@@ -204,7 +209,7 @@ export function ConfirmAlertModal({
         <ConfirmButtons
           onCancel={onCancel}
           onSubmit={onSubmit}
-          isConfirmed={confirmCheckbox}
+          isConfirmed={acknowledgementRequired ? confirmCheckbox : true}
         />
       }
     />

--- a/ui/ducks/confirm-alerts/confirm-alerts.ts
+++ b/ui/ducks/confirm-alerts/confirm-alerts.ts
@@ -44,6 +44,12 @@ export type Alert = {
   isOpenModalOnClick?: boolean;
 
   /**
+   * Whether acknowledgement requirements should be bypassed for this alert,
+   * even when the severity is set to Danger.
+   */
+  acknowledgeBypass?: boolean;
+
+  /**
    * The unique key of the alert.
    */
   key: string;

--- a/ui/hooks/useAlerts.ts
+++ b/ui/hooks/useAlerts.ts
@@ -84,7 +84,9 @@ const useAlerts = (ownerId: string) => {
 
   const unconfirmedDangerAlerts = alerts.filter(
     (alert) =>
-      !isAlertConfirmed(alert.key) && alert.severity === Severity.Danger,
+      !isAlertConfirmed(alert.key) &&
+      alert.severity === Severity.Danger &&
+      !alert.acknowledgeBypass,
   );
 
   const hasAlerts = alerts.length > 0;
@@ -97,7 +99,9 @@ const useAlerts = (ownerId: string) => {
 
   const unconfirmedFieldDangerAlerts = fieldAlerts.filter(
     (alert) =>
-      !isAlertConfirmed(alert.key) && alert.severity === Severity.Danger,
+      !isAlertConfirmed(alert.key) &&
+      alert.severity === Severity.Danger &&
+      !alert.acknowledgeBypass,
   );
 
   return {

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -180,6 +180,7 @@ export function useShieldCoverageAlert(): Alert[] {
         showArrow: false,
         isOpenModalOnClick: true,
         hideFromAlertNavigation: true,
+        acknowledgeBypass: true,
       },
     ];
   }, [status, modalBodyStr, showAlert, t]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37513?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6176

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="471" height="674" alt="Screenshot 2025-11-04 at 14 43 52" src="https://github.com/user-attachments/assets/bc0262af-2ce3-4331-9e5a-1749ae7dabfc" />
<img width="501" height="631" alt="Screenshot 2025-11-04 at 14 43 45" src="https://github.com/user-attachments/assets/608b5519-9f33-4434-8160-c1395839f964" />
<img width="526" height="679" alt="Screenshot 2025-11-04 at 14 43 41" src="https://github.com/user-attachments/assets/73bee619-015f-41ec-8ee2-a89e5e7ee4ca" />


### **After**

<!-- [screenshots/recordings] -->
<img width="428" height="623" alt="Screenshot 2025-11-04 at 15 10 02" src="https://github.com/user-attachments/assets/081413e8-03ba-46f6-aef2-491835dda8d0" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces acknowledgeBypass to let non-blocking danger alerts skip acknowledgement, simplifies the dApp swap comparison banner logic/UI, and updates related utils, selectors, and tests.
> 
> - **Alerts**:
>   - Add `acknowledgeBypass` to `Alert` and update acknowledgement logic (`requiresAcknowledgement`) across `AlertModal`, `ConfirmAlertModal`, and `useAlerts`.
>   - Mark shield coverage alert with `acknowledgeBypass: true`.
>   - Add tests for bypass behavior.
> - **Confirmations UI**:
>   - Simplify dApp swap comparison banner to only render tabs when `selectedQuote` exists; remove callout/benefits text and styles. Update tests/CSS accordingly.
>   - Tweak Simulation Details empty state (“No changes”) layout (remove right alignment/width). Update snapshots.
> - **Smart Transactions**:
>   - Stop storing `chainId` in smart transaction state; status page now reads `chainId` from selector. Update mock store.
> - **Domains & Name Resolution**:
>   - `lookupDomainName(domainName)` no longer accepts `chainId`; always uses current chain. Remove ENS reverse lookup dispatch from `useNameValidation`.
> - **Utils**:
>   - `sanitizeString` now only escapes LTR/RTL override (`\u202D`, `\u202E`); remove generic control-char escaping. Update tests.
>   - dApp swap utils: rename Seaport command handling to Permit2Permit and adjust parsing.
> - **Multichain Accounts/UI**:
>   - Header: assume presence of account data; always render avatar/link.
>   - Account details page: simplify param handling; remove early redirects for missing/unknown IDs.
>   - Selectors: remove null/empty guards and error throwing in `extractWalletIdFromGroupId`/`getMultichainAccountGroupById`. Update tests.
> - **E2E/Tests**:
>   - Replace `loginWithBalanceValidation` with `unlockWallet`; use testids for activity navigation.
>   - Adjust onboarding balance assertion format/currency.
> - **i18n**:
>   - Remove dApp swap strings from `app/_locales/en/messages.json` and `en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b00dc95f87216675de8c84199a29970316d9a91a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->