### PR TITLE
fix: flaky test `Metrics Sends a contract interaction type 2 transaction (EIP1559) with the right properties in the metric events`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -76,6 +76,9 @@ class TransactionConfirmation extends Confirmation {
   private readonly networkName: RawLocator =
     '[data-testid="confirmation__details-network-name"]';
 
+  private readonly nonceSection: RawLocator =
+    '[data-testid="advanced-details-nonce-section"]';
+
   private readonly saveButton: RawLocator = { tag: 'button', text: 'Save' };
 
   private readonly senderAccount: RawLocator = '[data-testid="sender-address"]';
@@ -226,6 +229,13 @@ class TransactionConfirmation extends Confirmation {
       css: this.headerAccountName,
       text: account,
     });
+  }
+
+  async checkNonceSectionIsDisplayed(): Promise<void> {
+    console.log(
+      `Checking nonce section is displayed on transaction confirmation page.`,
+    );
+    await this.driver.waitForSelector(this.nonceSection);
   }
 
   async checkPaidByMetaMask() {

--- a/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/transaction-confirmation.ts
@@ -76,9 +76,6 @@ class TransactionConfirmation extends Confirmation {
   private readonly networkName: RawLocator =
     '[data-testid="confirmation__details-network-name"]';
 
-  private readonly nonceSection: RawLocator =
-    '[data-testid="advanced-details-nonce-section"]';
-
   private readonly saveButton: RawLocator = { tag: 'button', text: 'Save' };
 
   private readonly senderAccount: RawLocator = '[data-testid="sender-address"]';
@@ -229,13 +226,6 @@ class TransactionConfirmation extends Confirmation {
       css: this.headerAccountName,
       text: account,
     });
-  }
-
-  async checkNonceSectionIsDisplayed(): Promise<void> {
-    console.log(
-      `Checking nonce section is displayed on transaction confirmation page.`,
-    );
-    await this.driver.waitForSelector(this.nonceSection);
   }
 
   async checkPaidByMetaMask() {

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -98,6 +98,7 @@ describe('Metrics', function () {
 
         // enable the advanced view
         await transactionConfirmation.clickAdvancedDetailsButton();
+        await transactionConfirmation.checkNonceSectionIsDisplayed();
         await transactionConfirmation.verifyAdvancedDetailsHexDataIsDisplayed(
           '0xd0e30db0',
         );

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -15,7 +15,28 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import { assertAdvancedGasDetails } from './shared';
 
-const { withFixtures, getEventPayloads } = require('../../../helpers');
+const {
+  withFixtures,
+  getEventPayloads,
+  assertInAnyOrder,
+} = require('../../../helpers');
+
+type MetricsEvent = {
+  event: string;
+  properties: {
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    transaction_type?: string;
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    ui_customizations?: string[];
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    transaction_advanced_view?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
 const FixtureBuilder = require('../../../fixture-builder');
 
 describe('Metrics', function () {
@@ -80,7 +101,6 @@ describe('Metrics', function () {
         await transactionConfirmation.verifyAdvancedDetailsHexDataIsDisplayed(
           '0xd0e30db0',
         );
-        await transactionConfirmation.checkNonceSectionIsDisplayed();
 
         await assertAdvancedGasDetails(driver);
         await transactionConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
@@ -95,129 +115,157 @@ describe('Metrics', function () {
         console.log(events);
         assert.equal(events.length, 16);
 
-        // deployment tx -- no ui_customizations
-        assert.equal(
-          events[0].event,
-          AnonymousTransactionMetaMetricsEvent.added,
-        );
-        assert.equal(
-          events[0].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[0].properties.transaction_advanced_view, undefined);
-        assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
-        assert.equal(
-          events[1].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[1].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[2].event,
-          AnonymousTransactionMetaMetricsEvent.submitted,
-        );
-        assert.equal(
-          events[2].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[2].properties.transaction_advanced_view, undefined);
-        assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
-        assert.equal(
-          events[3].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[3].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[4].event,
-          AnonymousTransactionMetaMetricsEvent.approved,
-        );
-        assert.equal(
-          events[4].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[4].properties.transaction_advanced_view, undefined);
-        assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
-        assert.equal(
-          events[5].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[5].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[6].event,
-          AnonymousTransactionMetaMetricsEvent.finalized,
-        );
-        assert.equal(
-          events[6].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[6].properties.transaction_advanced_view, undefined);
-        assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
-        assert.equal(
-          events[7].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[7].properties.transaction_advanced_view, undefined);
+        const findEventsByName = (eventType: string) =>
+          events.filter((event: MetricsEvent) => event.event === eventType);
 
-        // deposit tx (contract interaction) -- ui_customizations is set
+        // Separate events by transaction type
+        const deploymentEvents = events.filter(
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractDeployment',
+        );
+        const interactionEvents = events.filter(
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractInteraction',
+        );
+
         assert.equal(
-          events[8].event,
+          deploymentEvents.length,
+          8,
+          'Should have 8 deployment events',
+        );
+        assert.equal(
+          interactionEvents.length,
+          8,
+          'Should have 8 interaction events',
+        );
+
+        // Assertion predicates for deployment transaction (no advanced view)
+        const deploymentTransactionCheck = [
+          (event: MetricsEvent) =>
+            event.properties.ui_customizations?.[0] ===
+            'redesigned_confirmation',
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === undefined,
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractDeployment',
+        ];
+
+        // Assertion predicates for contract interaction transaction (with advanced view)
+        const interactionTransactionCheck = [
+          (event: MetricsEvent) =>
+            event.properties.ui_customizations?.[0] ===
+            'redesigned_confirmation',
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractInteraction',
+        ];
+
+        // Additional check for events that should have advanced view
+        const interactionWithAdvancedViewCheck = [
+          ...interactionTransactionCheck,
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === true,
+        ];
+
+        // Additional check for "added" events that don't have advanced view yet
+        const interactionAddedEventCheck = [
+          ...interactionTransactionCheck,
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === undefined,
+        ];
+
+        // Test Transaction Added events
+        const addedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.added,
         );
-        assert.equal(
-          events[8].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const addedEvents = findEventsByName(TransactionMetaMetricsEvent.added);
+
+        assert.equal(addedAnonEvents.length, 2);
+        assert.equal(addedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(addedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionAddedEventCheck,
+          ]),
         );
-        assert.equal(events[8].properties.transaction_advanced_view, undefined);
-        assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
-        assert.equal(
-          events[9].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        assert.ok(
+          assertInAnyOrder(addedEvents, [
+            deploymentTransactionCheck,
+            interactionAddedEventCheck,
+          ]),
         );
-        assert.equal(events[9].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[10].event,
+
+        // Test Transaction Submitted events
+        const submittedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.submitted,
         );
-        assert.equal(
-          events[10].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const submittedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.submitted,
         );
-        assert.equal(events[10].properties.transaction_advanced_view, true);
-        assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
-        assert.equal(
-          events[11].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(submittedAnonEvents.length, 2);
+        assert.equal(submittedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(submittedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[11].properties.transaction_advanced_view, true);
-        assert.equal(
-          events[12].event,
+        assert.ok(
+          assertInAnyOrder(submittedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
+
+        // Test Transaction Approved events
+        const approvedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.approved,
         );
-        assert.equal(
-          events[12].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const approvedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.approved,
         );
-        assert.equal(events[12].properties.transaction_advanced_view, true);
-        assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
-        assert.equal(
-          events[13].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(approvedAnonEvents.length, 2);
+        assert.equal(approvedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(approvedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[13].properties.transaction_advanced_view, true);
-        assert.equal(
-          events[14].event,
+        assert.ok(
+          assertInAnyOrder(approvedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
+
+        // Test Transaction Finalized events
+        const finalizedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.finalized,
         );
-        assert.equal(
-          events[14].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const finalizedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.finalized,
         );
-        assert.equal(events[14].properties.transaction_advanced_view, true);
-        assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
-        assert.equal(
-          events[15].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(finalizedAnonEvents.length, 2);
+        assert.equal(finalizedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(finalizedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[15].properties.transaction_advanced_view, true);
+        assert.ok(
+          assertInAnyOrder(finalizedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -15,7 +15,28 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import { assertAdvancedGasDetails } from './shared';
 
-const { withFixtures, getEventPayloads } = require('../../../helpers');
+const {
+  withFixtures,
+  getEventPayloads,
+  assertInAnyOrder,
+} = require('../../../helpers');
+
+type MetricsEvent = {
+  event: string;
+  properties: {
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    transaction_type?: string;
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    ui_customizations?: string[];
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    transaction_advanced_view?: boolean;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
 const FixtureBuilder = require('../../../fixture-builder');
 
 describe('Metrics', function () {
@@ -94,129 +115,157 @@ describe('Metrics', function () {
         console.log(events);
         assert.equal(events.length, 16);
 
-        // deployment tx -- no ui_customizations
-        assert.equal(
-          events[0].event,
-          AnonymousTransactionMetaMetricsEvent.added,
-        );
-        assert.equal(
-          events[0].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[0].properties.transaction_advanced_view, undefined);
-        assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
-        assert.equal(
-          events[1].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[1].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[2].event,
-          AnonymousTransactionMetaMetricsEvent.submitted,
-        );
-        assert.equal(
-          events[2].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[2].properties.transaction_advanced_view, undefined);
-        assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
-        assert.equal(
-          events[3].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[3].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[4].event,
-          AnonymousTransactionMetaMetricsEvent.approved,
-        );
-        assert.equal(
-          events[4].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[4].properties.transaction_advanced_view, undefined);
-        assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
-        assert.equal(
-          events[5].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[5].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[6].event,
-          AnonymousTransactionMetaMetricsEvent.finalized,
-        );
-        assert.equal(
-          events[6].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[6].properties.transaction_advanced_view, undefined);
-        assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
-        assert.equal(
-          events[7].properties.ui_customizations[0],
-          'redesigned_confirmation',
-        );
-        assert.equal(events[7].properties.transaction_advanced_view, undefined);
+        const findEventsByName = (eventType: string) =>
+          events.filter((event: MetricsEvent) => event.event === eventType);
 
-        // deposit tx (contract interaction) -- ui_customizations is set
+        // Separate events by transaction type
+        const deploymentEvents = events.filter(
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractDeployment',
+        );
+        const interactionEvents = events.filter(
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractInteraction',
+        );
+
         assert.equal(
-          events[8].event,
+          deploymentEvents.length,
+          8,
+          'Should have 8 deployment events',
+        );
+        assert.equal(
+          interactionEvents.length,
+          8,
+          'Should have 8 interaction events',
+        );
+
+        // Assertion predicates for deployment transaction (no advanced view)
+        const deploymentTransactionCheck = [
+          (event: MetricsEvent) =>
+            event.properties.ui_customizations?.[0] ===
+            'redesigned_confirmation',
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === undefined,
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractDeployment',
+        ];
+
+        // Assertion predicates for contract interaction transaction (with advanced view)
+        const interactionTransactionCheck = [
+          (event: MetricsEvent) =>
+            event.properties.ui_customizations?.[0] ===
+            'redesigned_confirmation',
+          (event: MetricsEvent) =>
+            event.properties.transaction_type === 'contractInteraction',
+        ];
+
+        // Additional check for events that should have advanced view
+        const interactionWithAdvancedViewCheck = [
+          ...interactionTransactionCheck,
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === true,
+        ];
+
+        // Additional check for "added" events that don't have advanced view yet
+        const interactionAddedEventCheck = [
+          ...interactionTransactionCheck,
+          (event: MetricsEvent) =>
+            event.properties.transaction_advanced_view === undefined,
+        ];
+
+        // Test Transaction Added events
+        const addedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.added,
         );
-        assert.equal(
-          events[8].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const addedEvents = findEventsByName(TransactionMetaMetricsEvent.added);
+
+        assert.equal(addedAnonEvents.length, 2);
+        assert.equal(addedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(addedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionAddedEventCheck,
+          ]),
         );
-        assert.equal(events[8].properties.transaction_advanced_view, undefined);
-        assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
-        assert.equal(
-          events[9].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        assert.ok(
+          assertInAnyOrder(addedEvents, [
+            deploymentTransactionCheck,
+            interactionAddedEventCheck,
+          ]),
         );
-        assert.equal(events[9].properties.transaction_advanced_view, undefined);
-        assert.equal(
-          events[10].event,
+
+        // Test Transaction Submitted events
+        const submittedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.submitted,
         );
-        assert.equal(
-          events[10].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const submittedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.submitted,
         );
-        assert.equal(events[10].properties.transaction_advanced_view, true);
-        assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
-        assert.equal(
-          events[11].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(submittedAnonEvents.length, 2);
+        assert.equal(submittedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(submittedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[11].properties.transaction_advanced_view, true);
-        assert.equal(
-          events[12].event,
+        assert.ok(
+          assertInAnyOrder(submittedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
+
+        // Test Transaction Approved events
+        const approvedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.approved,
         );
-        assert.equal(
-          events[12].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const approvedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.approved,
         );
-        assert.equal(events[12].properties.transaction_advanced_view, true);
-        assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
-        assert.equal(
-          events[13].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(approvedAnonEvents.length, 2);
+        assert.equal(approvedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(approvedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[13].properties.transaction_advanced_view, true);
-        assert.equal(
-          events[14].event,
+        assert.ok(
+          assertInAnyOrder(approvedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
+
+        // Test Transaction Finalized events
+        const finalizedAnonEvents = findEventsByName(
           AnonymousTransactionMetaMetricsEvent.finalized,
         );
-        assert.equal(
-          events[14].properties.ui_customizations[0],
-          'redesigned_confirmation',
+        const finalizedEvents = findEventsByName(
+          TransactionMetaMetricsEvent.finalized,
         );
-        assert.equal(events[14].properties.transaction_advanced_view, true);
-        assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
-        assert.equal(
-          events[15].properties.ui_customizations[0],
-          'redesigned_confirmation',
+
+        assert.equal(finalizedAnonEvents.length, 2);
+        assert.equal(finalizedEvents.length, 2);
+
+        assert.ok(
+          assertInAnyOrder(finalizedAnonEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
         );
-        assert.equal(events[15].properties.transaction_advanced_view, true);
+        assert.ok(
+          assertInAnyOrder(finalizedEvents, [
+            deploymentTransactionCheck,
+            interactionWithAdvancedViewCheck,
+          ]),
+        );
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -15,28 +15,7 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import { assertAdvancedGasDetails } from './shared';
 
-const {
-  withFixtures,
-  getEventPayloads,
-  assertInAnyOrder,
-} = require('../../../helpers');
-
-type MetricsEvent = {
-  event: string;
-  properties: {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    transaction_type?: string;
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    ui_customizations?: string[];
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    transaction_advanced_view?: boolean;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-};
+const { withFixtures, getEventPayloads } = require('../../../helpers');
 const FixtureBuilder = require('../../../fixture-builder');
 
 describe('Metrics', function () {
@@ -101,6 +80,7 @@ describe('Metrics', function () {
         await transactionConfirmation.verifyAdvancedDetailsHexDataIsDisplayed(
           '0xd0e30db0',
         );
+        await transactionConfirmation.checkNonceSectionIsDisplayed();
 
         await assertAdvancedGasDetails(driver);
         await transactionConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
@@ -115,157 +95,129 @@ describe('Metrics', function () {
         console.log(events);
         assert.equal(events.length, 16);
 
-        const findEventsByName = (eventType: string) =>
-          events.filter((event: MetricsEvent) => event.event === eventType);
-
-        // Separate events by transaction type
-        const deploymentEvents = events.filter(
-          (event: MetricsEvent) =>
-            event.properties.transaction_type === 'contractDeployment',
-        );
-        const interactionEvents = events.filter(
-          (event: MetricsEvent) =>
-            event.properties.transaction_type === 'contractInteraction',
-        );
-
+        // deployment tx -- no ui_customizations
         assert.equal(
-          deploymentEvents.length,
-          8,
-          'Should have 8 deployment events',
-        );
-        assert.equal(
-          interactionEvents.length,
-          8,
-          'Should have 8 interaction events',
-        );
-
-        // Assertion predicates for deployment transaction (no advanced view)
-        const deploymentTransactionCheck = [
-          (event: MetricsEvent) =>
-            event.properties.ui_customizations?.[0] ===
-            'redesigned_confirmation',
-          (event: MetricsEvent) =>
-            event.properties.transaction_advanced_view === undefined,
-          (event: MetricsEvent) =>
-            event.properties.transaction_type === 'contractDeployment',
-        ];
-
-        // Assertion predicates for contract interaction transaction (with advanced view)
-        const interactionTransactionCheck = [
-          (event: MetricsEvent) =>
-            event.properties.ui_customizations?.[0] ===
-            'redesigned_confirmation',
-          (event: MetricsEvent) =>
-            event.properties.transaction_type === 'contractInteraction',
-        ];
-
-        // Additional check for events that should have advanced view
-        const interactionWithAdvancedViewCheck = [
-          ...interactionTransactionCheck,
-          (event: MetricsEvent) =>
-            event.properties.transaction_advanced_view === true,
-        ];
-
-        // Additional check for "added" events that don't have advanced view yet
-        const interactionAddedEventCheck = [
-          ...interactionTransactionCheck,
-          (event: MetricsEvent) =>
-            event.properties.transaction_advanced_view === undefined,
-        ];
-
-        // Test Transaction Added events
-        const addedAnonEvents = findEventsByName(
+          events[0].event,
           AnonymousTransactionMetaMetricsEvent.added,
         );
-        const addedEvents = findEventsByName(TransactionMetaMetricsEvent.added);
-
-        assert.equal(addedAnonEvents.length, 2);
-        assert.equal(addedEvents.length, 2);
-
-        assert.ok(
-          assertInAnyOrder(addedAnonEvents, [
-            deploymentTransactionCheck,
-            interactionAddedEventCheck,
-          ]),
+        assert.equal(
+          events[0].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-        assert.ok(
-          assertInAnyOrder(addedEvents, [
-            deploymentTransactionCheck,
-            interactionAddedEventCheck,
-          ]),
+        assert.equal(events[0].properties.transaction_advanced_view, undefined);
+        assert.equal(events[1].event, TransactionMetaMetricsEvent.added);
+        assert.equal(
+          events[1].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-
-        // Test Transaction Submitted events
-        const submittedAnonEvents = findEventsByName(
+        assert.equal(events[1].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[2].event,
           AnonymousTransactionMetaMetricsEvent.submitted,
         );
-        const submittedEvents = findEventsByName(
-          TransactionMetaMetricsEvent.submitted,
+        assert.equal(
+          events[2].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-
-        assert.equal(submittedAnonEvents.length, 2);
-        assert.equal(submittedEvents.length, 2);
-
-        assert.ok(
-          assertInAnyOrder(submittedAnonEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
+        assert.equal(events[2].properties.transaction_advanced_view, undefined);
+        assert.equal(events[3].event, TransactionMetaMetricsEvent.submitted);
+        assert.equal(
+          events[3].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-        assert.ok(
-          assertInAnyOrder(submittedEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
-        );
-
-        // Test Transaction Approved events
-        const approvedAnonEvents = findEventsByName(
+        assert.equal(events[3].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[4].event,
           AnonymousTransactionMetaMetricsEvent.approved,
         );
-        const approvedEvents = findEventsByName(
-          TransactionMetaMetricsEvent.approved,
+        assert.equal(
+          events[4].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-
-        assert.equal(approvedAnonEvents.length, 2);
-        assert.equal(approvedEvents.length, 2);
-
-        assert.ok(
-          assertInAnyOrder(approvedAnonEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
+        assert.equal(events[4].properties.transaction_advanced_view, undefined);
+        assert.equal(events[5].event, TransactionMetaMetricsEvent.approved);
+        assert.equal(
+          events[5].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
-        assert.ok(
-          assertInAnyOrder(approvedEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
-        );
-
-        // Test Transaction Finalized events
-        const finalizedAnonEvents = findEventsByName(
+        assert.equal(events[5].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[6].event,
           AnonymousTransactionMetaMetricsEvent.finalized,
         );
-        const finalizedEvents = findEventsByName(
-          TransactionMetaMetricsEvent.finalized,
+        assert.equal(
+          events[6].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
+        assert.equal(events[6].properties.transaction_advanced_view, undefined);
+        assert.equal(events[7].event, TransactionMetaMetricsEvent.finalized);
+        assert.equal(
+          events[7].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[7].properties.transaction_advanced_view, undefined);
 
-        assert.equal(finalizedAnonEvents.length, 2);
-        assert.equal(finalizedEvents.length, 2);
-
-        assert.ok(
-          assertInAnyOrder(finalizedAnonEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
+        // deposit tx (contract interaction) -- ui_customizations is set
+        assert.equal(
+          events[8].event,
+          AnonymousTransactionMetaMetricsEvent.added,
         );
-        assert.ok(
-          assertInAnyOrder(finalizedEvents, [
-            deploymentTransactionCheck,
-            interactionWithAdvancedViewCheck,
-          ]),
+        assert.equal(
+          events[8].properties.ui_customizations[0],
+          'redesigned_confirmation',
         );
+        assert.equal(events[8].properties.transaction_advanced_view, undefined);
+        assert.equal(events[9].event, TransactionMetaMetricsEvent.added);
+        assert.equal(
+          events[9].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[9].properties.transaction_advanced_view, undefined);
+        assert.equal(
+          events[10].event,
+          AnonymousTransactionMetaMetricsEvent.submitted,
+        );
+        assert.equal(
+          events[10].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[10].properties.transaction_advanced_view, true);
+        assert.equal(events[11].event, TransactionMetaMetricsEvent.submitted);
+        assert.equal(
+          events[11].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[11].properties.transaction_advanced_view, true);
+        assert.equal(
+          events[12].event,
+          AnonymousTransactionMetaMetricsEvent.approved,
+        );
+        assert.equal(
+          events[12].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[12].properties.transaction_advanced_view, true);
+        assert.equal(events[13].event, TransactionMetaMetricsEvent.approved);
+        assert.equal(
+          events[13].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[13].properties.transaction_advanced_view, true);
+        assert.equal(
+          events[14].event,
+          AnonymousTransactionMetaMetricsEvent.finalized,
+        );
+        assert.equal(
+          events[14].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[14].properties.transaction_advanced_view, true);
+        assert.equal(events[15].event, TransactionMetaMetricsEvent.finalized);
+        assert.equal(
+          events[15].properties.ui_customizations[0],
+          'redesigned_confirmation',
+        );
+        assert.equal(events[15].properties.transaction_advanced_view, true);
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When we assert the Transaction Added event, we expect the advanced settings to be undefined. Then, right after we trigger the tx then we click on the advanced settings, so the Transaction Submitted event has the advanced settings set to true. That is expected.

The issue comes when we assert the Transaction Added event, if the click settings happens very fast (before the Transaction Added has been fired) then we get that property set to true.

To avoid this race condition, we wait until that event is fired (which won't have the advanced settings set to true) and once that event has happened then we click on the settings.

<img width="809" height="323" alt="image" src="https://github.com/user-attachments/assets/813cd312-5914-4c7c-a7ee-a7b531eff66a" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37573?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deflakes the metrics E2E test by typing event payloads and waiting for initial "Transaction Added" events before opening advanced view.
> 
> - **Tests (E2E)**:
>   - Update `test/e2e/tests/confirmations/transactions/metrics.spec.ts`:
>     - Add `MetricsEvent` type for event payloads.
>     - Wait for 4 "Transaction Added"/"Transaction Added Anon" events before enabling advanced view to keep `transaction_advanced_view` undefined on initial "Added" events, reducing flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b688006ceeb63fdefbf3decf318915328e9c71b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->