### PR TITLE
feat: add gas limit to shield subscription approval transaction

### DIFF
--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -9,12 +9,16 @@ import {
 } from '@metamask/subscription-controller';
 import log from 'loglevel';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionParams,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { getUserSubscriptions } from '../../selectors/subscription';
 import {
   addTransaction,
   cancelSubscription,
+  estimateGas,
   getSubscriptionBillingPortalUrl,
   getSubscriptions,
   getSubscriptionsEligibilities,
@@ -170,12 +174,13 @@ export const useSubscriptionCryptoApprovalTransaction = (
       spenderAddress,
       amount: decimalToHex(selectedToken.approvalAmount.approveAmount),
     });
-    const transactionParams = {
+    const transactionParams: TransactionParams = {
       from: evmInternalAccount?.address as Hex,
       to: selectedToken.address as Hex,
       value: '0x0',
       data: approvalData,
     };
+    transactionParams.gas = await estimateGas(transactionParams);
     const transactionOptions = {
       type: TransactionType.shieldSubscriptionApprove,
       networkClientId: networkClientId as string,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
1. At present, gas is not explicitly defined in the shield approval transaction parameters and is instead calculated with a 1.5x buffer. When the transaction is sponsored, Sentinel uses the gas value defined in the transaction parameters to fund the sender. However, this results in Sentinel allocating more gas than what is actually required for the transaction. 

2. To address this issue, we are updating the client-side implementation to use the estimated gas directly, without applying the buffer.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37550?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Explicitly sets gas on the shield subscription ERC-20 approval transaction by estimating gas and typing params.
> 
> - **Subscriptions hook (`ui/hooks/subscription/useSubscription.ts`)**:
>   - Set `transactionParams.gas` using `estimateGas` for the shield subscription ERC-20 approve flow.
>   - Use typed `TransactionParams`; add `estimateGas` action import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51f17fc6bbfca8f8b51500da2a3a2fb44833f986. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->