### PR TITLE
fix: styles for the fox icon when selecting future ETH as a gas token

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
@@ -220,10 +220,7 @@ function NativeToggle({
       >
         <img
           src="./images/logo/metamask-fox.svg"
-          height={15}
-          style={{
-            margin: 8,
-          }}
+          className="gas-fee-token-native-toggle-option__fox-icon"
         />
       </NativeToggleOption>
     </Box>

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/index.scss
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/index.scss
@@ -28,4 +28,10 @@
       background: var(--color-background-default-hover);
     }
   }
+
+  &__fox-icon {
+    height: 16px;
+    width: 16px;
+    margin: 8px;
+  }
 }


### PR DESCRIPTION
## **Description**
Fixes styles for the fox icon when selecting future ETH as a gas token.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37577?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes styles for the fox icon when selecting future ETH as a gas token

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6154

## **Manual testing steps**

1. Go to https://jumper.exchange/
2. Ensure you have near 0 ETH
3. Try to swap some ERC-20 token into ETH on Ethereum mainnet
4. On the Confirmation page in the extension in the network fee row click on the token name
5. Fox icon will now be the same size as the wallet icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="434" height="254" alt="image" src="https://github.com/user-attachments/assets/be22d1a9-1124-4f17-93a0-d8e4bebc57cd" />

### **After**
<img width="379" height="116" alt="image" src="https://github.com/user-attachments/assets/eeaaf1fa-2f3d-4959-b3b7-a74e67d594b6" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace inline styles with a CSS class for the MetaMask fox icon in the gas fee token modal to ensure consistent sizing.
> 
> - **UI**
>   - **Gas Fee Token Modal** (`ui/pages/.../gas-fee-token-modal.tsx`):
>     - Replace inline `img` sizing/margins with `className` `gas-fee-token-native-toggle-option__fox-icon`.
>   - **Styles** (`ui/pages/.../index.scss`):
>     - Add `.gas-fee-token-native-toggle-option__fox-icon` with fixed `height/width: 16px` and `margin: 8px` for consistent icon size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8c903e11defbd3790556ce09dff52fb5c992e18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->