### PR TITLE
fix: Disable default "Alert" text and the arrow for inline Confirmation alerts

### DIFF
--- a/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
+++ b/ui/components/app/confirm/info/row/alert-row/alert-row.tsx
@@ -108,8 +108,10 @@ export const ConfirmInfoAlertRow = ({
       <InlineAlert
         alertKey={alertKey}
         severity={selectedAlertSeverity}
-        showArrow={selectedAlertShowArrow}
-        textOverride={selectedAlertInlineAlertText}
+        showArrow={Boolean(
+          selectedAlertShowArrow && selectedAlertInlineAlertText,
+        )}
+        textOverride={selectedAlertInlineAlertText || ''}
         onClick={onClickHandler}
       />
     </Box>

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -355,6 +355,8 @@ const BalanceChangesAlert = ({ transactionId }: { transactionId: string }) => {
           <InlineAlert
             onClick={handleInlineAlertClick}
             severity={selectedAlertSeverity}
+            showArrow={false}
+            textOverride={''}
           />
         </Box>
       )}


### PR DESCRIPTION
## **Description**
Disables default "Alert" text and the arrow for inline Confirmation alerts.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37542?quickstart=1)

## **Changelog**

CHANGELOG entry: fix: Disable default "Alert" text and the arrow for inline Confirmation alerts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37362

## **Manual testing steps**

1. Go to the test dapp (https://metamask.github.io/test-dapp/)
2. Connect your wallet
3. Click on "SEND LEGACY TRANSACTION"
4. See that we don't show the "Error" text and the arrow anymore

## **Screenshots/Recordings**

### **Before**
<img width="388" height="214" alt="image" src="https://github.com/user-attachments/assets/419bf910-99f1-466a-9a02-82bac9b6af65" />


### **After**
<img width="385" height="219" alt="image" src="https://github.com/user-attachments/assets/9ea51aec-ed59-4f26-bab2-e03dcb62f4fe" />

<img width="391" height="327" alt="image" src="https://github.com/user-attachments/assets/8a97a265-1ff2-4bcf-8a77-36e7a2b7f63e" />

<img width="347" height="49" alt="image" src="https://github.com/user-attachments/assets/575afd7b-7c4f-47fd-85f3-55a4acdce87a" />

<img width="395" height="416" alt="image" src="https://github.com/user-attachments/assets/56d9caa8-3df2-43cc-b846-368efb0d8968" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes default inline alert label and arrow, only showing an arrow when custom text exists and forcing no arrow/empty text in simulation alerts.
> 
> - **UI**
>   - **`ui/components/app/confirm/info/row/alert-row/alert-row.tsx`**:
>     - `InlineAlert` now sets `showArrow` only if both `showArrow` and `inlineAlertText` are truthy, and defaults `textOverride` to an empty string.
>   - **`ui/pages/confirmations/components/simulation-details/simulation-details.tsx`**:
>     - Simulation inline alerts explicitly set `showArrow={false}` and `textOverride={''}` to hide the default label and arrow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 603509119c2986aa2400467556df7a7c5032023c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->