### PR TITLE
fix(INFRA-3081): correct platform parameter in release changelog workflow

### DIFF
--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       release-branch: ${{ github.ref_name }}
       repository-url: ${{ github.server_url }}/${{ github.repository }}
-      platform: mobile
+      platform: extension
       github-tools-version: 36dc168896c1b496f35fc880ee8a3625b4b837ba
       previous-version-ref: null
     secrets:


### PR DESCRIPTION
## Description

This PR fixes an incorrect platform parameter in the release changelog update workflow. The workflow was configured with `platform: mobile` when it should be `platform: extension` for the MetaMask Extension repository.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3081

## Changes

- Updated the `platform` parameter from `mobile` to `extension` in the `update-release-changelog.yml` workflow
- This ensures the changelog generation correctly identifies the repository as an extension project

## Impact

This is a low-risk fix that corrects a configuration error. The change only affects how the release changelog workflow processes changelog updates for release branches matching the `release/x.y.z` pattern.