### PR TITLE
chore: add network_filter property to account overview tab metric events

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { AccountOverviewTabKey } from '../../../../shared/constants/app-state';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { AccountOverviewTabs } from './account-overview-tabs';
+
+jest.mock('../../app/assets/asset-list', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../../app/transaction-list', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('AccountOverviewTabs - event metrics', () => {
+  const mockTrackEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes network_filter property with enabled networks in CAIP format', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        enabledNetworkMap: {
+          'eip155': {
+            [CHAIN_IDS.MAINNET]: true,
+            [CHAIN_IDS.POLYGON]: true,
+          },
+        },
+      },
+    });
+
+    const { getByText } = renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <AccountOverviewTabs
+          onTabClick={jest.fn()}
+          defaultHomeActiveTabName={AccountOverviewTabKey.Activity}
+          showTokens={true}
+          showNfts={false}
+          showActivity={true}
+          setBasicFunctionalityModalOpen={jest.fn()}
+          onSupportLinkClick={jest.fn()}
+        />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+
+    // Click a tab to trigger event
+    fireEvent.click(getByText('Tokens'));
+
+    // Verify network_filter property is included in correct format
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          network_filter: expect.arrayContaining(['eip155:1', 'eip155:137']),
+        }),
+      }),
+    );
+  });
+});

--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -4,32 +4,43 @@ import mockState from '../../../../test/data/mock-state.json';
 import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import { MetaMetricsEventCategory, MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { AccountOverviewTabKey } from '../../../../shared/constants/app-state';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { AccountOverviewTabs } from './account-overview-tabs';
 
 jest.mock('../../app/assets/asset-list', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: () => null,
 }));
 
 jest.mock('../../app/transaction-list', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: () => null,
 }));
 
 jest.mock('../../app/assets/nfts/nfts-tab', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: () => null,
 }));
 
-jest.mock('../../app/transaction-list/unified-transaction-list.component', () => ({
-  __esModule: true,
-  default: () => null,
-}));
+jest.mock(
+  '../../app/transaction-list/unified-transaction-list.component',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => null,
+  }),
+);
 
 jest.mock('../../app/assets/defi-list/defi-tab', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: () => null,
 }));
@@ -80,7 +91,12 @@ describe('AccountOverviewTabs - event metrics', () => {
       category: MetaMetricsEventCategory.Home,
       event: MetaMetricsEventName.TokenScreenOpened,
       properties: {
-        network_filter: ['eip155:1', 'eip155:137', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        network_filter: [
+          'eip155:1',
+          'eip155:137',
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ],
       },
     });
   });

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -84,9 +84,10 @@ export const AccountOverviewTabs = ({
             ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP[
               tabName as keyof typeof ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP
             ],
-            properties: {
-              network_filter: networkFilterForMetrics,
-            },
+          properties: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            network_filter: networkFilterForMetrics,
+          },
         });
       }
       if (defaultHomeActiveTabName) {

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Hex, isStrictHexString } from '@metamask/utils';
@@ -58,8 +58,12 @@ export const AccountOverviewTabs = ({
   const allEnabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
 
   // Convert enabled networks to CAIP format for metrics
-  const networkFilterForMetrics = allEnabledNetworks.map((chainId) =>
-    isStrictHexString(chainId) ? toEvmCaipChainId(chainId) : chainId,
+  const networkFilterForMetrics = useMemo(
+    () =>
+      allEnabledNetworks.map((chainId) =>
+        isStrictHexString(chainId) ? toEvmCaipChainId(chainId) : chainId,
+      ),
+    [allEnabledNetworks],
   );
 
   // EVM specific tokenBalance polling, updates state via polling loop per chainId

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { Hex } from '@metamask/utils';
+import { Hex, isStrictHexString } from '@metamask/utils';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import {
   ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP,
   ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP,
@@ -14,9 +15,10 @@ import { ASSET_ROUTE, DEFI_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useSafeChains } from '../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import {
-  getChainIdsToPoll,
+  getEnabledChainIds,
   getIsMultichainAccountsState2Enabled,
 } from '../../../selectors';
+import { getAllEnabledNetworksForAllNamespaces } from '../../../selectors/multichain/networks';
 import { detectNfts } from '../../../store/actions';
 import AssetList from '../../app/assets/asset-list';
 import DeFiTab from '../../app/assets/defi-list/defi-tab';
@@ -50,7 +52,15 @@ export const AccountOverviewTabs = ({
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
   const dispatch = useDispatch();
-  const selectedChainIds = useSelector(getChainIdsToPoll);
+  const selectedChainIds = useSelector(getEnabledChainIds);
+
+  // Get all enabled networks (what the user has actually selected)
+  const allEnabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
+
+  // Convert enabled networks to CAIP format for metrics
+  const networkFilterForMetrics = allEnabledNetworks.map((chainId) =>
+    isStrictHexString(chainId) ? toEvmCaipChainId(chainId) : chainId,
+  );
 
   // EVM specific tokenBalance polling, updates state via polling loop per chainId
   useTokenBalances({
@@ -70,6 +80,9 @@ export const AccountOverviewTabs = ({
             ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP[
               tabName as keyof typeof ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP
             ],
+            properties: {
+              network_filter: networkFilterForMetrics,
+            },
         });
       }
       if (defaultHomeActiveTabName) {
@@ -83,7 +96,7 @@ export const AccountOverviewTabs = ({
         name: ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP[tabName],
       });
     },
-    [onTabClick],
+    [networkFilterForMetrics, onTabClick],
   );
 
   const onClickAsset = useCallback(


### PR DESCRIPTION
## **Description**

This PR adds a `network_filter` property to tab click analytics events in the Account Overview component. This enables tracking which networks users have enabled when they interact with different tabs (Tokens, NFTs, Activity, DeFi).

**What is the reason for the change?**
We need better visibility into user behavior across different network configurations to understand how multi-chain support is being used.

**What is the improvement/solution?**
- Added `network_filter` property to all tab click events
- The property contains an array of enabled networks in CAIP format (e.g., `['eip155:1', 'eip155:137']`)
- Works across both EVM and non-EVM networks
- Uses `getAllEnabledNetworksForAllNamespaces` to get all enabled networks regardless of type

## **Changelog**

CHANGELOG entry: null 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-579

## **Manual testing steps**

1. Open MetaMask extension
2. Click on different tabs (Tokens, NFTs, Activity)
3. Check analytics events (these come up as "batch" in the Networks tab) to verify `network_filter` property is included with correct CAIP-formatted chain IDs
4. Select single networks as well as "All popular networks" and repeat

## **Screenshots/Recordings**

N/A - This is a metrics-only change with no user-visible UI changes

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CAIP-formatted enabled networks as network_filter to AccountOverview tab click metrics and adds a test covering EVM and Solana.
> 
> - **AccountOverviewTabs (`ui/components/multichain/account-overview/account-overview-tabs.tsx`)**:
>   - Add `properties.network_filter` to tab click metric events using enabled networks across namespaces.
>   - Derive enabled networks via `getAllEnabledNetworksForAllNamespaces`; convert EVM hex IDs to CAIP with `toEvmCaipChainId` and `isStrictHexString` (memoized).
>   - Replace `getChainIdsToPoll` with `getEnabledChainIds` for token balance polling; update callback deps.
> - **Tests (`ui/components/multichain/account-overview/account-overview-tabs.test.tsx`)**:
>   - Add test asserting `network_filter` includes CAIP IDs for both EVM (`eip155:1`, `eip155:137`) and Solana.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a4222c4270992d5180264540b3f10cf75d29db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->