### PR TITLE
refactor(5563): migrate `pages/swaps` to react-router-dom-v5-compat

### DIFF
--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -525,12 +525,12 @@ export {
   slice as swapsSlice,
 };
 
-export const navigateBackToPrepareSwap = (history) => {
+export const navigateBackToPrepareSwap = (navigate) => {
   return async (dispatch) => {
     // TODO: Ensure any fetch in progress is cancelled
     await dispatch(setBackgroundSwapRouteState(''));
     dispatch(navigatedBackToBuildQuote());
-    history.push(PREPARE_SWAP_ROUTE);
+    navigate(PREPARE_SWAP_ROUTE);
   };
 };
 
@@ -632,7 +632,7 @@ const isTokenAlreadyAdded = (tokenAddress, tokens) => {
 };
 
 export const fetchQuotesAndSetQuoteState = (
-  history,
+  navigate,
   inputValue,
   maxSlippage,
   trackEvent,
@@ -658,7 +658,7 @@ export const fetchQuotesAndSetQuoteState = (
     await dispatch(setSwapsLiveness(swapsLivenessForNetwork));
 
     if (!swapsLivenessForNetwork.swapsFeatureIsLive) {
-      await history.push(SWAPS_MAINTENANCE_ROUTE);
+      await navigate(SWAPS_MAINTENANCE_ROUTE);
       return;
     }
 
@@ -691,7 +691,7 @@ export const fetchQuotesAndSetQuoteState = (
     // In that case we just want to silently prefetch quotes without redirecting to the quotes loading page.
     if (!pageRedirectionDisabled) {
       await dispatch(setBackgroundSwapRouteState('loading'));
-      history.push(LOADING_QUOTES_ROUTE);
+      navigate(LOADING_QUOTES_ROUTE);
     }
     dispatch(setFetchingQuotes(true));
 
@@ -938,7 +938,7 @@ export const fetchQuotesAndSetQuoteState = (
 export const signAndSendSwapsSmartTransaction = ({
   unsignedTransaction,
   trackEvent,
-  history,
+  navigate,
   additionalTrackingParams,
 }) => {
   return async (dispatch, getState) => {
@@ -1020,7 +1020,7 @@ export const signAndSendSwapsSmartTransaction = ({
         },
       });
       await dispatch(setSwapsErrorKey(SWAP_FAILED_ERROR));
-      history.push(SWAPS_ERROR_ROUTE);
+      navigate(SWAPS_ERROR_ROUTE);
       return;
     }
 
@@ -1100,7 +1100,7 @@ export const signAndSendSwapsSmartTransaction = ({
           }),
         );
       }
-      history.push(SMART_TRANSACTION_STATUS_ROUTE);
+      navigate(SMART_TRANSACTION_STATUS_ROUTE);
       dispatch(setSwapsSTXSubmitLoading(false));
     } catch (e) {
       console.log('signAndSendSwapsSmartTransaction error', e);

--- a/ui/helpers/higher-order-components/feature-toggled-route.js
+++ b/ui/helpers/higher-order-components/feature-toggled-route.js
@@ -1,19 +1,16 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Redirect, Route } from 'react-router-dom';
+import { Navigate } from 'react-router-dom-v5-compat';
 
-export default function FeatureToggledRoute({ flag, redirectRoute, ...props }) {
-  const redirect = useMemo(
-    () => ({ pathname: redirectRoute }),
-    [redirectRoute],
-  );
+export default function FeatureToggledRoute({ flag, redirectRoute, element }) {
   if (flag) {
-    return <Route {...props} />;
+    return element;
   }
-  return <Redirect to={redirect} />;
+  return <Navigate to={redirectRoute} replace />;
 }
 
 FeatureToggledRoute.propTypes = {
   flag: PropTypes.bool.isRequired,
   redirectRoute: PropTypes.string.isRequired,
+  element: PropTypes.node.isRequired,
 };

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -178,6 +178,35 @@ import {
   showAppHeader,
 } from './utils';
 
+// V5-compat navigate function type for bridging v5 routes with v5-compat components
+type V5CompatNavigate = (
+  to: string | number,
+  options?: {
+    replace?: boolean;
+    state?: Record<string, unknown>;
+  },
+) => void;
+
+/**
+ * Creates a v5-compat navigate function from v5 history
+ * Used to bridge v5 routes with components expecting v5-compat navigation
+ *
+ * @param history
+ */
+const createV5CompatNavigate = (
+  history: RouteComponentProps['history'],
+): V5CompatNavigate => {
+  return (to, options = {}) => {
+    if (typeof to === 'number') {
+      history.go(to);
+    } else if (options.replace) {
+      history.replace(to, options.state);
+    } else {
+      history.push(to, options.state);
+    }
+  };
+};
+
 // TODO: Fix `as unknown as` casting once `mmLazy` is updated to handle named exports, wrapped components, and other React module types.
 // Casting is preferable over `@ts-expect-error` annotations in this case,
 // because it doesn't suppress competing error messages e.g. "Cannot find module..."
@@ -627,8 +656,9 @@ export default function Routes() {
           <Route path={SWAPS_ROUTE}>
             {(props: RouteComponentProps) => {
               const { location: v5Location } = props;
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const SwapsComponent = Swaps as any;
+              const SwapsComponent = Swaps as React.ComponentType<{
+                location: RouteComponentProps['location'];
+              }>;
               return (
                 <AuthenticatedV5Compat>
                   <SwapsComponent location={v5Location} />
@@ -645,24 +675,13 @@ export default function Routes() {
           >
             {(props: RouteComponentProps<{ srcTxMetaId: string }>) => {
               const { history: v5History, location: v5Location, match } = props;
-              const navigate = (
-                to: string | number,
-                options: {
-                  replace?: boolean;
-                  state?: Record<string, unknown>;
-                } = {},
-              ) => {
-                if (typeof to === 'number') {
-                  v5History.go(to);
-                } else if (options.replace) {
-                  v5History.replace(to, options.state);
-                } else {
-                  v5History.push(to, options.state);
-                }
-              };
+              const navigate = createV5CompatNavigate(v5History);
               const CrossChainSwapTxDetailsComponent =
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                CrossChainSwapTxDetails as any;
+                CrossChainSwapTxDetails as React.ComponentType<{
+                  location: RouteComponentProps['location'];
+                  navigate: V5CompatNavigate;
+                  params: { srcTxMetaId: string };
+                }>;
               return (
                 <AuthenticatedV5Compat>
                   <CrossChainSwapTxDetailsComponent
@@ -677,8 +696,10 @@ export default function Routes() {
           <Route path={CROSS_CHAIN_SWAP_ROUTE}>
             {(props: RouteComponentProps) => {
               const { location: v5Location } = props;
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const CrossChainSwapComponent = CrossChainSwap as any;
+              const CrossChainSwapComponent =
+                CrossChainSwap as React.ComponentType<{
+                  location: RouteComponentProps['location'];
+                }>;
               return (
                 <AuthenticatedV5Compat>
                   <CrossChainSwapComponent location={v5Location} />
@@ -712,20 +733,14 @@ export default function Routes() {
                 match: v5Match,
               } = props;
 
-              // Create a navigate function compatible with v5-compat for the component
-              const navigate = (
-                to: string,
-                options: { replace?: boolean } = {},
-              ) => {
-                if (options.replace) {
-                  v5History.replace(to);
-                } else {
-                  v5History.push(to);
-                }
-              };
+              const navigate = createV5CompatNavigate(v5History);
 
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const PermissionsConnectWithProps = PermissionsConnect as any;
+              const PermissionsConnectWithProps =
+                PermissionsConnect as React.ComponentType<{
+                  location: RouteComponentProps['location'];
+                  navigate: V5CompatNavigate;
+                  match: RouteComponentProps<{ id: string }>['match'];
+                }>;
               return (
                 <AuthenticatedV5Compat>
                   <PermissionsConnectWithProps
@@ -739,8 +754,10 @@ export default function Routes() {
           </Route>
           <Route path={`${ASSET_ROUTE}/image/:asset/:id`}>
             {(props: RouteComponentProps<{ asset: string; id: string }>) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const NftFullImageComponent = NftFullImage as any;
+              const NftFullImageComponent =
+                NftFullImage as React.ComponentType<{
+                  params: { asset: string; id: string };
+                }>;
               return (
                 <AuthenticatedV5Compat>
                   <NftFullImageComponent params={props.match.params} />
@@ -756,8 +773,9 @@ export default function Routes() {
                 id: string;
               }>,
             ) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const AssetComponent = Asset as any;
+              const AssetComponent = Asset as React.ComponentType<{
+                params: { chainId: string; asset: string; id: string };
+              }>;
               return (
                 <AuthenticatedV5Compat>
                   <AssetComponent params={props.match.params} />
@@ -772,8 +790,9 @@ export default function Routes() {
                 asset: string;
               }>,
             ) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const AssetComponent = Asset as any;
+              const AssetComponent = Asset as React.ComponentType<{
+                params: { chainId: string; asset: string };
+              }>;
               return (
                 <AuthenticatedV5Compat>
                   <AssetComponent params={props.match.params} />
@@ -783,8 +802,9 @@ export default function Routes() {
           </Route>
           <Route path={`${ASSET_ROUTE}/:chainId`}>
             {(props: RouteComponentProps<{ chainId: string }>) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const AssetComponent = Asset as any;
+              const AssetComponent = Asset as React.ComponentType<{
+                params: { chainId: string };
+              }>;
               return (
                 <AuthenticatedV5Compat>
                   <AssetComponent params={props.match.params} />

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -624,7 +624,18 @@ export default function Routes() {
             component={ConfirmTransaction}
           />
           <Authenticated path={`${SEND_ROUTE}/:page?`} component={SendPage} />
-          <Authenticated path={SWAPS_ROUTE} component={Swaps} />
+          <Route path={SWAPS_ROUTE}>
+            {(props: RouteComponentProps) => {
+              const { location: v5Location } = props;
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const SwapsComponent = Swaps as any;
+              return (
+                <AuthenticatedV5Compat>
+                  <SwapsComponent location={v5Location} />
+                </AuthenticatedV5Compat>
+              );
+            }}
+          </Route>
           <Route
             path={`${CROSS_CHAIN_SWAP_TX_DETAILS_ROUTE}/:srcTxMetaId`}
             // v5 Route supports exact with render props, but TS types don't recognize it

--- a/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
+++ b/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
-
 import { I18nContext } from '../../../contexts/i18n';
 import {
   getFetchParams,
@@ -18,10 +17,7 @@ import {
   getSmartTransactionsEnabled,
   getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
-import {
-  DEFAULT_ROUTE,
-  PREPARE_SWAP_ROUTE,
-} from '../../../helpers/constants/routes';
+import { PREPARE_SWAP_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import PulseLoader from '../../../components/ui/pulse-loader';
 import Box from '../../../components/ui/box';
 import {
@@ -39,7 +35,7 @@ import SwapStepIcon from './swap-step-icon';
 
 export default function AwaitingSignatures() {
   const t = useContext(I18nContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const fetchParams = useSelector(getFetchParams, isEqual);
   const { destinationTokenInfo, sourceTokenInfo } = fetchParams?.metaData || {};
@@ -149,8 +145,8 @@ export default function AwaitingSignatures() {
           await dispatch(prepareToLeaveSwaps());
           // Go to the default route and then to the build quote route in order to clean up
           // the `inputValue` local state in `pages/swaps/index.js`
-          history.push(DEFAULT_ROUTE);
-          history.push(PREPARE_SWAP_ROUTE);
+          navigate(DEFAULT_ROUTE, { replace: true });
+          setTimeout(() => navigate(PREPARE_SWAP_ROUTE, { replace: true }), 0);
         }}
         submitText={t('cancel')}
         hideCancel

--- a/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
+++ b/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
@@ -17,7 +17,7 @@ import {
   getSmartTransactionsEnabled,
   getSmartTransactionsOptInStatusForMetrics,
 } from '../../../../shared/modules/selectors';
-import { PREPARE_SWAP_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { PREPARE_SWAP_ROUTE } from '../../../helpers/constants/routes';
 import PulseLoader from '../../../components/ui/pulse-loader';
 import Box from '../../../components/ui/box';
 import {
@@ -143,10 +143,8 @@ export default function AwaitingSignatures() {
       <SwapsFooter
         onSubmit={async () => {
           await dispatch(prepareToLeaveSwaps());
-          // Go to the default route and then to the build quote route in order to clean up
-          // the `inputValue` local state in `pages/swaps/index.js`
-          navigate(DEFAULT_ROUTE, { replace: true });
-          setTimeout(() => navigate(PREPARE_SWAP_ROUTE, { replace: true }), 0);
+          // prepareToLeaveSwaps() clears all swaps state, so we can navigate directly
+          navigate(PREPARE_SWAP_ROUTE);
         }}
         submitText={t('cancel')}
         hideCancel

--- a/ui/pages/swaps/awaiting-signatures/awaiting-signatures.test.js
+++ b/ui/pages/swaps/awaiting-signatures/awaiting-signatures.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-} from '../../../../test/jest';
+import { createSwapsMockStore } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import AwaitingSignatures from '.';
 
 describe('AwaitingSignatures', () => {

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 import React, { useContext, useRef, useState, useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { I18nContext } from '../../../contexts/i18n';
@@ -80,7 +80,7 @@ export default function AwaitingSwap({
 }) {
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const animationEventEmitter = useRef(new EventEmitter());
@@ -329,31 +329,31 @@ export default function AwaitingSwap({
           /* istanbul ignore next */
           if (errorKey === OFFLINE_FOR_MAINTENANCE) {
             await dispatch(prepareToLeaveSwaps());
-            history.push(DEFAULT_ROUTE);
+            navigate(DEFAULT_ROUTE);
           } else if (errorKey === QUOTES_EXPIRED_ERROR) {
             dispatch(prepareForRetryGetQuotes());
             await dispatch(
               fetchQuotesAndSetQuoteState(
-                history,
+                navigate,
                 fromTokenInputValue,
                 maxSlippage,
                 trackEvent,
               ),
             );
           } else if (errorKey) {
-            await dispatch(navigateBackToPrepareSwap(history));
+            await dispatch(navigateBackToPrepareSwap(navigate));
           } else if (
             isSwapsDefaultTokenSymbol(destinationTokenSymbol, chainId) ||
             swapComplete
           ) {
-            history.push(DEFAULT_ROUTE);
+            navigate(DEFAULT_ROUTE);
           } else {
             await dispatch(setDefaultHomeActiveTabName('activity'));
-            history.push(DEFAULT_ROUTE);
+            navigate(DEFAULT_ROUTE);
           }
         }}
         onCancel={async () =>
-          await dispatch(navigateBackToPrepareSwap(history))
+          await dispatch(navigateBackToPrepareSwap(navigate))
         }
         submitText={submitText}
         disabled={submittingSwap}

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.test.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.test.js
@@ -3,11 +3,8 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { setBackgroundConnection } from '../../../store/background-connection';
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-  fireEvent,
-} from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { createSwapsMockStore, fireEvent } from '../../../../test/jest';
 import {
   Slippage,
   QUOTES_EXPIRED_ERROR,

--- a/ui/pages/swaps/create-new-swap/create-new-swap.js
+++ b/ui/pages/swaps/create-new-swap/create-new-swap.js
@@ -1,9 +1,8 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
-
 import Box from '../../../components/ui/box';
 import { I18nContext } from '../../../contexts/i18n';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -24,7 +23,7 @@ export default function CreateNewSwap({ sensitiveTrackingProperties }) {
   const trackEvent = useContext(MetaMetricsContext);
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
 
   return (
@@ -39,8 +38,8 @@ export default function CreateNewSwap({ sensitiveTrackingProperties }) {
               hd_entropy_index: hdEntropyIndex,
             },
           });
-          history.push(DEFAULT_ROUTE); // It cleans up Swaps state.
-          await dispatch(navigateBackToPrepareSwap(history));
+          navigate(DEFAULT_ROUTE); // It cleans up Swaps state.
+          await dispatch(navigateBackToPrepareSwap(navigate));
           dispatch(setSwapsFromToken(defaultSwapsToken));
         }}
       >

--- a/ui/pages/swaps/create-new-swap/create-new-swap.test.js
+++ b/ui/pages/swaps/create-new-swap/create-new-swap.test.js
@@ -3,11 +3,8 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { setBackgroundConnection } from '../../../store/background-connection';
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-  fireEvent,
-} from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { createSwapsMockStore, fireEvent } from '../../../../test/jest';
 import {
   setSwapsFromToken,
   navigateBackToPrepareSwap,

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -5,17 +5,13 @@ import React, {
   useState,
   useCallback,
 } from 'react';
+import PropTypes from 'prop-types';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import {
-  Switch,
-  Route,
-  useLocation,
-  useHistory,
-  Redirect,
-} from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { isEqual } from 'lodash';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { I18nContext } from '../../contexts/i18n';
+import { useSafeNavigation } from '../../hooks/useSafeNavigation';
 
 import {
   getSelectedAccount,
@@ -102,14 +98,15 @@ import AwaitingSwap from './awaiting-swap';
 import LoadingQuote from './loading-swaps-quotes';
 import NotificationPage from './notification-page/notification-page';
 
-export default function Swap() {
+export default function Swap({ location: propsLocation }) {
   const t = useContext(I18nContext);
-  const history = useHistory();
+  const { navigate, location: hookLocation } = useSafeNavigation();
+  const location = propsLocation || hookLocation;
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
 
-  const { pathname } = useLocation();
+  const { pathname } = location;
   const isAwaitingSwapRoute = pathname === AWAITING_SWAP_ROUTE;
   const isAwaitingSignaturesRoute = pathname === AWAITING_SIGNATURES_ROUTE;
   const isSwapsErrorRoute = pathname === SWAPS_ERROR_ROUTE;
@@ -154,13 +151,13 @@ export default function Swap() {
       await dispatch(prepareToLeaveSwaps());
       // We need to wait until "prepareToLeaveSwaps" is done, because otherwise
       // a user would be redirected from DEFAULT_ROUTE back to Swaps.
-      history.push(DEFAULT_ROUTE);
+      navigate(DEFAULT_ROUTE);
     };
 
     if (!isSwapsChain) {
       leaveSwaps();
     }
-  }, [isSwapsChain, dispatch, history]);
+  }, [isSwapsChain, dispatch, navigate]);
 
   // This will pre-load gas fees before going to the View Quote page.
   useGasFeeEstimates();
@@ -270,9 +267,9 @@ export default function Swap() {
     // If there is a swapsErrorKey and reviewSwapClicked is false, there was an error in silent quotes prefetching
     // and we don't want to show the error page in that case, because another API call for quotes can be successful.
     if (swapsErrorKey && !isSwapsErrorRoute && reviewSwapClicked) {
-      history.push(SWAPS_ERROR_ROUTE);
+      navigate(SWAPS_ERROR_ROUTE);
     }
-  }, [history, swapsErrorKey, isSwapsErrorRoute, reviewSwapClicked]);
+  }, [navigate, swapsErrorKey, isSwapsErrorRoute, reviewSwapClicked]);
 
   const beforeUnloadEventAddedRef = useRef();
   useEffect(() => {
@@ -345,8 +342,7 @@ export default function Swap() {
 
   const redirectToDefaultRoute = async () => {
     clearTemporaryTokenRef.current();
-    history.push({
-      pathname: DEFAULT_ROUTE,
+    navigate(DEFAULT_ROUTE, {
       state: { stayOnHomePage: true },
     });
     dispatch(clearSwapsState());
@@ -410,108 +406,106 @@ export default function Swap() {
           </Box>
         </div>
         <div className="swaps__content">
-          <Switch>
-            <FeatureToggledRoute
-              redirectRoute={SWAPS_MAINTENANCE_ROUTE}
-              flag={swapsEnabled}
+          <Routes>
+            <Route
               path={PREPARE_SWAP_ROUTE}
-              exact
-              render={() => (
-                <Redirect
-                  to={{
-                    pathname: `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`,
-                  }}
+              element={
+                <FeatureToggledRoute
+                  redirectRoute={SWAPS_MAINTENANCE_ROUTE}
+                  flag={swapsEnabled}
+                  element={
+                    <Navigate
+                      to={`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`}
+                      replace
+                    />
+                  }
                 />
-              )}
+              }
             />
             <Route
               path={SWAPS_ERROR_ROUTE}
-              exact
-              render={() => {
-                if (swapsErrorKey) {
-                  return (
-                    <AwaitingSwap
-                      swapComplete={false}
-                      errorKey={swapsErrorKey}
-                      txHash={tradeTxData?.hash}
-                      txId={tradeTxData?.id}
-                      submittedTime={tradeTxData?.submittedTime}
-                    />
-                  );
-                }
-                return <Redirect to={{ pathname: PREPARE_SWAP_ROUTE }} />;
-              }}
+              element={
+                swapsErrorKey ? (
+                  <AwaitingSwap
+                    swapComplete={false}
+                    errorKey={swapsErrorKey}
+                    txHash={tradeTxData?.hash}
+                    txId={tradeTxData?.id}
+                    submittedTime={tradeTxData?.submittedTime}
+                  />
+                ) : (
+                  <Navigate to={PREPARE_SWAP_ROUTE} replace />
+                )
+              }
             />
             <Route
               path={SWAPS_NOTIFICATION_ROUTE}
-              exact
-              render={() => {
-                if (!swapsErrorKey) {
-                  return <Redirect to={{ pathname: PREPARE_SWAP_ROUTE }} />;
-                }
-                return <NotificationPage notificationKey={swapsErrorKey} />;
-              }}
-            />
-            <FeatureToggledRoute
-              redirectRoute={SWAPS_MAINTENANCE_ROUTE}
-              flag={swapsEnabled}
-              path={LOADING_QUOTES_ROUTE}
-              exact
-              render={() => {
-                return aggregatorMetadata ? (
-                  <LoadingQuote
-                    loadingComplete={
-                      !fetchingQuotes && Boolean(Object.values(quotes).length)
-                    }
-                    onDone={async () => {
-                      await dispatch(setBackgroundSwapRouteState(''));
-                      if (
-                        swapsErrorKey === ERROR_FETCHING_QUOTES ||
-                        swapsErrorKey === QUOTES_NOT_AVAILABLE_ERROR
-                      ) {
-                        dispatch(setSwapsErrorKey(QUOTES_NOT_AVAILABLE_ERROR));
-                        history.push(SWAPS_ERROR_ROUTE);
-                      } else {
-                        history.push(PREPARE_SWAP_ROUTE);
-                      }
-                    }}
-                    aggregatorMetadata={aggregatorMetadata}
-                  />
+              element={
+                swapsErrorKey ? (
+                  <NotificationPage notificationKey={swapsErrorKey} />
                 ) : (
-                  <Redirect to={{ pathname: PREPARE_SWAP_ROUTE }} />
-                );
-              }}
+                  <Navigate to={PREPARE_SWAP_ROUTE} replace />
+                )
+              }
+            />
+            <Route
+              path={LOADING_QUOTES_ROUTE}
+              element={
+                <FeatureToggledRoute
+                  redirectRoute={SWAPS_MAINTENANCE_ROUTE}
+                  flag={swapsEnabled}
+                  element={
+                    aggregatorMetadata ? (
+                      <LoadingQuote
+                        loadingComplete={
+                          !fetchingQuotes &&
+                          Boolean(Object.values(quotes).length)
+                        }
+                        onDone={async () => {
+                          await dispatch(setBackgroundSwapRouteState(''));
+                          if (
+                            swapsErrorKey === ERROR_FETCHING_QUOTES ||
+                            swapsErrorKey === QUOTES_NOT_AVAILABLE_ERROR
+                          ) {
+                            dispatch(
+                              setSwapsErrorKey(QUOTES_NOT_AVAILABLE_ERROR),
+                            );
+                            navigate(SWAPS_ERROR_ROUTE);
+                          } else {
+                            navigate(PREPARE_SWAP_ROUTE);
+                          }
+                        }}
+                        aggregatorMetadata={aggregatorMetadata}
+                      />
+                    ) : (
+                      <Navigate to={PREPARE_SWAP_ROUTE} replace />
+                    )
+                  }
+                />
+              }
             />
             <Route
               path={SWAPS_MAINTENANCE_ROUTE}
-              exact
-              render={() => {
-                return swapsEnabled === false ? (
+              element={
+                swapsEnabled === false ? (
                   <AwaitingSwap errorKey={OFFLINE_FOR_MAINTENANCE} />
                 ) : (
-                  <Redirect to={{ pathname: PREPARE_SWAP_ROUTE }} />
-                );
-              }}
+                  <Navigate to={PREPARE_SWAP_ROUTE} replace />
+                )
+              }
             />
             <Route
               path={AWAITING_SIGNATURES_ROUTE}
-              exact
-              render={() => {
-                return <AwaitingSignatures />;
-              }}
+              element={<AwaitingSignatures />}
             />
             <Route
               path={SMART_TRANSACTION_STATUS_ROUTE}
-              exact
-              render={() => {
-                return <SmartTransactionStatus txId={tradeTxData?.id} />;
-              }}
+              element={<SmartTransactionStatus txId={tradeTxData?.id} />}
             />
             <Route
               path={AWAITING_SWAP_ROUTE}
-              exact
-              render={() => {
-                return routeState === 'awaiting' || tradeTxData ? (
+              element={
+                routeState === 'awaiting' || tradeTxData ? (
                   <AwaitingSwap
                     swapComplete={tradeConfirmed}
                     txHash={tradeTxData?.hash}
@@ -522,13 +516,17 @@ export default function Swap() {
                     }
                   />
                 ) : (
-                  <Redirect to={{ pathname: DEFAULT_ROUTE }} />
-                );
-              }}
+                  <Navigate to={DEFAULT_ROUTE} replace />
+                )
+              }
             />
-          </Switch>
+          </Routes>
         </div>
       </div>
     </div>
   );
 }
+
+Swap.propTypes = {
+  location: PropTypes.object,
+};

--- a/ui/pages/swaps/index.test.js
+++ b/ui/pages/swaps/index.test.js
@@ -5,27 +5,24 @@ import nock from 'nock';
 import { waitFor } from '@testing-library/react';
 
 import { setBackgroundConnection } from '../../store/background-connection';
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-  MOCKS,
-  CONSTANTS,
-} from '../../../test/jest';
+import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createSwapsMockStore, MOCKS, CONSTANTS } from '../../../test/jest';
 import Swap from '.';
 
 const middleware = [thunk];
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    replace: jest.fn(),
-  }),
-  useLocation: jest.fn(() => {
-    return {
-      pathname: '/swaps/prepare-swap-page',
-    };
-  }),
-}));
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockUseNavigate,
+    useLocation: jest.fn(() => {
+      return {
+        pathname: '/swaps/prepare-swap-page',
+      };
+    }),
+  };
+});
 
 setBackgroundConnection({
   getStatePatches: jest.fn().mockResolvedValue([]),

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { shuffle } from 'lodash';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 import {
   navigateBackToPrepareSwap,
@@ -46,7 +46,7 @@ export default function LoadingSwapsQuotes({
   const trackEvent = useContext(MetaMetricsContext);
   const dispatch = useDispatch();
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
-  const history = useHistory();
+  const navigate = useNavigate();
   const animationEventEmitter = useRef(new EventEmitter());
 
   const fetchParams = useSelector(getFetchParams, isEqual);
@@ -205,7 +205,7 @@ export default function LoadingSwapsQuotes({
         submitText={t('back')}
         onSubmit={async () => {
           trackEvent(quotesRequestCancelledEventConfig);
-          await dispatch(navigateBackToPrepareSwap(history));
+          await dispatch(navigateBackToPrepareSwap(navigate));
         }}
         hideCancel
       />

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.test.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-} from '../../../../test/jest';
+import { createSwapsMockStore } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import LoadingSwapsQuotes from '.';
 
 const createProps = (customProps = {}) => {

--- a/ui/pages/swaps/notification-page/notification-page.js
+++ b/ui/pages/swaps/notification-page/notification-page.js
@@ -1,8 +1,7 @@
 import React, { useContext } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
-
 import { I18nContext } from '../../../contexts/i18n';
 import { setSwapsErrorKey } from '../../../store/actions';
 import Box from '../../../components/ui/box';
@@ -21,7 +20,7 @@ import { QUOTES_EXPIRED_ERROR } from '../../../../shared/constants/swaps';
 
 export default function NotificationPage({ notificationKey }) {
   const t = useContext(I18nContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
 
   // TODO: Either add default values or redirect a user out if a notificationKey value is not supported.
@@ -64,7 +63,7 @@ export default function NotificationPage({ notificationKey }) {
       <SwapsFooter
         onSubmit={async () => {
           await dispatch(setSwapsErrorKey(''));
-          history.push(PREPARE_SWAP_ROUTE);
+          navigate(PREPARE_SWAP_ROUTE);
         }}
         submitText={buttonText}
         hideCancel

--- a/ui/pages/swaps/notification-page/notification-page.test.js
+++ b/ui/pages/swaps/notification-page/notification-page.test.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-} from '../../../../test/jest';
+import { createSwapsMockStore } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { QUOTES_EXPIRED_ERROR } from '../../../../shared/constants/swaps';
 import NotificationPage from './notification-page';
 

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -3,10 +3,9 @@ import BigNumber from 'bignumber.js';
 import PropTypes from 'prop-types';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { uniqBy, isEqual, isEmpty } from 'lodash';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { getAccountLink, getTokenTrackerLink } from '@metamask/etherscan-link';
 import classnames from 'classnames';
-
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   useTokensToSearch,
@@ -164,7 +163,7 @@ export default function PrepareSwapPage({
 }) {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const trackEvent = useContext(MetaMetricsContext);
   const { openBridgeExperience } = useBridging();
 
@@ -404,7 +403,7 @@ export default function PrepareSwapPage({
     loadingComplete,
     numberOfQuotes,
     dispatch,
-    history,
+    navigate,
     swapsErrorKey,
     numberOfAggregators,
     prefetchingQuotes,
@@ -659,7 +658,7 @@ export default function PrepareSwapPage({
       const pageRedirectionDisabled = true;
       await dispatch(
         fetchQuotesAndSetQuoteState(
-          history,
+          navigate,
           fromTokenInputValue,
           maxSlippage,
           trackEvent,
@@ -686,7 +685,7 @@ export default function PrepareSwapPage({
     return () => clearTimeout(timeoutIdForQuotesPrefetching);
   }, [
     dispatch,
-    history,
+    navigate,
     maxSlippage,
     trackEvent,
     isReviewSwapButtonDisabled,
@@ -752,9 +751,9 @@ export default function PrepareSwapPage({
 
   useEffect(() => {
     if (swapsErrorKey === QUOTES_EXPIRED_ERROR) {
-      history.push(SWAPS_NOTIFICATION_ROUTE);
+      navigate(SWAPS_NOTIFICATION_ROUTE);
     }
-  }, [swapsErrorKey, history]);
+  }, [swapsErrorKey, navigate]);
 
   useEffect(() => {
     if (showQuotesLoadingAnimation) {

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -7,7 +7,7 @@ import React, {
   useCallback,
 } from 'react';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import BigNumber from 'bignumber.js';
 import { isEqual } from 'lodash';
 import classnames from 'classnames';
@@ -187,7 +187,7 @@ export default function ReviewQuote({
   setReceiveToAmount,
   setIsEstimatedReturnLow,
 }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
@@ -217,11 +217,11 @@ export default function ReviewQuote({
   const quotes = useSelector(getQuotes, isEqual);
   useEffect(() => {
     if (!Object.values(quotes).length) {
-      history.push(PREPARE_SWAP_ROUTE);
+      navigate(PREPARE_SWAP_ROUTE);
     } else if (routeState === 'awaiting') {
-      history.push(AWAITING_SWAP_ROUTE);
+      navigate(AWAITING_SWAP_ROUTE);
     }
-  }, [history, quotes, routeState]);
+  }, [navigate, quotes, routeState]);
 
   const quotesLastFetched = useSelector(getQuotesLastFetched);
   const prevQuotesLastFetched = usePrevious(quotesLastFetched);
@@ -1079,23 +1079,23 @@ export default function ReviewQuote({
           signAndSendSwapsSmartTransaction({
             unsignedTransaction,
             trackEvent,
-            history,
+            navigate,
             additionalTrackingParams,
           }),
         );
       } else {
         dispatch(
           signAndSendTransactions(
-            history,
+            navigate,
             trackEvent,
             additionalTrackingParams,
           ),
         );
       }
     } else if (destinationToken.symbol === defaultSwapsToken.symbol) {
-      history.push(DEFAULT_ROUTE);
+      navigate(DEFAULT_ROUTE);
     } else {
-      history.push(`${ASSET_ROUTE}/${destinationToken.address}`);
+      navigate(`${ASSET_ROUTE}/${destinationToken.address}`);
     }
   };
 

--- a/ui/pages/swaps/prepare-swap-page/review-quote.test.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.test.js
@@ -4,10 +4,8 @@ import thunk from 'redux-thunk';
 
 import { NetworkType } from '@metamask/controller-utils';
 import { act } from '@testing-library/react';
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-} from '../../../../test/jest';
+import { createSwapsMockStore } from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { getSwap1559GasFeeEstimates } from '../swaps.util';
 import { getNetworkConfigurationByNetworkClientId } from '../../../store/actions';

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { isEqual } from 'lodash';
 import { I18nContext } from '../../../contexts/i18n';
@@ -64,7 +64,7 @@ import TimerIcon from './timer-icon';
 export default function SmartTransactionStatusPage() {
   const [cancelSwapLinkClicked, setCancelSwapLinkClicked] = useState(false);
   const t = useContext(I18nContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const fetchParams = useSelector(getFetchParams, isEqual) || {};
@@ -470,14 +470,14 @@ export default function SmartTransactionStatusPage() {
         onSubmit={async () => {
           if (showCloseButtonOnly) {
             await dispatch(prepareToLeaveSwaps());
-            history.push(DEFAULT_ROUTE);
+            navigate(DEFAULT_ROUTE);
           } else {
-            history.push(PREPARE_SWAP_ROUTE);
+            navigate(PREPARE_SWAP_ROUTE);
           }
         }}
         onCancel={async () => {
           await dispatch(prepareToLeaveSwaps());
-          history.push(DEFAULT_ROUTE);
+          navigate(DEFAULT_ROUTE);
         }}
         submitText={showCloseButtonOnly ? t('close') : t('tryAgain')}
         hideCancel={showCloseButtonOnly}

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.test.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.test.js
@@ -2,11 +2,8 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { setBackgroundConnection } from '../../../store/background-connection';
-import {
-  renderWithProvider,
-  createSwapsMockStore,
-  fireEvent,
-} from '../../../../test/jest';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { createSwapsMockStore, fireEvent } from '../../../../test/jest';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import SmartTransactionStatusLabel from '.';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Migrate swaps component to React Router v6 compatibility.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37561?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5563

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate Swaps routing to react-router-dom v5-compat, replacing history-based navigation with navigate, updating routes/components, and aligning tests.
> 
> - **Routing migration to v5-compat**:
>   - Replace `useHistory`, `Redirect`, `Switch`, and v5 `<Route render>` with `useNavigate`, `Navigate`, and `Routes` across `ui/pages/swaps/*`.
>   - Introduce `FeatureToggledRoute` using v5-compat `Navigate` and update consumers.
>   - Update swaps thunks in `ui/ducks/swaps/swaps.js` to accept/use `navigate` instead of `history` for redirects.
>   - In `routes.component.tsx`, add `createV5CompatNavigate` helper and wrap Swaps/Cross-chain Swap routes with `AuthenticatedV5Compat`, passing v5-compatible props.
> - **Swaps pages refactor**:
>   - Refactor navigation/redirect logic in `awaiting-*`, `loading-swaps-quotes`, `notification-page`, `prepare-swap-page`, `review-quote`, `smart-transaction-status`, and `index` to v5-compat APIs; minor prop types added/adjusted.
>   - `Swap` now uses `useSafeNavigation`, v5-compat `Routes`, and `FeatureToggledRoute` for maintenance gating.
> - **Tests**:
>   - Update tests to use `render-helpers-navigate` and v5-compat `useNavigate` mocks; remove legacy helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aecb26c8dc9d37e30f2a71c0363cd52f0fcdca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->