### PR TITLE
fix: Consider client active once it is open and unlocked

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7151,7 +7151,11 @@ export default class MetamaskController extends EventEmitter {
           return !isUnlocked;
         },
         getIsActive: () => {
-          return this._isClientOpen;
+          const { isUnlocked } = this.controllerMessenger.call(
+            'KeyringController:getState',
+          );
+
+          return this._isClientOpen && isUnlocked;
         },
         getInterfaceState: (...args) =>
           this.controllerMessenger.call(

--- a/test/e2e/snaps/test-snap-clientstatus.spec.ts
+++ b/test/e2e/snaps/test-snap-clientstatus.spec.ts
@@ -45,7 +45,7 @@ describe('Test Snap Client Status', function () {
 
         // Validate the client status is accurate
         await testSnaps.checkClientStatus(
-          JSON.stringify({ locked: true, active: true }, null, 2),
+          JSON.stringify({ locked: true, active: false }, null, 2),
         );
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We recently changed it so `onActive` fires once the client has been unlocked. This PR adjusts the hook that provides the `active` flag to the same behavior.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37607?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates client activity to require both UI open and wallet unlocked, and adjusts Snap client-status E2E test expectations.
> 
> - **Snaps / Controller**:
>   - Update `getIsActive` in `app/scripts/metamask-controller.js` to return `this._isClientOpen && isUnlocked` (was only `this._isClientOpen`).
> - **Tests**:
>   - Adjust `test/e2e/snaps/test-snap-clientstatus.spec.ts` to expect `active: false` when `locked: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c0bf495606268aee655a576586f47bf6c3abdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->