### PR TITLE
feat: updated details copywriting and removed footer

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2743,7 +2743,8 @@
     "message": "form"
   },
   "freeTrialDays": {
-    "message": "$1 days free trial"
+    "message": "Free $1-day trial",
+    "description": "The $1 is the number of days"
   },
   "from": {
     "message": "From"
@@ -6089,10 +6090,6 @@
     "message": "$1/year",
     "description": "The $1 is the price of the annual plan"
   },
-  "shieldPlanAutoRenew": {
-    "message": "Auto renews for $1 until canceled",
-    "description": "The $1 is the price of the monthly plan"
-  },
   "shieldPlanBillingDate": {
     "message": "Billing date"
   },
@@ -6103,16 +6100,20 @@
     "message": "Plan details"
   },
   "shieldPlanDetails1": {
-    "message": "No charge now, try free for $1 days"
-  },
-  "shieldPlanDetails2": {
-    "message": "Pre-approve membership (default 1 year), with fees charged only on a monthly basis"
+    "message": "Free $1-day trial",
+    "description": "The $1 is the number of days"
   },
   "shieldPlanDetails2Card": {
-    "message": "Plan auto-renews at the end of the term"
+    "message": "Plan auto-renews until canceled"
+  },
+  "shieldPlanDetails2CryptoMonth": {
+    "message": "Monthly fees are pre-approved for a year, so your coverage stays active"
+  },
+  "shieldPlanDetails2CryptoYear": {
+    "message": "Fees are paid upfront for a year, so your coverage stays active"
   },
   "shieldPlanDetails3": {
-    "message": "Secures your assets from risky transactions"
+    "message": "Billed monthly, cancel anytime"
   },
   "shieldPlanMonthly": {
     "message": "Monthly"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2743,7 +2743,8 @@
     "message": "form"
   },
   "freeTrialDays": {
-    "message": "$1 days free trial"
+    "message": "Free $1-day trial",
+    "description": "The $1 is the number of days"
   },
   "from": {
     "message": "From"
@@ -6089,10 +6090,6 @@
     "message": "$1/year",
     "description": "The $1 is the price of the annual plan"
   },
-  "shieldPlanAutoRenew": {
-    "message": "Auto renews for $1 until canceled",
-    "description": "The $1 is the price of the monthly plan"
-  },
   "shieldPlanBillingDate": {
     "message": "Billing date"
   },
@@ -6103,16 +6100,20 @@
     "message": "Plan details"
   },
   "shieldPlanDetails1": {
-    "message": "No charge now, try free for $1 days"
-  },
-  "shieldPlanDetails2": {
-    "message": "Pre-approve membership (default 1 year), with fees charged only on a monthly basis"
+    "message": "Free $1-day trial",
+    "description": "The $1 is the number of days"
   },
   "shieldPlanDetails2Card": {
-    "message": "Plan auto-renews at the end of the term"
+    "message": "Plan auto-renews until canceled"
+  },
+  "shieldPlanDetails2CryptoMonth": {
+    "message": "Monthly fees are pre-approved for a year, so your coverage stays active"
+  },
+  "shieldPlanDetails2CryptoYear": {
+    "message": "Fees are paid upfront for a year, so your coverage stays active"
   },
   "shieldPlanDetails3": {
-    "message": "Secures your assets from risky transactions"
+    "message": "Billed monthly, cancel anytime"
   },
   "shieldPlanMonthly": {
     "message": "Monthly"

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -2601,7 +2601,8 @@
     "message": "foirm"
   },
   "freeTrialDays": {
-    "message": "$1 days free trial"
+    "message": "$1 days free trial",
+    "description": "The $1 is the number of days"
   },
   "from": {
     "message": "Ó"
@@ -5693,10 +5694,6 @@
     "message": "$1/bliain",
     "description": "The $1 is the price of the annual plan"
   },
-  "shieldPlanAutoRenew": {
-    "message": "Athnuachan uathoibríoch ar $1 go dtí go gcealófar é",
-    "description": "The $1 is the price of the monthly plan"
-  },
   "shieldPlanCard": {
     "message": "Cárta"
   },
@@ -5704,10 +5701,8 @@
     "message": "Sonraí an phlean"
   },
   "shieldPlanDetails1": {
-    "message": "Gan aon táille anois, bain triail as saor in aisce ar feadh $1 lá"
-  },
-  "shieldPlanDetails2": {
-    "message": "Réamhcheadú ballraíochta (1 bhliain réamhshocraithe), agus táillí á ngearradh go míosúil amháin"
+    "message": "Gan aon táille anois, bain triail as saor in aisce ar feadh $1 lá",
+    "description": "The $1 is the number of days"
   },
   "shieldPlanDetails2Card": {
     "message": "Athnuaitear an plean go huathoibríoch ag deireadh na téarma"

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -273,7 +273,6 @@ const ShieldPlan = () => {
         ) ?? [],
     [pricingPlans, t],
   );
-  const selectedPlanData = plans.find((plan) => plan.id === selectedPlan);
 
   const planDetails = useMemo(() => {
     const details = [];
@@ -285,14 +284,20 @@ const ShieldPlan = () => {
         ]),
       );
     }
