### PR TITLE
fix: fix filter nfts on send flow

### DIFF
--- a/ui/pages/confirmations/hooks/send/useSendNfts.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendNfts.test.ts
@@ -40,12 +40,14 @@ describe('useSendNfts', () => {
           tokenId: '1',
           name: 'Test NFT 1',
           standard: AssetStandard.ERC721,
+          isCurrentlyOwned: true,
         },
         {
           address: '0xNft2',
           tokenId: '2',
           name: 'Test NFT 2',
           standard: AssetStandard.ERC1155,
+          isCurrentlyOwned: true,
         },
       ],
       '137': [
@@ -54,6 +56,7 @@ describe('useSendNfts', () => {
           tokenId: '3',
           name: 'Polygon NFT',
           standard: AssetStandard.ERC721,
+          isCurrentlyOwned: true,
         },
       ],
     },
@@ -64,6 +67,7 @@ describe('useSendNfts', () => {
           tokenId: '4',
           name: 'Account2 NFT',
           standard: AssetStandard.ERC721,
+          isCurrentlyOwned: true,
         },
       ],
     },
@@ -129,6 +133,7 @@ describe('useSendNfts', () => {
         chainId: '1',
         networkName: 'Ethereum',
         networkImage: 'eth.svg',
+        isCurrentlyOwned: true,
       });
     });
   });
@@ -301,6 +306,7 @@ describe('useSendNfts', () => {
             tokenId: '100',
             name: 'New NFT',
             standard: AssetStandard.ERC721,
+            isCurrentlyOwned: true,
           },
         ],
       },

--- a/ui/pages/confirmations/hooks/send/useSendNfts.ts
+++ b/ui/pages/confirmations/hooks/send/useSendNfts.ts
@@ -86,9 +86,12 @@ export const useSendNfts = () => {
 
     const updateNfts = async () => {
       const nftsWithBalances = await fetchNftsWithBalances(transformedNfts);
+      const ownedNftsWithoutBalances = nftsWithBalances.filter(
+        (nft) => (nft as Nft).isCurrentlyOwned === true,
+      );
 
       if (!isCancelled) {
-        setNfts(nftsWithBalances);
+        setNfts(ownedNftsWithoutBalances);
       }
     };
 


### PR DESCRIPTION
## **Description**

Filter NFTs on send flow

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37558?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes a bug where when a user no longer owns an NFT it still shows up in the list when clicking Send button from home page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37422

## **Manual testing steps**

1. Go to home page
2. Click on Send button
3. Send any of your NFTs
4. Go back to home page
5. Click on Send page
6. The NFT you sent should not appear on the list of NFTs


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1790" height="1056" alt="Screenshot 2025-11-05 at 20 54 41" src="https://github.com/user-attachments/assets/23357aef-d9b0-465e-9209-74b33e4e4ec9" />

### **After**

<!-- [screenshots/recordings] -->
<img width="1798" height="1083" alt="Screenshot 2025-11-05 at 20 52 34" src="https://github.com/user-attachments/assets/783c0062-0dc4-4088-99b5-e203e72d3b28" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters the send-flow NFT list to only include NFTs marked as currently owned and updates tests accordingly.
> 
> - **Send NFTs hook (`useSendNfts.ts`)**:
>   - After fetching balances, filters NFTs to those with `isCurrentlyOwned === true` before setting state.
> - **Tests (`useSendNfts.test.ts`)**:
>   - Adds `isCurrentlyOwned` to mocked NFTs and expected asset shapes.
>   - Updates assertions to reflect filtering behavior and owned-only results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65f48eb8d138f8a6afc51d2986fe6b116e455a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->