### PR TITLE
chore: Improve Mock Segment Server to Print Event Properties

### DIFF
--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -40,16 +40,26 @@ function onRequest(_request, response, events) {
       properties &&
       typeof properties === 'object' &&
       Object.keys(properties).length > 0;
-    if (!hasProperties) {
-      return;
-    }
     const label = getTypeLabel(event);
     const nameOrId = getNameOrId(event);
-    console.log(`${prefix}: ${label} event received: ${nameOrId}`);
-    try {
-      console.log(JSON.stringify(properties, null, 2));
-    } catch (_) {
-      console.log(String(properties));
+    if (hasProperties) {
+      try {
+        console.log(
+          `${prefix}: ${label} event received: ${nameOrId}\n${JSON.stringify(
+            properties,
+            null,
+            2,
+          )}`,
+        );
+      } catch (_) {
+        console.log(
+          `${prefix}: ${label} event received: ${nameOrId}\n${String(
+            properties,
+          )}`,
+        );
+      }
+    } else {
+      console.log(`${prefix}: ${label} event received: ${nameOrId}`);
     }
   });
 

--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -6,19 +6,36 @@ const DEFAULT_PORT = 9090;
 const prefix = '[mock-segment]';
 
 function onRequest(_request, response, events) {
-  const getDescription = (e) => {
+  const getTypeLabel = (e) => {
+    switch (e.type) {
+      case 'track':
+        return 'Track';
+      case 'page':
+        return 'Page';
+      case 'identify':
+        return 'Identify';
+      default:
+        return 'Unknown';
+    }
+  };
+  const getNameOrId = (e) => {
     switch (e.type) {
       case 'track':
         return e.event || '(no name)';
       case 'page':
         return e.name || '(no name)';
+      case 'identify':
+        return e.userId || e.anonymousId || '(no id)';
       default:
         return `[Unrecognized event type: ${e.type}]`;
     }
   };
 
   events.forEach((event) => {
-    const properties = event && event.properties ? event.properties : undefined;
+    const properties =
+      event && (event.properties || event.traits)
+        ? event.properties || event.traits
+        : undefined;
     const hasProperties =
       properties &&
       typeof properties === 'object' &&
@@ -26,8 +43,9 @@ function onRequest(_request, response, events) {
     if (!hasProperties) {
       return;
     }
-    const name = getDescription(event);
-    console.log(`${prefix}: ${name}`);
+    const label = getTypeLabel(event);
+    const nameOrId = getNameOrId(event);
+    console.log(`${prefix}: ${label} event received: ${nameOrId}`);
     try {
       console.log(JSON.stringify(properties, null, 2));
     } catch (_) {

--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -33,9 +33,9 @@ function onRequest(_request, response, events) {
 
   events.forEach((event) => {
     const properties =
-      event && (event.properties || event.traits)
-        ? event.properties || event.traits
-        : undefined;
+      event && event.type === 'identify'
+        ? event.traits
+        : event && event.properties;
     const hasProperties =
       properties &&
       typeof properties === 'object' &&
@@ -43,21 +43,13 @@ function onRequest(_request, response, events) {
     const label = getTypeLabel(event);
     const nameOrId = getNameOrId(event);
     if (hasProperties) {
-      try {
-        console.log(
-          `${prefix}: ${label} event received: ${nameOrId}\n${JSON.stringify(
-            properties,
-            null,
-            2,
-          )}`,
-        );
-      } catch (_) {
-        console.log(
-          `${prefix}: ${label} event received: ${nameOrId}\n${String(
-            properties,
-          )}`,
-        );
-      }
+      console.log(
+        `${prefix}: ${label} event received: ${nameOrId}\n${JSON.stringify(
+          properties,
+          null,
+          2,
+        )}`,
+      );
     } else {
       console.log(`${prefix}: ${label} event received: ${nameOrId}`);
     }


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- Properties within segment events are just as important as the events themselves these days. Properties are used to deduplicate events with more details and are often more difficult to test than the mere event.
- Printing the properties by default will make event testing much easier to debug. 
- This server also did not support logging Identify events which are fired when updating the user properties, logging these make it easier to debug when these properties are updated.
3. What is the improvement/solution?
- Pretty print event properties that are fired with the events.
- This is a developer facing change and will have no impact on users.
- Add support for event type === identify

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37635?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**
- checkout this branch
- follow these exact steps: https://github.com/MetaMask/metamask-extension/blob/main/development/README.md#segment
- Notice that there are now properties being logged with each event.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

// Identify event (not supported)
```
[mock-segment]: Events received: [Unrecognized event type: identify]
[mock-segment]: POST /v1/batch
```

```
[mock-segment]: Events received: Account Menu Opened
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: Account List Page
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: Import Secret Recovery Phrase Page
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: Home
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: DeFi Stats
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: [Unrecognized event type: identify]
...

[mock-segment]: Events received: [Unrecognized event type: identify]
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: Port Stream Chunked
[mock-segment]: POST /v1/batch
[mock-segment]: Events received: Import Secret Recovery Phrase Completed
```

### **After**


// Identify event

```
[mock-segment]: Identify event received: 0x51c51cdfc644de86d3df8f612e349787cfd279e485ba472bc59c6a50d18b11f0
{
  "address_book_entries": 12,
  "number_of_accounts": 36,
  "petname_addresses_count": 12
}
```

// Importing a new wallet
```
[mock-segment]: Track event received: Account Menu Opened
{
  "location": "Home",
  "category": "Navigation",
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "popup"
}
[mock-segment]: Page event received: Account List Page
{
  "params": {},
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "popup"
}
[mock-segment]: Page event received: Import Secret Recovery Phrase Page
{
  "params": {},
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "popup"
}
[mock-segment]: Page event received: Home
{
  "params": {},
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "popup"
}
[mock-segment]: Identify event received: 0x51c51cdfc644de86d3df8f612e349787cfd279e485ba472bc59c6a50d18b11f0
{
  "address_book_entries": 2,
  "number_of_accounts": 4,
  "number_of_hd_entropies": 2,
  "petname_addresses_count": 2
}
[mock-segment]: Track event received: DeFi Stats
{
  "totalMarketValueUSD": 0,
  "totalPositions": 0,
  "breakdown": [],
  "category": "DeFi",
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "background"
}
[mock-segment]: Track event received: Profile Activity Updated
{
  "event": {
    "feature_name": "Multichain Account Syncing",
    "action": "group_added",
    "profile_id": "4796375c-f5f1-4868-a761-6ff84eab8bad"
  },
  "category": "Backup And Sync",
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "background"
}

.....

[mock-segment]: Track event received: Import Secret Recovery Phrase Completed
{
  "hd_entropy_index": 1,
  "number_of_solana_accounts_discovered": 0,
  "number_of_bitcoin_accounts_discovered": 0,
  "locale": "en",
  "chain_id": "0xaa36a7",
  "environment_type": "background"
}
```

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `development/mock-segment.js` to log each Segment event with type, name/id, and pretty-printed properties, adding support for `identify` events.
> 
> - **Mock Segment Server (`development/mock-segment.js`)**:
>   - Logs each event individually with type labels (`Track`, `Page`, `Identify`) and name/id.
>   - Pretty-prints event data: uses `event.properties` for non-identify and `event.traits` for `identify`.
>   - Adds support for `identify` events and handles unknown types gracefully.
>   - Simplifies output by removing request URL/method and aggregate "Events received" summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d10612fdece7cea4b221c3732555c493e2d692. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->