### PR TITLE
fix: season state api error results in couldn't load when no cached data

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5542,6 +5542,10 @@
     "message": "$1 points",
     "description": "$1 is the formatted number of rewards points"
   },
+  "rewardsPointsBalance_couldntLoad": {
+    "message": "Couldn't load",
+    "description": "Text shown when points balance couldn't be loaded"
+  },
   "rewardsPointsIcon": {
     "message": "Rewards Points",
     "description": "Alt text for the rewards points icon"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5542,6 +5542,10 @@
     "message": "$1 points",
     "description": "$1 is the formatted number of rewards points"
   },
+  "rewardsPointsBalance_couldntLoad": {
+    "message": "Couldn't load",
+    "description": "Text shown when points balance couldn't be loaded"
+  },
   "rewardsPointsIcon": {
     "message": "Rewards Points",
     "description": "Alt text for the rewards points icon"

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -20,6 +20,9 @@ jest.mock('../../../hooks/useI18nContext', () => ({
     if (key === 'rewardsPointsIcon') {
       return 'Rewards Points Icon';
     }
+    if (key === 'rewardsPointsBalance_couldntLoad') {
+      return "Couldn't load";
+    }
     return key;
   }),
 }));
@@ -367,5 +370,57 @@ describe('RewardsPointsBalance', () => {
       'bg-background-muted',
       'rounded',
     );
+  });
+
+  it('should render error state when seasonStatusError exists and no balance', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: null,
+      seasonStatusError: 'Failed to fetch season status',
+      seasonStatusLoading: false,
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const container = screen.getByTestId('rewards-points-balance');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass('gap-1', 'bg-background-transparent');
+    expect(
+      screen.getByTestId('rewards-points-balance-value'),
+    ).toHaveTextContent("Couldn't load");
+  });
+
+  it('should render error state with correct props when seasonStatusError exists', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: null,
+      seasonStatusError: 'Network error',
+      seasonStatusLoading: false,
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const container = screen.getByTestId('rewards-points-balance');
+    const textElement = screen.getByTestId('rewards-points-balance-value');
+
+    expect(container).toHaveClass('gap-1', 'bg-background-transparent');
+    expect(textElement).toHaveClass('text-alternative');
+    expect(textElement).toHaveTextContent("Couldn't load");
+  });
+
+  it('should not render error state when loading', () => {
+    mockUseRewardsContext.mockReturnValue({
+      ...mockRewardsContextValue,
+      seasonStatus: null,
+      seasonStatusError: 'Error occurred',
+      seasonStatusLoading: true,
+    });
+
+    render(<RewardsPointsBalance />);
+
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('rewards-points-balance'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { useRewardsContext } from '../../../contexts/rewards';
 import { Skeleton } from '../../component-library/skeleton';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { RewardsBadge } from './RewardsBadge';
 
 /**
@@ -12,11 +13,12 @@ import { RewardsBadge } from './RewardsBadge';
  */
 export const RewardsPointsBalance = () => {
   const locale = useSelector(getIntlLocale);
-
+  const t = useI18nContext();
   const {
     rewardsEnabled,
     seasonStatus,
     seasonStatusLoading,
+    seasonStatusError,
     candidateSubscriptionId,
     refetchSeasonStatus,
   } = useRewardsContext();
@@ -33,6 +35,18 @@ export const RewardsPointsBalance = () => {
 
   if (seasonStatusLoading && !seasonStatus?.balance) {
     return <Skeleton width="100px" />;
+  }
+
+  if (seasonStatusError && !seasonStatus?.balance) {
+    return (
+      <RewardsBadge
+        formattedPoints={t('rewardsPointsBalance_couldntLoad')}
+        withPointsSuffix={false}
+        boxClassName="gap-1 bg-background-transparent"
+        textClassName="text-alternative"
+        useAlternativeIconColor
+      />
+    );
   }
 
   // Format the points balance with proper locale-aware number formatting


### PR DESCRIPTION
## **Description**

This PR makes it so that when:

- if we've determined that a user has opted in rewards
- if we can't determine the season status because of an API error
- there's no cached season status state

we show a distinct state for this edge case instead of showing 0 points.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-772

## **Screenshots/Recordings**

### **After**

<img width="247" height="75" alt="image" src="https://github.com/user-attachments/assets/3d3ab2bc-888f-4282-bf90-a510861c3e80" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display a "Couldn't load" error state for Rewards points when season status fetch errors and no balance is available; adds i18n strings and tests.
> 
> - **Rewards UI**:
>   - Update `ui/components/app/rewards/RewardsPointsBalance.tsx` to render an error badge ("Couldn't load") when `seasonStatusError` exists and no `seasonStatus.balance`.
>   - Integrate `useI18nContext` and adjust styles (`bg-background-transparent`, `text-alternative`, alternative icon color) for the error state.
> - **Localization**:
>   - Add `rewardsPointsBalance_couldntLoad` to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Expand `RewardsPointsBalance.test.tsx` with cases for error vs loading states and mock the new i18n key; verify classes and rendered text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93914fcdb90c78868f0b0177bac0e38cf4e8983d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->