### PR TITLE
fix: on paste error validation

### DIFF
--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -60,17 +60,23 @@ export default function SrpInputImport({
 
   const srpRefs = useRef<ListOfTextFieldRefs>({});
 
-  const checkForInvalidWords = useCallback(() => {
-    draftSrp.forEach((word) => {
-      const isInWordlist = wordlist.includes(word.word);
-      const alreadyInMisspelled = misSpelledWords.some((w) => w.id === word.id);
-      if (isInWordlist && alreadyInMisspelled) {
-        setMisSpelledWords((prev) => prev.filter((w) => w.id !== word.id));
-      } else if (!isInWordlist && !alreadyInMisspelled && word.word !== '') {
-        setMisSpelledWords((prev) => [...prev, word]);
-      }
-    });
-  }, [draftSrp, misSpelledWords]);
+  const checkForInvalidWords = useCallback(
+    (srp?: DraftSrp[]) => {
+      const draftSrpToCheck = srp ?? draftSrp;
+      draftSrpToCheck.forEach((word) => {
+        const isInWordlist = wordlist.includes(word.word);
+        const alreadyInMisspelled = misSpelledWords.some(
+          (w) => w.id === word.id,
+        );
+        if (isInWordlist && alreadyInMisspelled) {
+          setMisSpelledWords((prev) => prev.filter((w) => w.id !== word.id));
+        } else if (!isInWordlist && !alreadyInMisspelled && word.word !== '') {
+          setMisSpelledWords((prev) => [...prev, word]);
+        }
+      });
+    },
+    [draftSrp, misSpelledWords],
+  );
 
   const initializeSrp = () => {
     const firstWordId = uuidv4();
@@ -109,6 +115,7 @@ export default function SrpInputImport({
       });
     }
 
+    checkForInvalidWords(newDraftSrp);
     setDraftSrp(newDraftSrp);
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, it immediately validates the pasted SRP by invoking it on paste.

Jira Link: https://consensyssoftware.atlassian.net/browse/SL-279

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37611?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: validate seedphrase when user paste the data.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/e371ccb1-2573-4334-b7e4-a50ef93f1147



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Immediately validates pasted SRP words by refactoring the invalid-word checker to accept an SRP list and invoking it on paste.
> 
> - **SRP Import (`ui/components/app/srp-input-import/srp-input-import.tsx`)**:
>   - Refactor `checkForInvalidWords` to accept an optional `srp` array, defaulting to current `draftSrp`.
>   - Invoke `checkForInvalidWords(newDraftSrp)` during paste handling to flag invalid words immediately after parsing input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b6ee4e5a8e70b6fc3ce2e5439c000c7475d2e2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->