### PR TITLE
chore: move discover button to global menu

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
@@ -75,6 +75,9 @@ import {
   getThirdPartyNotifySnaps,
   getUseExternalServices,
   getPreferences,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+  getDataCollectionForMarketing,
 } from '../../../selectors';
 import {
   AlignItems,
@@ -94,6 +97,8 @@ import { AccountDetailsMenuItem, ViewExplorerMenuItem } from '../menu-items';
 import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
 import { useUserSubscriptions } from '../../../hooks/subscription/useSubscription';
 import { getIsShieldSubscriptionActive } from '../../../../shared/lib/shield';
+import { useRewardsContext } from '../../../contexts/rewards';
+import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 
 const METRICS_LOCATION = 'Global Menu';
 
@@ -112,6 +117,7 @@ export const GlobalMenu = ({
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
   const basicFunctionality = useSelector(getUseExternalServices);
+  const { rewardsEnabled } = useRewardsContext();
 
   const history = useHistory();
 
@@ -141,6 +147,10 @@ export const GlobalMenu = ({
 
   const hasUnapprovedTransactions =
     Object.keys(unapprovedTransactions).length > 0;
+
+  const metaMetricsId = useSelector(getMetaMetricsId);
+  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   /**
    * This condition is used to control whether the client shows the "turn on notifications"
@@ -285,6 +295,25 @@ export const GlobalMenu = ({
     closeMenu();
   };
 
+  const handlePortfolioOnClick = useCallback(() => {
+    const url = getPortfolioUrl(
+      'explore/tokens',
+      'ext_portfolio_button',
+      metaMetricsId,
+      isMetaMetricsEnabled,
+      isMarketingEnabled,
+    );
+    global.platform.openTab({ url });
+    trackEvent({
+      category: MetaMetricsEventCategory.Navigation,
+      event: MetaMetricsEventName.PortfolioLinkClicked,
+      properties: {
+        location: 'Home',
+        text: 'Portfolio',
+      },
+    });
+  }, [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, trackEvent]);
+
   return (
     <Popover
       data-testid="global-menu"
@@ -317,6 +346,24 @@ export const GlobalMenu = ({
               {notificationsUnreadCount === 0 &&
                 !isMetamaskNotificationFeatureSeen && <NewFeatureTag />}
               <NotificationsTagCounter />
+            </Box>
+          </MenuItem>
+        </>
+      )}
+      {rewardsEnabled && (
+        <>
+          <MenuItem
+            iconName={IconName.Export}
+            onClick={() => handlePortfolioOnClick()}
+            data-testid="portfolio-menu-item"
+          >
+            <Box
+              display={Display.Flex}
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              justifyContent={JustifyContent.spaceBetween}
+            >
+              {t('discover')}
             </Box>
           </MenuItem>
         </>

--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
@@ -75,9 +75,6 @@ import {
   getThirdPartyNotifySnaps,
   getUseExternalServices,
   getPreferences,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
-  getDataCollectionForMarketing,
 } from '../../../selectors';
 import {
   AlignItems,
@@ -93,12 +90,15 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { AccountDetailsMenuItem, ViewExplorerMenuItem } from '../menu-items';
+import {
+  AccountDetailsMenuItem,
+  DiscoverMenuItem,
+  ViewExplorerMenuItem,
+} from '../menu-items';
 import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
 import { useUserSubscriptions } from '../../../hooks/subscription/useSubscription';
 import { getIsShieldSubscriptionActive } from '../../../../shared/lib/shield';
 import { useRewardsContext } from '../../../contexts/rewards';
-import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 
 const METRICS_LOCATION = 'Global Menu';
 
@@ -147,10 +147,6 @@ export const GlobalMenu = ({
 
   const hasUnapprovedTransactions =
     Object.keys(unapprovedTransactions).length > 0;
-
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
-  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   /**
    * This condition is used to control whether the client shows the "turn on notifications"
@@ -295,32 +291,6 @@ export const GlobalMenu = ({
     closeMenu();
   };
 
-  const handlePortfolioOnClick = useCallback(() => {
-    const url = getPortfolioUrl(
-      'explore/tokens',
-      'ext_portfolio_button',
-      metaMetricsId,
-      isMetaMetricsEnabled,
-      isMarketingEnabled,
-    );
-    global.platform.openTab({ url });
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.PortfolioLinkClicked,
-      properties: {
-        location: 'Home',
-        text: 'Portfolio',
-      },
-    });
-    closeMenu();
-  }, [
-    closeMenu,
-    isMarketingEnabled,
-    isMetaMetricsEnabled,
-    metaMetricsId,
-    trackEvent,
-  ]);
-
   return (
     <Popover
       data-testid="global-menu"
@@ -358,22 +328,10 @@ export const GlobalMenu = ({
         </>
       )}
       {rewardsEnabled && (
-        <>
-          <MenuItem
-            iconName={IconName.Export}
-            onClick={() => handlePortfolioOnClick()}
-            data-testid="portfolio-menu-item"
-          >
-            <Box
-              display={Display.Flex}
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
-              justifyContent={JustifyContent.spaceBetween}
-            >
-              {t('discover')}
-            </Box>
-          </MenuItem>
-        </>
+        <DiscoverMenuItem
+          metricsLocation={METRICS_LOCATION}
+          closeMenu={closeMenu}
+        />
       )}
       {account && (
         <>

--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -312,7 +312,14 @@ export const GlobalMenu = ({
         text: 'Portfolio',
       },
     });
-  }, [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, trackEvent]);
+    closeMenu();
+  }, [
+    closeMenu,
+    isMarketingEnabled,
+    isMetaMetricsEnabled,
+    metaMetricsId,
+    trackEvent,
+  ]);
 
   return (
     <Popover

--- a/ui/components/multichain/menu-items/discover-menu-item.test.tsx
+++ b/ui/components/multichain/menu-items/discover-menu-item.test.tsx
@@ -42,7 +42,9 @@ describe('DiscoverMenuItem', () => {
 
     expect(openTabSpy).toHaveBeenCalled();
     expect(openTabSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ url: expect.stringContaining('explore/tokens') }),
+      expect.objectContaining({
+        url: expect.stringContaining('explore/tokens'),
+      }),
     );
     expect(closeMenu).toHaveBeenCalled();
   });

--- a/ui/components/multichain/menu-items/discover-menu-item.test.tsx
+++ b/ui/components/multichain/menu-items/discover-menu-item.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, renderWithProvider } from '../../../../test/jest';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import { DiscoverMenuItem } from './discover-menu-item';
+
+const render = (closeMenu = jest.fn()) => {
+  const defaultState = {
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      completedOnboarding: true,
+    },
+  };
+  const store = configureStore(defaultState);
+  return {
+    ...renderWithProvider(
+      <DiscoverMenuItem metricsLocation="Global Menu" closeMenu={closeMenu} />,
+      store,
+    ),
+    closeMenu,
+  };
+};
+
+describe('DiscoverMenuItem', () => {
+  it('renders discover menu item', () => {
+    // @ts-expect-error mocking platform
+    global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
+
+    const { getByTestId } = render();
+    expect(getByTestId('portfolio-menu-item')).toBeInTheDocument();
+  });
+
+  it('opens portfolio and closes menu on click', () => {
+    // @ts-expect-error mocking platform
+    global.platform = { openTab: jest.fn(), closeCurrentWindow: jest.fn() };
+
+    const { getByTestId, closeMenu } = render();
+    const openTabSpy = jest.spyOn(global.platform, 'openTab');
+
+    fireEvent.click(getByTestId('portfolio-menu-item'));
+
+    expect(openTabSpy).toHaveBeenCalled();
+    expect(openTabSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.stringContaining('explore/tokens') }),
+    );
+    expect(closeMenu).toHaveBeenCalled();
+  });
+});

--- a/ui/components/multichain/menu-items/discover-menu-item.tsx
+++ b/ui/components/multichain/menu-items/discover-menu-item.tsx
@@ -19,7 +19,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { Box, IconName } from '../../component-library';
+import { Box } from '@metamask/design-system-react';
+import { IconName } from '../../component-library';
 
 export const DiscoverMenuItem = ({
   closeMenu,
@@ -66,12 +67,7 @@ export const DiscoverMenuItem = ({
       onClick={() => handlePortfolioOnClick()}
       data-testid="portfolio-menu-item"
     >
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.spaceBetween}
-      >
+      <Box className="flex flex-row items-center justify-between">
         {t('discover')}
       </Box>
     </MenuItem>

--- a/ui/components/multichain/menu-items/discover-menu-item.tsx
+++ b/ui/components/multichain/menu-items/discover-menu-item.tsx
@@ -1,25 +1,19 @@
-import { MenuItem } from '../../ui/menu';
-import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  JustifyContent,
-} from '../../../helpers/constants/design-system';
-import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
+import React, { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react';
+import { MenuItem } from '../../ui/menu';
+import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import {
   getDataCollectionForMarketing,
   getMetaMetricsId,
   getParticipateInMetaMetrics,
 } from '../../../selectors';
-import React, { useCallback, useContext } from 'react';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { Box } from '@metamask/design-system-react';
 import { IconName } from '../../component-library';
 
 export const DiscoverMenuItem = ({

--- a/ui/components/multichain/menu-items/discover-menu-item.tsx
+++ b/ui/components/multichain/menu-items/discover-menu-item.tsx
@@ -1,0 +1,79 @@
+import { MenuItem } from '../../ui/menu';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
+import { useSelector } from 'react-redux';
+import {
+  getDataCollectionForMarketing,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+} from '../../../selectors';
+import React, { useCallback, useContext } from 'react';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { Box, IconName } from '../../component-library';
+
+export const DiscoverMenuItem = ({
+  closeMenu,
+  metricsLocation,
+}: {
+  closeMenu: () => void;
+  metricsLocation: string;
+}) => {
+  const metaMetricsId = useSelector(getMetaMetricsId);
+  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
+  const trackEvent = useContext(MetaMetricsContext);
+  const t = useI18nContext();
+
+  const handlePortfolioOnClick = useCallback(() => {
+    const url = getPortfolioUrl(
+      'explore/tokens',
+      'ext_portfolio_button',
+      metaMetricsId,
+      isMetaMetricsEnabled,
+      isMarketingEnabled,
+    );
+    global.platform.openTab({ url });
+    trackEvent({
+      category: MetaMetricsEventCategory.Navigation,
+      event: MetaMetricsEventName.PortfolioLinkClicked,
+      properties: {
+        location: metricsLocation,
+        text: 'Portfolio',
+      },
+    });
+    closeMenu();
+  }, [
+    closeMenu,
+    isMarketingEnabled,
+    isMetaMetricsEnabled,
+    metaMetricsId,
+    trackEvent,
+  ]);
+
+  return (
+    <MenuItem
+      iconName={IconName.Export}
+      onClick={() => handlePortfolioOnClick()}
+      data-testid="portfolio-menu-item"
+    >
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.spaceBetween}
+      >
+        {t('discover')}
+      </Box>
+    </MenuItem>
+  );
+};

--- a/ui/components/multichain/menu-items/index.js
+++ b/ui/components/multichain/menu-items/index.js
@@ -1,2 +1,3 @@
 export { AccountDetailsMenuItem } from './account-details-menu-item';
 export { ViewExplorerMenuItem } from './view-explorer-menu-item';
+export { DiscoverMenuItem } from './discover-menu-item';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-756
Add 'Discover' button to global menu when rewardsEnabled
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37551?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Move "Discover" button to global menu

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="971" height="590" alt="Screenshot 2025-11-05 at 11 42 45 AM" src="https://github.com/user-attachments/assets/81e52c13-82b5-45a1-b27b-6f9049eadc35" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Discover entry to the Global Menu (shown when `rewardsEnabled`) that opens Portfolio Explore/Tokens, tracks metrics, and closes the menu.
> 
> - **UI/Global Menu**:
>   - Add `DiscoverMenuItem` to `global-menu.tsx`, rendered only when `useRewardsContext().rewardsEnabled`.
> - **New Component**: `menu-items/discover-menu-item.tsx`
>   - Opens Portfolio via `getPortfolioUrl('explore/tokens', ...)` using `global.platform.openTab`.
>   - Tracks `PortfolioLinkClicked` with location and closes the menu.
> - **Exports**: Add `DiscoverMenuItem` to `menu-items/index.js`.
> - **Tests**: `discover-menu-item.test.tsx` verifies render and that click opens Portfolio (Explore/Tokens) and invokes `closeMenu`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634dec3721e3f6a1825014183a533a67508c5895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->