### PR TITLE
feat: show points estimate in swaps / bridge

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -981,6 +981,34 @@
   "bridgeNoMMFee": {
     "message": "No MM fee"
   },
+  "bridgePoints": {
+    "message": "Est. points",
+    "description": "Label for estimated points that can be earned from a bridge or swap"
+  },
+  "bridgePoints_couldntLoad": {
+    "message": "Couldn't load",
+    "description": "Text shown in rewards badge when points couldn't be loaded"
+  },
+  "bridgePoints_error": {
+    "message": "Couldn't load points",
+    "description": "Tooltip title when there's an error fetching estimated points"
+  },
+  "bridgePoints_error_content": {
+    "message": "Don't worry, you're still earning points. They'll show up in your account soon, or you can check in the Rewards tab on MetaMask Mobile.",
+    "description": "Error message when points estimation fails"
+  },
+  "bridgePoints_tooltip": {
+    "message": "Points",
+    "description": "Tooltip title for points"
+  },
+  "bridgePoints_tooltip_content_1": {
+    "message": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
+    "description": "First part of tooltip content explaining rewards points"
+  },
+  "bridgePoints_tooltip_content_2": {
+    "message": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "description": "Second part of tooltip content explaining how points are calculated"
+  },
   "bridgePriceImpact": {
     "message": "Price impact"
   },
@@ -5484,9 +5512,6 @@
   },
   "reward": {
     "message": "Reward"
-  },
-  "rewardsOptIn": {
-    "message": "Sign up for Rewards"
   },
   "rewardsPointsBalance": {
     "message": "$1 points",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -981,6 +981,34 @@
   "bridgeNoMMFee": {
     "message": "No MM fee"
   },
+  "bridgePoints": {
+    "message": "Est. points",
+    "description": "Label for estimated points that can be earned from a bridge or swap"
+  },
+  "bridgePoints_couldntLoad": {
+    "message": "Couldn't load",
+    "description": "Text shown in rewards badge when points couldn't be loaded"
+  },
+  "bridgePoints_error": {
+    "message": "Couldn't load points",
+    "description": "Tooltip title when there's an error fetching estimated points"
+  },
+  "bridgePoints_error_content": {
+    "message": "Don't worry, you're still earning points. They'll show up in your account soon, or you can check in the Rewards tab on MetaMask Mobile.",
+    "description": "Error message when points estimation fails"
+  },
+  "bridgePoints_tooltip": {
+    "message": "Points",
+    "description": "Tooltip title for points"
+  },
+  "bridgePoints_tooltip_content_1": {
+    "message": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
+    "description": "First part of tooltip content explaining rewards points"
+  },
+  "bridgePoints_tooltip_content_2": {
+    "message": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "description": "Second part of tooltip content explaining how points are calculated"
+  },
   "bridgePriceImpact": {
     "message": "Price impact"
   },
@@ -5484,9 +5512,6 @@
   },
   "reward": {
     "message": "Reward"
-  },
-  "rewardsOptIn": {
-    "message": "Sign up for Rewards"
   },
   "rewardsPointsBalance": {
     "message": "$1 points",

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -771,30 +771,36 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should fetch opt-in status when not cached', async () => {
-      await withController(
-        { isDisabled: false },
-        async ({ controller, mockMessengerCall }) => {
-          mockMessengerCall.mockImplementation((actionType) => {
-            if (actionType === 'RewardsDataService:getOptInStatus') {
-              return Promise.resolve({
-                ois: [true],
-                sids: [MOCK_SUBSCRIPTION_ID],
-              });
-            } else if (
-              actionType === 'AccountsController:listMultichainAccounts'
-            ) {
-              return [MOCK_INTERNAL_ACCOUNT];
-            }
-            return undefined;
-          });
+    it('should return false when account has not opted in', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: false,
+            subscriptionId: null,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
 
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller }) => {
           const result =
             await controller.getHasAccountOptedIn(MOCK_CAIP_ACCOUNT);
 
-          expect(result).toBe(true);
+          expect(result).toBe(false);
         },
       );
+    });
+
+    it('should return false when account is not in state', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const result = await controller.getHasAccountOptedIn(MOCK_CAIP_ACCOUNT);
+
+        expect(result).toBe(false);
+      });
     });
   });
 

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -29,7 +29,11 @@ import {
   RewardsControllerMessenger,
 } from '../../controller-init/messengers';
 import { getRootMessenger } from '../../lib/messenger';
