### PR TITLE
feat: debounce points estimation & alt fox icon if points is 0

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -53,6 +53,7 @@ import {
   InvalidTimestampError,
   AccountAlreadyRegisteredError,
   AuthorizationFailedError,
+  SeasonNotFoundError,
 } from './rewards-data-service';
 import {
   RewardsDataServiceEstimatePointsAction,
@@ -2154,6 +2155,9 @@ describe('Additional RewardsController edge cases', () => {
             lastPerpsDiscountRateFetched: null,
           },
         },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
       };
 
       await withController(
@@ -2166,6 +2170,57 @@ describe('Additional RewardsController edge cases', () => {
           );
 
           expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+
+    it('should perform silent auth when account is opted-in but no subscription token available', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve(MOCK_LOGIN_RESPONSE);
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            MOCK_INTERNAL_ACCOUNT,
+            true,
+            true,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(controller.state.rewardsActiveAccount).toMatchObject({
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+          });
+          expect(
+            controller.state.rewardsSubscriptionTokens[MOCK_SUBSCRIPTION_ID],
+          ).toBe(MOCK_SESSION_TOKEN);
         },
       );
     });
@@ -2402,6 +2457,99 @@ describe('Additional RewardsController edge cases', () => {
           );
 
           expect(result).toBeDefined();
+        },
+      );
+    });
+
+    it('should handle SeasonNotFoundError and invalidate cache and clear seasons', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsSeasons: {
+          [MOCK_SEASON_ID]: {
+            id: MOCK_SEASON_ID,
+            name: 'Season 1',
+            startDate: new Date('2024-01-01').getTime(),
+            endDate: new Date('2024-12-31').getTime(),
+            tiers: MOCK_SEASON_TIERS,
+          },
+        },
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+        rewardsSubscriptions: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+        },
+        rewardsSeasonStatuses: {
+          [`${MOCK_SEASON_ID}:${MOCK_SUBSCRIPTION_ID}`]: {
+            season: {
+              id: MOCK_SEASON_ID,
+              name: 'Season 1',
+              startDate: new Date('2024-01-01').getTime(),
+              endDate: new Date('2024-12-31').getTime(),
+              tiers: MOCK_SEASON_TIERS,
+            },
+            balance: { total: 100 },
+            tier: {
+              currentTier: MOCK_SEASON_TIERS[0],
+              nextTier: MOCK_SEASON_TIERS[1],
+              nextTierPointsNeeded: 50,
+            },
+            // Set lastFetched to an old timestamp to make cache stale
+            // Cache TTL is 1 minute, so use 2 minutes ago to ensure cache miss
+            lastFetched: Date.now() - 2 * 60 * 1000,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getSeasonStatus') {
+              throw new SeasonNotFoundError('Season not found');
+            }
+            return undefined;
+          });
+
+          await expect(
+            controller.getSeasonStatus(MOCK_SUBSCRIPTION_ID, MOCK_SEASON_ID),
+          ).rejects.toThrow(SeasonNotFoundError);
+
+          // Verify that subscription cache was invalidated
+          expect(
+            controller.state.rewardsSeasonStatuses[
+              `${MOCK_SEASON_ID}:${MOCK_SUBSCRIPTION_ID}`
+            ],
+          ).toBeUndefined();
+
+          // Verify that accounts and subscriptions were invalidated
+          expect(controller.state.rewardsAccounts).toEqual({});
+          expect(controller.state.rewardsSubscriptions).toEqual({});
+          expect(controller.state.rewardsSubscriptionTokens).toEqual({});
+
+          // Verify that rewardsActiveAccount was invalidated
+          expect(controller.state.rewardsActiveAccount?.hasOptedIn).toBe(false);
+          expect(
+            controller.state.rewardsActiveAccount?.subscriptionId,
+          ).toBeNull();
+
+          // Verify that rewardsSeasons was cleared
+          expect(controller.state.rewardsSeasons).toEqual({});
         },
       );
     });
