### PR TITLE
fix: removed unused error calls from sentry cp-13.9.0

### DIFF
--- a/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch
+++ b/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch
@@ -1,0 +1,54 @@
+diff --git a/rive.js b/rive.js
+index 03eeff276d0495d77ce0c4715160db4b80a5fc87..79d6a4b12d62a12a4005e2d7f6f9249ce2ddeb55 100644
+--- a/rive.js
++++ b/rive.js
+@@ -5418,7 +5418,7 @@ var RiveFile = /** @class */ (function () {
+                             });
+                         }
+                         else {
+-                            this.fireLoadError(RiveFile.fileLoadErrorMessage);
++                            // this.fireLoadError(RiveFile.fileLoadErrorMessage);
+                         }
+                         return [2 /*return*/];
+                 }
+@@ -5433,7 +5433,8 @@ var RiveFile = /** @class */ (function () {
+                     case 0:
+                         // If no source file url specified, it's a bust
+                         if (!this.src && !this.buffer) {
+-                            this.fireLoadError(RiveFile.missingErrorMessage);
++                            // this.fireLoadError(RiveFile.missingErrorMessage);
++                            console.warn(RiveFile.missingErrorMessage);
+                             return [2 /*return*/];
+                         }
+                         _b.label = 1;
+@@ -5452,7 +5453,8 @@ var RiveFile = /** @class */ (function () {
+                         return [3 /*break*/, 5];
+                     case 4:
+                         error_1 = _b.sent();
+-                        this.fireLoadError(error_1 instanceof Error ? error_1.message : RiveFile.fileLoadErrorMessage);
++                        // this.fireLoadError(error_1 instanceof Error ? error_1.message : RiveFile.fileLoadErrorMessage);
++                        console.warn(error_1 instanceof Error ? error_1.message : RiveFile.fileLoadErrorMessage);
+                         return [3 /*break*/, 5];
+                     case 5: return [2 /*return*/];
+                 }
+@@ -5464,7 +5466,8 @@ var RiveFile = /** @class */ (function () {
+             type: EventType.LoadError,
+             data: message,
+         });
+-        throw new Error(message);
++        // throw new Error(message);
++        console.warn(message);
+     };
+     /**
+      * Subscribe to Rive-generated events
+@@ -5692,7 +5695,9 @@ var Rive = /** @class */ (function () {
+         this.riveFile = riveFile;
+         // If no source file url specified, it's a bust
+         if (!this.src && !this.buffer && !this.riveFile) {
+-            throw new RiveError(Rive.missingErrorMessage);
++            // throw new RiveError(Rive.missingErrorMessage);
++            console.warn(Rive.missingErrorMessage);
++            return;
+         }
+         // List of animations that should be initialized.
+         var startingAnimationNames = mapToStringArray(animations);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4665,7 +4665,6 @@ export default class MetamaskController extends EventEmitter {
 
       return mnemonic;
     } catch (error) {
-      log.error('Error restoring social backup and getting seed phrase', error);
       if (error instanceof RecoveryError) {
         throw new JsonRpcError(-32603, error.message, error.data);
       }

--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     "@endo/env-options@npm:^1.1.7": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
-    "@rive-app/canvas@npm:2.31.5": "patch:@rive-app/canvas@patch%3A@rive-app/canvas@npm%253A2.31.5%23~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%3A%3Aversion=2.31.5&hash=1ed092#~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch"
+    "@rive-app/canvas@npm:2.31.5": "patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -639,7 +639,6 @@ export function restoreSocialBackupAndGetSeedPhrase(
       await forceUpdateMetamaskState(dispatch);
       return mnemonic;
     } catch (error) {
-      log.error('[restoreSocialBackupAndGetSeedPhrase] error', error);
       dispatch(displayWarning(error.message));
       throw error;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10267,10 +10267,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@npm%253A2.31.5%23~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%3A%3Aversion=2.31.5&hash=1ed092#~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch":
+"@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@npm%253A2.31.5%23~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%3A%3Aversion=2.31.5&hash=1ed092#~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch::version=2.31.5&hash=19c5d0":
   version: 2.31.5
   resolution: "@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@npm%253A2.31.5%23~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%3A%3Aversion=2.31.5&hash=1ed092#~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch::version=2.31.5&hash=19c5d0"
   checksum: 10/f8d4243fa29146bfa7958adf2284fd9a3d88a11c2f99a49b439da40d71ac710ad9a9737aeea628eff397889ec2256b4dd8fa547aa39ebc4f548eabcc488df60f
+  languageName: node
+  linkType: hard
+
+"@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch":
+  version: 2.31.5
+  resolution: "@rive-app/canvas@patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch::version=2.31.5&hash=410688"
+  checksum: 10/96e2414409aae7b87bbd06bbd643a8daa13c9a20444e0ca336328ba2a85aade5cad351076b1fb843d61627d1e2d7d7ee9cf943d1b198d800119024e3735d83dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, Downgrades Rive file load errors to warnings and removes redundant error logging in social backup restore, adding a new @rive-app/canvas patch reference.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37649?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades Rive file load errors to warnings and removes redundant error logging in social backup restore, adding a new @rive-app/canvas patch reference.
> 
> - **Animations (@rive-app/canvas patch)**:
>   - Suppress hard failures in `rive.js` by commenting out `fireLoadError`/`throw` paths and using `console.warn`; add early return when missing source.
> - **Error Logging**:
>   - Remove `log.error` lines in `restoreSocialBackupAndGetSeedPhrase` (background and UI) to reduce noisy reports.
> - **Dependencies**:
>   - Add new yarn patch `@rive-app-canvas-patch-03752f0c3b.patch` and update `package.json`/`yarn.lock` to chain patches for `@rive-app/canvas@2.31.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f9a476f995509096c073cde3c45750c420768d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->