### PR TITLE
test: fix flaky test "Preinstalled example Snap displays the Snap settings page"

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -1,10 +1,15 @@
 import { strict as assert } from 'assert';
 import { Mockttp } from 'mockttp';
+import {
+  largeDelayMs,
+  withFixtures,
+  WINDOW_TITLES,
+  sentryRegEx,
+} from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import FixtureBuilder from '../../fixture-builder';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import { withFixtures, WINDOW_TITLES, sentryRegEx } from '../../helpers';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PreinstalledExampleSettings from '../../page-objects/pages/settings/preinstalled-example-settings';
 import { TestSnaps } from '../../page-objects/pages/test-snaps';
@@ -60,15 +65,17 @@ describe('Preinstalled example Snap', function () {
         const preInstalledExample = new PreinstalledExampleSettings(driver);
         await navigateToPreInstalledExample(driver);
 
+        // toggle setting 1
         await preInstalledExample.clickToggleButtonOn();
-        await preInstalledExample.selectRadioOption('Option 2');
-        await preInstalledExample.selectDropdownOption('Option 2');
         await preInstalledExample.checkIsToggleOn();
-        assert.equal(
-          await preInstalledExample.checkSelectedRadioOption('Option 2'),
-          true,
-        );
-        await preInstalledExample.checkSelectedDropdownOption('Option 2');
+
+        // select radio option for setting 2
+        await preInstalledExample.selectRadioOption('Option 2');
+        await driver.delay(largeDelayMs);
+
+        // select dropdown option for setting 3
+        await preInstalledExample.selectDropdownOption('Option 2');
+        await driver.delay(largeDelayMs);
         await driver.clickElement(
           '.settings-page__header__title-container__close-button',
         );

--- a/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
+++ b/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
@@ -57,23 +57,6 @@ class PreinstalledExampleSettings {
     console.log('Checking if the toggle is on');
     await this.driver.waitForSelector(`${this.toggleButton}--on`);
   }
-
-  async checkSelectedRadioOption(option: string): Promise<boolean> {
-    console.log(`Checking if the radio option "${option}" is selected`);
-    const radioOption = await this.driver.findElement(
-      `input[type="radio"][id="${option}"]`,
-    );
-    const isChecked = (await radioOption.getAttribute('checked')) === 'true';
-    return isChecked;
-  }
-
-  async checkSelectedDropdownOption(option: string): Promise<void> {
-    console.log(`Checking if the dropdown option "${option}" is selected`);
-    await this.driver.waitForSelector({
-      css: this.settingsDropdown,
-      text: option,
-    });
-  }
 }
 
 export default PreinstalledExampleSettings;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This test was flaky because a race condition occurs after we select options for each setting. While investigating, with @seaona and @Unik0rnMaggie we found that the originally implemented check functions were not actually effective (see comments and recordings on this PR), so I had to add 2 small delays since no other UI changes we can use to check option status.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37514?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Tests should pass and be robust

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies trust-signal scanning and UI by removing spender-specific logic, updates default network names, switches smart-transaction chain ID sourcing to selector, and stabilizes the preinstalled snap e2e test with timing adjustments.
> 
> - **Network Controller**:
>   - Update default names for popular networks (`BSC Mainnet`, `Sei Mainnet`, `Polygon Mainnet`, `Optimism Mainnet`, `Arbitrum One`).
>   - Remove redundant name overrides in `controller-init`.
> - **Trust Signals**:
>   - Middleware now scans only transaction `to` and typed-data `verifyingContract`; removes approval/permit spender parsing and related error paths.
>   - Tests updated to drop spender scenarios and mocks; keep verifying contract and URL scan coverage.
> - **Smart Transactions**:
>   - Remove `chainId` from `smartTransaction` request state; status page derives chain ID via selector.
>   - Adjust mock store accordingly.
> - **UI/Confirmations**:
>   - Replace spender alert rows with plain `ConfirmInfoRow`; remove `RowAlertKey.Spender`, spender alerts hook, and its inclusion in `useConfirmationAlerts`.
>   - Minor style cleanup on info rows.
> - **App Header (Multichain)**:
>   - Simplify account name/address rendering and always show network subtitle link/avatar.
> - **Utilities**:
>   - `sanitizeString` now escapes only LTR/RTL overrides (U+202D/U+202E); tests updated.
>   - Make `useTrustSignal` `chainId` optional.
>   - Relax multichain selectors/utils to accept IDs without strict null checks; tests updated.
> - **E2E/Tests**:
>   - Stabilize preinstalled snap settings test by adding delays and simplifying page-object checks.
>   - Minor deep link/onboarding test tweaks (balance assertion and flow order).
> - **Unlock Page**:
>   - Remove `error_type` from rehydration failed event properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 124d2c158c2d3425d87bac538be0833797186c83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->