### PR TITLE
fix: bind backup and sync in onboarding to settings

### DIFF
--- a/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
+++ b/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
@@ -155,11 +155,16 @@ export const BackupAndSyncFeaturesToggles = () => {
   const { setIsBackupAndSyncFeatureEnabled } = useBackupAndSync();
 
   // Reverse cascading: if all sub-features are manually turned off, turn off main toggle
+  // Guard against race conditions by not running while updates are in progress
   useEffect(() => {
     const allSubFeaturesDisabled =
       !isAccountSyncingEnabled && !isContactSyncingEnabled;
 
-    if (isBackupAndSyncEnabled && allSubFeaturesDisabled) {
+    if (
+      isBackupAndSyncEnabled &&
+      allSubFeaturesDisabled &&
+      !isBackupAndSyncUpdateLoading
+    ) {
       (async () => {
         try {
           await setIsBackupAndSyncFeatureEnabled(
@@ -175,6 +180,7 @@ export const BackupAndSyncFeaturesToggles = () => {
     isBackupAndSyncEnabled,
     isAccountSyncingEnabled,
     isContactSyncingEnabled,
+    isBackupAndSyncUpdateLoading,
     setIsBackupAndSyncFeatureEnabled,
   ]);
 

--- a/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
+++ b/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-storage';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -149,6 +149,34 @@ export const BackupAndSyncFeaturesToggles = () => {
   const isBackupAndSyncUpdateLoading = useSelector(
     selectIsBackupAndSyncUpdateLoading,
   );
+  const isAccountSyncingEnabled = useSelector(selectIsAccountSyncingEnabled);
+  const isContactSyncingEnabled = useSelector(selectIsContactSyncingEnabled);
+
+  const { setIsBackupAndSyncFeatureEnabled } = useBackupAndSync();
+
+  // Reverse cascading: if all sub-features are manually turned off, turn off main toggle
+  useEffect(() => {
+    const allSubFeaturesDisabled =
+      !isAccountSyncingEnabled && !isContactSyncingEnabled;
+
+    if (isBackupAndSyncEnabled && allSubFeaturesDisabled) {
+      (async () => {
+        try {
+          await setIsBackupAndSyncFeatureEnabled(
+            BACKUPANDSYNC_FEATURES.main,
+            false,
+          );
+        } catch (err) {
+          console.error('Failed to disable main backup and sync toggle:', err);
+        }
+      })();
+    }
+  }, [
+    isBackupAndSyncEnabled,
+    isAccountSyncingEnabled,
+    isContactSyncingEnabled,
+    setIsBackupAndSyncFeatureEnabled,
+  ]);
 
   return (
     <Box

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Redux from 'react-redux';
 import configureMockStore from 'redux-mock-store';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-storage';
 import { MetamaskIdentityProvider } from '../../../../contexts/identity';
 import * as useBackupAndSyncHook from '../../../../hooks/identity/useBackupAndSync/useBackupAndSync';
@@ -122,6 +122,69 @@ describe('BackupAndSyncToggle', () => {
         name: CONFIRM_TURN_ON_BACKUP_AND_SYNC_MODAL_NAME,
         enableBackupAndSync: expect.any(Function),
       }),
+    );
+  });
+
+  it('disables all backup and sync features when basic functionality is disabled', async () => {
+    const store = initialStore();
+    store.metamask.isBackupAndSyncEnabled = true;
+    store.metamask.useExternalServices = false; // Basic functionality disabled
+
+    const { setIsBackupAndSyncFeatureEnabledMock } = arrangeMocks();
+
+    render(
+      <Redux.Provider store={mockStore(store)}>
+        <BackupAndSyncToggle />
+      </Redux.Provider>,
+    );
+
+    // Wait for the async useEffect to complete
+    await waitFor(() => {
+      expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+    });
+
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      false,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
+      false,
+    );
+  });
+
+  it('disables all sub-features when manually turning off backup and sync', async () => {
+    const store = initialStore();
+    store.metamask.isBackupAndSyncEnabled = true;
+
+    const { setIsBackupAndSyncFeatureEnabledMock } = arrangeMocks();
+
+    const { getByTestId } = render(
+      <Redux.Provider store={mockStore(store)}>
+        <BackupAndSyncToggle />
+      </Redux.Provider>,
+    );
+
+    fireEvent.click(getByTestId(backupAndSyncToggleTestIds.toggleButton));
+
+    // Wait for the async toggle handler to complete
+    await waitFor(() => {
+      expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+    });
+
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      false,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
+      false,
     );
   });
 

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
@@ -235,7 +235,7 @@ describe('BackupAndSyncToggle', () => {
     );
 
     // Wait a bit to ensure useEffect doesn't fire
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Should not have called the disable function at all
     expect(setIsBackupAndSyncFeatureEnabledMock).not.toHaveBeenCalled();

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
@@ -87,7 +87,7 @@ describe('BackupAndSyncToggle', () => {
     });
   });
 
-  it('enables backup and sync when the toggle is turned on and basic functionality is already on', () => {
+  it('enables backup and sync and all sub-features when the toggle is turned on and basic functionality is already on', async () => {
     const store = initialStore();
     store.metamask.isBackupAndSyncEnabled = false;
 
@@ -98,14 +98,29 @@ describe('BackupAndSyncToggle', () => {
         <BackupAndSyncToggle />
       </Redux.Provider>,
     );
+
     fireEvent.click(getByTestId(backupAndSyncToggleTestIds.toggleButton));
+
+    // Wait for the async toggle handler to complete
+    await waitFor(() => {
+      expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.main,
+        true,
+      );
+    });
+
+    // Should also enable all sub-features for 1-click restore convenience
     expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
-      BACKUPANDSYNC_FEATURES.main,
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      true,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
       true,
     );
   });
 
-  it('opens the confirm modal when the toggle is turned on and basic functionality is off', () => {
+  it('opens the confirm modal when the toggle is turned on and basic functionality is off', async () => {
     const store = initialStore();
     store.metamask.isBackupAndSyncEnabled = false;
     store.metamask.useExternalServices = false;
@@ -122,6 +137,24 @@ describe('BackupAndSyncToggle', () => {
         name: CONFIRM_TURN_ON_BACKUP_AND_SYNC_MODAL_NAME,
         enableBackupAndSync: expect.any(Function),
       }),
+    );
+
+    // Test that the modal's enableBackupAndSync callback enables all features
+    const modalAction = mockDispatch.mock.calls[0][0];
+    const enableCallback = modalAction.payload.enableBackupAndSync;
+    await enableCallback();
+
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.main,
+      true,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      true,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
+      true,
     );
   });
 

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.test.tsx
@@ -156,6 +156,91 @@ describe('BackupAndSyncToggle', () => {
     );
   });
 
+  it('disables all backup and sync features when onboarding basic functionality is disabled', async () => {
+    const store = initialStore();
+    store.metamask.isBackupAndSyncEnabled = true;
+    store.metamask.useExternalServices = true; // Production basic functionality enabled
+    store.appState.externalServicesOnboardingToggleState = false; // Onboarding basic functionality disabled
+
+    const { setIsBackupAndSyncFeatureEnabledMock } = arrangeMocks();
+
+    render(
+      <Redux.Provider store={mockStore(store)}>
+        <BackupAndSyncToggle />
+      </Redux.Provider>,
+    );
+
+    // Wait for the async useEffect to complete
+    await waitFor(() => {
+      expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+    });
+
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      false,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
+      false,
+    );
+  });
+
+  it('disables all backup and sync features when both basic functionality states are disabled', async () => {
+    const store = initialStore();
+    store.metamask.isBackupAndSyncEnabled = true;
+    store.metamask.useExternalServices = false; // Production basic functionality disabled
+    store.appState.externalServicesOnboardingToggleState = false; // Onboarding basic functionality disabled
+
+    const { setIsBackupAndSyncFeatureEnabledMock } = arrangeMocks();
+
+    render(
+      <Redux.Provider store={mockStore(store)}>
+        <BackupAndSyncToggle />
+      </Redux.Provider>,
+    );
+
+    // Wait for the async useEffect to complete
+    await waitFor(() => {
+      expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+    });
+
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.accountSyncing,
+      false,
+    );
+    expect(setIsBackupAndSyncFeatureEnabledMock).toHaveBeenCalledWith(
+      BACKUPANDSYNC_FEATURES.contactSyncing,
+      false,
+    );
+  });
+
+  it('does not disable backup and sync when both basic functionality states are enabled', async () => {
+    const store = initialStore();
+    store.metamask.isBackupAndSyncEnabled = true;
+    store.metamask.useExternalServices = true; // Production basic functionality enabled
+    store.appState.externalServicesOnboardingToggleState = true; // Onboarding basic functionality enabled
+
+    const { setIsBackupAndSyncFeatureEnabledMock } = arrangeMocks();
+
+    render(
+      <Redux.Provider store={mockStore(store)}>
+        <BackupAndSyncToggle />
+      </Redux.Provider>,
+    );
+
+    // Wait a bit to ensure useEffect doesn't fire
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Should not have called the disable function at all
+    expect(setIsBackupAndSyncFeatureEnabledMock).not.toHaveBeenCalled();
+  });
+
   it('disables all sub-features when manually turning off backup and sync', async () => {
     const store = initialStore();
     store.metamask.isBackupAndSyncEnabled = true;

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -98,12 +98,21 @@ export const BackupAndSyncToggle = () => {
       (async () => {
         try {
           // Turn off main backup and sync
-          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
+          await setIsBackupAndSyncFeatureEnabled(
+            BACKUPANDSYNC_FEATURES.main,
+            false,
+          );
           // Also turn off all sub-features when basic functionality is disabled
-          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.accountSyncing, false);
-          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.contactSyncing, false);
-        } catch (error) {
-          console.error('Failed to disable backup and sync features:', error);
+          await setIsBackupAndSyncFeatureEnabled(
+            BACKUPANDSYNC_FEATURES.accountSyncing,
+            false,
+          );
+          await setIsBackupAndSyncFeatureEnabled(
+            BACKUPANDSYNC_FEATURES.contactSyncing,
+            false,
+          );
+        } catch (err) {
+          console.error('Failed to disable backup and sync features:', err);
         }
       })();
     }

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -151,16 +151,36 @@ export const BackupAndSyncToggle = () => {
           showModal({
             name: CONFIRM_TURN_ON_BACKUP_AND_SYNC_MODAL_NAME,
             enableBackupAndSync: async () => {
+              // Turn on main backup and sync
               await setIsBackupAndSyncFeatureEnabled(
                 BACKUPANDSYNC_FEATURES.main,
+                true,
+              );
+              // Also turn on all sub-features for convenient 1-click restore
+              await setIsBackupAndSyncFeatureEnabled(
+                BACKUPANDSYNC_FEATURES.accountSyncing,
+                true,
+              );
+              await setIsBackupAndSyncFeatureEnabled(
+                BACKUPANDSYNC_FEATURES.contactSyncing,
                 true,
               );
             },
           }),
         );
       } else {
+        // Turn on main backup and sync
         await setIsBackupAndSyncFeatureEnabled(
           BACKUPANDSYNC_FEATURES.main,
+          true,
+        );
+        // Also turn on all sub-features for convenient 1-click restore
+        await setIsBackupAndSyncFeatureEnabled(
+          BACKUPANDSYNC_FEATURES.accountSyncing,
+          true,
+        );
+        await setIsBackupAndSyncFeatureEnabled(
+          BACKUPANDSYNC_FEATURES.contactSyncing,
           true,
         );
       }

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -90,7 +90,11 @@ export const BackupAndSyncToggle = () => {
   // Cascading side effects
   useEffect(() => {
     if (!isBasicFunctionalityEnabled && isBackupAndSyncEnabled) {
+      // Turn off main backup and sync
       setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
+      // Also turn off all sub-features when basic functionality is disabled
+      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.accountSyncing, false);
+      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.contactSyncing, false);
     }
   }, [
     isBasicFunctionalityEnabled,
@@ -101,8 +105,18 @@ export const BackupAndSyncToggle = () => {
   const handleBackupAndSyncToggleSetValue = async () => {
     if (isBackupAndSyncEnabled) {
       trackBackupAndSyncToggleEvent(false);
+      // Turn off main backup and sync
       await setIsBackupAndSyncFeatureEnabled(
         BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+      // Also turn off all sub-features when main toggle is disabled
+      await setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.accountSyncing,
+        false,
+      );
+      await setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.contactSyncing,
         false,
       );
     } else {

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -87,9 +87,14 @@ export const BackupAndSyncToggle = () => {
     [trackEvent, isBackupAndSyncEnabled, isMetamaskNotificationsEnabled],
   );
 
-  // Cascading side effects
+  // Cascading side effects - disable backup & sync when basic functionality is disabled
   useEffect(() => {
-    if (!isBasicFunctionalityEnabled && isBackupAndSyncEnabled) {
+    // Check both basic functionality states: production and onboarding
+    const isBasicFunctionalityDisabled =
+      isBasicFunctionalityEnabled === false ||
+      isOnboardingBasicFunctionalityEnabled === false;
+
+    if (isBasicFunctionalityDisabled && isBackupAndSyncEnabled) {
       (async () => {
         try {
           // Turn off main backup and sync
@@ -104,6 +109,7 @@ export const BackupAndSyncToggle = () => {
     }
   }, [
     isBasicFunctionalityEnabled,
+    isOnboardingBasicFunctionalityEnabled,
     isBackupAndSyncEnabled,
     setIsBackupAndSyncFeatureEnabled,
   ]);

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -90,11 +90,17 @@ export const BackupAndSyncToggle = () => {
   // Cascading side effects
   useEffect(() => {
     if (!isBasicFunctionalityEnabled && isBackupAndSyncEnabled) {
-      // Turn off main backup and sync
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
-      // Also turn off all sub-features when basic functionality is disabled
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.accountSyncing, false);
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.contactSyncing, false);
+      (async () => {
+        try {
+          // Turn off main backup and sync
+          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
+          // Also turn off all sub-features when basic functionality is disabled
+          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.accountSyncing, false);
+          await setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.contactSyncing, false);
+        } catch (error) {
+          console.error('Failed to disable backup and sync features:', error);
+        }
+      })();
     }
   }, [
     isBasicFunctionalityEnabled,

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -1,14 +1,12 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import classnames from 'classnames';
 import { ButtonVariant } from '@metamask/snaps-sdk';
-import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-storage';
 import log from 'loglevel';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { addUrlProtocolPrefix } from '../../../../app/scripts/lib/util';
-import { useBackupAndSync } from '../../../hooks/identity/useBackupAndSync';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -138,17 +136,6 @@ export default function PrivacySettings() {
 
   const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
 
-  const { setIsBackupAndSyncFeatureEnabled, error: backupAndSyncError } =
-    useBackupAndSync();
-
-  useEffect(() => {
-    if (externalServicesOnboardingToggleState) {
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, true);
-    } else {
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
-    }
-  }, [externalServicesOnboardingToggleState, setIsBackupAndSyncFeatureEnabled]);
-
   const handleSubmit = () => {
     dispatch(setUse4ByteResolution(turnOn4ByteResolution));
     dispatch(setUseTokenDetection(turnOnTokenDetection));
@@ -159,11 +146,6 @@ export default function PrivacySettings() {
     dispatch(setUseAddressBarEnsResolution(addressBarResolution));
     setUseTransactionSimulations(isTransactionSimulationsEnabled);
     setUseExternalNameSources(turnOnExternalNameSources);
-
-    // Backup and sync Setup
-    if (!externalServicesOnboardingToggleState) {
-      setIsBackupAndSyncFeatureEnabled(BACKUPANDSYNC_FEATURES.main, false);
-    }
 
     if (ipfsURL && !ipfsError) {
       const { host } = new URL(addUrlProtocolPrefix(ipfsURL));
@@ -424,18 +406,6 @@ export default function PrivacySettings() {
                   />
 
                   <BackupAndSyncToggle />
-
-                  {backupAndSyncError && (
-                    <Box paddingBottom={4}>
-                      <Text
-                        as="p"
-                        color={TextColor.errorDefault}
-                        variant={TextVariant.bodySm}
-                      >
-                        {t('notificationsSettingsBoxError')}
-                      </Text>
-                    </Box>
-                  )}
 
                   <Setting
                     title={t('onboardingAdvancedPrivacyNetworkTitle')}


### PR DESCRIPTION
## **Description**

This PR fixes a bug where turning off backup and sync during onboarding didn't persist the user's preference. After completing onboarding, the backup and sync toggles in Settings would still show as "ON" instead of respecting the user's choice to turn them off.

**Root Cause**: 
1. A `useEffect` in `privacy-settings.js` was automatically forcing backup & sync to follow the basic functionality toggle, overriding manual user choices
2. When the main backup & sync toggle was disabled, sub-features (accounts/contacts syncing) weren't being turned off, creating visual inconsistency

**Solution**:
- Removed the automatic coupling between backup & sync and basic functionality during onboarding to respect manual user choices
- Implemented smart toggle behavior that provides both visual clarity and user convenience:
  - **When B&S OFF**: All sub-features also turn OFF (visual consistency)  
  - **When B&S ON**: All sub-features also turn ON (1-click restore convenience)
- Fixed async race conditions in cascading effects with proper error handling
- Added comprehensive test coverage for all toggle scenarios

## **Changelog**

CHANGELOG entry: fixed backup and sync toggle not persisting user's choice during onboarding

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/35546

## **Manual testing steps**

1. Start a fresh onboarding flow (create new wallet or import SRP)
2. Navigate to the "Default settings" screen during onboarding  
3. Click on "General" category
4. Turn OFF the "Turn on backup and sync" toggle (should show as OFF)
5. Complete the onboarding process
6. Navigate to Settings → Backup and sync
7. Verify all toggles show correctly:
   - "Turn on backup and sync": OFF ☑️ 
   - "Accounts": OFF ☑️
   - "Contacts": OFF ☑️

**Additional test case**:
1. Repeat steps 1-4 but turn OFF "Basic functionality" toggle first
2. Verify backup & sync automatically turns OFF (cascading effect)
3. Complete onboarding and verify settings persist as OFF

## **Screenshots/Recordings**

### **Before**
- Main backup & sync toggle showed correctly as OFF
- Sub-feature toggles (Accounts/Contacts) incorrectly showed as ON (though disabled)

(see [bug](https://github.com/MetaMask/metamask-extension/issues/35546))

### **After**  
- All toggles correctly show as OFF when user disables backup & sync during onboarding
- User's choice persists after completing onboarding


https://github.com/user-attachments/assets/265ebe95-c9cf-4f45-aa53-3e25e37e83e1



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements cascading enable/disable behavior for Backup & Sync (including sub-features), adds reverse cascade, and removes onboarding auto-coupling, with comprehensive tests.
> 
> - **Backup & Sync behavior**
>   - **Main toggle (`ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx`)**:
>     - Disables main and sub-features when basic functionality (prod or onboarding) is off.
>     - Turning OFF main also turns OFF `accountSyncing` and `contactSyncing`.
>     - Turning ON main also turns ON sub-features; modal callback enables all as well.
>     - Adds error handling and extends `useEffect` dependencies.
>   - **Sub-feature toggles (`ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx`)**:
>     - Adds reverse cascade: when all sub-features are OFF, auto-disable main (guarded by loading state).
> - **Onboarding privacy settings (`ui/pages/onboarding-flow/privacy-settings/privacy-settings.js`)**
>   - Removes auto-coupling that forced Backup & Sync state during onboarding; cleans up related code.
> - **Tests**
>   - Expands coverage with `waitFor` and new scenarios validating cascading and reverse-cascading across main and sub-feature toggles, and basic functionality interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea7b5704fc94d4572a75a1dab224028a475eea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->