-    details.push(
-      selectedPaymentMethod === PAYMENT_TYPES.byCrypto
-        ? t('shieldPlanDetails2')
-        : t('shieldPlanDetails2Card'),
-    );
-    details.push(t('shieldPlanDetails3'));
+
+    let planDetails2 = t('shieldPlanDetails2Card');
+    if (selectedPaymentMethod === PAYMENT_TYPES.byCrypto) {
+      planDetails2 =
+        selectedPlan === RECURRING_INTERVALS.year
+          ? t('shieldPlanDetails2CryptoYear')
+          : t('shieldPlanDetails2CryptoMonth');
+    }
+    details.push(planDetails2);
+    if (selectedPlan === RECURRING_INTERVALS.month) {
+      details.push(t('shieldPlanDetails3'));
+    }
     return details;
-  }, [t, selectedPaymentMethod, isTrialed, selectedProductPrice]);
+  }, [t, selectedPaymentMethod, isTrialed, selectedProductPrice, selectedPlan]);
 
   const [showPaymentModal, setShowPaymentModal] = useState(false);
 
@@ -485,7 +490,6 @@ const ShieldPlan = () => {
           <Footer
             className="shield-plan-page__footer"
             flexDirection={FlexDirection.Column}
-            gap={3}
             backgroundColor={BackgroundColor.backgroundMuted}
           >
             <Button
@@ -497,13 +501,6 @@ const ShieldPlan = () => {
             >
               {t('continue')}
             </Button>
-            <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.textAlternative}
-              textAlign={TextAlign.Center}
-            >
-              {t('shieldPlanAutoRenew', [selectedPlanData?.price])}
-            </Text>
           </Footer>
         </>
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Updated copywriting for `Shield plan` page and `Subscription confirmation` page
- Removed `Shield plan` footer note

https://www.figma.com/design/HTAO1SrmixV4ppv7qIvLoa/Metamask-Transaction-Shield?node-id=12769-126948&t=dpj6EeZul3sgHFVg-4
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37595?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Shield plan copywriting update and removed footer note

## **Related issues**

Fixes:

## **Manual testing steps**

1. Login to an account without shield subscription but has enough token for subscription
2. Go to Menu > Settings > Transaction Shield
3. You will be redirected to Shield plan page
4. Toggle Payment methods and Payment terms and observe changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
**Crypto payment monthly and yearly**
<img width="412" height="614" alt="Screenshot 2025-11-07 at 2 51 47 AM" src="https://github.com/user-attachments/assets/91485b4e-789f-482c-9a0d-0999a76fb0fc" />
<img width="414" height="614" alt="Screenshot 2025-11-07 at 2 51 36 AM" src="https://github.com/user-attachments/assets/9a7ac4e4-9f59-4212-a11a-a07bec9273ce" />


**Card payment monthly and yearly**
<img width="413" height="614" alt="Screenshot 2025-11-07 at 2 52 17 AM" src="https://github.com/user-attachments/assets/7ffc10b0-b828-4377-b511-399a2ea575f9" />
<img width="411" height="614" alt="Screenshot 2025-11-07 at 2 52 06 AM" src="https://github.com/user-attachments/assets/9fc5c95f-3932-4e80-baea-27c3959e9b1e" />


**14 days free trial**
<img width="514" height="723" alt="Screenshot 2025-11-07 at 2 53 01 AM" src="https://github.com/user-attachments/assets/2fb92c8a-d319-4c05-9049-c632c0ba06fc" />
<!-- [screenshots/recordings] -->

### **After**
**Crypto payment monthly and yearly**
<img width="411" height="612" alt="Screenshot 2025-11-07 at 2 49 26 AM" src="https://github.com/user-attachments/assets/0b485c60-bd1e-489b-99c7-bb1bfdbeb216" />
<img width="410" height="611" alt="Screenshot 2025-11-07 at 2 48 29 AM" src="https://github.com/user-attachments/assets/408a20db-60b4-44de-8bf9-1ec0e97a6480" />


**Card payment monthly and yearly**
<img width="409" height="609" alt="Screenshot 2025-11-07 at 2 49 48 AM" src="https://github.com/user-attachments/assets/b682e747-cc91-4ee3-9ae8-297159253c7e" />
<img width="409" height="611" alt="Screenshot 2025-11-07 at 2 49 38 AM" src="https://github.com/user-attachments/assets/d067aa9c-e57b-49a8-bc45-2af2e3487dc2" />


**Free 14-day trial**
<img width="514" height="723" alt="Screenshot 2025-11-07 at 2 56 09 AM" src="https://github.com/user-attachments/assets/a28c572c-2011-4974-a0cd-69b4db7e4e04" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Shield Plan copy and dynamic plan details (card/crypto, month/year), removes footer auto‑renew note, and aligns i18n strings.
> 
> - **Shield Plan UI (`ui/pages/shield-plan/shield-plan.tsx`)**:
>   - Refactors `planDetails` to show context-aware copy:
>     - Card: `shieldPlanDetails2Card`.
>     - Crypto: Uses `shieldPlanDetails2CryptoMonth` or `shieldPlanDetails2CryptoYear` based on plan; adds `shieldPlanDetails3` only for monthly.
>   - Removes footer auto-renew note under the Continue button.
>   - Cleans up unused var and updates hook deps.
> - **Localization (`app/_locales/*/messages.json`)**:
>   - Updates trial copy to `"Free $1-day trial"` with descriptions.
>   - Replaces/introduces Shield Plan detail keys: `shieldPlanDetails2Card`, new `shieldPlanDetails2CryptoMonth`/`Year`, and sets `shieldPlanDetails3` to "Billed monthly, cancel anytime".
>   - Removes deprecated `shieldPlanAutoRenew` and old `shieldPlanDetails2` (en/en_GB); aligns en/GB; minor additions in `ga`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b36097aa45b6aa39f0d15ab3ece9db4ddc3045. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->