### PR TITLE
test(snaps): Improve settings E2E stability and correctness

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -4,7 +4,12 @@ import { Driver } from '../../webdriver/driver';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import FixtureBuilder from '../../fixture-builder';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import { withFixtures, WINDOW_TITLES, sentryRegEx, largeDelayMs } from '../../helpers';
+import {
+  withFixtures,
+  WINDOW_TITLES,
+  sentryRegEx,
+  largeDelayMs,
+} from '../../helpers';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PreinstalledExampleSettings from '../../page-objects/pages/settings/preinstalled-example-settings';
 import { TestSnaps } from '../../page-objects/pages/test-snaps';

--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -64,11 +64,8 @@ describe('Preinstalled example Snap', function () {
         await preInstalledExample.selectRadioOption('Option 2');
         await preInstalledExample.selectDropdownOption('Option 2');
         await preInstalledExample.checkIsToggleOn();
-        assert.equal(
-          await preInstalledExample.checkSelectedRadioOption('Option 2'),
-          true,
-        );
-        await preInstalledExample.checkSelectedDropdownOption('Option 2');
+        await preInstalledExample.checkSelectedRadioOption('option2');
+        await preInstalledExample.checkSelectedDropdownOption('option2');
         await driver.clickElement(
           '.settings-page__header__title-container__close-button',
         );
@@ -79,7 +76,7 @@ describe('Preinstalled example Snap', function () {
         await testSnaps.openPage();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await testSnaps.clickButton('getSettingsStateButton');
-        const jsonTextValidation = '"setting1": true';
+        const jsonTextValidation = '"setting1": true, "setting2": "option2", "setting3": "option2"';
         await testSnaps.checkMessageResultSpan(
           'rpcResultSpan',
           jsonTextValidation,

--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -4,7 +4,7 @@ import { Driver } from '../../webdriver/driver';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import FixtureBuilder from '../../fixture-builder';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import { withFixtures, WINDOW_TITLES, sentryRegEx } from '../../helpers';
+import { withFixtures, WINDOW_TITLES, sentryRegEx, largeDelayMs } from '../../helpers';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PreinstalledExampleSettings from '../../page-objects/pages/settings/preinstalled-example-settings';
 import { TestSnaps } from '../../page-objects/pages/test-snaps';
@@ -61,8 +61,17 @@ describe('Preinstalled example Snap', function () {
         await navigateToPreInstalledExample(driver);
 
         await preInstalledExample.clickToggleButtonOn();
+        // TODO: Remove this when the race condition is fixed in the Snap.
+        await driver.delay(largeDelayMs);
+
         await preInstalledExample.selectRadioOption('Option 2');
+        // TODO: Remove this when the race condition is fixed in the Snap.
+        await driver.delay(largeDelayMs);
+
         await preInstalledExample.selectDropdownOption('Option 2');
+        // TODO: Remove this when the race condition is fixed in the Snap.
+        await driver.delay(largeDelayMs);
+
         await preInstalledExample.checkIsToggleOn();
         await preInstalledExample.checkSelectedRadioOption('option2');
         await preInstalledExample.checkSelectedDropdownOption('option2');

--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -76,7 +76,11 @@ describe('Preinstalled example Snap', function () {
         await testSnaps.openPage();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await testSnaps.clickButton('getSettingsStateButton');
-        const jsonTextValidation = '"setting1": true, "setting2": "option2", "setting3": "option2"';
+        const jsonTextValidation = JSON.stringify(
+          { setting1: true, setting2: 'option2', setting3: 'option2' },
+          null,
+          2,
+        );
         await testSnaps.checkMessageResultSpan(
           'rpcResultSpan',
           jsonTextValidation,

--- a/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
+++ b/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
@@ -60,24 +60,28 @@ class PreinstalledExampleSettings {
 
   async checkSelectedRadioOption(option: string): Promise<void> {
     console.log(`Checking if the radio option "${option}" is selected`);
-    return this.driver.waitUntil(async () => {
-      const radioOption = await this.driver.findElement(
-        `input[type="radio"][value="${option}"]`,
-      );
-      const isChecked = (await radioOption.getAttribute('checked')) === 'true';
-      return isChecked;
-    }, { timeout: this.driver.timeout, interval: 500 })
+    return this.driver.waitUntil(
+      async () => {
+        const radioOption = await this.driver.findElement(
+          `input[type="radio"][value="${option}"]`,
+        );
+        return (await radioOption.getAttribute('checked')) === 'true';
+      },
+      { timeout: this.driver.timeout, interval: 500 },
+    );
   }
 
   async checkSelectedDropdownOption(option: string): Promise<void> {
     console.log(`Checking if the dropdown option "${option}" is selected`);
-    return this.driver.waitUntil(async () => {
-      const dropdownOption = await this.driver.findElement(
-        `option[value="${option}"]`,
-      );
-      const isSelected = (await dropdownOption.getAttribute('selected')) === 'true';
-      return isSelected;
-    }, { timeout: this.driver.timeout, interval: 500 })
+    return this.driver.waitUntil(
+      async () => {
+        const dropdownOption = await this.driver.findElement(
+          `option[value="${option}"]`,
+        );
+        return (await dropdownOption.getAttribute('selected')) === 'true';
+      },
+      { timeout: this.driver.timeout, interval: 500 },
+    );
   }
 }
 

--- a/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
+++ b/test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts
@@ -58,21 +58,26 @@ class PreinstalledExampleSettings {
     await this.driver.waitForSelector(`${this.toggleButton}--on`);
   }
 
-  async checkSelectedRadioOption(option: string): Promise<boolean> {
+  async checkSelectedRadioOption(option: string): Promise<void> {
     console.log(`Checking if the radio option "${option}" is selected`);
-    const radioOption = await this.driver.findElement(
-      `input[type="radio"][id="${option}"]`,
-    );
-    const isChecked = (await radioOption.getAttribute('checked')) === 'true';
-    return isChecked;
+    return this.driver.waitUntil(async () => {
+      const radioOption = await this.driver.findElement(
+        `input[type="radio"][value="${option}"]`,
+      );
+      const isChecked = (await radioOption.getAttribute('checked')) === 'true';
+      return isChecked;
+    }, { timeout: this.driver.timeout, interval: 500 })
   }
 
   async checkSelectedDropdownOption(option: string): Promise<void> {
     console.log(`Checking if the dropdown option "${option}" is selected`);
-    await this.driver.waitForSelector({
-      css: this.settingsDropdown,
-      text: option,
-    });
+    return this.driver.waitUntil(async () => {
+      const dropdownOption = await this.driver.findElement(
+        `option[value="${option}"]`,
+      );
+      const isSelected = (await dropdownOption.getAttribute('selected')) === 'true';
+      return isSelected;
+    }, { timeout: this.driver.timeout, interval: 500 })
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improve stability and correctness of the E2E test that uses the settings page for the preinstalled example Snap.

We were not correctly asserting the response value from the RPC method, this has been fixed. Additionally we were not effectively detecting whether dropdowns and radio buttons had been selected. This PR also temporarily adds some delay between each input action since a race condition was identified in the Snap that affects the final result. These can be removed in the near future.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37535?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the preinstalled example Snap settings E2E by adding delays, improving selection checks, and asserting the full settings state from RPC.
> 
> - **E2E tests** (`test/e2e/flask/snaps/preinstalled-example.spec.ts`):
>   - Import `largeDelayMs` and add delays after toggle/radio/dropdown interactions to mitigate race conditions.
>   - Update verification to `checkSelectedRadioOption('option2')` and `checkSelectedDropdownOption('option2')`.
>   - Validate full RPC settings state via `JSON.stringify({ setting1: true, setting2: 'option2', setting3: 'option2' }, null, 2)`.
> - **Page object** (`test/e2e/page-objects/pages/settings/preinstalled-example-settings.ts`):
>   - Replace direct selectors with `waitUntil`-based checks:
>     - Radio: query `input[type="radio"][value="${option}"]` and wait for `checked === 'true'`.
>     - Dropdown: query `option[value="${option}"]` and wait for `selected === 'true'`.
>   - Change `checkSelectedRadioOption` return type to `void`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b223942bc84cdc2f119430ec4d135cf4ed8e960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->