### PR TITLE
fix: shield plan token approval amount incorrect when plan change

### DIFF
--- a/ui/hooks/subscription/useSubscriptionPricing.ts
+++ b/ui/hooks/subscription/useSubscriptionPricing.ts
@@ -43,7 +43,11 @@ export const useAvailableTokenBalances = (params: {
   paymentChains?: ChainPaymentInfo[];
   price?: ProductPrice;
   productType: ProductType;
-}): TokenWithApprovalAmount[] => {
+}): {
+  availableTokenBalances: TokenWithApprovalAmount[];
+  pending: boolean;
+  error: Error | undefined;
+} => {
   const { paymentChains, price, productType } = params;
 
   const paymentChainIds = useMemo(
@@ -70,10 +74,6 @@ export const useAvailableTokenBalances = (params: {
   // Poll and update evm balances for payment chains
   pollAndUpdateEvmBalances({ chainIds: paymentChainIds });
 
-  const [availableTokenBalances, setAvailableTokenBalances] = useState<
-    TokenWithApprovalAmount[]
-  >([]);
-
   const validTokenBalances = useMemo(() => {
     return evmBalances.filter((token) => {
       const supportedTokensForChain =
@@ -96,72 +96,74 @@ export const useAvailableTokenBalances = (params: {
     });
   }, [evmBalances, paymentChainTokenMap]);
 
-  useEffect(() => {
+  const {
+    value: availableTokenBalances,
+    pending,
+    error,
+  } = useAsyncResult(async (): Promise<TokenWithApprovalAmount[]> => {
     if (!price || !paymentChainTokenMap) {
-      return;
+      return [];
     }
 
-    const getAvailableTokenBalances = async () => {
-      const availableTokens: TokenWithApprovalAmount[] = [];
+    const availableTokens: TokenWithApprovalAmount[] = [];
 
-      const cryptoApprovalAmounts = await Promise.all(
-        validTokenBalances.map((token) => {
-          const tokenPaymentInfo = paymentChainTokenMap?.[
-            token.chainId as Hex
-          ]?.find(
-            (t) => t.address.toLowerCase() === token.address.toLowerCase(),
+    const cryptoApprovalAmounts = await Promise.all(
+      validTokenBalances.map((token) => {
+        const tokenPaymentInfo = paymentChainTokenMap?.[
+          token.chainId as Hex
+        ]?.find((t) => t.address.toLowerCase() === token.address.toLowerCase());
+        if (!tokenPaymentInfo) {
+          log.error(
+            '[useAvailableTokenBalances] tokenPaymentInfo not found',
+            token,
           );
-          if (!tokenPaymentInfo) {
-            log.error(
-              '[useAvailableTokenBalances] tokenPaymentInfo not found',
-              token,
-            );
-            return null;
-          }
-          return getSubscriptionCryptoApprovalAmount({
+          return null;
+        }
+        return getSubscriptionCryptoApprovalAmount({
+          chainId: token.chainId as Hex,
+          paymentTokenAddress: token.address as Hex,
+          productType,
+          interval: price.interval,
+        });
+      }),
+    );
+
+    cryptoApprovalAmounts.forEach((amount, index) => {
+      const token = validTokenBalances[index];
+      if (!token.balance) {
+        return;
+      }
+      // NOTE: we are using stable coin for subscription atm, so we need to scale the balance by the decimals
+      const scaledFactor = 10n ** 6n;
+      const scaledBalance =
+        BigInt(Math.round(Number(token.balance) * Number(scaledFactor))) /
+        scaledFactor;
+      const tokenHasEnoughBalance =
+        amount &&
+        scaledBalance * BigInt(10 ** token.decimals) >=
+          BigInt(amount.approveAmount);
+      if (tokenHasEnoughBalance) {
+        availableTokens.push({
+          ...token,
+          approvalAmount: {
+            approveAmount: amount.approveAmount,
             chainId: token.chainId as Hex,
-            paymentTokenAddress: token.address as Hex,
-            productType,
-            interval: price.interval,
-          });
-        }),
-      );
+            paymentAddress: amount.paymentAddress,
+            paymentTokenAddress: amount.paymentTokenAddress,
+          },
+          type: token.isNative ? AssetType.native : AssetType.token,
+        } as TokenWithApprovalAmount);
+      }
+    });
 
-      cryptoApprovalAmounts.forEach((amount, index) => {
-        const token = validTokenBalances[index];
-        if (!token.balance) {
-          return;
-        }
-        // NOTE: we are using stable coin for subscription atm, so we need to scale the balance by the decimals
-        const scaledFactor = 10n ** 6n;
-        const scaledBalance =
-          BigInt(Math.round(Number(token.balance) * Number(scaledFactor))) /
-          scaledFactor;
-        const tokenHasEnoughBalance =
-          amount &&
-          scaledBalance * BigInt(10 ** token.decimals) >=
-            BigInt(amount.approveAmount);
-        if (tokenHasEnoughBalance) {
-          availableTokens.push({
-            ...token,
-            approvalAmount: {
-              approveAmount: amount.approveAmount,
-              chainId: token.chainId as Hex,
-              paymentAddress: amount.paymentAddress,
-              paymentTokenAddress: amount.paymentTokenAddress,
-            },
-            type: token.isNative ? AssetType.native : AssetType.token,
-          } as TokenWithApprovalAmount);
-        }
-      });
+    return availableTokens;
+  }, [price, paymentChainTokenMap, validTokenBalances]);
 
-      setAvailableTokenBalances(availableTokens);
-    };
-
-    getAvailableTokenBalances();
-  }, [price, productType, paymentChainTokenMap, validTokenBalances]);
-
-  return availableTokenBalances;
+  return {
+    availableTokenBalances: availableTokenBalances ?? [],
+    pending,
+    error,
+  };
 };
 
 /**

--- a/ui/hooks/subscription/useSubscriptionPricing.ts
+++ b/ui/hooks/subscription/useSubscriptionPricing.ts
@@ -157,7 +157,7 @@ export const useAvailableTokenBalances = (params: {
     });
 
     return availableTokens;
-  }, [price, paymentChainTokenMap, validTokenBalances]);
+  }, [price, productType, paymentChainTokenMap, validTokenBalances]);
 
   return {
     availableTokenBalances: availableTokenBalances ?? [],

--- a/ui/hooks/subscription/useSubscriptionPricing.ts
+++ b/ui/hooks/subscription/useSubscriptionPricing.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import log from 'loglevel';
 import {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Previously in shield plan screen, when user change plan, the selected token approval amount didn't get updated hence user will see outdated approval amount in the confirmation screen
This PR reset the selected token when plan change to get correct latest approval amount

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37585?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix incorrect token approval amount when change shield plan

## **Related issues**

Fixes:

## **Manual testing steps**

1. shield plan page
2. select a plan and go to confirm page
3. go back and select a different plan
4. go to confirm page should reflect the new approval amount

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale approval amounts by resetting the selected token when the plan changes and refactors `useAvailableTokenBalances` to return `{availableTokenBalances, pending, error}` via `useAsyncResult`.
> 
> - **Hooks**:
>   - **`useAvailableTokenBalances`**:
>     - Returns `{ availableTokenBalances, pending, error }` instead of an array; leverages `useAsyncResult` (removes local `useState/useEffect`).
>     - Adds early return when missing `price` or chain map; logs when token payment info missing.
>     - Computes approval amounts and filters tokens with sufficient balance; keeps polling balances for payment chains.
> - **Shield Plan Page (`ui/pages/shield-plan/shield-plan.tsx`)**:
>   - Consumes new hook shape; uses `pending` to defer token selection until data ready.
>   - Resets `selectedToken` when `selectedPlan` changes; only restores last-used token if it matches current plan.
>   - Defaults payment method to crypto when a token is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab428cec7f79220731f3909a1cbf3d5a249217f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->