### PR TITLE
feat: show priority tag when shield subscription is paused

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
@@ -97,7 +97,10 @@ import {
 } from '../menu-items';
 import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
 import { useUserSubscriptions } from '../../../hooks/subscription/useSubscription';
-import { getIsShieldSubscriptionActive } from '../../../../shared/lib/shield';
+import {
+  getIsShieldSubscriptionActive,
+  getIsShieldSubscriptionPaused,
+} from '../../../../shared/lib/shield';
 import { useRewardsContext } from '../../../contexts/rewards';
 
 const METRICS_LOCATION = 'Global Menu';
@@ -127,6 +130,8 @@ export const GlobalMenu = ({
   const { subscriptions } = useUserSubscriptions();
   const isActiveShieldSubscription =
     getIsShieldSubscriptionActive(subscriptions);
+  const isPausedShieldSubscription =
+    getIsShieldSubscriptionPaused(subscriptions);
 
   const account = useSelector(getSelectedInternalAccount);
 
@@ -164,6 +169,17 @@ export const GlobalMenu = ({
   // Check if side panel is currently the default (vs popup)
   const preferences = useSelector(getPreferences);
   const isSidePanelDefault = preferences?.useSidePanelAsDefault ?? true;
+
+  const showPriorityTag = useMemo(
+    () =>
+      (isActiveShieldSubscription || isPausedShieldSubscription) &&
+      basicFunctionality,
+    [
+      isActiveShieldSubscription,
+      isPausedShieldSubscription,
+      basicFunctionality,
+    ],
+  );
 
   /**
    * Toggles between side panel and popup as the default extension behavior
@@ -469,7 +485,7 @@ export const GlobalMenu = ({
           justifyContent={JustifyContent.spaceBetween}
         >
           {supportText}
-          {isActiveShieldSubscription && basicFunctionality && (
+          {showPriorityTag && (
             <Tag
               label={t('priority')}
               labelProps={{


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Show Priority Tag on Menu > Support when shield subscription is active or paused

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37590?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show Priority Tag on Menu > Support when shield subscription is active or paused

## **Related issues** Add shield icon with animation

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays a Priority tag on Global Menu > Support when Shield subscription is active or paused, using a memoized `showPriorityTag` condition.
> 
> - **UI (Global Menu)** (`ui/components/multichain/global-menu/global-menu.tsx`):
>   - Show `Tag` with `priority` label on Support when `getIsShieldSubscriptionActive` or `getIsShieldSubscriptionPaused` and `basicFunctionality` are true.
>   - Add `getIsShieldSubscriptionPaused` import and introduce `useMemo`-based `showPriorityTag`.
>   - Replace inline condition with `showPriorityTag` for rendering the Priority tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51991c0d77ece60b8c70879cc6d2cf98b7687c08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->