### PR TITLE
fix: fixed User Login Cancelled Error for firefox cp-13.9.0

### DIFF
--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -1,6 +1,9 @@
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import log from 'loglevel';
-import { OAuthErrorMessages } from '../../../../shared/modules/error';
+import {
+  isUserCancelledLoginError,
+  OAuthErrorMessages,
+} from '../../../../shared/modules/error';
 import { checkForLastError } from '../../../../shared/modules/browser-runtime.utils';
 import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { BaseLoginHandler } from './base-login-handler';
@@ -204,12 +207,13 @@ export default class OAuthService {
                   reject(error);
                 }
               } else {
-                if (this.#isUserCancelledLoginError()) {
-                  reject(
-                    new Error(OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR),
-                  );
+                const userCancelledLoginError =
+                  this.#getUserCancelledLoginError();
+                if (userCancelledLoginError) {
+                  reject(userCancelledLoginError);
                   return;
                 }
+                // Throw default error for no redirect URL found
                 reject(
                   new Error(OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR),
                 );
@@ -357,9 +361,12 @@ export default class OAuthService {
     return url.searchParams.get('code');
   }
 
-  #isUserCancelledLoginError(): boolean {
+  #getUserCancelledLoginError(): Error | undefined {
     const error = checkForLastError();
-    return error?.message === OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR;
+    if (isUserCancelledLoginError(error)) {
+      return error;
+    }
+    return undefined;
   }
 
   async setMarketingConsent(

--- a/shared/modules/error.ts
+++ b/shared/modules/error.ts
@@ -39,6 +39,9 @@ export enum OAuthErrorMessages {
   USER_CANCELLED_LOGIN_ERROR = 'The user did not approve access.',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
+  USER_CANCELLED_LOGIN_ERROR_FIREFOX = 'User cancelled or denied access.',
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   NO_REDIRECT_URL_FOUND_ERROR = 'No redirect URL found',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -46,4 +49,18 @@ export enum OAuthErrorMessages {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   INVALID_OAUTH_STATE_ERROR = 'Invalid OAuth state',
+}
+
+/**
+ * Checks if the Web Authentication error is a user cancelled error.
+ *
+ * @param error - The error to check.
+ * @returns True if the error is a user cancelled login error, false otherwise.
+ */
+export function isUserCancelledLoginError(error: Error | undefined): boolean {
+  // NOTE: Firefox and chrome have different error messages for user cancelled the social login window.
+  return (
+    error?.message === OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR ||
+    error?.message === OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR_FIREFOX
+  );
 }

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import log from 'loglevel';
 import { Box } from '../../../components/component-library';
 import {
   ONBOARDING_COMPLETION_ROUTE,
@@ -41,7 +40,10 @@ import {
 import { getIsSeedlessOnboardingFeatureEnabled } from '../../../../shared/modules/environment';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
-import { OAuthErrorMessages } from '../../../../shared/modules/error';
+import {
+  isUserCancelledLoginError,
+  OAuthErrorMessages,
+} from '../../../../shared/modules/error';
 import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import {
   AlignItems,
@@ -214,7 +216,7 @@ export default function OnboardingWelcome() {
         error instanceof Error ? error.message : 'Unknown error';
 
       // Map raw OAuth error messages to UI modal-friendly constants
-      if (errorMessage === OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR) {
+      if (isUserCancelledLoginError(error)) {
         setLoginError(null);
         return;
       }
@@ -354,9 +356,7 @@ export default function OnboardingWelcome() {
   );
 
   const handleLoginError = useCallback((error) => {
-    log.error('handleLoginError::error', error);
-    const errorMessage = error.message;
-    if (errorMessage === OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR) {
+    if (isUserCancelledLoginError(error)) {
       setLoginError(null);
     } else {
       setLoginError(LOGIN_ERROR.GENERIC);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37658?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37645

## **Manual testing steps**

1. In firefox, start new onboarding with social login.
2. Before completing the social login, close the window.
3. User should not see Login Error modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-browser detection of user-cancelled OAuth login (including Firefox) and updates flows to treat it as a non-error.
> 
> - **Shared Errors**:
>   - Add `OAuthErrorMessages.USER_CANCELLED_LOGIN_ERROR_FIREFOX`.
>   - Introduce `isUserCancelledLoginError(error)` helper for cross-browser detection.
> - **OAuth Service (`app/scripts/services/oauth/oauth-service.ts`)**:
>   - Replace `#isUserCancelledLoginError()` with `#getUserCancelledLoginError()` returning the actual `Error` when cancel is detected via `checkForLastError()` and `isUserCancelledLoginError`.
>   - When no `responseUrl`, reject with user-cancelled error if present; otherwise default to `OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR`.
> - **Onboarding UI (`ui/pages/onboarding-flow/welcome/welcome.js`)**:
>   - Use `isUserCancelledLoginError` in login error handlers to suppress UI errors when the user cancels.
>   - Map remaining OAuth errors to existing UI error states as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3ff02661b18eacb79e8cc89fe1af67274b33372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->