### PR TITLE
fix: handle non-standard semver formats in BIP-44 banner check

### DIFF
--- a/ui/hooks/useMultichainAccountsIntroModal.test.ts
+++ b/ui/hooks/useMultichainAccountsIntroModal.test.ts
@@ -19,7 +19,10 @@ describe('BIP-44 Banner Logic', () => {
         (() => {
           try {
             const coercedVersion = semverCoerce(lastUpdatedFromVersion);
-            return coercedVersion && semverLt(coercedVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION);
+            return (
+              coercedVersion &&
+              semverLt(coercedVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION)
+            );
           } catch {
             return false;
           }

--- a/ui/hooks/useMultichainAccountsIntroModal.test.ts
+++ b/ui/hooks/useMultichainAccountsIntroModal.test.ts
@@ -1,4 +1,4 @@
-import { lt as semverLt } from 'semver';
+import { lt as semverLt, coerce as semverCoerce } from 'semver';
 
 // Test the core logic independently of React hooks
 describe('BIP-44 Banner Logic', () => {
@@ -16,7 +16,14 @@ describe('BIP-44 Banner Logic', () => {
     const isUpgradeFromLowerThanBip44Version = Boolean(
       lastUpdatedFromVersion &&
         typeof lastUpdatedFromVersion === 'string' &&
-        semverLt(lastUpdatedFromVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION),
+        (() => {
+          try {
+            const coercedVersion = semverCoerce(lastUpdatedFromVersion);
+            return coercedVersion && semverLt(coercedVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION);
+          } catch {
+            return false;
+          }
+        })(),
     );
 
     return (
@@ -170,6 +177,33 @@ describe('BIP-44 Banner Logic', () => {
         true,
       );
       expect(result).toBe(false);
+    });
+
+    it('handles invalid semver version like 13.9.0.150 (4-part version)', () => {
+      // This tests the bug fix for extensions with non-standard version formats
+      const result = shouldShowBip44Banner(
+        true,
+        true,
+        false,
+        Date.now(),
+        '13.9.0.150', // Invalid semver - 4 parts
+        true,
+      );
+      // Should gracefully handle and return false (coerced to 13.9.0 which is >= 13.5.0)
+      expect(result).toBe(false);
+    });
+
+    it('handles invalid semver for older version like 13.4.0.100', () => {
+      const result = shouldShowBip44Banner(
+        true,
+        true,
+        false,
+        Date.now(),
+        '13.4.0.100', // Invalid semver - 4 parts, but coerces to 13.4.0
+        true,
+      );
+      // Should coerce to 13.4.0 and show banner
+      expect(result).toBe(true);
     });
   });
 });

--- a/ui/hooks/useMultichainAccountsIntroModal.ts
+++ b/ui/hooks/useMultichainAccountsIntroModal.ts
@@ -47,7 +47,10 @@ export function useMultichainAccountsIntroModal(
         (() => {
           try {
             const coercedVersion = semverCoerce(lastUpdatedFromVersion);
-            return coercedVersion && semverLt(coercedVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION);
+            return (
+              coercedVersion &&
+              semverLt(coercedVersion, BIP44_ACCOUNTS_INTRODUCTION_VERSION)
+            );
           } catch {
             // If version can't be parsed, assume it's not from an old version
             return false;


### PR DESCRIPTION
## **Description**

Fixes a critical bug where the extension crashes on startup due to invalid semver version comparison.

See: https://consensys.slack.com/archives/CTQAGKY5V/p1762443107241399

### Problem
Extension versions can be non-standard formats like `13.9.0.150` (4-part versions), which causes `semver.lt()` to throw:
```
TypeError: Invalid Version: 13.9.0.150
```

This crashes the extension on startup for users upgrading from these version formats.

### Solution
- Use `semver.coerce()` to normalize versions before comparison (e.g., `13.9.0.150` → `13.9.0`)
- Add try/catch error handling for graceful fallback
- Add test cases for 4-part version formats

### Test Coverage
- ✅ Handles `13.9.0.150` → coerces to `13.9.0` → compares safely
- ✅ Handles `13.4.0.100` → coerces to `13.4.0` → compares safely
- ✅ Graceful fallback on unparseable versions

## **Changelog**



CHANGELOG entry: null

## **Related issues**

Follow-up: https://github.com/MetaMask/metamask-extension/pull/37324/files

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Coerces extension version strings before semver comparison to avoid crashes and ensure correct BIP-44 intro modal behavior, with new tests for 4-part versions.
> 
> - **Hook (`ui/hooks/useMultichainAccountsIntroModal.ts`)**:
>   - Use `semver.coerce` with try/catch to normalize `lastUpdatedFromVersion` before `semverLt` for `isUpgradeFromLowerThanBip44Version`.
>   - Keeps modal gating logic unchanged; only improves version parsing robustness.
> - **Tests (`ui/hooks/useMultichainAccountsIntroModal.test.ts`)**:
>   - Mirror hook logic using `semver.coerce`.
>   - Add cases for non-standard versions like `13.9.0.150` (no banner) and `13.4.0.100` (shows banner).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f28f155132a39e2ad4d117782ffbbe53eb11470e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->