-import { SeasonDtoState } from '../../../../shared/types/rewards';
+import {
+  EstimatedPointsDto,
+  EstimatePointsDto,
+  SeasonDtoState,
+} from '../../../../shared/types/rewards';
 import {
   RewardsController,
   getRewardsControllerDefaultState,
@@ -41,8 +45,6 @@ import type {
   SeasonTierDto,
   LoginResponseDto,
   SubscriptionDto,
-  EstimatePointsDto,
-  EstimatedPointsDto,
   DiscoverSeasonsDto,
   SeasonMetadataDto,
   SeasonStateDto,
@@ -73,8 +75,6 @@ type AllEvents = MessengerEvents<RewardsControllerMessenger>;
 jest.mock('loglevel', () => ({
   error: jest.fn(),
   warn: jest.fn(),
-  info: jest.fn(),
-  log: jest.fn(),
   debug: jest.fn(),
 }));
 
@@ -1705,7 +1705,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should force fresh check for not-opted-in accounts checked more than 5 minutes ago', async () => {
+    it('should force fresh check for not-opted-in accounts checked more than 60 minutes ago', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
@@ -1714,7 +1714,7 @@ describe('RewardsController', () => {
             subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
-            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 6, // 6 minutes ago (exceeds 5 minute threshold)
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 61, // 61 minutes ago (exceeds 60 minute threshold)
           },
         },
       };
@@ -1737,7 +1737,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should use cached data for not-opted-in accounts checked within 5 minutes', async () => {
+    it('should use cached data for not-opted-in accounts checked within 60 minutes', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
@@ -1746,7 +1746,7 @@ describe('RewardsController', () => {
             subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
-            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 2, // 2 minutes ago (within 5 minute threshold)
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 30, // 30 minutes ago (within 60 minute threshold)
           },
         },
       };
@@ -1848,7 +1848,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should skip for not-opted-in accounts checked within 5 minutes', async () => {
+    it('should skip for not-opted-in accounts checked within 60 minutes', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
@@ -1857,7 +1857,7 @@ describe('RewardsController', () => {
             subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
-            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 2, // 2 minutes ago (within 5 minute threshold)
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 30, // 30 minutes ago (within 60 minute threshold)
           },
         },
       };
@@ -1881,7 +1881,7 @@ describe('RewardsController', () => {
             subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
-            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 6, // 6 minutes ago (exceeds 5 minute threshold)
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 61, // 61 minutes ago (exceeds 60 minute threshold)
           },
         },
       };
@@ -2928,7 +2928,7 @@ describe('Additional RewardsController edge cases', () => {
   });
 
   describe('handleAuthenticationTrigger - additional scenarios', () => {
-    it('should try all accounts until one succeeds', async () => {
+    it('should set active account to first account when no accounts succeed but account state exists', async () => {
       const account2: InternalAccount = {
         id: 'account-2',
         address: MOCK_ACCOUNT_ADDRESS_ALT,
@@ -2945,11 +2945,21 @@ describe('Additional RewardsController edge cases', () => {
         },
       };
 
-      await withController(
-        { isDisabled: false },
-        async ({ controller, mockMessengerCall }) => {
-          let attemptCount = 0;
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
 
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
           mockMessengerCall.mockImplementation((actionType) => {
             if (
               actionType ===
@@ -2957,31 +2967,47 @@ describe('Additional RewardsController edge cases', () => {
             ) {
               return [MOCK_INTERNAL_ACCOUNT, account2];
             }
-            if (actionType === 'AccountsController:listMultichainAccounts') {
-              return [MOCK_INTERNAL_ACCOUNT, account2];
-            }
             if (actionType === 'KeyringController:signPersonalMessage') {
-              return Promise.resolve('0xmocksignature');
-            }
-            if (actionType === 'RewardsDataService:login') {
-              attemptCount += 1;
-              if (attemptCount === 1) {
-                return Promise.reject(new Error('First account failed'));
-              }
-              return Promise.resolve(MOCK_LOGIN_RESPONSE);
-            }
-            if (actionType === 'RewardsDataService:getOptInStatus') {
-              return Promise.resolve({
-                ois: [true],
-                sids: [MOCK_SUBSCRIPTION_ID],
-              });
+              return Promise.reject(new Error('All accounts failed'));
             }
             return undefined;
           });
 
           await controller.handleAuthenticationTrigger('Test trigger');
 
-          expect(attemptCount).toBe(2);
+          // Should set active account to first account since it has account state
+          expect(controller.state.rewardsActiveAccount).toMatchObject({
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+          });
+        },
+      );
+    });
+
+    it('should not set active account when successful account has no account state after conversion fails', async () => {
+      const invalidAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        scopes: [], // Invalid scope to make conversion fail
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (
+              actionType ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [invalidAccount];
+            }
+            return undefined;
+          });
+
+          await controller.handleAuthenticationTrigger('Test trigger');
+
+          // Should not set active account since conversion fails
+          expect(controller.state.rewardsActiveAccount).toBeNull();
         },
       );
     });
@@ -3003,6 +3029,58 @@ describe('Additional RewardsController edge cases', () => {
           await expect(
             controller.handleAuthenticationTrigger('Test trigger'),
           ).resolves.not.toThrow();
+        },
+      );
+    });
+
+    it('should handle getOptInStatus error gracefully and continue authentication flow', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          let getOptInStatusCallCount = 0;
+          let loginCallCount = 0;
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (
+              actionType ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [MOCK_INTERNAL_ACCOUNT];
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              getOptInStatusCallCount += 1;
+              // Throw error on getOptInStatus call from performSilentAuth
+              // Error should be caught silently and login should proceed
+              throw new Error('Failed to get opt-in status');
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:login') {
+              loginCallCount += 1;
+              return Promise.resolve(MOCK_LOGIN_RESPONSE);
+            }
+            return undefined;
+          });
+
+          await expect(
+            controller.handleAuthenticationTrigger('Test trigger'),
+          ).resolves.not.toThrow();
+
+          // Verify getOptInStatus was called from performSilentAuth
+          // Error should be caught silently
+          expect(getOptInStatusCallCount).toBeGreaterThanOrEqual(1);
+          // Verify that login still proceeded despite getOptInStatus errors
+          expect(loginCallCount).toBe(1);
+          // Verify that authentication succeeded and active account was set
+          expect(controller.state.rewardsActiveAccount).toMatchObject({
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+          });
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -13,6 +13,8 @@ import { HandleSnapRequest } from '@metamask/snaps-controllers';
 import { RewardsControllerMessenger } from '../../controller-init/messengers/rewards-controller-messenger';
 import { isHardwareAccount } from '../../../../shared/lib/accounts';
 import {
+  EstimatedPointsDto,
+  EstimatePointsDto,
   SeasonDtoState,
   SeasonStatusState,
   SeasonTierState,
@@ -21,8 +23,6 @@ import {
   type RewardsControllerState,
   type RewardsAccountState,
   type LoginResponseDto,
-  type EstimatePointsDto,
-  type EstimatedPointsDto,
   type SeasonTierDto,
   type SeasonStatusDto,
   type SubscriptionDto,
@@ -52,7 +52,7 @@ const SEASON_STATUS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
 
 // Opt-in status stale threshold for not opted-in accounts to force a fresh check (less strict than in mobile for now)
-const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
+const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
 
 /**
  * State metadata for the RewardsController
@@ -521,25 +521,19 @@ export class RewardsController extends BaseController<
         from: account.address,
       },
     );
-    log.info(
-      'RewardsController: EVM message signed for account',
-      account.address,
-    );
     return signature;
   }
 
   /**
    * Handle authentication triggers (account changes, keyring unlock)
    */
-  async handleAuthenticationTrigger(reason?: string): Promise<void> {
+  async handleAuthenticationTrigger(_reason?: string): Promise<void> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
 
     if (!rewardsEnabled) {
       await this.performSilentAuth(null, true, true);
       return;
     }
-
-    log.log('RewardsController: handleAuthenticationTrigger', reason);
 
     try {
       const accounts = this.messenger.call(
@@ -552,30 +546,41 @@ export class RewardsController extends BaseController<
         const sortedAccounts = sortAccounts(accounts);
 
         // Try silent auth on each account until one succeeds
+        let successAccount: InternalAccount | null = null;
         for (const account of sortedAccounts) {
           try {
             const subscriptionId = await this.performSilentAuth(
               account,
-              true,
+              false,
               true,
             );
-            if (subscriptionId) {
-              break; // Stop on first success
+            if (subscriptionId && !successAccount) {
+              successAccount = account;
             }
           } catch {
             // Continue to next account
           }
         }
+
+        // Set the active account to the first successful account or the first account in the sorted accounts array
+        const activeAccountCandidate: InternalAccount =
+          successAccount || sortedAccounts[0];
+        if (activeAccountCandidate) {
+          const caipAccount = this.convertInternalAccountToCaipAccountId(
+            activeAccountCandidate,
+          );
+          if (caipAccount) {
+            const accountState = this.#getAccountState(caipAccount);
+            if (accountState) {
+              this.update((state: RewardsControllerState) => {
+                state.rewardsActiveAccount = accountState;
+              });
+            }
+          }
+        }
       }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      if (errorMessage && !errorMessage?.includes('Engine does not exis')) {
-        log.log(
-          'RewardsController: Silent authentication failed:',
-          error instanceof Error ? error.message : String(error),
-        );
-      }
+    } catch {
+      // Silent authentication failed
     }
   }
 
@@ -740,10 +745,6 @@ export class RewardsController extends BaseController<
 
         // Check if the account has not opted in (result is false)
         if (optInStatusResult.ois && optInStatusResult.ois[0] === false) {
-          log.info(
-            'RewardsController: Account has not opted in, skipping silent auth',
-            internalAccount.address,
-          );
           // Account hasn't opted in, don't proceed with login
           subscription = null;
           // Update state to reflect not opted in
@@ -795,9 +796,6 @@ export class RewardsController extends BaseController<
         ) {
           const errorMessage = (signError as Error).message;
           if (errorMessage.includes('controller is locked')) {
-            log.info(
-              'RewardsController: Keyring is locked, skipping silent auth',
-            );
             return null; // Exit silently when keyring is locked
           }
         }
@@ -823,10 +821,6 @@ export class RewardsController extends BaseController<
             retryAttempt < MAX_RETRY_ATTEMPTS
           ) {
             retryAttempt += 1;
-            log.info(
-              'RewardsController: Retrying silent auth with server timestamp',
-              { originalTimestamp: ts, newTimestamp: error.timestamp },
-            );
             // Use the timestamp from the error for retry
             timestamp = error.timestamp;
             signature = await this.#signRewardsMessage(
@@ -849,8 +843,6 @@ export class RewardsController extends BaseController<
 
       // Store the session token for this subscription
       this.#storeSubscriptionToken(subscription.id, loginResponse.sessionId);
-
-      log.info('RewardsController: Silent auth successful', account);
     } catch (error: unknown) {
       if (error instanceof Error && error.message.includes('401')) {
         // Not opted in
@@ -1013,15 +1005,6 @@ export class RewardsController extends BaseController<
       let freshOptInResults: boolean[] = [];
       let freshSubscriptionIds: (string | null)[] = [];
       if (addressesNeedingFresh.length > 0) {
-        log.info(
-          'RewardsController: Making fresh opt-in status API call for addresses without cached data',
-          {
-            cachedCount: cachedOptInResults.filter((result) => result !== null)
-              .length,
-            needFreshCount: addressesNeedingFresh.length,
-          },
-        );
-
         const freshResponse = await this.messenger.call(
           'RewardsDataService:getOptInStatus',
           { addresses: addressesNeedingFresh },
@@ -1167,11 +1150,6 @@ export class RewardsController extends BaseController<
       },
 
       fetchFresh: async () => {
-        log.info(
-          'RewardsController: Fetching fresh season metadata via API call for type',
-          type,
-        );
-
         // Get discover seasons to find if this season has a valid start date
         const discoverSeasons = (await this.messenger.call(
           'RewardsDataService:getDiscoverSeasons',
@@ -1187,11 +1165,6 @@ export class RewardsController extends BaseController<
 
         // If found with valid start date, fetch metadata and populate cache
         if (seasonInfo?.startDate) {
-          log.info(
-            'RewardsController: Found season with valid start date, fetching metadata for',
-            type,
-          );
-
           // Fetch season metadata
           const seasonMetadata = (await this.messenger.call(
             'RewardsDataService:getSeasonMetadata',
@@ -1268,11 +1241,6 @@ export class RewardsController extends BaseController<
       },
       fetchFresh: async () => {
         try {
-          log.info(
-            'RewardsController: Fetching fresh season status data via API call for subscriptionId & seasonId',
-            subscriptionId,
-            seasonId,
-          );
           const subscriptionToken = this.#getSubscriptionToken(subscriptionId);
           if (!subscriptionToken) {
             throw new AuthorizationFailedError(
@@ -1302,9 +1270,6 @@ export class RewardsController extends BaseController<
                 const account = await this.messenger.call(
                   'AccountsController:getSelectedMultichainAccount',
                 );
-                log.info(
-                  'RewardsController: Attempting to reauth with a valid account after 403 error',
-                );
                 await this.performSilentAuth(account, false, false); // try and auth.
               } else if (
                 this.state.rewardsAccounts &&
@@ -1326,9 +1291,6 @@ export class RewardsController extends BaseController<
                     },
                   );
                   if (intAccountForSub) {
-                    log.info(
-                      'RewardsController: Attempting to reauth with any valid account after 403 error',
-                    );
                     await this.performSilentAuth(
                       intAccountForSub as InternalAccount,
                       false,
@@ -1355,10 +1317,6 @@ export class RewardsController extends BaseController<
               const seasonStatus = this.convertToSeasonStatusDto(
                 season,
                 seasonState,
-              );
-              log.info(
-                'RewardsController: Successfully fetched season status after reauth',
-                seasonStatus,
               );
               return this.#convertSeasonStatusToSubscriptionState(seasonStatus);
             } catch {
@@ -1404,7 +1362,6 @@ export class RewardsController extends BaseController<
       state.rewardsSubscriptions = {};
       state.rewardsSubscriptionTokens = {};
     });
-    log.info('RewardsController: Invalidated accounts and subscriptions');
   }
 
   /**
@@ -1415,9 +1372,6 @@ export class RewardsController extends BaseController<
   async optIn(referralCode?: string): Promise<string | null> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
-      log.info(
-        'RewardsController: Rewards feature is disabled, skipping optin',
-      );
       return null;
     }
 
@@ -1426,18 +1380,8 @@ export class RewardsController extends BaseController<
     );
 
     if (!accounts || accounts.length === 0) {
-      log.info(
-        'RewardsController: No accounts found in selected account group, skipping optin',
-      );
       return null;
     }
-
-    log.info(
-      'RewardsController: Starting optin process based on account group with {{accountCount}} accounts',
-      {
-        accountCount: accounts.length,
-      },
-    );
 
     // Sort accounts using utility function
     const sortedAccounts = sortAccounts(accounts);
@@ -1450,11 +1394,6 @@ export class RewardsController extends BaseController<
     } | null = null;
 
     for (const accountToTry of sortedAccounts) {
-      log.info(
-        'RewardsController: Trying opt-in for account',
-        accountToTry.address,
-      );
-
       try {
         optinResult = await this.#optIn(accountToTry, referralCode);
       } catch {
@@ -1463,10 +1402,6 @@ export class RewardsController extends BaseController<
 
       if (optinResult) {
         successfulAccount = accountToTry;
-        log.info(
-          'RewardsController: Opt-in successful for account',
-          accountToTry.address,
-        );
         break;
       }
     }
@@ -1482,14 +1417,6 @@ export class RewardsController extends BaseController<
     );
 
     if (remainingAccounts.length > 0) {
-      log.info(
-        'RewardsController: Linking remaining {{count}} accounts to subscription',
-        {
-          count: remainingAccounts.length,
-          subscriptionId: optinResult.subscription.id,
-        },
-      );
-
       await this.linkAccountsToSubscriptionCandidate(remainingAccounts);
     }
 
@@ -1509,17 +1436,8 @@ export class RewardsController extends BaseController<
   ): Promise<{ subscription: SubscriptionDto; sessionId: string } | null> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
-      log.info(
-        'RewardsController: Rewards feature is disabled, skipping optin',
-        {
-          account: account.address,
-        },
-      );
       return null;
     }
-    log.info('RewardsController: Starting optin process', {
-      account: account.address,
-    });
     // Generate timestamp and sign the message for mobile optin
     let timestamp = Math.floor(Date.now() / 1000);
     let signature = await this.#signRewardsMessage(account, timestamp);
@@ -1543,10 +1461,6 @@ export class RewardsController extends BaseController<
           retryAttempt < MAX_RETRY_ATTEMPTS
         ) {
           retryAttempt += 1;
-          log.info('RewardsController: Retrying with server timestamp', {
-            originalTimestamp: ts,
-            newTimestamp: error.timestamp,
-          });
           // Use the timestamp from the error for retry
           timestamp = error.timestamp;
           signature = await this.#signRewardsMessage(account, timestamp);
@@ -1583,10 +1497,6 @@ export class RewardsController extends BaseController<
     };
     try {
       const optinResponse = await executeMobileOptin(timestamp, signature);
-      log.info(
-        'RewardsController: Optin successful, updating controller state...',
-        account.address,
-      );
       // Store the subscription token for authenticated requests
       if (optinResponse.subscription?.id && optinResponse.sessionId) {
         this.#storeSubscriptionToken(
@@ -1624,11 +1534,6 @@ export class RewardsController extends BaseController<
         sessionId: optinResponse.sessionId,
       };
     } catch (error) {
-      log.info(
-        'RewardsController: Opt-in failed for account',
-        account.address,
-        error instanceof Error ? error.message : String(error),
-      );
       return null;
     }
   }
@@ -1648,15 +1553,10 @@ export class RewardsController extends BaseController<
     }
 
     if (this.#geoLocation) {
-      log.log('RewardsController: Using cached geo location', {
-        location: this.#geoLocation,
-      });
       return this.#geoLocation;
     }
 
     try {
-      log.log('RewardsController: Fetching geo location for rewards metadata');
-
       // Get geo location from data service
       const geoLocation = await this.messenger.call(
         'RewardsDataService:fetchGeoLocation',
@@ -1672,15 +1572,9 @@ export class RewardsController extends BaseController<
         optinAllowedForGeo,
       };
 
-      log.log('RewardsController: Geo rewards metadata retrieved', result);
       this.#geoLocation = result;
       return result;
     } catch (error) {
-      log.log(
-        'RewardsController: Failed to get geo rewards metadata:',
-        error instanceof Error ? error.message : String(error),
-      );
-
       // Return fallback metadata on error
       return {
         geoLocation: 'UNKNOWN',
@@ -1709,19 +1603,11 @@ export class RewardsController extends BaseController<
       return false;
     }
 
-    try {
-      const response = await this.messenger.call(
-        'RewardsDataService:validateReferralCode',
-        code,
-      );
-      return response.valid;
-    } catch (error) {
-      log.info(
-        'RewardsController: Failed to validate referral code:',
-        error instanceof Error ? error.message : String(error),
-      );
-      throw error;
-    }
+    const response = await this.messenger.call(
+      'RewardsDataService:validateReferralCode',
+      code,
+    );
+    return response.valid;
   }
 
   /**
@@ -1767,15 +1653,8 @@ export class RewardsController extends BaseController<
       // Call opt-in status check
       const optInStatusResponse = await this.getOptInStatus({ addresses });
       if (!optInStatusResponse?.ois?.filter((ois: boolean) => ois).length) {
-        log.info(
-          'RewardsController: No candidate subscription ID found. No opted in accounts found via opt-in status response.',
-        );
         return null;
       }
-
-      log.info(
-        'RewardsController: Found opted in account via opt-in status response. Attempting silent auth to determine candidate subscription ID.',
-      );
 
       // Loop through all accounts that have opted in (ois[i] === true)
       // Only process the first 10 accounts with a 500ms delay between each
@@ -1816,13 +1695,6 @@ export class RewardsController extends BaseController<
             false, // respectSkipSilentAuth = false
           );
           if (subscriptionId) {
-            log.info(
-              'RewardsController: Found candidate subscription ID via opt-in status response.',
-              {
-                subscriptionId,
-              },
-            );
-
             return subscriptionId;
           }
         } catch (error) {
@@ -1858,7 +1730,6 @@ export class RewardsController extends BaseController<
   ): Promise<boolean> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
-      log.info('RewardsController: Rewards feature is disabled');
       return false;
     }
 
@@ -1871,10 +1742,6 @@ export class RewardsController extends BaseController<
     // Check if account already has a subscription (short-circuit)
     const existingAccountState = this.#getAccountState(caipAccount);
     if (existingAccountState?.subscriptionId) {
-      log.info('RewardsController: Account to link already has subscription', {
-        account: caipAccount,
-        subscriptionId: existingAccountState.subscriptionId,
-      });
       const existingSubscription =
         this.state.rewardsSubscriptions[existingAccountState.subscriptionId];
       if (existingSubscription) {
@@ -1889,7 +1756,6 @@ export class RewardsController extends BaseController<
     }
 
     if (!this.isOptInSupported(account)) {
-      log.info('RewardsController: Account is not supported for opt-in');
       return false;
     }
 
@@ -1930,10 +1796,6 @@ export class RewardsController extends BaseController<
             retryAttempt < MAX_RETRY_ATTEMPTS
           ) {
             retryAttempt += 1;
-            log.info('RewardsController: Retrying with server timestamp', {
-              originalTimestamp: ts,
-              newTimestamp: error.timestamp,
-            });
             // Use the timestamp from the error for retry
             timestamp = error.timestamp;
             signature = await this.#signRewardsMessage(account, timestamp);
@@ -1980,14 +1842,6 @@ export class RewardsController extends BaseController<
         }
       });
 
-      log.info(
-        'RewardsController: Successfully linked account to subscription',
-        {
-          account: caipAccount,
-          subscriptionId: updatedSubscription.id,
-        },
-      );
-
       // Only invalidate related data if requested
       if (invalidateRelatedData) {
         // Invalidate cache for the linked account
@@ -2022,7 +1876,6 @@ export class RewardsController extends BaseController<
   ): Promise<{ account: InternalAccount; success: boolean }[]> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
-      log.info('RewardsController: Rewards feature is disabled');
       return accounts.map((account) => ({ account, success: false }));
     }
 
@@ -2107,11 +1960,5 @@ export class RewardsController extends BaseController<
         });
       });
     }
-
-    log.info(
-      'RewardsController: Invalidated cache for subscription',
-      subscriptionId,
-      seasonId || 'all seasons',
-    );
   }
 }

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -892,16 +892,7 @@ export class RewardsController extends BaseController<
     if (!rewardsEnabled) {
       return false;
     }
-    const accountState = this.#getAccountState(account);
-    if (accountState?.hasOptedIn) {
-      return accountState.hasOptedIn;
-    }
-
-    // Right now we'll derive this from either cached map state or perps fee discount api call.
-    const optInStatusData = await this.getOptInStatus({
-      addresses: [account.toString()],
-    });
-    return Boolean(optInStatusData.ois[0]);
+    return this.#getAccountState(account)?.hasOptedIn ?? false;
   }
 
   checkOptInStatusAgainstCache(

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,6 +1,8 @@
-import { CaipAccountId, CaipAssetType } from '@metamask/utils';
+import { CaipAccountId } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
+  EstimatedPointsDto,
+  EstimatePointsDto,
   SeasonDtoState,
   SeasonRewardType,
   SeasonStatusState,
@@ -73,107 +75,6 @@ export type MobileOptinDto = {
    */
   referralCode?: string;
 };
-
-export type EstimateAssetDto = {
-  /**
-   * Asset identifier in CAIP-19 format
-   *
-   * @example 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-   */
-  id: CaipAssetType;
-  /**
-   * Amount of the asset as a string
-   *
-   * @example '25739959426'
-   */
-  amount: string;
-  /**
-   * Asset price in USD PER TOKEN. Using ETH as an example, 1 ETH = 4493.23 USD at the time of writing. If provided, this will be used instead of doing a network call to get the current price.
-   *
-   * @example '4512.34'
-   */
-  usdPrice?: string;
-};
-
-export type EstimateSwapContextDto = {
-  /**
-   * Source asset information, in caip19 format
-   *
-   * @example {
-   *   id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-   *   amount: '25739959426'
-   * }
-   */
-  srcAsset: EstimateAssetDto;
-
-  /**
-   * Destination asset information, in caip19 format.
-   *
-   * @example {
-   *   id: 'eip155:1/slip44:60',
-   *   amount: '9912500000000000000'
-   * }
-   */
-  destAsset: EstimateAssetDto;
-
-  /**
-   * Fee asset information, in caip19 format
-   *
-   * @example {
-   *   id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-   *   amount: '100'
-   * }
-   */
-  feeAsset: EstimateAssetDto;
-};
-
-export type EstimatePerpsContextDto = {
-  /**
-   * Type of the PERPS action (open position, close position, stop/loss, take profit, ...)
-   *
-   * @example 'OPEN_POSITION'
-   */
-  type: 'OPEN_POSITION' | 'CLOSE_POSITION' | 'STOP_LOSS' | 'TAKE_PROFIT';
-
-  /**
-   * USD fee value
-   *
-   * @example '12.34'
-   */
-  usdFeeValue: string;
-
-  /**
-   * Asset symbol (e.g., "ETH", "BTC")
-   *
-   * @example 'ETH'
-   */
-  coin: string;
-};
-
-export type EstimatePointsContextDto = {
-  /**
-   * Swap context data, must be present for SWAP activity
-   */
-  swapContext?: EstimateSwapContextDto;
-
-  /**
-   * PERPS context data, must be present for PERPS activity
-   */
-  perpsContext?: EstimatePerpsContextDto;
-};
-
-/**
- * Type of point earning activity. Swap is for swaps and bridges. PERPS is for perps activities.
- *
- * @example 'SWAP'
- */
-export type PointsEventEarnType =
-  | 'SWAP'
-  | 'PERPS'
-  | 'REFERRAL'
-  | 'SIGN_UP_BONUS'
-  | 'LOYALTY_BONUS'
-  | 'ONE_TIME_BONUS';
 
 export type GetPointsEventsDto = {
   seasonId: string;
@@ -355,43 +256,6 @@ export type PointsEventDto = BasePointsEventDto &
         payload: null;
       }
   );
-
-export type EstimatePointsDto = {
-  /**
-   * Type of point earning activity
-   *
-   * @example 'SWAP'
-   */
-  activityType: PointsEventEarnType;
-
-  /**
-   * Account address performing the activity in CAIP-10 format
-   *
-   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
-   */
-  account: CaipAccountId;
-
-  /**
-   * Context data specific to the activity type
-   */
-  activityContext: EstimatePointsContextDto;
-};
-
-export type EstimatedPointsDto = {
-  /**
-   * Earnable for the activity
-   *
-   * @example 100
-   */
-  pointsEstimate: number;
-
-  /**
-   * Bonus applied to the points estimate, in basis points. 100 = 1%
-   *
-   * @example 200
-   */
-  bonusBips: number;
-};
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SeasonTierDto = {

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -9,6 +9,10 @@ import { ENVIRONMENT } from '../../../../development/build/constants';
 import { RewardsDataServiceMessenger } from '../../controller-init/messengers/reward-data-service-messenger';
 import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
 import {
+  EstimatePointsDto,
+  EstimatedPointsDto,
+} from '../../../../shared/types/rewards';
+import {
   RewardsDataService,
   InvalidTimestampError,
   AuthorizationFailedError,
@@ -16,8 +20,6 @@ import {
 } from './rewards-data-service';
 import type {
   LoginResponseDto,
-  EstimatePointsDto,
-  EstimatedPointsDto,
   SeasonStateDto,
   MobileLoginDto,
   MobileOptinDto,

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -7,10 +7,12 @@ import ExtensionPlatform from '../../platforms/extension';
 import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
 import type { RewardsDataServiceMessenger } from '../../controller-init/messengers/reward-data-service-messenger';
 import { FALLBACK_LOCALE } from '../../../../shared/modules/i18n';
-import type {
-  LoginResponseDto,
+import {
   EstimatePointsDto,
   EstimatedPointsDto,
+} from '../../../../shared/types/rewards';
+import type {
+  LoginResponseDto,
   MobileLoginDto,
   SubscriptionDto,
   OptInStatusInputDto,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -742,6 +742,7 @@ export default class MetamaskController extends EventEmitter {
     this.nameController = controllersByName.NameController;
     this.announcementController = controllersByName.AnnouncementController;
     this.accountOrderController = controllersByName.AccountOrderController;
+    this.rewardsController = controllersByName.RewardsController;
 
     this.backup = new Backup({
       preferencesController: this.preferencesController,
@@ -2445,17 +2446,22 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // rewards
-      getCandidateSubscriptionId: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'RewardsController:getCandidateSubscriptionId',
+      getRewardsCandidateSubscriptionId:
+        this.rewardsController.getCandidateSubscriptionId.bind(
+          this.rewardsController,
+        ),
+      getRewardsSeasonMetadata: this.rewardsController.getSeasonMetadata.bind(
+        this.rewardsController,
       ),
-      getRewardsSeasonMetadata: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'RewardsController:getSeasonMetadata',
+      getRewardsSeasonStatus: this.rewardsController.getSeasonStatus.bind(
+        this.rewardsController,
       ),
-      getRewardsSeasonStatus: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'RewardsController:getSeasonStatus',
+      getRewardsHasAccountOptedIn:
+        this.rewardsController.getHasAccountOptedIn.bind(
+          this.rewardsController,
+        ),
+      estimateRewardsPoints: this.rewardsController.estimatePoints.bind(
+        this.rewardsController,
       ),
 
       // hardware wallets

--- a/shared/types/rewards.ts
+++ b/shared/types/rewards.ts
@@ -3,6 +3,8 @@
  * These types are used across UI and background to avoid import restrictions
  */
 
+import { CaipAccountId, CaipAssetType } from '@metamask/utils';
+
 export enum SeasonRewardType {
   Generic = 'Generic',
   PerpsDiscount = 'PerpsDiscount',
@@ -59,4 +61,142 @@ export type SeasonStatusState = {
   balance: SeasonStatusBalanceDtoState;
   tier: SeasonTierState;
   lastFetched?: number;
+};
+
+export type EstimatePointsDto = {
+  /**
+   * Type of point earning activity
+   *
+   * @example 'SWAP'
+   */
+  activityType: PointsEventEarnType;
+
+  /**
+   * Account address performing the activity in CAIP-10 format
+   *
+   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
+   */
+  account: CaipAccountId;
+
+  /**
+   * Context data specific to the activity type
+   */
+  activityContext: EstimatePointsContextDto;
+};
+
+export type EstimateAssetDto = {
+  /**
+   * Asset identifier in CAIP-19 format
+   *
+   * @example 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+   */
+  id: CaipAssetType;
+  /**
+   * Amount of the asset as a string
+   *
+   * @example '25739959426'
+   */
+  amount: string;
+  /**
+   * Asset price in USD PER TOKEN. Using ETH as an example, 1 ETH = 4493.23 USD at the time of writing. If provided, this will be used instead of doing a network call to get the current price.
+   *
+   * @example '4512.34'
+   */
+  usdPrice?: string;
+};
+
+export type EstimateSwapContextDto = {
+  /**
+   * Source asset information, in caip19 format
+   *
+   * @example {
+   *   id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+   *   amount: '25739959426'
+   * }
+   */
+  srcAsset: EstimateAssetDto;
+
+  /**
+   * Destination asset information, in caip19 format.
+   *
+   * @example {
+   *   id: 'eip155:1/slip44:60',
+   *   amount: '9912500000000000000'
+   * }
+   */
+  destAsset: EstimateAssetDto;
+
+  /**
+   * Fee asset information, in caip19 format
+   *
+   * @example {
+   *   id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+   *   amount: '100'
+   * }
+   */
+  feeAsset: EstimateAssetDto;
+};
+
+export type EstimatePerpsContextDto = {
+  /**
+   * Type of the PERPS action (open position, close position, stop/loss, take profit, ...)
+   *
+   * @example 'OPEN_POSITION'
+   */
+  type: 'OPEN_POSITION' | 'CLOSE_POSITION' | 'STOP_LOSS' | 'TAKE_PROFIT';
+
+  /**
+   * USD fee value
+   *
+   * @example '12.34'
+   */
+  usdFeeValue: string;
+
+  /**
+   * Asset symbol (e.g., "ETH", "BTC")
+   *
+   * @example 'ETH'
+   */
+  coin: string;
+};
+
+export type EstimatePointsContextDto = {
+  /**
+   * Swap context data, must be present for SWAP activity
+   */
+  swapContext?: EstimateSwapContextDto;
+
+  /**
+   * PERPS context data, must be present for PERPS activity
+   */
+  perpsContext?: EstimatePerpsContextDto;
+};
+
+/**
+ * Type of point earning activity. Swap is for swaps and bridges. PERPS is for perps activities.
+ *
+ * @example 'SWAP'
+ */
+export type PointsEventEarnType =
+  | 'SWAP'
+  | 'PERPS'
+  | 'REFERRAL'
+  | 'SIGN_UP_BONUS'
+  | 'LOYALTY_BONUS'
+  | 'ONE_TIME_BONUS';
+
+export type EstimatedPointsDto = {
+  /**
+   * Earnable for the activity
+   *
+   * @example 100
+   */
+  pointsEstimate: number;
+
+  /**
+   * Bonus applied to the points estimate, in basis points. 100 = 1%
+   *
+   * @example 200
+   */
+  bonusBips: number;
 };

--- a/ui/components/app/rewards/RewardsBadge.test.tsx
+++ b/ui/components/app/rewards/RewardsBadge.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { RewardsBadge } from './RewardsBadge';
+
+// Mock dependencies
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(),
+}));
+
+const mockUseI18nContext = useI18nContext as jest.MockedFunction<
+  typeof useI18nContext
+>;
+
+describe('RewardsBadge', () => {
+  const mockT = jest.fn((key: string, values?: string[]) => {
+    if (key === 'rewardsPointsBalance' && values) {
+      return `${values[0]} points`;
+    }
+    if (key === 'rewardsPointsIcon') {
+      return 'Rewards Points Icon';
+    }
+    return key;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseI18nContext.mockReturnValue(mockT);
+  });
+
+  describe('rendering', () => {
+    it('should render the component with formatted points', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      expect(screen.getByTestId('rewards-points-balance')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('rewards-points-balance-value'),
+      ).toBeInTheDocument();
+    });
+
+    it('should render the image with correct attributes', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      const image = screen.getByAltText('Rewards Points Icon');
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute(
+        'src',
+        './images/metamask-rewards-points.svg',
+      );
+      expect(image).toHaveAttribute('width', '16');
+      expect(image).toHaveAttribute('height', '16');
+    });
+
+    it('should render points with suffix by default', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveTextContent('1,000 points');
+    });
+
+    it('should render points without suffix when withPointsSuffix is false', () => {
+      render(<RewardsBadge formattedPoints="1,000" withPointsSuffix={false} />);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveTextContent('1,000');
+    });
+
+    it('should apply boxClassName when provided', () => {
+      render(
+        <RewardsBadge formattedPoints="1,000" boxClassName="custom-box" />,
+      );
+
+      const container = screen.getByTestId('rewards-points-balance');
+      expect(container).toHaveClass('flex', 'items-center', 'custom-box');
+    });
+
+    it('should apply textClassName when provided', () => {
+      render(
+        <RewardsBadge formattedPoints="1,000" textClassName="custom-text" />,
+      );
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveClass('custom-text');
+    });
+
+    it('should apply both boxClassName and textClassName', () => {
+      render(
+        <RewardsBadge
+          formattedPoints="1,000"
+          boxClassName="custom-box"
+          textClassName="custom-text"
+        />,
+      );
+
+      const container = screen.getByTestId('rewards-points-balance');
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+
+      expect(container).toHaveClass('custom-box');
+      expect(textElement).toHaveClass('custom-text');
+    });
+
+    it('should have default flex and items-center classes', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      const container = screen.getByTestId('rewards-points-balance');
+      expect(container).toHaveClass('flex', 'items-center');
+    });
+  });
+
+  describe('translation', () => {
+    it('should call translation function with rewardsPointsBalance key and formatted points', () => {
+      render(<RewardsBadge formattedPoints="5,000" />);
+
+      expect(mockT).toHaveBeenCalledWith('rewardsPointsBalance', ['5,000']);
+    });
+
+    it('should call translation function with rewardsPointsIcon key for image alt text', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      expect(mockT).toHaveBeenCalledWith('rewardsPointsIcon');
+    });
+
+    it('should not call translation function when withPointsSuffix is false', () => {
+      render(<RewardsBadge formattedPoints="5,000" withPointsSuffix={false} />);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveTextContent('5,000');
+      // Should still be called for the icon alt text
+      expect(mockT).toHaveBeenCalledWith('rewardsPointsIcon');
+    });
+  });
+
+  describe('image error handling', () => {
+    it('should hide image when onError is triggered', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      const image = screen.getByAltText('Rewards Points Icon');
+      expect(image).toBeInTheDocument();
+
+      fireEvent.error(image);
+
+      expect(
+        screen.queryByAltText('Rewards Points Icon'),
+      ).not.toBeInTheDocument();
+      // Text should still be visible
+      expect(
+        screen.getByTestId('rewards-points-balance-value'),
+      ).toBeInTheDocument();
+    });
+
+    it('should render text content even when image fails to load', () => {
+      render(<RewardsBadge formattedPoints="2,500" />);
+
+      const image = screen.getByAltText('Rewards Points Icon');
+      fireEvent.error(image);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toBeInTheDocument();
+      expect(textElement).toHaveTextContent('2,500 points');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle zero points', () => {
+      render(<RewardsBadge formattedPoints="0" />);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveTextContent('0 points');
+    });
+
+    it('should handle large numbers', () => {
+      render(<RewardsBadge formattedPoints="1,234,567" />);
+
+      const textElement = screen.getByTestId('rewards-points-balance-value');
+      expect(textElement).toHaveTextContent('1,234,567 points');
+    });
+  });
+
+  describe('component structure', () => {
+    it('should have correct data-testid attributes', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      expect(screen.getByTestId('rewards-points-balance')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('rewards-points-balance-value'),
+      ).toBeInTheDocument();
+    });
+
+    it('should call useI18nContext hook', () => {
+      render(<RewardsBadge formattedPoints="1,000" />);
+
+      expect(mockUseI18nContext).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/app/rewards/RewardsBadge.tsx
+++ b/ui/components/app/rewards/RewardsBadge.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export const RewardsBadge = ({
+  formattedPoints,
+  boxClassName,
+  textClassName,
+  withPointsSuffix = true,
+  useAlternativeIconColor = false,
+}: {
+  formattedPoints: string;
+  boxClassName?: string;
+  textClassName?: string;
+  withPointsSuffix?: boolean;
+  useAlternativeIconColor?: boolean;
+}) => {
+  const t = useI18nContext();
+  const [imageLoadError, setImageLoadError] = useState(false);
+
+  return (
+    <Box
+      className={`flex items-center${boxClassName ? ` ${boxClassName}` : ''}`}
+      data-testid="rewards-points-balance"
+    >
+      {!imageLoadError && (
+        <img
+          src="./images/metamask-rewards-points.svg"
+          alt={t('rewardsPointsIcon')}
+          width={16}
+          height={16}
+          onError={() => setImageLoadError(true)}
+          style={
+            useAlternativeIconColor
+              ? {
+                  filter: 'grayscale(100%)',
+                }
+              : undefined
+          }
+        />
+      )}
+      <Text
+        variant={TextVariant.BodySm}
+        className={textClassName}
+        data-testid="rewards-points-balance-value"
+      >
+        {withPointsSuffix
+          ? t('rewardsPointsBalance', [formattedPoints])
+          : formattedPoints}
+      </Text>
+    </Box>
+  );
+};

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useSelector } from 'react-redux';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useRewardsContext } from '../../../contexts/rewards';
 import type { RewardsContextValue } from '../../../contexts/rewards';
+import { getIntlLocale } from '../../../ducks/locale/locale';
 import { RewardsPointsBalance } from './RewardsPointsBalance';
 
 // Mock dependencies
@@ -13,7 +13,15 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../../../hooks/useI18nContext', () => ({
-  useI18nContext: jest.fn(),
+  useI18nContext: jest.fn(() => (key: string, values?: string[]) => {
+    if (key === 'rewardsPointsBalance' && values) {
+      return `${values[0]} points`;
+    }
+    if (key === 'rewardsPointsIcon') {
+      return 'Rewards Points Icon';
+    }
+    return key;
+  }),
 }));
 
 jest.mock('../../../contexts/rewards', () => ({
@@ -29,27 +37,11 @@ jest.mock('../../component-library/skeleton', () => ({
 }));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockUseI18nContext = useI18nContext as jest.MockedFunction<
-  typeof useI18nContext
->;
 const mockUseRewardsContext = useRewardsContext as jest.MockedFunction<
   typeof useRewardsContext
 >;
 
 describe('RewardsPointsBalance', () => {
-  const mockT = jest.fn((key: string, values?: string[]) => {
-    if (key === 'rewardsOptIn') {
-      return 'Opt In';
-    }
-    if (key === 'rewardsPointsBalance' && values) {
-      return `${values[0]} points`;
-    }
-    if (key === 'rewardsPointsIcon') {
-      return 'Rewards Points Icon';
-    }
-    return key;
-  });
-
   // Mock season status with complete structure
   const mockSeasonStatus = {
     season: {
@@ -92,7 +84,6 @@ describe('RewardsPointsBalance', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseI18nContext.mockReturnValue(mockT);
     mockUseSelector.mockReturnValue('en-US'); // Default locale
   });
 
@@ -240,7 +231,6 @@ describe('RewardsPointsBalance', () => {
       'src',
       './images/metamask-rewards-points.svg',
     );
-    expect(image).toHaveStyle({ width: '16px', height: '16px' });
   });
 
   it('should call useSelector with getIntlLocale selector', () => {
@@ -248,15 +238,7 @@ describe('RewardsPointsBalance', () => {
 
     render(<RewardsPointsBalance />);
 
-    expect(mockUseSelector).toHaveBeenCalled();
-  });
-
-  it('should call useI18nContext hook', () => {
-    mockUseRewardsContext.mockReturnValue(mockRewardsContextValue);
-
-    render(<RewardsPointsBalance />);
-
-    expect(mockUseI18nContext).toHaveBeenCalled();
+    expect(mockUseSelector).toHaveBeenCalledWith(getIntlLocale);
   });
 
   it('should call useRewardsContext hook', () => {
@@ -265,5 +247,125 @@ describe('RewardsPointsBalance', () => {
     render(<RewardsPointsBalance />);
 
     expect(mockUseRewardsContext).toHaveBeenCalled();
+  });
+
+  it('should handle undefined balance total gracefully', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: {
+        ...mockSeasonStatus,
+        balance: {
+          total: undefined as unknown as number,
+        },
+      },
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(screen.getByTestId('rewards-points-balance')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent('0 points');
+  });
+
+  it('should handle null balance gracefully', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: {
+        ...mockSeasonStatus,
+        balance: null as unknown as { total: number },
+      },
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(screen.getByTestId('rewards-points-balance')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent('0 points');
+  });
+
+  it('should format large numbers correctly with US locale', () => {
+    mockUseSelector.mockReturnValue('en-US');
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: {
+        ...mockSeasonStatus,
+        balance: {
+          total: 1234567,
+        },
+      },
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent('1,234,567 points');
+  });
+
+  it('should format numbers correctly with French locale', () => {
+    mockUseSelector.mockReturnValue('fr-FR');
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: {
+        ...mockSeasonStatus,
+        balance: {
+          total: 12345,
+        },
+      },
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent('12 345 points');
+  });
+
+  it('should format numbers correctly with Spanish locale', () => {
+    mockUseSelector.mockReturnValue('es-ES');
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: {
+        ...mockSeasonStatus,
+        balance: {
+          total: 12345,
+        },
+      },
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent('12.345 points');
+  });
+
+  it('should not render skeleton when seasonStatus is null and not loading', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: null,
+      seasonStatusLoading: false,
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+    expect(screen.getByTestId('rewards-points-balance')).toBeInTheDocument();
+  });
+
+  it('should apply correct boxClassName to RewardsBadge', () => {
+    mockUseRewardsContext.mockReturnValue(mockRewardsContextValue);
+
+    render(<RewardsPointsBalance />);
+
+    const container = screen.getByTestId('rewards-points-balance');
+    expect(container).toHaveClass(
+      'gap-1',
+      'px-1.5',
+      'bg-background-muted',
+      'rounded',
+    );
   });
 });

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -1,33 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Box, Text, TextVariant } from '@metamask/design-system-react';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { useRewardsContext } from '../../../contexts/rewards';
 import { Skeleton } from '../../component-library/skeleton';
-
-const RewardsBadge = ({ text }: { text: string }) => {
-  const t = useI18nContext();
-
-  return (
-    <Box
-      className="flex items-center gap-1 px-1.5 bg-background-muted rounded"
-      data-testid="rewards-points-balance"
-    >
-      <img
-        src="./images/metamask-rewards-points.svg"
-        alt={t('rewardsPointsIcon')}
-        style={{ width: '16px', height: '16px' }}
-      />
-      <Text
-        variant={TextVariant.BodySm}
-        data-testid="rewards-points-balance-value"
-      >
-        {text}
-      </Text>
-    </Box>
-  );
-};
+import { RewardsBadge } from './RewardsBadge';
 
 /**
  * Component to display the rewards points balance
@@ -35,7 +11,6 @@ const RewardsBadge = ({ text }: { text: string }) => {
  * (i.e., when rewardsActiveAccount?.subscriptionId is null)
  */
 export const RewardsPointsBalance = () => {
-  const t = useI18nContext();
   const locale = useSelector(getIntlLocale);
 
   const {
@@ -43,13 +18,16 @@ export const RewardsPointsBalance = () => {
     seasonStatus,
     seasonStatusLoading,
     candidateSubscriptionId,
+    refetchSeasonStatus,
   } = useRewardsContext();
 
-  if (!rewardsEnabled) {
-    return null;
-  }
+  useEffect(() => {
+    if (rewardsEnabled) {
+      refetchSeasonStatus();
+    }
+  }, [refetchSeasonStatus, rewardsEnabled]);
 
-  if (!candidateSubscriptionId) {
+  if (!rewardsEnabled || !candidateSubscriptionId) {
     return null;
   }
 
@@ -62,5 +40,10 @@ export const RewardsPointsBalance = () => {
     seasonStatus?.balance?.total ?? 0,
   );
 
-  return <RewardsBadge text={t('rewardsPointsBalance', [formattedPoints])} />;
+  return (
+    <RewardsBadge
+      formattedPoints={formattedPoints}
+      boxClassName="gap-1 px-1.5 bg-background-muted rounded"
+    />
+  );
 };

--- a/ui/components/app/rewards/index.ts
+++ b/ui/components/app/rewards/index.ts
@@ -1,1 +1,2 @@
 export { RewardsPointsBalance } from './RewardsPointsBalance';
+export { RewardsBadge } from './RewardsBadge';

--- a/ui/hooks/bridge/useRewards.test.ts
+++ b/ui/hooks/bridge/useRewards.test.ts
@@ -1,0 +1,813 @@
+import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import log from 'loglevel';
+import { useSelector } from 'react-redux';
+import { selectBridgeQuotes } from '@metamask/bridge-controller';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
+import {
+  getRewardsHasAccountOptedIn,
+  estimateRewardsPoints,
+} from '../../store/actions';
+import { useRewardsContext } from '../rewards';
+import { usePrevious } from '../usePrevious';
+import { useMultichainSelector } from '../useMultichainSelector';
+import {
+  getFromToken,
+  getToToken,
+  getQuoteRequest,
+} from '../../ducks/bridge/selectors';
+import {
+  getInternalAccountBySelectedAccountGroupAndCaip,
+  getSelectedAccountGroup,
+  getInternalAccountsFromGroupById,
+} from '../../selectors/multichain-accounts/account-tree';
+import { useRewards, getUsdPricePerToken } from './useRewards';
+
+// Mock dependencies
+jest.mock('../../store/actions', () => ({
+  getRewardsHasAccountOptedIn: jest.fn(),
+  estimateRewardsPoints: jest.fn(),
+}));
+
+jest.mock('../rewards', () => ({
+  useRewardsContext: jest.fn(),
+}));
+
+jest.mock('../usePrevious', () => ({
+  usePrevious: jest.fn(),
+}));
+
+jest.mock('../useMultichainSelector', () => ({
+  useMultichainSelector: jest.fn(),
+}));
+
+jest.mock('../../ducks/bridge/selectors', () => ({
+  getFromToken: jest.fn(),
+  getToToken: jest.fn(),
+  getQuoteRequest: jest.fn(),
+}));
+
+jest.mock('../../selectors/multichain-accounts/account-tree', () => ({
+  getInternalAccountBySelectedAccountGroupAndCaip: jest.fn(),
+  getSelectedAccountGroup: jest.fn((_state: unknown) => 'account-group-1'),
+  getInternalAccountsFromGroupById: jest.fn(
+    (_state: unknown, _groupId: string) => [],
+  ),
+}));
+
+jest.mock('loglevel', () => ({
+  error: jest.fn(),
+  setLevel: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const mockGetRewardsHasAccountOptedIn =
+  getRewardsHasAccountOptedIn as jest.MockedFunction<
+    typeof getRewardsHasAccountOptedIn
+  >;
+const mockEstimateRewardsPoints = estimateRewardsPoints as jest.MockedFunction<
+  typeof estimateRewardsPoints
+>;
+const mockUseRewardsContext = useRewardsContext as jest.MockedFunction<
+  typeof useRewardsContext
+>;
+const mockUsePrevious = usePrevious as jest.MockedFunction<typeof usePrevious>;
+const mockUseMultichainSelector = useMultichainSelector as jest.MockedFunction<
+  typeof useMultichainSelector
+>;
+const mockLogError = log.error as jest.MockedFunction<typeof log.error>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const mockGetFromToken = getFromToken as jest.MockedFunction<
+  typeof getFromToken
+>;
+const mockGetToToken = getToToken as jest.MockedFunction<typeof getToToken>;
+const mockGetQuoteRequest = getQuoteRequest as jest.MockedFunction<
+  typeof getQuoteRequest
+>;
+const mockGetInternalAccountBySelectedAccountGroupAndCaip =
+  getInternalAccountBySelectedAccountGroupAndCaip as jest.MockedFunction<
+    typeof getInternalAccountBySelectedAccountGroupAndCaip
+  >;
+const mockGetSelectedAccountGroup =
+  getSelectedAccountGroup as jest.MockedFunction<
+    typeof getSelectedAccountGroup
+  >;
+const mockGetInternalAccountsFromGroupById =
+  getInternalAccountsFromGroupById as jest.MockedFunction<
+    typeof getInternalAccountsFromGroupById
+  >;
+
+describe('useRewards', () => {
+  const mockAddress = '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6';
+  const mockCaipAccount = 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6';
+  const mockChainId = '1';
+  const mockQuoteRequestId = 'quote-123';
+  const mockSrcTokenAmount = '1000000000000000000'; // 1 ETH
+
+  const mockFromToken = {
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'ETH',
+    decimals: 18,
+  } as unknown as ReturnType<typeof getFromToken>;
+
+  const mockToToken = {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    symbol: 'USDC',
+    decimals: 6,
+  } as unknown as ReturnType<typeof getToToken>;
+
+  const mockQuoteRequest = {
+    srcTokenAmount: mockSrcTokenAmount,
+  } as ReturnType<typeof getQuoteRequest>;
+
+  const mockSelectedAccount = createMockInternalAccount({
+    address: mockAddress,
+    id: 'account-1',
+  });
+
+  const mockActiveQuote = {
+    requestId: mockQuoteRequestId,
+    srcTokenAmount: '1000000000000000000',
+    destTokenAmount: '3000000000',
+    srcAsset: {
+      assetId: 'eip155:1/slip44:60',
+      decimals: 18,
+    },
+    destAsset: {
+      assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      decimals: 6,
+    },
+    feeData: {
+      metabridge: {
+        asset: {
+          assetId: 'eip155:1/slip44:60',
+          decimals: 18,
+        },
+        amount: '10000000000000000', // 0.01 ETH
+      },
+    },
+    priceData: {
+      totalFeeAmountUsd: '30.00',
+    },
+  } as unknown as NonNullable<
+    ReturnType<typeof selectBridgeQuotes>['activeQuote']
+  >['quote'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRewardsContext.mockReturnValue({
+      rewardsEnabled: true,
+      candidateSubscriptionId: 'sub-123',
+      candidateSubscriptionIdError: false,
+      seasonStatus: null,
+      seasonStatusError: null,
+      seasonStatusLoading: false,
+      refetchSeasonStatus: jest.fn(),
+    });
+    mockUsePrevious.mockReturnValue(undefined);
+    mockUseMultichainSelector.mockReturnValue(mockChainId);
+    mockGetFromToken.mockReturnValue(mockFromToken);
+    mockGetToToken.mockReturnValue(mockToToken);
+    mockGetQuoteRequest.mockReturnValue(mockQuoteRequest);
+    mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
+      mockSelectedAccount,
+    );
+    // Mock getSelectedAccountGroup to return a default value
+    mockGetSelectedAccountGroup.mockReturnValue('account-group-1' as never);
+    // Mock getInternalAccountsFromGroupById to return an empty array by default
+    mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+    mockUseSelector.mockImplementation(((selector: unknown) => {
+      if (selector === mockGetFromToken) {
+        return mockGetFromToken({} as never);
+      }
+      if (selector === mockGetToToken) {
+        return mockGetToToken({} as never);
+      }
+      if (selector === mockGetQuoteRequest) {
+        return mockGetQuoteRequest({} as never);
+      }
+      // Handle the account selector: selector(state) => getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId)
+      if (typeof selector === 'function') {
+        try {
+          // Call the selector function with mock state
+          // The selector will internally call getInternalAccountBySelectedAccountGroupAndCaip
+          // which is mocked to return mockSelectedAccount
+          const result = selector({} as never);
+          return result;
+        } catch {
+          // Not the account selector or error occurred
+        }
+      }
+      return null;
+    }) as never);
+  });
+
+  describe('getUsdPricePerToken', () => {
+    it('should calculate USD price per token correctly', () => {
+      const result = getUsdPricePerToken('30.00', '10000000000000000', 18);
+      expect(result).toBe('3000');
+    });
+
+    it('should return undefined when totalFeeAmountUsd is zero', () => {
+      const result = getUsdPricePerToken('0', '10000000000000000', 18);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when feeAmountAtomic is zero', () => {
+      const result = getUsdPricePerToken('30.00', '0', 18);
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle different decimals correctly', () => {
+      const result = getUsdPricePerToken('30.00', '30000000', 6);
+      expect(result).toBe('1');
+    });
+
+    it('should return undefined on error', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      // Force an error by passing invalid values
+      const result = getUsdPricePerToken('invalid', 'invalid', 18);
+      expect(result).toBeUndefined();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Initial State', () => {
+    it('should return initial values', () => {
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: null }),
+        {},
+      );
+
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.estimatedPoints).toBeNull();
+      expect(result.current.hasError).toBe(false);
+    });
+  });
+
+  describe('Early Returns', () => {
+    it('should not estimate points when activeQuote is null', async () => {
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: null }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+        expect(result.current.estimatedPoints).toBeNull();
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+      expect(mockEstimateRewardsPoints).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when fromToken is missing', async () => {
+      mockGetFromToken.mockReturnValue(null);
+      mockUseSelector.mockImplementation(((selector: unknown) => {
+        if (selector === mockGetFromToken) {
+          return mockGetFromToken({} as never);
+        }
+        if (selector === mockGetToToken) {
+          return mockGetToToken({} as never);
+        }
+        if (selector === mockGetQuoteRequest) {
+          return mockGetQuoteRequest({} as never);
+        }
+        // Handle the account selector
+        if (typeof selector === 'function') {
+          try {
+            const result = selector({} as never);
+            return result;
+          } catch {
+            // Not the account selector or error occurred
+          }
+        }
+        return null;
+      }) as never);
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when toToken is missing', async () => {
+      mockGetToToken.mockReturnValue(null);
+      mockUseSelector.mockImplementation(((selector: unknown) => {
+        if (selector === mockGetFromToken) {
+          return mockGetFromToken({} as never);
+        }
+        if (selector === mockGetToToken) {
+          return null;
+        }
+        if (selector === mockGetQuoteRequest) {
+          return mockGetQuoteRequest({} as never);
+        }
+
+        return null;
+      }) as never);
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when quoteRequest.srcTokenAmount is missing', async () => {
+      mockGetQuoteRequest.mockReturnValue({
+        srcTokenAmount: undefined,
+      } as ReturnType<typeof getQuoteRequest>);
+      mockUseSelector.mockImplementation(((selector: unknown) => {
+        if (selector === mockGetFromToken) {
+          return mockGetFromToken({} as never);
+        }
+        if (selector === mockGetToToken) {
+          return mockGetToToken({} as never);
+        }
+        if (selector === mockGetQuoteRequest) {
+          return {
+            srcTokenAmount: undefined,
+          } as ReturnType<typeof getQuoteRequest>;
+        }
+        return null;
+      }) as never);
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when selectedAccount is missing', async () => {
+      mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
+        null as never,
+      );
+      mockUseSelector.mockImplementation(((selector: unknown) => {
+        if (selector === mockGetFromToken) {
+          return mockGetFromToken({} as never);
+        }
+        if (selector === mockGetToToken) {
+          return mockGetToToken({} as never);
+        }
+        if (selector === mockGetQuoteRequest) {
+          return mockGetQuoteRequest({} as never);
+        }
+        // Handle the account selector
+        if (typeof selector === 'function') {
+          try {
+            const result = selector({} as never);
+            return result;
+          } catch {
+            // Not the account selector or error occurred
+          }
+        }
+        return null;
+      }) as never);
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when currentChainId is missing', async () => {
+      mockUseMultichainSelector.mockReturnValue(null as never);
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+
+    it('should not estimate points when rewardsEnabled is false', async () => {
+      mockUseRewardsContext.mockReturnValue({
+        rewardsEnabled: false,
+        candidateSubscriptionId: 'sub-123',
+        candidateSubscriptionIdError: false,
+        seasonStatus: null,
+        seasonStatusError: null,
+        seasonStatusLoading: false,
+        refetchSeasonStatus: jest.fn(),
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Opt-in Check', () => {
+    it('should not estimate points when account has not opted in', async () => {
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(false),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.shouldShowRewardsRow).toBe(false);
+        expect(result.current.estimatedPoints).toBeNull();
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).toHaveBeenCalledWith(
+        mockCaipAccount,
+      );
+      expect(mockEstimateRewardsPoints).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Successful Point Estimation', () => {
+    it('should estimate points successfully when all conditions are met', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).toHaveBeenCalledWith(
+        mockCaipAccount,
+      );
+      expect(mockEstimateRewardsPoints).toHaveBeenCalled();
+      expect(result.current.estimatedPoints).toBe(100);
+      expect(result.current.shouldShowRewardsRow).toBe(true);
+      expect(result.current.hasError).toBe(false);
+    });
+
+    it('should include USD price in fee asset when available', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const estimateCall = mockEstimateRewardsPoints.mock.calls[0];
+      const estimateRequest = estimateCall[0];
+
+      expect(
+        estimateRequest.activityContext.swapContext?.feeAsset.usdPrice,
+      ).toBe('3000');
+    });
+
+    it('should omit USD price when calculation fails', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+      const quoteWithoutUsdPrice = {
+        ...mockActiveQuote,
+        priceData: {
+          totalFeeAmountUsd: '0',
+        },
+      };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: quoteWithoutUsdPrice }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const estimateCall = mockEstimateRewardsPoints.mock.calls[0];
+      const estimateRequest = estimateCall[0];
+
+      expect(
+        estimateRequest.activityContext.swapContext?.feeAsset.usdPrice,
+      ).toBeUndefined();
+    });
+
+    it('should construct correct estimate request', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const estimateCall = mockEstimateRewardsPoints.mock.calls[0];
+      const estimateRequest = estimateCall[0];
+
+      expect(estimateRequest.activityType).toBe('SWAP');
+      expect(estimateRequest.account).toBe(mockCaipAccount);
+      expect(estimateRequest.activityContext.swapContext?.srcAsset).toEqual({
+        id: 'eip155:1/slip44:60',
+        amount: '1000000000000000000',
+      });
+      expect(estimateRequest.activityContext.swapContext?.destAsset).toEqual({
+        id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        amount: '3000000000',
+      });
+      expect(estimateRequest.activityContext.swapContext?.feeAsset.id).toBe(
+        'eip155:1/slip44:60',
+      );
+      expect(estimateRequest.activityContext.swapContext?.feeAsset.amount).toBe(
+        '10000000000000000',
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle errors during point estimation', async () => {
+      const error = new Error('Estimation failed');
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockRejectedValue(error),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasError).toBe(true);
+      expect(result.current.estimatedPoints).toBeNull();
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useRewards] Error estimating points:',
+        error,
+      );
+    });
+
+    it('should handle errors during opt-in check', async () => {
+      const error = new Error('Opt-in check failed');
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockRejectedValue(error),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasError).toBe(true);
+      expect(mockEstimateRewardsPoints).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Quote Request ID Changes', () => {
+    it('should re-estimate when quote request ID changes', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      // First render with initial quote
+      const { result: result1 } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result1.current.isLoading).toBe(false);
+      });
+
+      expect(mockEstimateRewardsPoints).toHaveBeenCalledTimes(1);
+
+      // Second render with different quote ID
+      mockUsePrevious.mockReturnValue(mockQuoteRequestId);
+
+      const newQuote = {
+        ...mockActiveQuote,
+        requestId: 'quote-456',
+      };
+
+      const { result: result2 } = renderHookWithProvider(
+        () => useRewards({ activeQuote: newQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result2.current.isLoading).toBe(false);
+      });
+
+      // Should have been called again for the new quote
+      expect(mockEstimateRewardsPoints.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should not re-estimate when quote request ID does not change', async () => {
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const initialCallCount = mockEstimateRewardsPoints.mock.calls.length;
+
+      // Re-render with same quote
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(mockEstimateRewardsPoints).toHaveBeenCalledTimes(initialCallCount);
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should set loading state during estimation', async () => {
+      let resolveEstimation: (value: {
+        pointsEstimate: number;
+        bonusBips: number;
+      }) => void;
+      const estimationPromise = new Promise<{
+        pointsEstimate: number;
+        bonusBips: number;
+      }>((resolve) => {
+        resolveEstimation = resolve;
+      });
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockReturnValue(estimationPromise),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.shouldShowRewardsRow).toBe(true);
+      });
+
+      await act(async () => {
+        resolveEstimation({ pointsEstimate: 100, bonusBips: 0 });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe('Address Formatting', () => {
+    it('should handle checksummed addresses', async () => {
+      const checksummedAddress = '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6';
+      const mockAccount = createMockInternalAccount({
+        address: checksummedAddress.toLowerCase(),
+        id: 'account-1',
+      });
+      mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
+        mockAccount,
+      );
+      mockUseSelector.mockImplementation(((selector: unknown) => {
+        if (selector === mockGetFromToken) {
+          return mockGetFromToken({} as never);
+        }
+        if (selector === mockGetToToken) {
+          return mockGetToToken({} as never);
+        }
+        if (selector === mockGetQuoteRequest) {
+          return mockGetQuoteRequest({} as never);
+        }
+        // Handle the account selector
+        if (typeof selector === 'function') {
+          try {
+            const result = selector({} as never);
+            return result;
+          } catch {
+            // Not the account selector or error occurred
+          }
+        }
+        return null;
+      }) as never);
+
+      const mockEstimatedPoints = { pointsEstimate: 100, bonusBips: 0 };
+
+      mockGetRewardsHasAccountOptedIn.mockReturnValue(
+        jest.fn().mockResolvedValue(true),
+      );
+      mockEstimateRewardsPoints.mockReturnValue(
+        jest.fn().mockResolvedValue(mockEstimatedPoints),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useRewards({ activeQuote: mockActiveQuote }),
+        {},
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetRewardsHasAccountOptedIn).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/hooks/bridge/useRewards.ts
+++ b/ui/hooks/bridge/useRewards.ts
@@ -1,0 +1,276 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { BigNumber } from 'bignumber.js';
+import {
+  formatChainIdToCaip,
+  selectBridgeQuotes,
+} from '@metamask/bridge-controller';
+import {
+  toCaipAccountId,
+  parseCaipChainId,
+  type CaipAccountId,
+  isValidHexAddress,
+  Hex,
+} from '@metamask/utils';
+import log from 'loglevel';
+import {
+  getFromToken,
+  getToToken,
+  getQuoteRequest,
+} from '../../ducks/bridge/selectors';
+import { getMultichainCurrentChainId } from '../../selectors/multichain';
+import { usePrevious } from '../usePrevious';
+import { useMultichainSelector } from '../useMultichainSelector';
+import {
+  getRewardsHasAccountOptedIn,
+  estimateRewardsPoints,
+} from '../../store/actions';
+import {
+  EstimateAssetDto,
+  EstimatePointsDto,
+  EstimatedPointsDto,
+} from '../../../shared/types/rewards';
+import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+import { useRewardsContext } from '../rewards';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
+
+/**
+ *
+ * @param totalFeeAmountUsd - The total fee amount in USD
+ * @param feeAmountAtomic - The fee amount in atomic units
+ * @param feeAssetDecimals - The decimals of the fee asset
+ * @returns The USD price per token
+ */
+export const getUsdPricePerToken = (
+  totalFeeAmountUsd: string,
+  feeAmountAtomic: string,
+  feeAssetDecimals: number,
+): string | undefined => {
+  try {
+    // Use BigNumber for precision-safe arithmetic
+    const totalFeeUsd = new BigNumber(totalFeeAmountUsd);
+    const feeAmountAtomicBN = new BigNumber(feeAmountAtomic);
+    const feeAmountBN = feeAmountAtomicBN.div(
+      new BigNumber(10).pow(feeAssetDecimals),
+    );
+
+    if (totalFeeUsd.isZero() || feeAmountBN.isZero()) {
+      return undefined;
+    }
+
+    return totalFeeUsd.dividedBy(feeAmountBN).toString();
+  } catch (error) {
+    console.error(
+      error as Error,
+      'useRewards: Error calculating USD price per token',
+    );
+    return undefined;
+  }
+};
+
+type UseRewardsResult = {
+  shouldShowRewardsRow: boolean;
+  isLoading: boolean;
+  estimatedPoints: number | null;
+  hasError: boolean;
+};
+
+/**
+ * Formats an address to CAIP-10 account ID
+ *
+ * @param address
+ * @param chainId
+ */
+const formatAccountToCaipAccountId = (
+  address: string,
+  chainId: string,
+): CaipAccountId | null => {
+  try {
+    const caipChainId = formatChainIdToCaip(chainId);
+    const { namespace, reference } = parseCaipChainId(caipChainId);
+    const coercedAddress = isValidHexAddress(address as Hex)
+      ? toChecksumHexAddress(address)
+      : address;
+    return toCaipAccountId(namespace, reference, coercedAddress);
+  } catch (error) {
+    log.error('[useRewards] Error formatting account to CAIP-10:', error);
+    return null;
+  }
+};
+
+type UseRewardsParams = {
+  activeQuote: NonNullable<
+    NonNullable<ReturnType<typeof selectBridgeQuotes>['activeQuote']>['quote']
+  > | null;
+};
+
+export const useRewards = ({
+  activeQuote,
+}: UseRewardsParams): UseRewardsResult => {
+  const dispatch = useDispatch();
+  const [isLoading, setIsLoading] = useState(false);
+  const [estimatedPoints, setEstimatedPoints] = useState<number | null>(null);
+  const [shouldShowRewardsRow, setShouldShowRewardsRow] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const prevRequestId = usePrevious(activeQuote?.requestId);
+  const fromToken = useSelector(getFromToken);
+  const toToken = useSelector(getToToken);
+  const quoteRequest = useSelector(getQuoteRequest);
+  const { rewardsEnabled } = useRewardsContext();
+  const currentChainId = useMultichainSelector(getMultichainCurrentChainId);
+  const caipChainId = currentChainId
+    ? formatChainIdToCaip(currentChainId.toString())
+    : null;
+  const selectedAccount = useSelector((state) =>
+    caipChainId
+      ? getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId)
+      : null,
+  );
+
+  const estimatePoints = useCallback(
+    async (
+      estimationQuoteArg:
+        | NonNullable<
+            ReturnType<typeof selectBridgeQuotes>['activeQuote']
+          >['quote']
+        | null,
+    ) => {
+      // Skip if no active quote or missing required data
+      if (
+        !estimationQuoteArg ||
+        !fromToken ||
+        !toToken ||
+        !selectedAccount?.address ||
+        !quoteRequest.srcTokenAmount ||
+        !currentChainId ||
+        !rewardsEnabled
+      ) {
+        setEstimatedPoints(null);
+        setShouldShowRewardsRow(false);
+        setIsLoading(false);
+        setHasError(false);
+        return;
+      }
+
+      setIsLoading(false);
+      setShouldShowRewardsRow(false);
+      setHasError(false);
+      setEstimatedPoints(null);
+
+      try {
+        // Format account to CAIP-10
+        const caipAccount = formatAccountToCaipAccountId(
+          selectedAccount.address,
+          currentChainId.toString(),
+        );
+
+        if (!caipAccount) {
+          return;
+        }
+
+        // Check if account has opted in
+        const hasOptedIn = await dispatch(
+          getRewardsHasAccountOptedIn(caipAccount),
+        );
+
+        if (!hasOptedIn) {
+          return;
+        }
+
+        setIsLoading(true);
+        setShouldShowRewardsRow(true);
+        setHasError(false);
+
+        // Convert source amount to atomic unit
+        const atomicSourceAmount = estimationQuoteArg.srcTokenAmount;
+
+        // Get destination amount from quote
+        const atomicDestAmount = estimationQuoteArg.destTokenAmount;
+
+        // Prepare source asset
+        const srcAsset: EstimateAssetDto = {
+          id: estimationQuoteArg.srcAsset.assetId,
+          amount: atomicSourceAmount,
+        };
+
+        // Prepare destination asset
+        const destAsset: EstimateAssetDto = {
+          id: estimationQuoteArg.destAsset.assetId,
+          amount: atomicDestAmount,
+        };
+
+        // Prepare fee asset (using MetaMask fee from quote data)
+        const feeAsset: EstimateAssetDto = {
+          id: estimationQuoteArg.feeData.metabridge.asset.assetId,
+          amount: estimationQuoteArg.feeData.metabridge.amount || '0',
+        };
+
+        const usdPricePerToken = getUsdPricePerToken(
+          estimationQuoteArg.priceData?.totalFeeAmountUsd || '0',
+          feeAsset.amount,
+          estimationQuoteArg.feeData.metabridge.asset.decimals,
+        );
+
+        const feeAssetWithUsdPrice: EstimateAssetDto = {
+          ...feeAsset,
+          ...(usdPricePerToken ? { usdPrice: usdPricePerToken } : {}),
+        };
+
+        // Create estimate request
+        const estimateRequest: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: caipAccount,
+          activityContext: {
+            swapContext: {
+              srcAsset,
+              destAsset,
+              feeAsset: feeAssetWithUsdPrice,
+            },
+          },
+        };
+
+        // Call rewards controller to estimate points
+        const result = (await dispatch(
+          estimateRewardsPoints(estimateRequest),
+        )) as unknown as EstimatedPointsDto;
+
+        setEstimatedPoints(result.pointsEstimate);
+      } catch (error) {
+        log.error('[useRewards] Error estimating points:', error);
+        setEstimatedPoints(null);
+        setHasError(true);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      fromToken,
+      toToken,
+      quoteRequest?.srcTokenAmount,
+      selectedAccount?.address,
+      currentChainId,
+      rewardsEnabled,
+      dispatch,
+    ],
+  );
+
+  // Estimate points when dependencies change
+  useEffect(() => {
+    if (prevRequestId !== activeQuote?.requestId) {
+      estimatePoints(activeQuote);
+    }
+  }, [
+    estimatePoints,
+    // Only re-estimate when quote changes (not during loading)
+    activeQuote?.requestId,
+    activeQuote,
+    prevRequestId,
+  ]);
+
+  return {
+    shouldShowRewardsRow,
+    isLoading,
+    estimatedPoints,
+    hasError,
+  };
+};

--- a/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
@@ -153,8 +153,7 @@ describe('useCandidateSubscriptionId', () => {
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-          'getCandidateSubscriptionId',
-          [],
+          'getRewardsCandidateSubscriptionId',
         );
       });
 
@@ -169,11 +168,14 @@ describe('useCandidateSubscriptionId', () => {
       const mockId = 'test-subscription-id';
       mockSubmitRequestToBackground.mockResolvedValue(mockId);
 
-      const { result } = renderHookWithProvider(
+      // Start with rewards disabled to prevent useEffect from auto-fetching
+      mockUseRewardsEnabled.mockReturnValue(false);
+
+      const { result, rerender } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
         {
           metamask: {
-            isUnlocked: true,
+            isUnlocked: false, // Lock wallet to prevent useEffect from auto-fetching
             rewardsActiveAccount: {
               account: 'eip155:1:0x123',
               subscriptionId: 'sub-123',
@@ -183,14 +185,24 @@ describe('useCandidateSubscriptionId', () => {
         },
       );
 
+      // Clear any calls that may have happened during render
+      mockSubmitRequestToBackground.mockClear();
+
+      // Enable rewards and rerender to update the hook's callback
+      mockUseRewardsEnabled.mockReturnValue(true);
+      act(() => {
+        rerender();
+      });
+
       await act(async () => {
         await result.current.fetchCandidateSubscriptionId();
       });
 
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-        'getCandidateSubscriptionId',
-        [],
-      );
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'getRewardsCandidateSubscriptionId',
+        );
+      });
       expect(result.current.candidateSubscriptionId).toBe(mockId);
       expect(result.current.candidateSubscriptionIdError).toBe(false);
     });
@@ -199,11 +211,14 @@ describe('useCandidateSubscriptionId', () => {
       const mockError = new Error('API Error');
       mockSubmitRequestToBackground.mockRejectedValue(mockError);
 
-      const { result } = renderHookWithProvider(
+      // Start with rewards disabled to prevent useEffect from auto-fetching
+      mockUseRewardsEnabled.mockReturnValue(false);
+
+      const { result, rerender } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
         {
           metamask: {
-            isUnlocked: true,
+            isUnlocked: false, // Lock wallet to prevent useEffect from auto-fetching
             rewardsActiveAccount: {
               account: 'eip155:1:0x123',
               subscriptionId: 'sub-123',
@@ -213,46 +228,30 @@ describe('useCandidateSubscriptionId', () => {
         },
       );
 
+      // Clear any calls that may have happened during render
+      mockSubmitRequestToBackground.mockClear();
+
+      // Enable rewards and rerender to update the hook's callback
+      mockUseRewardsEnabled.mockReturnValue(true);
+      act(() => {
+        rerender();
+      });
+
       await act(async () => {
         await result.current.fetchCandidateSubscriptionId();
       });
 
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-        'getCandidateSubscriptionId',
-        [],
-      );
+      await waitFor(() => {
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'getRewardsCandidateSubscriptionId',
+        );
+      });
       expect(result.current.candidateSubscriptionId).toBeNull();
       expect(result.current.candidateSubscriptionIdError).toBe(true);
       expect(mockLogError).toHaveBeenCalledWith(
         '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
         mockError,
       );
-    });
-
-    it('should not fetch when rewards are disabled in fetchCandidateSubscriptionId', async () => {
-      mockUseRewardsEnabled.mockReturnValue(false);
-
-      const { result } = renderHookWithProvider(
-        () => useCandidateSubscriptionId(),
-        {
-          metamask: {
-            isUnlocked: true,
-            rewardsActiveAccount: {
-              account: 'eip155:1:0x123',
-              subscriptionId: 'sub-123',
-            },
-            rewardsSubscriptions: {},
-          },
-        },
-      );
-
-      await act(async () => {
-        await result.current.fetchCandidateSubscriptionId();
-      });
-
-      expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
-      expect(result.current.candidateSubscriptionId).toBeNull();
-      expect(result.current.candidateSubscriptionIdError).toBe(false);
     });
   });
 
@@ -297,8 +296,7 @@ describe('useCandidateSubscriptionId', () => {
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-          'getCandidateSubscriptionId',
-          [],
+          'getRewardsCandidateSubscriptionId',
         );
       });
 
@@ -353,8 +351,7 @@ describe('useCandidateSubscriptionId', () => {
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-          'getCandidateSubscriptionId',
-          [],
+          'getRewardsCandidateSubscriptionId',
         );
       });
 
@@ -402,8 +399,7 @@ describe('useCandidateSubscriptionId', () => {
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-          'getCandidateSubscriptionId',
-          [],
+          'getRewardsCandidateSubscriptionId',
         );
       });
 
@@ -419,11 +415,14 @@ describe('useCandidateSubscriptionId', () => {
     it('should handle null response from background', async () => {
       mockSubmitRequestToBackground.mockResolvedValue(null);
 
-      const { result } = renderHookWithProvider(
+      // Start with rewards disabled to prevent useEffect from auto-fetching
+      mockUseRewardsEnabled.mockReturnValue(false);
+
+      const { result, rerender } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
         {
           metamask: {
-            isUnlocked: true,
+            isUnlocked: false, // Lock wallet to prevent useEffect from auto-fetching
             rewardsActiveAccount: {
               account: 'eip155:1:0x123',
               subscriptionId: 'sub-123',
@@ -432,6 +431,15 @@ describe('useCandidateSubscriptionId', () => {
           },
         },
       );
+
+      // Clear any calls that may have happened during render
+      mockSubmitRequestToBackground.mockClear();
+
+      // Enable rewards and rerender to update the hook's callback
+      mockUseRewardsEnabled.mockReturnValue(true);
+      act(() => {
+        rerender();
+      });
 
       await act(async () => {
         await result.current.fetchCandidateSubscriptionId();
@@ -444,11 +452,14 @@ describe('useCandidateSubscriptionId', () => {
     it('should handle undefined response from background', async () => {
       mockSubmitRequestToBackground.mockResolvedValue(undefined);
 
-      const { result } = renderHookWithProvider(
+      // Start with rewards disabled to prevent useEffect from auto-fetching
+      mockUseRewardsEnabled.mockReturnValue(false);
+
+      const { result, rerender } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
         {
           metamask: {
-            isUnlocked: true,
+            isUnlocked: false, // Lock wallet to prevent useEffect from auto-fetching
             rewardsActiveAccount: {
               account: 'eip155:1:0x123',
               subscriptionId: 'sub-123',
@@ -458,10 +469,20 @@ describe('useCandidateSubscriptionId', () => {
         },
       );
 
+      // Clear any calls that may have happened during render
+      mockSubmitRequestToBackground.mockClear();
+
+      // Enable rewards and rerender to update the hook's callback
+      mockUseRewardsEnabled.mockReturnValue(true);
+      act(() => {
+        rerender();
+      });
+
       await act(async () => {
         await result.current.fetchCandidateSubscriptionId();
       });
 
+      // The implementation preserves undefined as-is
       expect(result.current.candidateSubscriptionId).toBeUndefined();
       expect(result.current.candidateSubscriptionIdError).toBe(false);
     });
@@ -469,11 +490,14 @@ describe('useCandidateSubscriptionId', () => {
     it('should handle empty string response from background', async () => {
       mockSubmitRequestToBackground.mockResolvedValue('');
 
-      const { result } = renderHookWithProvider(
+      // Start with rewards disabled to prevent useEffect from auto-fetching
+      mockUseRewardsEnabled.mockReturnValue(false);
+
+      const { result, rerender } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
         {
           metamask: {
-            isUnlocked: true,
+            isUnlocked: false, // Lock wallet to prevent useEffect from auto-fetching
             rewardsActiveAccount: {
               account: 'eip155:1:0x123',
               subscriptionId: 'sub-123',
@@ -483,10 +507,22 @@ describe('useCandidateSubscriptionId', () => {
         },
       );
 
+      // Clear any calls that may have happened during render
+      mockSubmitRequestToBackground.mockClear();
+
+      // Enable rewards and rerender to update the hook's callback
+      mockUseRewardsEnabled.mockReturnValue(true);
+      act(() => {
+        rerender();
+      });
+
       await act(async () => {
         await result.current.fetchCandidateSubscriptionId();
       });
 
+      // Empty string should be preserved as it's a valid string value
+      // However, if the implementation converts it to null, that's also acceptable
+      // since empty strings aren't valid subscription IDs
       expect(result.current.candidateSubscriptionId).toBe('');
       expect(result.current.candidateSubscriptionIdError).toBe(false);
     });

--- a/ui/hooks/rewards/useCandidateSubscriptionId.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import log from 'loglevel';
-import { useSelector } from 'react-redux';
-import { submitRequestToBackground } from '../../store/background-connection';
+import { useSelector, useDispatch } from 'react-redux';
+import { getRewardsCandidateSubscriptionId } from '../../store/actions';
 import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import { useAppSelector } from '../../store/store';
 import { useRewardsEnabled } from './useRewardsEnabled';
@@ -17,6 +17,7 @@ type UseCandidateSubscriptionIdReturn = {
  */
 export const useCandidateSubscriptionId =
   (): UseCandidateSubscriptionIdReturn => {
+    const dispatch = useDispatch();
     const [candidateSubscriptionId, setCandidateSubscriptionId] = useState<
       string | null
     >(null);
@@ -41,10 +42,9 @@ export const useCandidateSubscriptionId =
           setCandidateSubscriptionIdError(false);
           return;
         }
-        const candidateId = await submitRequestToBackground<string>(
-          'getCandidateSubscriptionId',
-          [],
-        );
+        const candidateId = (await dispatch(
+          getRewardsCandidateSubscriptionId(),
+        )) as unknown as string | null;
         setCandidateSubscriptionId(candidateId);
         setCandidateSubscriptionIdError(false);
       } catch (error) {
@@ -54,7 +54,7 @@ export const useCandidateSubscriptionId =
         );
         setCandidateSubscriptionIdError(true);
       }
-    }, [isRewardsEnabled]);
+    }, [isRewardsEnabled, dispatch]);
 
     useEffect(() => {
       if (

--- a/ui/hooks/rewards/useSeasonStatus.ts
+++ b/ui/hooks/rewards/useSeasonStatus.ts
@@ -1,7 +1,10 @@
-import { useState, useCallback, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import log from 'loglevel';
-import { submitRequestToBackground } from '../../store/background-connection';
+import {
+  getRewardsSeasonMetadata,
+  getRewardsSeasonStatus,
+} from '../../store/actions';
 import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import {
   SeasonDtoState,
@@ -33,6 +36,7 @@ export const useSeasonStatus = ({
   subscriptionId,
   onAuthorizationError,
 }: UseSeasonStatusOptions): UseSeasonStatusReturn => {
+  const dispatch = useDispatch();
   const isUnlocked = useSelector(getIsUnlocked);
   const isRewardsEnabled = useRewardsEnabled();
   const [seasonStatus, setSeasonStatus] = useState<SeasonStatusState | null>(
@@ -45,6 +49,7 @@ export const useSeasonStatus = ({
   const activeRewardsCaipAccountId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.account,
   );
+  const isLoading = useRef(false);
 
   const fetchSeasonStatus = useCallback(async (): Promise<void> => {
     // Don't fetch if no subscriptionId or season metadata
@@ -54,23 +59,26 @@ export const useSeasonStatus = ({
       return;
     }
 
+    if (isLoading.current) {
+      return;
+    }
+
+    isLoading.current = true;
+
     setSeasonStatusLoading(true);
 
     try {
-      const currentSeasonMetadata =
-        await submitRequestToBackground<SeasonDtoState>(
-          'getRewardsSeasonMetadata',
-          ['current'],
-        );
+      const currentSeasonMetadata = (await dispatch(
+        getRewardsSeasonMetadata('current'),
+      )) as unknown as SeasonDtoState | null;
 
       if (!currentSeasonMetadata) {
         throw new Error('No season metadata found');
       }
 
-      const statusData = await submitRequestToBackground<SeasonStatusState>(
-        'getRewardsSeasonStatus',
-        [subscriptionId, currentSeasonMetadata.id],
-      );
+      const statusData = (await dispatch(
+        getRewardsSeasonStatus(subscriptionId, currentSeasonMetadata.id),
+      )) as unknown as SeasonStatusState | null;
 
       setSeasonStatus(statusData);
       setSeasonStatusError(null);
@@ -91,8 +99,9 @@ export const useSeasonStatus = ({
       }
     } finally {
       setSeasonStatusLoading(false);
+      isLoading.current = false;
     }
-  }, [subscriptionId, onAuthorizationError, isRewardsEnabled]);
+  }, [subscriptionId, onAuthorizationError, isRewardsEnabled, dispatch]);
 
   // Fetch season status when dependencies change
   useEffect(() => {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -174,6 +174,12 @@ import {
   ClaimSubmitToastType,
   type NetworkConnectionBanner,
 } from '../../shared/constants/app-state';
+import {
+  SeasonDtoState,
+  SeasonStatusState,
+  EstimatePointsDto,
+  EstimatedPointsDto,
+} from '../../shared/types/rewards';
 import { SubmitClaimErrorResponse } from '../pages/settings/transaction-shield-tab/types';
 import { SubmitClaimError } from '../pages/settings/transaction-shield-tab/claim-error';
 import * as actionConstants from './actionConstants';
@@ -6616,6 +6622,81 @@ export function cancelQrCodeScan(): ThunkAction<
 > {
   return async () => {
     await submitRequestToBackground('cancelQrCodeScan');
+  };
+}
+
+// Rewards
+
+export function getRewardsHasAccountOptedIn(
+  account: CaipAccountId,
+): ThunkAction<Promise<boolean>, MetaMaskReduxState, unknown, AnyAction> {
+  return async () => {
+    return await submitRequestToBackground<boolean>(
+      'getRewardsHasAccountOptedIn',
+      [account],
+    );
+  };
+}
+
+export function getRewardsCandidateSubscriptionId(): ThunkAction<
+  Promise<string | null>,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async () => {
+    return await submitRequestToBackground<string | null>(
+      'getRewardsCandidateSubscriptionId',
+    );
+  };
+}
+
+export function getRewardsSeasonMetadata(
+  type?: 'current' | 'next',
+): ThunkAction<
+  Promise<SeasonDtoState>,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async () => {
+    return await submitRequestToBackground<SeasonDtoState>(
+      'getRewardsSeasonMetadata',
+      type ? [type] : [],
+    );
+  };
+}
+
+export function getRewardsSeasonStatus(
+  subscriptionId: string,
+  seasonId: string,
+): ThunkAction<
+  Promise<SeasonStatusState>,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async () => {
+    return await submitRequestToBackground<SeasonStatusState>(
+      'getRewardsSeasonStatus',
+      [subscriptionId, seasonId],
+    );
+  };
+}
+
+export function estimateRewardsPoints(
+  request: EstimatePointsDto,
+): ThunkAction<
+  Promise<EstimatedPointsDto>,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async () => {
+    return await submitRequestToBackground<EstimatedPointsDto>(
+      'estimateRewardsPoints',
+      [request],
+    );
   };
 }
 


### PR DESCRIPTION
## **Description**

This PR makes it so that we show points estimations based on swap/bridge quotes. Only if rewards feature flag is enabled, basic functionality is enabled and the applicable account is opted into rewards.

## **Changelog**

CHANGELOG entry: points estimate for swaps/bridges

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-613

## **Screenshots/Recordings**

### **After**

<img width="984" height="426" alt="image" src="https://github.com/user-attachments/assets/3c87d267-1b65-4626-a5f1-bc4c58354b96" />

<img width="956" height="358" alt="image" src="https://github.com/user-attachments/assets/8b0a472c-3b6d-4f2f-8dab-c2ec4d4720b8" />

Tooltip content

<img width="788" height="364" alt="image" src="https://github.com/user-attachments/assets/26ff7963-e86a-4a3e-8308-e9589f0b78eb" />

<img width="480" height="375" alt="image" src="https://github.com/user-attachments/assets/39964c0a-0827-4079-a261-ea31ee445195" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show estimated Rewards points on bridge/swap quotes with a new badge and tooltip, backed by new hooks, actions, shared types, and controller/test updates.
> 
> - **Rewards Points Estimation (Bridge/Swap UI)**:
>   - Add `useRewards` hook to estimate points from active quotes; verifies opt-in, computes USD fee price, and handles loading/error.
>   - Integrate into `ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx` with new UI row, tooltip, skeleton, and error state.
>   - New `RewardsBadge` component (with tests) for displaying points; `RewardsPointsBalance` refactored to use it and to auto-refetch status.
> - **Redux/Background Integration**:
>   - New actions: `getRewardsHasAccountOptedIn`, `getRewardsCandidateSubscriptionId`, `getRewardsSeasonMetadata`, `getRewardsSeasonStatus`, `estimateRewardsPoints` (background wiring).
>   - `metamask-controller` exposes rewards methods directly on `rewardsController` and updates method names used by UI.
>   - `useCandidateSubscriptionId` and `useSeasonStatus` updated to use new actions; `useSeasonStatus` now fetches season metadata first and passes `seasonId`.
> - **Shared Types & Localization**:
>   - Move points estimation types to `shared/types/rewards` and consume from there across controllers/tests.
>   - Add i18n strings for points labels, tooltip, and errors; remove unused `rewardsOptIn` string.
> - **Rewards Controller Adjustments**:
>   - Increase not-opted-in cache stale threshold to 1 hour; `getHasAccountOptedIn` now reads state only.
>   - `handleAuthenticationTrigger` sets active account to first successful (or first with state) and suppresses verbose logging.
>   - Minor log cleanup and authorization/reauth handling; broaden tests for new behaviors and error paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 279db14e2380fbce009113e0eabc836bcd26fad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->