### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
@@ -48,6 +48,32 @@ describe('GasFeeTokenListItem', () => {
     expect(result.getByText('Bal: $2,345.00 USD')).toBeInTheDocument();
   });
 
+  it('renders fallback when fiat balance is unavailable', () => {
+    const storeWithoutFiat = configureStore(
+      getMockConfirmStateForTransaction(
+        genUnapprovedContractInteractionConfirmation({
+          address: FROM_MOCK,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        }),
+        {
+          metamask: {
+            preferences: {
+              showFiatInTestnets: false,
+            },
+          },
+        },
+      ),
+    );
+
+    const result = renderWithConfirmContextProvider(
+      <GasFeeTokenListItem tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,
+      storeWithoutFiat,
+    );
+
+    expect(result.getByText('Bal: --')).toBeInTheDocument();
+  });
+
   it('renders token amount', () => {
     const result = renderWithConfirmContextProvider(
       <GasFeeTokenListItem tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
@@ -65,9 +65,13 @@ export function GasFeeTokenListItem({
       }
       isSelected={isSelected}
       leftPrimary={symbol}
-      leftSecondary={`${t(
-        'confirmGasFeeTokenBalance',
-      )} ${balanceFiat} ${currentCurrency.toUpperCase()}`}
+      leftSecondary={
+        balanceFiat
+          ? `${t(
+              'confirmGasFeeTokenBalance',
+            )} ${balanceFiat} ${currentCurrency.toUpperCase()}`
+          : `${t('confirmGasFeeTokenBalance')} --`
+      }
       rightPrimary={amountFiat}
       rightSecondary={`${amountFormatted} ${symbol}`}
       warning={warning && <WarningIndicator text={warning} />}


### PR DESCRIPTION
Fixes gas token fiat balance displaying "undefined USD" when conversion is unavailable.

Previously, the `useEthFiatAmount` hook could return `undefined`, leading to "Bal: undefined USD" in the gas token selection modal. This PR adds a null check to display "Bal: --" instead, improving the user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-41f076fb-807b-42a6-a53b-95dc0951a25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41f076fb-807b-42a6-a53b-95dc0951a25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

