### PR TITLE
fix: show different message when cancelling paused subscriptions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6156,6 +6156,10 @@
     "message": "If you cancel, your wallet and transactions will not be covered starting $1.",
     "description": "The $1 is the date subscription ends"
   },
+  "shieldTxCancelWhenPausedDetails": {
+    "message": "Your coverage isn't active while paused. If you cancel, your membership will end on $1.",
+    "description": "The $1 is the date subscription ends"
+  },
   "shieldTxDetails1Description": {
     "message": "Secures your assets from risky transactions"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6156,6 +6156,10 @@
     "message": "If you cancel, your wallet and transactions will not be covered starting $1.",
     "description": "The $1 is the date subscription ends"
   },
+  "shieldTxCancelWhenPausedDetails": {
+    "message": "Your coverage isn't active while paused. If you cancel, your membership will end on $1.",
+    "description": "The $1 is the date subscription ends"
+  },
   "shieldTxDetails1Description": {
     "message": "Secures your assets from risky transactions"
   },

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5738,7 +5738,11 @@
     "message": "Sciath Idirbhirt"
   },
   "shieldTxCancelDetails": {
-    "message": "Mura gcealaíonn tú, ní bheidh do sparán ná d’idirbhearta clúdaithe ag tosú le $1.",
+    "message": "Mura gcealaíonn tú, ní bheidh do sparán ná d'idirbhearta clúdaithe ag tosú le $1.",
+    "description": "The $1 is the date subscription ends"
+  },
+  "shieldTxCancelWhenPausedDetails": {
+    "message": "Níl do chlúdach gníomhach agus é ar sos. Má chealaíonn tú, cuirfear deireadh le do bhallraíocht ar $1.",
     "description": "The $1 is the date subscription ends"
   },
   "shieldTxDetails1Description": {

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5738,7 +5738,7 @@
     "message": "Sciath Idirbhirt"
   },
   "shieldTxCancelDetails": {
-    "message": "Mura gcealaíonn tú, ní bheidh do sparán ná d'idirbhearta clúdaithe ag tosú le $1.",
+    "message": "Mura gcealaíonn tú, ní bheidh do sparán ná d’idirbhearta clúdaithe ag tosú le $1.",
     "description": "The $1 is the date subscription ends"
   },
   "shieldTxDetails1Description": {

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5741,10 +5741,6 @@
     "message": "Mura gcealaíonn tú, ní bheidh do sparán ná d'idirbhearta clúdaithe ag tosú le $1.",
     "description": "The $1 is the date subscription ends"
   },
-  "shieldTxCancelWhenPausedDetails": {
-    "message": "Níl do chlúdach gníomhach agus é ar sos. Má chealaíonn tú, cuirfear deireadh le do bhallraíocht ar $1.",
-    "description": "The $1 is the date subscription ends"
-  },
   "shieldTxDetails1Description": {
     "message": "Cosnaíonn sé do shócmhainní ó idirbhearta contúirteacha"
   },

--- a/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.tsx
+++ b/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getShortDateFormatterV2 } from '../../asset/util';
-import { PausedSubscriptionStatuses } from '../../../../shared/constants/subscriptions';
+import { getIsShieldSubscriptionPaused } from '../../../../shared/lib/shield';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -29,7 +29,7 @@ export default function CancelMembershipModal({
   subscription: Subscription;
 }) {
   const t = useI18nContext();
-  const isPaused = PausedSubscriptionStatuses.includes(subscription.status);
+  const isPaused = getIsShieldSubscriptionPaused(subscription);
   const messageKey = isPaused
     ? 'shieldTxCancelWhenPausedDetails'
     : 'shieldTxCancelDetails';

--- a/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.tsx
+++ b/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getShortDateFormatterV2 } from '../../asset/util';
+import { PausedSubscriptionStatuses } from '../../../../shared/constants/subscriptions';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -28,6 +29,10 @@ export default function CancelMembershipModal({
   subscription: Subscription;
 }) {
   const t = useI18nContext();
+  const isPaused = PausedSubscriptionStatuses.includes(subscription.status);
+  const messageKey = isPaused
+    ? 'shieldTxCancelWhenPausedDetails'
+    : 'shieldTxCancelDetails';
 
   return (
     <Modal
@@ -41,7 +46,7 @@ export default function CancelMembershipModal({
         <ModalHeader onClose={onClose}>{t('areYouSure')}</ModalHeader>
         <ModalBody>
           <Text variant={TextVariant.bodyMd}>
-            {t('shieldTxCancelDetails', [
+            {t(messageKey, [
               <Text
                 key="cancel-date"
                 variant={TextVariant.bodyMdMedium}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
When membership paused but users click cancel, we should use a different message to inform users

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37655?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SUBS-684

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="776" height="249" alt="image" src="https://github.com/user-attachments/assets/2761a9b0-5bb0-4e14-9c93-606066c81c1e" />


<!-- [screenshots/recordings] -->

### **After**
<img width="650" height="334" alt="image" src="https://github.com/user-attachments/assets/73cf7b07-4dad-4416-a0f3-c46b087de408" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cancel membership modal now shows different text when a Transaction Shield subscription is paused; adds new i18n key.
> 
> - **UI (Transaction Shield)**:
>   - `cancel-membership-modal.tsx`: Use `getIsShieldSubscriptionPaused(subscription)` to select `shieldTxCancelWhenPausedDetails` vs `shieldTxCancelDetails`; update translation call accordingly.
> - **Localization**:
>   - Add `shieldTxCancelWhenPausedDetails` to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9424937bf795589c965902302efa3b987124b523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->