### PR TITLE
refactor(556x): migrate unlock, deeplink, defi page to react-router-dom-v5-compat

### DIFF
--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -12,7 +12,7 @@ import React, {
   useContext,
 } from 'react';
 import PropTypes from 'prop-types';
-import { matchPath, useLocation } from 'react-router-dom';
+import { matchPath, useLocation } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 
 import { omit } from 'lodash';
@@ -157,11 +157,14 @@ export function MetaMetricsProvider({ children }) {
    */
   useEffect(() => {
     const environmentType = getEnvironmentType();
-    const match = matchPath(location.pathname, {
-      path: getPaths(),
-      exact: true,
-      strict: true,
-    });
+    const match = matchPath(
+      {
+        path: getPaths(),
+        end: true,
+        caseSensitive: true,
+      },
+      location.pathname,
+    );
     // Start by checking for a missing match route. If this falls through to
     // the else if, then we know we have a matched route for tracking.
     if (!match) {

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -153,7 +153,6 @@ export function MetaMetricsProvider({ children }) {
 
   // Used to prevent double tracking page calls
   const previousMatch = useRef();
-  const previousPathname = useRef();
 
   /**
    * Anytime the location changes, track a page change with segment.
@@ -162,12 +161,6 @@ export function MetaMetricsProvider({ children }) {
    * which page the user is on and their navigation path.
    */
   useEffect(() => {
-    // Only run if pathname actually changed
-    if (previousPathname.current === location.pathname) {
-      return;
-    }
-    previousPathname.current = location.pathname;
-
     const environmentType = getEnvironmentType();
     // v6 matchPath doesn't support array of paths, so we loop to find first match
     const paths = getPaths();
@@ -181,7 +174,7 @@ export function MetaMetricsProvider({ children }) {
         {
           path,
           end: true,
-          caseSensitive: true,
+          caseSensitive: false, // Match v5 behavior (case-insensitive by default)
         },
         location.pathname,
       );

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -157,14 +157,22 @@ export function MetaMetricsProvider({ children }) {
    */
   useEffect(() => {
     const environmentType = getEnvironmentType();
-    const match = matchPath(
-      {
-        path: getPaths(),
-        end: true,
-        caseSensitive: true,
-      },
-      location.pathname,
-    );
+    // v6 matchPath doesn't support array of paths, so we loop to find first match
+    const paths = getPaths();
+    let match = null;
+    for (const path of paths) {
+      match = matchPath(
+        {
+          path,
+          end: true,
+          caseSensitive: true,
+        },
+        location.pathname,
+      );
+      if (match) {
+        break;
+      }
+    }
     // Start by checking for a missing match route. If this falls through to
     // the else if, then we know we have a matched route for tracking.
     if (!match) {

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -12,7 +12,12 @@ import React, {
   useContext,
 } from 'react';
 import PropTypes from 'prop-types';
-import { matchPath, useLocation } from 'react-router-dom-v5-compat';
+// NOTE: Mixed v5/v5-compat imports during router migration
+// - useLocation from v5: Works with the v5 HashRouter to detect navigation changes
+// - matchPath from v5-compat: Provides v6 API (reversed args, pattern.path structure)
+// When v6 migration is complete, change both imports to: import { useLocation, matchPath } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { matchPath } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 
 import { omit } from 'lodash';
@@ -148,6 +153,7 @@ export function MetaMetricsProvider({ children }) {
 
   // Used to prevent double tracking page calls
   const previousMatch = useRef();
+  const previousPathname = useRef();
 
   /**
    * Anytime the location changes, track a page change with segment.
@@ -156,11 +162,21 @@ export function MetaMetricsProvider({ children }) {
    * which page the user is on and their navigation path.
    */
   useEffect(() => {
+    // Only run if pathname actually changed
+    if (previousPathname.current === location.pathname) {
+      return;
+    }
+    previousPathname.current = location.pathname;
+
     const environmentType = getEnvironmentType();
     // v6 matchPath doesn't support array of paths, so we loop to find first match
     const paths = getPaths();
     let match = null;
     for (const path of paths) {
+      // Skip empty string paths - they don't work correctly with v6 matchPath
+      if (path === '') {
+        continue;
+      }
       match = matchPath(
         {
           path,
@@ -183,10 +199,10 @@ export function MetaMetricsProvider({ children }) {
         },
       });
     } else if (
-      previousMatch.current !== match.path &&
+      previousMatch.current !== match.pattern.path &&
       !(
         environmentType === 'notification' &&
-        match.path === '/' &&
+        match.pattern.path === '/' &&
         previousMatch.current === undefined
       )
     ) {
@@ -195,7 +211,8 @@ export function MetaMetricsProvider({ children }) {
       // this we keep track of the previousMatch, and we skip the event track
       // in the event that we are dealing with the initial load of the
       // homepage
-      const { path, params } = match;
+      const { pattern, params } = match;
+      const { path } = pattern;
       const name = PATH_NAME_MAP.get(path);
       trackMetaMetricsPage(
         {
@@ -212,8 +229,9 @@ export function MetaMetricsProvider({ children }) {
         },
       );
     }
-    previousMatch.current = match?.path;
-  }, [location, context]);
+    previousMatch.current = match?.pattern?.path;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname, location.search, location.hash]);
 
   // For backwards compatibility, attach the new methods as properties to trackEvent
   const trackEventWithMethods = trackEvent;

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -230,8 +230,13 @@ export function MetaMetricsProvider({ children }) {
       );
     }
     previousMatch.current = match?.pattern?.path;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname, location.search, location.hash]);
+  }, [
+    location.pathname,
+    location.search,
+    location.hash,
+    context.page,
+    context.referrer,
+  ]);
 
   // For backwards compatibility, attach the new methods as properties to trackEvent
   const trackEventWithMethods = trackEvent;

--- a/ui/contexts/metametrics.js
+++ b/ui/contexts/metametrics.js
@@ -25,7 +25,11 @@ import { captureException, captureMessage } from '../../shared/lib/sentry';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../app/scripts/lib/util';
-import { PATH_NAME_MAP, getPaths } from '../helpers/constants/routes';
+import {
+  PATH_NAME_MAP,
+  getPaths,
+  DEFAULT_ROUTE,
+} from '../helpers/constants/routes';
 import { MetaMetricsContextProp } from '../../shared/constants/metametrics';
 import { useSegmentContext } from '../hooks/useSegmentContext';
 import { getParticipateInMetaMetrics } from '../selectors';
@@ -166,13 +170,11 @@ export function MetaMetricsProvider({ children }) {
     const paths = getPaths();
     let match = null;
     for (const path of paths) {
-      // Skip empty string paths - they don't work correctly with v6 matchPath
-      if (path === '') {
-        continue;
-      }
+      // Normalize empty string paths to '/' - they're aliases for the Home route
+      const normalizedPath = path === '' ? DEFAULT_ROUTE : path;
       match = matchPath(
         {
-          path,
+          path: normalizedPath,
           end: true,
           caseSensitive: false, // Match v5 behavior (case-insensitive by default)
         },

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
@@ -6,6 +6,10 @@ import configureStore from 'redux-mock-store';
 import { ONBOARDING_ROUTE } from '../../constants/routes';
 import InitializedV5Compat from './initialized-v5-compat';
 
+jest.mock('../../../ducks/metamask/metamask', () => ({
+  getCompletedOnboarding: (state: any) => state.metamask.completedOnboarding,
+}));
+
 const mockStore = configureStore();
 
 describe('InitializedV5Compat', () => {

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Routes, Route } from 'react-router-dom-v5-compat';
+import configureStore from 'redux-mock-store';
+import { ONBOARDING_ROUTE } from '../../constants/routes';
+import InitializedV5Compat from './initialized-v5-compat';
+
+const mockStore = configureStore();
+
+describe('InitializedV5Compat', () => {
+  const MockChildComponent = () => (
+    <div data-testid="child-component">Child Component</div>
+  );
+  const MockOnboardingComponent = () => (
+    <div data-testid="onboarding">Onboarding Page</div>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render children when onboarding is completed', () => {
+    const store = mockStore({
+      metamask: {
+        completedOnboarding: true,
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/test-route']}>
+          <Routes>
+            <Route
+              path="/test-route"
+              element={
+                <InitializedV5Compat>
+                  <MockChildComponent />
+                </InitializedV5Compat>
+              }
+            />
+            <Route
+              path={ONBOARDING_ROUTE}
+              element={<MockOnboardingComponent />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('child-component')).toBeInTheDocument();
+    expect(screen.getByText('Child Component')).toBeInTheDocument();
+    expect(screen.queryByTestId('onboarding')).not.toBeInTheDocument();
+  });
+
+  it('should redirect to onboarding route when onboarding is not completed', () => {
+    const store = mockStore({
+      metamask: {
+        completedOnboarding: false,
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/test-route']}>
+          <Routes>
+            <Route
+              path="/test-route"
+              element={
+                <InitializedV5Compat>
+                  <MockChildComponent />
+                </InitializedV5Compat>
+              }
+            />
+            <Route
+              path={ONBOARDING_ROUTE}
+              element={<MockOnboardingComponent />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.queryByTestId('child-component')).not.toBeInTheDocument();
+    expect(screen.getByTestId('onboarding')).toBeInTheDocument();
+    expect(screen.getByText('Onboarding Page')).toBeInTheDocument();
+  });
+
+  it('should accept and render complex React node structures as children', () => {
+    const store = mockStore({
+      metamask: {
+        completedOnboarding: true,
+      },
+    });
+
+    const NestedComponent = () => (
+      <span data-testid="nested">Nested Content</span>
+    );
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/test-route']}>
+          <Routes>
+            <Route
+              path="/test-route"
+              element={
+                <InitializedV5Compat>
+                  <div data-testid="parent">
+                    <NestedComponent />
+                    <p data-testid="paragraph">Some text</p>
+                  </div>
+                </InitializedV5Compat>
+              }
+            />
+            <Route
+              path={ONBOARDING_ROUTE}
+              element={<MockOnboardingComponent />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('parent')).toBeInTheDocument();
+    expect(screen.getByTestId('nested')).toBeInTheDocument();
+    expect(screen.getByTestId('paragraph')).toBeInTheDocument();
+    expect(screen.getByText('Nested Content')).toBeInTheDocument();
+    expect(screen.getByText('Some text')).toBeInTheDocument();
+  });
+});
+

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.test.tsx
@@ -7,7 +7,9 @@ import { ONBOARDING_ROUTE } from '../../constants/routes';
 import InitializedV5Compat from './initialized-v5-compat';
 
 jest.mock('../../../ducks/metamask/metamask', () => ({
-  getCompletedOnboarding: (state: any) => state.metamask.completedOnboarding,
+  getCompletedOnboarding: (state: {
+    metamask: { completedOnboarding: boolean };
+  }) => state.metamask.completedOnboarding,
 }));
 
 const mockStore = configureStore();
@@ -132,4 +134,3 @@ describe('InitializedV5Compat', () => {
     expect(screen.getByText('Some text')).toBeInTheDocument();
   });
 });
-

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
@@ -34,4 +34,3 @@ const InitializedV5Compat = ({ children }: InitializedV5CompatProps) => {
 };
 
 export default InitializedV5Compat;
-

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom-v5-compat';
+import { ONBOARDING_ROUTE } from '../../constants/routes';
+
+type InitializedV5CompatProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * InitializedV5Compat - A wrapper component for v5-compat routes that require initialization
+ *
+ * This component checks if the user has completed onboarding.
+ * If not, it redirects to the onboarding route using v5-compat Navigate.
+ *
+ * Unlike the v5 Initialized HOC, this returns the element directly (not wrapped in Route)
+ * because v5-compat Routes handle their children differently.
+ *
+ * @param props - Component props
+ * @param props.children - Child components to render when initialized
+ * @returns Navigate component or children
+ */
+const InitializedV5Compat = ({ children }: InitializedV5CompatProps) => {
+  const completedOnboarding = useSelector(
+    (state: { metamask: { completedOnboarding: boolean } }) =>
+      state.metamask.completedOnboarding,
+  );
+
+  if (!completedOnboarding) {
+    return <Navigate to={ONBOARDING_ROUTE} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default InitializedV5Compat;
+

--- a/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
+++ b/ui/helpers/higher-order-components/initialized/initialized-v5-compat.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom-v5-compat';
+import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 import { ONBOARDING_ROUTE } from '../../constants/routes';
 
 type InitializedV5CompatProps = {
@@ -21,10 +22,7 @@ type InitializedV5CompatProps = {
  * @returns Navigate component or children
  */
 const InitializedV5Compat = ({ children }: InitializedV5CompatProps) => {
-  const completedOnboarding = useSelector(
-    (state: { metamask: { completedOnboarding: boolean } }) =>
-      state.metamask.completedOnboarding,
-  );
+  const completedOnboarding = useSelector(getCompletedOnboarding);
 
   if (!completedOnboarding) {
     return <Navigate to={ONBOARDING_ROUTE} replace />;

--- a/ui/pages/deep-link/deep-link.tsx
+++ b/ui/pages/deep-link/deep-link.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import type { Location } from 'react-router-dom';
 import log from 'loglevel';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -154,8 +154,11 @@ async function updateStateFromUrl(
   }
 }
 
-export const DeepLink = () => {
-  const location = useLocation();
+type DeepLinkProps = {
+  location: Location;
+};
+
+export const DeepLink = ({ location }: DeepLinkProps) => {
   const t = useI18nContext() as TranslateFunction;
   const dispatch = useDispatch();
   // it's technically not possible for a natural flow to reach this page

--- a/ui/pages/deep-link/deep-link.tsx
+++ b/ui/pages/deep-link/deep-link.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import type { Location } from 'react-router-dom';
+import type { Location as RouterLocation } from 'react-router-dom-v5-compat';
 import log from 'loglevel';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -155,7 +155,7 @@ async function updateStateFromUrl(
 }
 
 type DeepLinkProps = {
-  location: Location;
+  location: RouterLocation;
 };
 
 export const DeepLink = ({ location }: DeepLinkProps) => {

--- a/ui/pages/defi/components/defi-details-list.test.tsx
+++ b/ui/pages/defi/components/defi-details-list.test.tsx
@@ -22,7 +22,7 @@ jest.mock('react-router-dom-v5-compat', () => {
 describe('DeFiDetailsPage', () => {
   const store = configureMockStore([thunk])(mockState);
 
-  beforeAll(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 

--- a/ui/pages/defi/components/defi-details-page.test.tsx
+++ b/ui/pages/defi/components/defi-details-page.test.tsx
@@ -6,16 +6,7 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import mockState from '../../../../test/data/mock-state.json';
 import DeFiPage from './defi-details-page';
 
-const mockUseParams = jest
-  .fn()
-  .mockReturnValue({ chainId: CHAIN_IDS.MAINNET, protocolId: 'aave' });
-
-jest.mock('react-router-dom', () => {
-  return {
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => mockUseParams(),
-  };
-});
+const mockNavigate = jest.fn();
 
 describe('DeFiDetailsPage', () => {
   const mockStore = {
@@ -79,7 +70,7 @@ describe('DeFiDetailsPage', () => {
 
   const store = configureMockStore([thunk])(mockStore);
 
-  beforeAll(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
@@ -89,7 +80,13 @@ describe('DeFiDetailsPage', () => {
   });
 
   it('renders defi asset page', () => {
-    const { container } = renderWithProvider(<DeFiPage />, store);
+    const { container } = renderWithProvider(
+      <DeFiPage
+        navigate={mockNavigate}
+        params={{ chainId: CHAIN_IDS.MAINNET, protocolId: 'aave' }}
+      />,
+      store,
+    );
 
     expect(container).toMatchSnapshot();
   });

--- a/ui/pages/defi/components/defi-details-page.tsx
+++ b/ui/pages/defi/components/defi-details-page.tsx
@@ -61,7 +61,9 @@ const DeFiPage = ({ navigate, params }: DeFiPageProps) => {
 
   // TODO: Get value in user's preferred currency
   const protocolPosition =
-    defiPositions[selectedAccount.address]?.[chainId]?.protocols[protocolId];
+    defiPositions[selectedAccount.address]?.[
+      chainId as keyof (typeof defiPositions)[string]
+    ]?.protocols[protocolId];
 
   const extractedTokens = useMemo(() => {
     return Object.keys(protocolPosition?.positionTypes || {}).reduce(
@@ -120,7 +122,7 @@ const DeFiPage = ({ navigate, params }: DeFiPageProps) => {
           {protocolPosition.protocolDetails.name}
         </Text>
         <AssetCellBadge
-          chainId={chainId}
+          chainId={chainId as (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS]}
           tokenImage={protocolPosition.protocolDetails.iconUrl}
           symbol={protocolPosition.protocolDetails.name}
           data-testid="defi-details-page-protocol-badge"

--- a/ui/pages/defi/components/defi-details-page.tsx
+++ b/ui/pages/defi/components/defi-details-page.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useHistory, useParams, Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom-v5-compat';
 import { useSelector } from 'react-redux';
 import {
   Display,
@@ -45,16 +45,17 @@ const useExtractUnderlyingTokens = (
     );
   }, [positions]);
 
-const DeFiPage = () => {
-  const { chainId, protocolId } = useParams<{
-    chainId: '0x' & string;
-    protocolId: string;
-  }>() as { chainId: '0x' & string; protocolId: string };
+type DeFiPageProps = {
+  navigate: (to: string | number) => void;
+  params: { chainId: string; protocolId: string };
+};
+
+const DeFiPage = ({ navigate, params }: DeFiPageProps) => {
   const { formatCurrencyWithMinThreshold } = useFormatters();
+  const { chainId, protocolId } = params;
   const defiPositions = useSelector(getDefiPositions);
   const selectedAccount = useSelector(getSelectedAccount);
 
-  const history = useHistory();
   const t = useI18nContext();
   const { privacyMode } = useSelector(getPreferences);
 
@@ -82,7 +83,7 @@ const DeFiPage = () => {
   };
 
   if (!protocolPosition) {
-    return <Redirect to={{ pathname: DEFAULT_ROUTE }} />;
+    return <Navigate to={DEFAULT_ROUTE} replace />;
   }
 
   return (
@@ -100,7 +101,7 @@ const DeFiPage = () => {
           size={ButtonIconSize.Sm}
           ariaLabel={t('back')}
           iconName={IconName.ArrowLeft}
-          onClick={() => history.push(DEFAULT_ROUTE)}
+          onClick={() => navigate(DEFAULT_ROUTE)}
         />
       </Box>
 

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -1,7 +1,7 @@
 import qrCode from 'qrcode-generator';
 import React, { useContext, useEffect, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useParams } from 'react-router-dom';
 import { getErrorMessage } from '../../../shared/modules/error';
 import {
   MetaMetricsEventCategory,
@@ -44,9 +44,7 @@ import { endTrace, trace, TraceName } from '../../../shared/lib/trace';
 const PASSWORD_PROMPT_SCREEN = 'PASSWORD_PROMPT_SCREEN';
 const REVEAL_SEED_SCREEN = 'REVEAL_SEED_SCREEN';
 
-export default function RevealSeedPage() {
-  const history = useHistory();
-  const { keyringId } = useParams();
+function RevealSeedPage({ navigate, keyringId }) {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
@@ -267,7 +265,7 @@ export default function RevealSeedPage() {
                 hd_entropy_index: hdEntropyIndex,
               },
             });
-            history.goBack();
+            navigate(-1);
           }}
         >
           {t('cancel')}
@@ -316,7 +314,7 @@ export default function RevealSeedPage() {
                 key_type: MetaMetricsEventKeyType.Srp,
               },
             });
-            history.goBack();
+            navigate(-1);
           }}
         >
           {t('close')}
@@ -409,3 +407,10 @@ export default function RevealSeedPage() {
     </Box>
   );
 }
+
+RevealSeedPage.propTypes = {
+  navigate: PropTypes.func.isRequired,
+  keyringId: PropTypes.string,
+};
+
+export default RevealSeedPage;

--- a/ui/pages/keychains/reveal-seed.test.js
+++ b/ui/pages/keychains/reveal-seed.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent, waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
-import { renderWithProvider } from '../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import mockState from '../../../test/data/mock-state.json';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import {
@@ -29,24 +29,13 @@ const mockRequestRevealSeedWords = jest
   .fn()
   .mockImplementation(mockSuccessfulSrpReveal);
 const mockShowModal = jest.fn();
-const mockUseParams = jest
-  .fn()
-  .mockReturnValue({ keyringId: 'ULID01234567890ABCDEFGHIJKLMN' });
+const mockNavigate = jest.fn();
 const password = 'password';
 
 jest.mock('../../store/actions.ts', () => ({
   ...jest.requireActual('../../store/actions.ts'),
   requestRevealSeedWords: (userPassword, keyringId) =>
     mockRequestRevealSeedWords(userPassword, keyringId),
-}));
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: jest.fn(),
-    goBack: jest.fn(),
-  }),
-  useParams: () => mockUseParams(),
 }));
 
 const mockStateWithModal = {
@@ -68,19 +57,26 @@ const mockStateWithModal = {
 describe('Reveal Seed Page', () => {
   const mockStore = configureMockStore([thunk])(mockStateWithModal);
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should match snapshot', () => {
-    const { container } = renderWithProvider(<RevealSeedPage />, mockStore);
+    const { container } = renderWithProvider(
+      <RevealSeedPage navigate={mockNavigate} />,
+      mockStore,
+    );
 
     expect(container).toMatchSnapshot();
   });
 
   it('form submit', async () => {
     const { queryByTestId, queryByText } = renderWithProvider(
-      <RevealSeedPage />,
+      <RevealSeedPage navigate={mockNavigate} />,
       mockStore,
     );
 
@@ -97,7 +93,7 @@ describe('Reveal Seed Page', () => {
 
   it('shows hold to reveal', async () => {
     const { queryByTestId, queryByText } = renderWithProvider(
-      <RevealSeedPage />,
+      <RevealSeedPage navigate={mockNavigate} />,
       mockStore,
     );
 
@@ -116,7 +112,7 @@ describe('Reveal Seed Page', () => {
     mockRequestRevealSeedWords.mockImplementation(mockUnsuccessfulSrpReveal);
 
     const { queryByTestId, queryByText } = renderWithProvider(
-      <RevealSeedPage />,
+      <RevealSeedPage navigate={mockNavigate} />,
       mockStore,
     );
 
@@ -138,7 +134,7 @@ describe('Reveal Seed Page', () => {
     const { queryByTestId, queryByText } = renderWithProvider(
       <div>
         <Modal />
-        <RevealSeedPage />
+        <RevealSeedPage navigate={mockNavigate} />
       </div>,
       store,
     );
@@ -168,7 +164,7 @@ describe('Reveal Seed Page', () => {
       renderWithProvider(
         <MetaMetricsContext.Provider value={mockTrackEvent}>
           <Modal />
-          <RevealSeedPage />
+          <RevealSeedPage navigate={mockNavigate} />
         </MetaMetricsContext.Provider>,
         store,
       );
@@ -344,7 +340,7 @@ describe('Reveal Seed Page', () => {
     const mockTrackEvent = jest.fn();
     const { queryByText } = renderWithProvider(
       <MetaMetricsContext.Provider value={mockTrackEvent}>
-        <RevealSeedPage />
+        <RevealSeedPage navigate={mockNavigate} />
       </MetaMetricsContext.Provider>,
       mockStore,
     );
@@ -375,9 +371,8 @@ describe('Reveal Seed Page', () => {
   describe('multi-srp', () => {
     it('passes the keyringId to the requestRevealSeedWords action', async () => {
       const keyringId = 'ULID01234567890ABCDEFGHIJKLMN';
-      mockUseParams.mockReturnValue({ keyringId });
       const { queryByTestId, queryByText } = renderWithProvider(
-        <RevealSeedPage />,
+        <RevealSeedPage navigate={mockNavigate} keyringId={keyringId} />,
         mockStore,
       );
 
@@ -397,9 +392,8 @@ describe('Reveal Seed Page', () => {
 
     it('passes undefined for keyringId if there is no param', async () => {
       const keyringId = undefined;
-      mockUseParams.mockReturnValue({ keyringId });
       const { queryByTestId, queryByText } = renderWithProvider(
-        <RevealSeedPage />,
+        <RevealSeedPage navigate={mockNavigate} keyringId={keyringId} />,
         mockStore,
       );
 

--- a/ui/pages/lock/lock.component.js
+++ b/ui/pages/lock/lock.component.js
@@ -5,18 +5,18 @@ import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 
 export default class Lock extends PureComponent {
   static propTypes = {
-    history: PropTypes.object,
+    navigate: PropTypes.func,
     isUnlocked: PropTypes.bool,
     lockMetamask: PropTypes.func,
   };
 
   componentDidMount() {
-    const { lockMetamask, isUnlocked, history } = this.props;
+    const { lockMetamask, isUnlocked, navigate } = this.props;
 
     if (isUnlocked) {
-      lockMetamask().then(() => history.push(DEFAULT_ROUTE));
+      lockMetamask().then(() => navigate(DEFAULT_ROUTE));
     } else {
-      history.replace(DEFAULT_ROUTE);
+      navigate(DEFAULT_ROUTE, { replace: true });
     }
   }
 

--- a/ui/pages/lock/lock.container.js
+++ b/ui/pages/lock/lock.container.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { lockMetamask } from '../../store/actions';
+import withRouterHooks from '../../helpers/higher-order-components/with-router-hooks/with-router-hooks';
 import Lock from './lock.component';
 
 const mapStateToProps = (state) => {
@@ -21,6 +21,6 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 export default compose(
-  withRouter,
+  withRouterHooks,
   connect(mapStateToProps, mapDispatchToProps),
 )(Lock);

--- a/ui/pages/lock/lock.test.js
+++ b/ui/pages/lock/lock.test.js
@@ -1,29 +1,30 @@
 import React from 'react';
 import sinon from 'sinon';
-import { renderWithProvider } from '../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import Lock from './lock.component';
 
+const mockUseNavigate = jest.fn();
+
 describe('Lock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('replaces history with default route when isUnlocked false', () => {
     const props = {
       isUnlocked: false,
-      history: {
-        replace: sinon.spy(),
-      },
+      navigate: mockUseNavigate,
     };
 
     renderWithProvider(<Lock {...props} />);
 
-    expect(props.history.replace.getCall(0).args[0]).toStrictEqual('/');
+    expect(mockUseNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 
   it('locks and pushes history with default route when isUnlocked true', async () => {
     const props = {
       isUnlocked: true,
       lockMetamask: sinon.stub(),
-      history: {
-        push: sinon.spy(),
-      },
+      navigate: mockUseNavigate,
     };
 
     props.lockMetamask.resolves();
@@ -31,6 +32,6 @@ describe('Lock', () => {
     renderWithProvider(<Lock {...props} />);
 
     expect(await props.lockMetamask.calledOnce).toStrictEqual(true);
-    expect(props.history.push.getCall(0).args[0]).toStrictEqual('/');
+    expect(mockUseNavigate).toHaveBeenCalledWith('/');
   });
 });

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -209,18 +209,6 @@ const createV5CompatNavigate = (
 };
 
 /**
- * Props that can be passed to v5-compat components
- */
-type V5CompatComponentProps<
-  TParams extends Record<string, string | undefined>,
-> = {
-  navigate?: V5CompatNavigate;
-  location?: RouteComponentProps['location'];
-  match?: RouteComponentProps<TParams>['match'];
-  params?: TParams;
-} & Partial<TParams>;
-
-/**
  * Helper to create v5-compat route wrappers with less boilerplate.
  * Handles authentication, navigation, and prop passing for v5-to-v5-compat transition.
  *
@@ -238,9 +226,13 @@ type V5CompatComponentProps<
  * @returns Route render function
  */
 const createV5CompatRoute = <
-  TParams extends Record<string, string | undefined>,
+  TParams extends Record<string, string | undefined> = Record<
+    string,
+    string | undefined
+  >,
 >(
-  Component: React.ComponentType<V5CompatComponentProps<TParams>>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Component: React.ComponentType<any>,
   options: {
     wrapper?: React.ComponentType<{ children: React.ReactNode }> | null;
     includeNavigate?: boolean;
@@ -262,7 +254,7 @@ const createV5CompatRoute = <
   return (props: RouteComponentProps<TParams>) => {
     const { history: v5History, location: v5Location, match } = props;
 
-    const componentProps: Partial<V5CompatComponentProps<TParams>> = {};
+    const componentProps: Record<string, unknown> = {};
 
     if (includeNavigate) {
       componentProps.navigate = createV5CompatNavigate(v5History);
@@ -281,11 +273,11 @@ const createV5CompatRoute = <
       }
     }
 
-    const element = (
-      <Component {...(componentProps as V5CompatComponentProps<TParams>)} />
-    );
+    const element = <Component {...componentProps} />;
 
-    return wrapper ? React.createElement(wrapper, {}, element) : element;
+    return wrapper
+      ? React.createElement(wrapper, { children: element })
+      : element;
   };
 };
 

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -618,7 +618,13 @@ export default function Routes() {
           <Route path={ONBOARDING_ROUTE} component={OnboardingFlow} />
           {/** @ts-expect-error TODO: Replace `component` prop with `element` once `react-router` is upgraded to v6 */}
           <Route path={LOCK_ROUTE} component={Lock} exact />
-          <Route path={UNLOCK_ROUTE} exact>
+          <Route
+            path={UNLOCK_ROUTE}
+            // v5 Route supports exact with render props, but TS types don't recognize it
+            // Using spread operator with type assertion to bypass incorrect type definitions
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            {...({ exact: true } as any)}
+          >
             {(props: RouteComponentProps) => {
               const { history: v5History, location: v5Location } = props;
               const navigate = createV5CompatNavigate(v5History);
@@ -666,15 +672,12 @@ export default function Routes() {
                   keyringId?: string;
                 }>;
               return (
-                <Authenticated
-                  path={`${REVEAL_SEED_ROUTE}/:keyringId?`}
-                  component={() => (
-                    <RevealSeedConfirmationComponent
-                      navigate={navigate}
-                      keyringId={match.params.keyringId}
-                    />
-                  )}
-                />
+                <AuthenticatedV5Compat>
+                  <RevealSeedConfirmationComponent
+                    navigate={navigate}
+                    keyringId={match.params.keyringId}
+                  />
+                </AuthenticatedV5Compat>
               );
             }}
           </Route>
@@ -870,15 +873,12 @@ export default function Routes() {
                 params: { chainId: string; protocolId: string };
               }>;
               return (
-                <Authenticated
-                  path={`${DEFI_ROUTE}/:chainId/:protocolId`}
-                  component={() => (
-                    <DeFiPageComponent
-                      navigate={navigate}
-                      params={match.params}
-                    />
-                  )}
-                />
+                <AuthenticatedV5Compat>
+                  <DeFiPageComponent
+                    navigate={navigate}
+                    params={match.params}
+                  />
+                </AuthenticatedV5Compat>
               );
             }}
           </Route>
@@ -1121,7 +1121,12 @@ export default function Routes() {
         {renderRoutes()}
       </Box>
       {isUnlocked ? <Alerts history={history} /> : null}
-      <ToastMaster location={location} />
+      {React.createElement(
+        ToastMaster as React.ComponentType<{
+          location: RouteComponentProps['location'];
+        }>,
+        { location },
+      )}
     </div>
   );
 }

--- a/ui/pages/unlock-page/README.mdx
+++ b/ui/pages/unlock-page/README.mdx
@@ -1,6 +1,6 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
-import UnlockPage from '.';
+import UnlockPage from './unlock-page.component';
 
 # Unlock Page
 
@@ -14,7 +14,7 @@ Portal page for user to auth the access of their account
 
 | Name                       | Description                                                                |
 | -------------------------- | -------------------------------------------------------------------------- |
-| `history`                  | History router for redirect after action `object`                          |
+| `navigate`                 | Navigate function for redirect after action `object`                       |
 | `isUnlocked`               | If isUnlocked is true will redirect to most recent route in history `bool` |
 | `onRestore`                | onClick handler for "Forgot password?" link `func`                         |
 | `onSubmit`                 | onSumbit handler when form is submitted `func`                             |

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -64,13 +64,17 @@ class UnlockPage extends Component {
 
   static propTypes = {
     /**
-     * History router for redirect after action
+     * navigate function for redirect after action
      */
-    history: PropTypes.object.isRequired,
+    navigate: PropTypes.func.isRequired,
     /**
      * Location router for redirect after action
      */
     location: PropTypes.object.isRequired,
+    /**
+     * Navigation state from v5-compat navigation context
+     */
+    navState: PropTypes.object,
     /**
      * If isUnlocked is true will redirect to most recent route in history
      */
@@ -149,16 +153,18 @@ class UnlockPage extends Component {
   }
 
   UNSAFE_componentWillMount() {
-    const { isUnlocked, history, location } = this.props;
+    const { isUnlocked, navigate, location, navState } = this.props;
 
     if (isUnlocked) {
       // Redirect to the intended route if available, otherwise DEFAULT_ROUTE
       let redirectTo = DEFAULT_ROUTE;
-      if (location.state?.from?.pathname) {
-        const search = location.state.from.search || '';
-        redirectTo = location.state.from.pathname + search;
+      // Read from both v5 location.state and v5-compat navState
+      const fromLocation = location.state?.from || navState?.from;
+      if (fromLocation?.pathname) {
+        const search = fromLocation.search || '';
+        redirectTo = fromLocation.pathname + search;
       }
-      history.push(redirectTo);
+      navigate(redirectTo);
     }
   }
 
@@ -415,7 +421,7 @@ class UnlockPage extends Component {
   };
 
   onForgotPasswordOrLoginWithDiffMethods = async () => {
-    const { isSocialLoginFlow, history, isOnboardingCompleted } = this.props;
+    const { isSocialLoginFlow, navigate, isOnboardingCompleted } = this.props;
 
     // in `onboarding_unlock` route, if the user is on a social login flow and onboarding is not completed,
     // we can redirect to `onboarding_welcome` route to select a different login method
@@ -431,7 +437,7 @@ class UnlockPage extends Component {
 
       await this.props.loginWithDifferentMethod();
       await this.props.forceUpdateMetamaskState();
-      history.replace(ONBOARDING_WELCOME_ROUTE);
+      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
       return;
     }
 
@@ -463,7 +469,7 @@ class UnlockPage extends Component {
     this.setState({ showLoginErrorModal: false });
     await this.props.resetWallet();
     await this.props.forceUpdateMetamaskState();
-    this.props.history.replace(DEFAULT_ROUTE);
+    this.props.navigate(DEFAULT_ROUTE, { replace: true });
   };
 
   render() {

--- a/ui/pages/unlock-page/unlock-page.container.js
+++ b/ui/pages/unlock-page/unlock-page.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -105,11 +106,22 @@ const UnlockPageConnected = compose(
   connect(mapStateToProps, mapDispatchToProps, mergeProps),
 )(UnlockPage);
 
-// Inject navState from NavigationStateContext for v5-compat navigation
-// eslint-disable-next-line react/prop-types
+/**
+ * Inject navState from NavigationStateContext for v5-compat navigation.
+ * This wrapper ensures the unlock page can read navigation state from both
+ * v5 location.state and v5-compat NavigationStateContext.
+ *
+ * @param {object} props - Component props (navigate, location from route)
+ * @returns {React.ReactElement} UnlockPage with navState injected
+ */
 const UnlockPageWithNavState = (props) => {
   const navState = useNavState();
   return <UnlockPageConnected {...props} navState={navState} />;
+};
+
+UnlockPageWithNavState.propTypes = {
+  navigate: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired,
 };
 
 // Export the connected component for Storybook/testing

--- a/ui/pages/unlock-page/unlock-page.container.js
+++ b/ui/pages/unlock-page/unlock-page.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import React from 'react';
 import { compose } from 'redux';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -22,10 +23,9 @@ import {
   getTheme,
 } from '../../selectors';
 import { getCompletedOnboarding } from '../../ducks/metamask/metamask';
-import UnlockPage from './unlock-page.component';
-import withRouterHooks from "../../helpers/higher-order-components/with-router-hooks/with-router-hooks";
-import React from 'react';
+import withRouterHooks from '../../helpers/higher-order-components/with-router-hooks/with-router-hooks';
 import { useNavState } from '../../contexts/navigation-state';
+import UnlockPage from './unlock-page.component';
 
 const mapStateToProps = (state) => {
   const {

--- a/ui/pages/unlock-page/unlock-page.container.js
+++ b/ui/pages/unlock-page/unlock-page.container.js
@@ -112,4 +112,7 @@ const UnlockPageWithNavState = (props) => {
   return <UnlockPageConnected {...props} navState={navState} />;
 };
 
+// Export the connected component for Storybook/testing
+export { UnlockPageConnected };
+
 export default UnlockPageWithNavState;

--- a/ui/pages/unlock-page/unlock-page.stories.js
+++ b/ui/pages/unlock-page/unlock-page.stories.js
@@ -1,4 +1,3 @@
-import { createBrowserHistory } from 'history';
 import React from 'react';
 import README from './README.mdx';
 import UnlockPage from './unlock-page.component';
@@ -13,7 +12,8 @@ export default {
     },
   },
   argTypes: {
-    history: { control: 'object' },
+    navigate: { control: 'object' },
+    location: { control: 'object' },
     isUnlocked: { control: 'boolean' },
     onRestore: { action: 'onRestore' },
     onSubmit: { action: 'onSubmit' },
@@ -22,8 +22,9 @@ export default {
 };
 
 export const DefaultStory = (args) => {
-  const history = createBrowserHistory();
-  return <UnlockPage {...args} history={history} />;
+  const navigate = (path) => console.log('Navigate to:', path);
+  const location = { pathname: '/unlock', search: '', state: null };
+  return <UnlockPage {...args} navigate={navigate} location={location} />;
 };
 
 DefaultStory.storyName = 'Default';

--- a/ui/pages/unlock-page/unlock-page.test.js
+++ b/ui/pages/unlock-page/unlock-page.test.js
@@ -295,40 +295,4 @@ describe('Unlock Page', () => {
       expect(queryByTestId('login-error-modal')).toBeInTheDocument();
     });
   });
-
-  it('should show login error modal when authentication error is thrown', async () => {
-    const pathname = '/unlock';
-    const mockStateNonUnlocked = {
-      metamask: { isUnlocked: false, completedOnboarding: true },
-    };
-    const store = configureMockStore([thunk])(mockStateNonUnlocked);
-
-    mockTryUnlockMetamask.mockImplementationOnce(
-      jest.fn(() => {
-        return Promise.reject(
-          new Error(
-            SeedlessOnboardingControllerErrorMessage.AuthenticationError,
-          ),
-        );
-      }),
-    );
-    const mockForceUpdateMetamaskState = jest.fn();
-
-    const { queryByTestId } = renderWithProvider(
-      <UnlockPage forceUpdateMetamaskState={mockForceUpdateMetamaskState} />,
-      store,
-      {
-        pathname,
-      },
-    );
-
-    const passwordField = queryByTestId('unlock-password');
-    const loginButton = queryByTestId('unlock-submit');
-    fireEvent.change(passwordField, { target: { value: 'a-password' } });
-    fireEvent.click(loginButton);
-
-    await waitFor(() => {
-      expect(queryByTestId('login-error-modal')).toBeInTheDocument();
-    });
-  });
 });

--- a/ui/pages/unlock-page/unlock-page.test.js
+++ b/ui/pages/unlock-page/unlock-page.test.js
@@ -2,13 +2,26 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent, waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
 import { SeedlessOnboardingControllerErrorMessage } from '@metamask/seedless-onboarding-controller';
-import { renderWithProvider } from '../../../test/lib/render-helpers';
+import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import { ONBOARDING_WELCOME_ROUTE } from '../../helpers/constants/routes';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import UnlockPage from '.';
+
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockUseNavigate,
+  };
+});
+
+const mockUseNavState = jest.fn(() => null);
+jest.mock('../../contexts/navigation-state', () => ({
+  useNavState: () => mockUseNavState(),
+  useSetNavState: () => jest.fn(),
+  NavigationStateProvider: ({ children }) => children,
+}));
 
 const mockTryUnlockMetamask = jest.fn(() => {
   return async () => {
@@ -46,6 +59,11 @@ describe('Unlock Page', () => {
     metamask: {},
   };
   const mockStore = configureMockStore([thunk])(mockState);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavState.mockReturnValue(null); // Reset navState to null for each test
+  });
 
   it('should match snapshot', () => {
     const { container } = renderWithProvider(<UnlockPage />, mockStore);
@@ -111,11 +129,6 @@ describe('Unlock Page', () => {
     };
     const store = configureMockStore([thunk])(mockStateWithUnlock);
 
-    const history = createMemoryHistory({
-      initialEntries: [{ pathname: '/unlock' }],
-    });
-
-    jest.spyOn(history, 'replace');
     const mockLoginWithDifferentMethod = jest.fn();
     const mockForceUpdateMetamaskState = jest.fn();
 
@@ -125,10 +138,9 @@ describe('Unlock Page', () => {
     };
 
     const { queryByText } = renderWithProvider(
-      <Router history={history}>
-        <UnlockPage {...props} />
-      </Router>,
+      <UnlockPage {...props} />,
       store,
+      '/unlock',
     );
 
     fireEvent.click(queryByText('Use a different login method'));
@@ -136,55 +148,72 @@ describe('Unlock Page', () => {
     await waitFor(() => {
       expect(mockLoginWithDifferentMethod).toHaveBeenCalled();
       expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-      expect(history.replace).toHaveBeenCalledWith(ONBOARDING_WELCOME_ROUTE);
+      expect(mockUseNavigate).toHaveBeenCalledWith(ONBOARDING_WELCOME_ROUTE, {
+        replace: true,
+      });
     });
   });
-
-  it('should redirect to history location when unlocked', () => {
+  it('should redirect to history location when unlocked (from state)', () => {
     const intendedPath = '/previous-route';
     const mockStateWithUnlock = {
       metamask: { isUnlocked: true },
     };
     const store = configureMockStore([thunk])(mockStateWithUnlock);
-    const history = createMemoryHistory({
-      initialEntries: [
-        { pathname: '/unlock', state: { from: { pathname: intendedPath } } },
-      ],
+
+    // Set up the router to have the location state that would come from a redirect
+    const pathname = '/unlock';
+    const locationState = { from: { pathname: intendedPath } };
+
+    renderWithProvider(<UnlockPage />, store, {
+      pathname,
+      state: locationState,
     });
-    jest.spyOn(history, 'push');
-    renderWithProvider(
-      <Router history={history}>
-        <UnlockPage />
-      </Router>,
-      store,
-    );
-    expect(history.push).toHaveBeenCalledTimes(1);
-    expect(history.push).toHaveBeenCalledWith(intendedPath);
-    expect(history.location.pathname).toBe(intendedPath);
+
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath);
   });
 
-  it('changes password, submits, and redirects to the specified route', async () => {
+  it('should redirect to context-stored location when unlocked (HashRouter v5-compat workaround)', () => {
+    const intendedPath = '/previous-route';
+    const mockStateWithUnlock = {
+      metamask: { isUnlocked: true },
+    };
+    const store = configureMockStore([thunk])(mockStateWithUnlock);
+
+    const pathname = '/unlock';
+
+    // Mock navState to provide the redirect location (v5-compat way)
+    mockUseNavState.mockReturnValueOnce({
+      from: { pathname: intendedPath },
+    });
+
+    renderWithProvider(<UnlockPage />, store, {
+      pathname,
+    });
+
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath);
+  });
+
+  it('changes password, submits, and redirects to the specified route (from location.state)', async () => {
     const intendedPath = '/intended-route';
     const intendedSearch = '?abc=123';
     const mockStateNonUnlocked = {
       metamask: { isUnlocked: false },
     };
     const store = configureMockStore([thunk])(mockStateNonUnlocked);
-    const history = createMemoryHistory({
-      initialEntries: [
-        {
-          pathname: '/unlock',
-          state: { from: { pathname: intendedPath, search: intendedSearch } },
-        },
-      ],
+
+    // Set up the router to have the location state that would come from a redirect
+    const pathname = '/unlock';
+    const locationState = {
+      from: { pathname: intendedPath, search: intendedSearch },
+    };
+
+    const { queryByTestId } = renderWithProvider(<UnlockPage />, store, {
+      pathname,
+      state: locationState,
     });
-    jest.spyOn(history, 'push');
-    const { queryByTestId } = renderWithProvider(
-      <Router history={history}>
-        <UnlockPage />
-      </Router>,
-      store,
-    );
+
     const passwordField = queryByTestId('unlock-password');
     const loginButton = queryByTestId('unlock-submit');
     fireEvent.change(passwordField, { target: { value: 'a-password' } });
@@ -192,10 +221,38 @@ describe('Unlock Page', () => {
     await Promise.resolve(); // Wait for async operations
 
     expect(mockTryUnlockMetamask).toHaveBeenCalledTimes(1);
-    expect(history.push).toHaveBeenCalledTimes(1);
-    expect(history.push).toHaveBeenCalledWith(intendedPath + intendedSearch);
-    expect(history.location.pathname).toBe(intendedPath);
-    expect(history.location.search).toBe(intendedSearch);
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath + intendedSearch);
+  });
+
+  it('changes password, submits, and redirects to the specified route (from navState)', async () => {
+    const intendedPath = '/intended-route';
+    const intendedSearch = '?abc=123';
+    const mockStateNonUnlocked = {
+      metamask: { isUnlocked: false },
+    };
+    const store = configureMockStore([thunk])(mockStateNonUnlocked);
+
+    const pathname = '/unlock';
+
+    // Mock navState to provide the redirect location (v5-compat way)
+    mockUseNavState.mockReturnValue({
+      from: { pathname: intendedPath, search: intendedSearch },
+    });
+
+    const { queryByTestId } = renderWithProvider(<UnlockPage />, store, {
+      pathname,
+    });
+
+    const passwordField = queryByTestId('unlock-password');
+    const loginButton = queryByTestId('unlock-submit');
+    fireEvent.change(passwordField, { target: { value: 'a-password' } });
+    fireEvent.click(loginButton);
+    await Promise.resolve(); // Wait for async operations
+
+    expect(mockTryUnlockMetamask).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath + intendedSearch);
   });
 
   it('should show login error modal when authentication error is thrown', async () => {
@@ -205,15 +262,11 @@ describe('Unlock Page', () => {
       metamask: { isUnlocked: false, completedOnboarding: true },
     };
     const store = configureMockStore([thunk])(mockStateNonUnlocked);
-    const history = createMemoryHistory({
-      initialEntries: [
-        {
-          pathname: '/unlock',
-          state: { from: { pathname: intendedPath, search: intendedSearch } },
-        },
-      ],
+    const pathname = '/unlock';
+    // Mock navState to provide the redirect location (v5-compat way)
+    mockUseNavState.mockReturnValue({
+      from: { pathname: intendedPath, search: intendedSearch },
     });
-    jest.spyOn(history, 'push');
 
     mockTryUnlockMetamask.mockImplementationOnce(
       jest.fn(() => {
@@ -227,11 +280,48 @@ describe('Unlock Page', () => {
     const mockForceUpdateMetamaskState = jest.fn();
 
     const { queryByTestId } = renderWithProvider(
-      <Router history={history}>
-        <UnlockPage forceUpdateMetamaskState={mockForceUpdateMetamaskState} />
-      </Router>,
+      <UnlockPage forceUpdateMetamaskState={mockForceUpdateMetamaskState} />,
       store,
+      {
+        pathname,
+      },
     );
+    const passwordField = queryByTestId('unlock-password');
+    const loginButton = queryByTestId('unlock-submit');
+    fireEvent.change(passwordField, { target: { value: 'a-password' } });
+    fireEvent.click(loginButton);
+
+    await waitFor(() => {
+      expect(queryByTestId('login-error-modal')).toBeInTheDocument();
+    });
+  });
+
+  it('should show login error modal when authentication error is thrown', async () => {
+    const pathname = '/unlock';
+    const mockStateNonUnlocked = {
+      metamask: { isUnlocked: false, completedOnboarding: true },
+    };
+    const store = configureMockStore([thunk])(mockStateNonUnlocked);
+
+    mockTryUnlockMetamask.mockImplementationOnce(
+      jest.fn(() => {
+        return Promise.reject(
+          new Error(
+            SeedlessOnboardingControllerErrorMessage.AuthenticationError,
+          ),
+        );
+      }),
+    );
+    const mockForceUpdateMetamaskState = jest.fn();
+
+    const { queryByTestId } = renderWithProvider(
+      <UnlockPage forceUpdateMetamaskState={mockForceUpdateMetamaskState} />,
+      store,
+      {
+        pathname,
+      },
+    );
+
     const passwordField = queryByTestId('unlock-password');
     const loginButton = queryByTestId('unlock-submit');
     fireEvent.change(passwordField, { target: { value: 'a-password' } });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Migrate migrate unlock, deeplink, defi page and MetaMetricsContext to `react-router-dom-v5-compat`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37586?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: part of https://github.com/MetaMask/MetaMask-planning/issues/3261

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate unlock, deep link, DeFi details, reveal-seed, and lock flows to react-router-dom-v5-compat with a v5→v5-compat routing bridge; update MetaMetrics page matching and tests accordingly.
> 
> - **Router / Navigation**:
>   - Introduce `createV5CompatRoute` helper and use it across routes to pass `navigate`, `location`, `params`, and wrappers.
>   - Switch several routes to render v5-compat components (`UnlockPage`, `DeepLink`, `DeFiPage`, `RevealSeedConfirmation`, swaps/bridge variants) and wrap with `AuthenticatedV5Compat`/`InitializedV5Compat` where needed.
>   - Replace history pushes with `navigate` usage; update `ToastMaster` instantiation to accept `location`.
> - **Components migrated to v5-compat props**:
>   - `unlock-page`: accept `navigate`, read redirect from `location.state` or `navState`; container injects `navState` and uses `withRouterHooks`.
>   - `deep-link`: accept `location` prop from v5-compat.
>   - `defi-details-page`: accept `navigate` and `params`; use `Navigate` for redirects.
>   - `reveal-seed`: accept `navigate` and optional `keyringId`; replace history calls with `navigate`.
>   - `lock`: accept `navigate` and replace history with `navigate`.
> - **New / Updated HOCs & Context**:
>   - Add `InitializedV5Compat` to gate routes by onboarding completion (uses v5-compat `Navigate`).
>   - MetaMetrics: use `react-router-dom-v5-compat` `matchPath` (v6-style) with manual loop over `getPaths()` and normalize default route; update effect deps and path comparisons to `match.pattern.path`.
> - **Tests / Stories / Docs**:
>   - Update tests to `render-helpers-navigate`, v5-compat hooks (`useNavigate`, `useParams`), and new props; snapshot updates.
>   - Update Unlock README and Story to use `navigate`/`location` props.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fcd4e9d653ee34e91fd12d3b351603298f62495. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->