@@ -2955,8 +3103,8 @@ describe('Additional RewardsController edge cases', () => {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
             account: MOCK_CAIP_ACCOUNT,
-            hasOptedIn: true,
-            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            hasOptedIn: false,
+            subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
           },
@@ -2976,6 +3124,12 @@ describe('Additional RewardsController edge cases', () => {
             if (actionType === 'KeyringController:signPersonalMessage') {
               return Promise.reject(new Error('All accounts failed'));
             }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [false, false],
+                sids: [null, null],
+              });
+            }
             return undefined;
           });
 
@@ -2984,8 +3138,8 @@ describe('Additional RewardsController edge cases', () => {
           // Should set active account to first account since it has account state
           expect(controller.state.rewardsActiveAccount).toMatchObject({
             account: MOCK_CAIP_ACCOUNT,
-            hasOptedIn: true,
-            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            hasOptedIn: undefined, // as we had an error when trying to signPersonalMessage
+            subscriptionId: null,
           });
         },
       );

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -2461,7 +2461,7 @@ describe('Additional RewardsController edge cases', () => {
       );
     });
 
-    it('should handle SeasonNotFoundError and invalidate cache and clear seasons', async () => {
+    it('should handle SeasonNotFoundError and clear seasons', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsSeasons: {
           [MOCK_SEASON_ID]: {
@@ -2530,26 +2530,31 @@ describe('Additional RewardsController edge cases', () => {
             controller.getSeasonStatus(MOCK_SUBSCRIPTION_ID, MOCK_SEASON_ID),
           ).rejects.toThrow(SeasonNotFoundError);
 
-          // Verify that subscription cache was invalidated
-          expect(
-            controller.state.rewardsSeasonStatuses[
-              `${MOCK_SEASON_ID}:${MOCK_SUBSCRIPTION_ID}`
-            ],
-          ).toBeUndefined();
-
-          // Verify that accounts and subscriptions were invalidated
-          expect(controller.state.rewardsAccounts).toEqual({});
-          expect(controller.state.rewardsSubscriptions).toEqual({});
-          expect(controller.state.rewardsSubscriptionTokens).toEqual({});
-
-          // Verify that rewardsActiveAccount was invalidated
-          expect(controller.state.rewardsActiveAccount?.hasOptedIn).toBe(false);
-          expect(
-            controller.state.rewardsActiveAccount?.subscriptionId,
-          ).toBeNull();
-
           // Verify that rewardsSeasons was cleared
           expect(controller.state.rewardsSeasons).toEqual({});
+
+          // Verify that accounts and subscriptions were NOT invalidated
+          expect(controller.state.rewardsAccounts).toEqual({
+            [MOCK_CAIP_ACCOUNT]: {
+              account: MOCK_CAIP_ACCOUNT,
+              hasOptedIn: true,
+              subscriptionId: MOCK_SUBSCRIPTION_ID,
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+            },
+          });
+          expect(controller.state.rewardsSubscriptions).toEqual({
+            [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+          });
+          expect(controller.state.rewardsSubscriptionTokens).toEqual({
+            [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+          });
+
+          // Verify that rewardsActiveAccount was NOT invalidated
+          expect(controller.state.rewardsActiveAccount?.hasOptedIn).toBe(true);
+          expect(controller.state.rewardsActiveAccount?.subscriptionId).toBe(
+            MOCK_SUBSCRIPTION_ID,
+          );
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -37,6 +37,7 @@ import {
   AccountAlreadyRegisteredError,
   AuthorizationFailedError,
   InvalidTimestampError,
+  SeasonNotFoundError,
 } from './rewards-data-service';
 import { signSolanaRewardsMessage } from './utils/solana-snap';
 import { sortAccounts } from './utils/sortAccounts';
@@ -545,6 +546,15 @@ export class RewardsController extends BaseController<
       } else {
         const sortedAccounts = sortAccounts(accounts);
 
+        try {
+          // Prefer to get opt in status in bulk for sorted accounts.
+          await this.getOptInStatus({
+            addresses: sortedAccounts.map((account) => account.address),
+          });
+        } catch {
+          // Failed to get opt in status in bulk for sorted accounts, let silent auth do it individually
+        }
+
         // Try silent auth on each account until one succeeds
         let successAccount: InternalAccount | null = null;
         for (const account of sortedAccounts) {
@@ -609,7 +619,12 @@ export class RewardsController extends BaseController<
         );
       }
 
-      return true;
+      return (
+        Boolean(accountState.subscriptionId) &&
+        Boolean(
+          this.#getSubscriptionToken(accountState.subscriptionId as string),
+        )
+      );
     }
 
     return false;
@@ -1319,6 +1334,13 @@ export class RewardsController extends BaseController<
               this.invalidateAccountsAndSubscriptions();
               throw error;
             }
+          } else if (error instanceof SeasonNotFoundError) {
+            this.invalidateSubscriptionCache(subscriptionId);
+            this.invalidateAccountsAndSubscriptions();
+            this.update((state: RewardsControllerState) => {
+              state.rewardsSeasons = {};
+            });
+            throw error;
           }
           log.error(
             'RewardsController: Failed to get season status:',

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -1335,8 +1335,6 @@ export class RewardsController extends BaseController<
               throw error;
             }
           } else if (error instanceof SeasonNotFoundError) {
-            this.invalidateSubscriptionCache(subscriptionId);
-            this.invalidateAccountsAndSubscriptions();
             this.update((state: RewardsControllerState) => {
               state.rewardsSeasons = {};
             });

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -47,6 +47,16 @@ export class AuthorizationFailedError extends Error {
 }
 
 /**
+ * Custom error for season not found
+ */
+export class SeasonNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeasonNotFoundError';
+  }
+}
+
+/**
  * Custom error for account already registered (409 conflict)
  */
 export class AccountAlreadyRegisteredError extends Error {
@@ -394,6 +404,12 @@ export class RewardsDataService {
       if (errorData?.message?.includes('Rewards authorization failed')) {
         throw new AuthorizationFailedError(
           'Rewards authorization failed. Please login and try again.',
+        );
+      }
+
+      if (errorData?.message?.includes('Season not found')) {
+        throw new SeasonNotFoundError(
+          'Season not found. Please try again with a different season.',
         );
       }
 

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -486,6 +486,7 @@ export const MultichainBridgeQuoteCard = ({
                     withPointsSuffix={false}
                     boxClassName="gap-1 bg-background-transparent"
                     textClassName="text-alternative"
+                    useAlternativeIconColor={!estimatedPoints}
                   />
                 )}
             </Row>


### PR DESCRIPTION
## **Description**

Previous PR related to rewards point estimation for swaps/bridge was not debouncing the estimation API call, which due to react dependency for active quote, resulted in sometimes doing X API calls instead of 1 for the last active quote.

This PR fixes that by adding debouncing logic to `useRewards`. It also changes the fox icon color to alternative variant if points retrieved is 0. (just like in mobile)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-613

## **Manual testing steps**

1. Have an account that is opted into rewards
2. Go to swaps page and open network tab
3. There should only be 1 call made to the estimation endpoint for rewards

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Debounces rewards points estimation in useRewards, adds alt icon when points = 0, improves auth/opt-in flow and handles SeasonNotFound errors, with comprehensive tests.
> 
> - **Hooks (useRewards)**:
>   - Add 750ms debounced `estimateRewardsPoints` flow using `lodash.debounce` to prevent duplicate calls.
>   - Refine opt-in checks, loading/error states, and USD fee price calculation; guard early-return conditions.
>   - Extensive tests for debounce behavior, error handling, loading, and selector stubs; use fake timers.
> - **Controller (RewardsController)**:
>   - Prefetch bulk `getOptInStatus` during auth trigger; iterate silent auth by sorted accounts.
>   - Tighten `shouldSkipSilentAuth` to require both `subscriptionId` and a session token.
>   - On `SeasonNotFoundError`, clear `rewardsSeasons` only; preserve accounts/subscriptions.
>   - Tests for silent auth without token and season-not-found cache clearing.
> - **Data Service (RewardsDataService)**:
>   - Introduce `SeasonNotFoundError`; map 404 "Season not found" responses in `getSeasonStatus`.
>   - Tests for season-not-found and message-based detection.
> - **UI**:
>   - `MultichainBridgeQuoteCard`: pass `useAlternativeIconColor` to `RewardsBadge` when estimated points is 0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7915f7927642e6968ade504b1866d41cae912d3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->