### PR TITLE
chore: use preferred avatar in SiteCellTooltip

### DIFF
--- a/ui/components/app/preferred-avatar/preferred-avatar.tsx
+++ b/ui/components/app/preferred-avatar/preferred-avatar.tsx
@@ -24,7 +24,9 @@ const avatarTypeMap = {
   blockies: AvatarAccountVariant.Blockies,
 };
 
-function getAvatarType({ metamask: { preferences } }: MetaMaskReduxState) {
+export function getAvatarType({
+  metamask: { preferences },
+}: MetaMaskReduxState) {
   const avatarType = preferences?.avatarType;
   return avatarType ? avatarTypeMap[avatarType] : undefined;
 }

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-tippy';
-import { useSelector } from 'react-redux';
-import {
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
-} from '@metamask/design-system-react';
+import { AvatarAccountSize } from '@metamask/design-system-react';
 import {
   AlignItems,
   BackgroundColor,
@@ -25,18 +20,14 @@ import {
   Box,
   Text,
 } from '../../../../component-library';
-import { getUseBlockie } from '../../../../../selectors';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../../shared/constants/network';
+import { PreferredAvatar } from '../../../../app/preferred-avatar';
 
 export const SiteCellTooltip = ({ accounts, networks }) => {
   const t = useI18nContext();
   const AVATAR_GROUP_LIMIT = 4;
   const TOOLTIP_LIMIT = 4;
-  const useBlockie = useSelector(getUseBlockie);
-  const avatarAccountVariant = useBlockie
-    ? AvatarAccountVariant.Blockies
-    : AvatarAccountVariant.Jazzicon;
 
   const avatarAccountsData = accounts?.map((account) => ({
     avatarValue: account.address,
@@ -69,11 +60,9 @@ export const SiteCellTooltip = ({ accounts, networks }) => {
                   paddingInline={2}
                   gap={2}
                 >
-                  <AvatarAccount
-                    size={AvatarAccountSize.Xs}
+                  <PreferredAvatar
                     address={acc.address}
-                    variant={avatarAccountVariant}
-                    borderStyle={BorderStyle.none}
+                    size={AvatarAccountSize.Xs}
                   />
                   <Text
                     color={TextColor.overlayInverse}

--- a/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
+++ b/ui/components/multichain/pages/review-permissions-page/site-cell/site-cell-tooltip.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-tippy';
-import { AvatarAccountSize } from '@metamask/design-system-react';
+import { useSelector } from 'react-redux';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+} from '@metamask/design-system-react';
 import {
   AlignItems,
   BackgroundColor,
@@ -22,12 +26,13 @@ import {
 } from '../../../../component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../../shared/constants/network';
-import { PreferredAvatar } from '../../../../app/preferred-avatar';
+import { getAvatarType } from '../../../../app/preferred-avatar/preferred-avatar';
 
 export const SiteCellTooltip = ({ accounts, networks }) => {
   const t = useI18nContext();
   const AVATAR_GROUP_LIMIT = 4;
   const TOOLTIP_LIMIT = 4;
+  const avatarAccountVariant = useSelector(getAvatarType);
 
   const avatarAccountsData = accounts?.map((account) => ({
     avatarValue: account.address,
@@ -60,9 +65,11 @@ export const SiteCellTooltip = ({ accounts, networks }) => {
                   paddingInline={2}
                   gap={2}
                 >
-                  <PreferredAvatar
-                    address={acc.address}
+                  <AvatarAccount
                     size={AvatarAccountSize.Xs}
+                    address={acc.address}
+                    variant={avatarAccountVariant}
+                    borderStyle={BorderStyle.none}
                   />
                   <Text
                     color={TextColor.overlayInverse}


### PR DESCRIPTION
## **Description**

Replace the useBlockie usage with the user's preferred avatar variant

Prerequisite to removing the useBlockie global state

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37634?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: use preferred avatar in site tooltip

## **Related issues**

Fixes:

## **Manual testing steps**
0. Disable multichain. 
1. Connect to dApp
2. Menu > All permissions
3. Click on connected site

Since multichain is the default now, this is an unlikely scenario and more more of a cleanup PR

## **Screenshots/Recordings**

(AvatarGroup will be fixed seperately)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="236" height="251" alt="Screenshot 2025-11-10 at 7 36 20 PM" src="https://github.com/user-attachments/assets/06a4318d-9e83-4bdb-bbae-68f2558198c3" />


<!-- [screenshots/recordings] -->

### **After**

<img width="238" height="232" alt="Screenshot 2025-11-10 at 7 40 17 PM" src="https://github.com/user-attachments/assets/f87d5617-9040-44ae-a422-e54a6e128f04" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> SiteCellTooltip now derives AvatarAccount variant from user preferences via getAvatarType, and getAvatarType is exported from PreferredAvatar.
> 
> - **UI**:
>   - **`ui/components/multichain/.../site-cell-tooltip.js`**:
>     - Use `useSelector(getAvatarType)` to set `AvatarAccount` `variant`, replacing `getUseBlockie` and inline `AvatarAccountVariant` logic.
>   - **`ui/components/app/preferred-avatar/preferred-avatar.tsx`**:
>     - Export `getAvatarType` selector mapping `preferences.avatarType` to `AvatarAccountVariant`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b900aa733d62d9ca3b21cdceb1b3d7910f459f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->