### PR TITLE
feat: Add deep link redirect for /predict route

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2007,6 +2007,9 @@
   "deepLink_thePerpsPage": {
     "message": "the perps page"
   },
+  "deepLink_thePredictPage": {
+    "message": "the predict page"
+  },
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2007,6 +2007,9 @@
   "deepLink_thePerpsPage": {
     "message": "the perps page"
   },
+  "deepLink_thePredictPage": {
+    "message": "the predict page"
+  },
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"
   },

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -4,6 +4,7 @@ import notifications from './notifications';
 import swap from './swap';
 import nonevm from './nonevm';
 import perps from './perps';
+import predict from './predict';
 import rewards from './rewards';
 
 import type { Route } from './route';
@@ -38,5 +39,6 @@ addRoute(notifications);
 addRoute(swap);
 addRoute(nonevm);
 addRoute(perps);
+addRoute(predict);
 addRoute(rewards);
 addRoute(shield);

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -1,0 +1,15 @@
+import { BaseUrl } from '../../../constants/urls';
+import { Route } from './route';
+
+export default new Route({
+  pathname: '/predict',
+  getTitle: (_: URLSearchParams) => 'deepLink_thePredictPage',
+  handler: function handler(params: URLSearchParams) {
+    const predictUrl = new URL('/predict', BaseUrl.MetaMask);
+    params.forEach((value, key) => predictUrl.searchParams.append(key, value));
+    return {
+      redirectTo: predictUrl,
+    };
+  },
+});
+

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -12,4 +12,3 @@ export default new Route({
     };
   },
 });
-

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -257,6 +257,36 @@ and we'll take you to the right place.`
     );
   });
 
+  it('handles /predict route redirect', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = `https://link.metamask.io/predict`;
+        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl);
+
+        // test signed flow
+        await driver.openNewURL(signedUrl);
+
+        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/predict` });
+
+        await driver.navigate();
+        await homePage.checkPageIsLoaded();
+
+        // test unsigned flow
+        await driver.openNewURL(rawUrl);
+
+        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/predict` });
+      },
+    );
+  });
+
   it('handles /rewards route redirect', async function () {
     await withFixtures(
       await getConfig(this.test?.fullTitle()),


### PR DESCRIPTION
## **Description**

This PR adds a deep link handler for the Predict page, enabling redirection from `https://link.metamask.io/predict` to `https://metamask.io/predict` with query parameter preservation.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37622?quickstart=1)

## **Changelog**

CHANGELOG entry: Add Predict deeplink handler

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to `https://link.metamask.io/predict`
2. Should be routed to `https://metamask.io/predict`
3. Test with query parameters: `https://link.metamask.io/predict?param=value`
4. Verify parameters are preserved in the redirect

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/31f480eb-ee37-4149-a0bd-19581332e5ee

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds deep link support for `/predict`, redirecting to `metamask.io/predict` with query params preserved, plus i18n strings and e2e tests.
> 
> - **Deep Links**:
>   - Add new route `shared/lib/deep-links/routes/predict.ts` that redirects `/predict` to `BaseUrl.MetaMask/predict`, preserving query params.
>   - Register route in `shared/lib/deep-links/routes/index.ts` via `addRoute(predict)`.
> - **Localization**:
>   - Add `deepLink_thePredictPage` message key to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Extend `test/e2e/tests/deep-link/deep-link.spec.ts` with a case verifying signed/unsigned `/predict` redirects to `${BaseUrl.MetaMask}/predict`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57a885d50db3c4fb2b8b2aa0d1783367d7c44225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->