### PR TITLE
feat: order swap networks using chainRanking feature flag

### DIFF
--- a/test/data/bridge/mock-bridge-store.ts
+++ b/test/data/bridge/mock-bridge-store.ts
@@ -407,6 +407,14 @@ export const createBridgeMockStore = ({
             refreshRate: 5000,
             maxRefreshCount: 5,
             ...featureFlagOverrides?.bridgeConfig,
+            chainRanking: [
+              { chainId: formatChainIdToCaip('0x1') },
+              ...Object.keys(
+                featureFlagOverrides?.bridgeConfig?.chains ?? [],
+              ).map((chainId) => ({
+                chainId: formatChainIdToCaip(chainId),
+              })),
+            ],
             chains: {
               [formatChainIdToCaip('0x1')]: {
                 isActiveSrc: true,
@@ -421,6 +429,7 @@ export const createBridgeMockStore = ({
                 ]),
               ),
             },
+            ...featureFlagOverrides?.bridgeConfig,
           },
         },
       },

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -369,15 +369,13 @@ async function mockFeatureFlags(
   mockServer: Mockttp,
   featureFlags: Partial<FeatureFlagResponse>,
 ) {
-  await mockServer
-    .forGet('https://client-config.api.cx.metamask.io/v1/flags')
-    .thenCallback(() => {
-      return {
-        ok: true,
-        statusCode: 200,
-        json: [{ bridgeConfig: featureFlags }],
-      };
-    });
+  await mockServer.forGet(/flags/u).thenCallback(() => {
+    return {
+      ok: true,
+      statusCode: 200,
+      json: [{ bridgeConfig: featureFlags }],
+    };
+  });
 }
 
 async function mockSwapETHtoMUSD(mockServer: Mockttp) {

--- a/test/e2e/tests/bridge/constants.ts
+++ b/test/e2e/tests/bridge/constants.ts
@@ -1,4 +1,8 @@
-import { type FeatureFlagResponse } from '@metamask/bridge-controller';
+import {
+  ChainId,
+  formatChainIdToCaip,
+  type FeatureFlagResponse,
+} from '@metamask/bridge-controller';
 
 export const SSE_RESPONSE_HEADER = { 'Content-Type': 'text/event-stream' };
 
@@ -13,24 +17,27 @@ export const DEFAULT_BRIDGE_FEATURE_FLAGS: FeatureFlagResponse & {
     '1': {
       isActiveSrc: true,
       isActiveDest: true,
-      isSingleSwapBridgeButtonEnabled: true,
     },
     '42161': {
       isActiveSrc: true,
       isActiveDest: true,
-      isSingleSwapBridgeButtonEnabled: true,
     },
     '59144': {
       isActiveSrc: true,
       isActiveDest: true,
-      isSingleSwapBridgeButtonEnabled: true,
     },
     '8453': {
       isActiveSrc: true,
       isActiveDest: true,
-      isSingleSwapBridgeButtonEnabled: true,
     },
   },
+  // @ts-expect-error chainRanking is not a valid property in the FeatureFlagResponse type yet
+  chainRanking: [
+    { chainId: formatChainIdToCaip(ChainId.ETH) },
+    { chainId: formatChainIdToCaip(ChainId.ARBITRUM) },
+    { chainId: formatChainIdToCaip(ChainId.LINEA) },
+    { chainId: formatChainIdToCaip(ChainId.BASE) },
+  ],
 };
 
 export const BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED: FeatureFlagResponse & {

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -106,12 +106,13 @@ const bridgeSlice = createSlice({
     setFromToken: (state, { payload }: TokenPayload) => {
       state.fromToken = toBridgeToken(payload);
       state.fromTokenBalance = null;
+      state.fromTokenInputValue = null;
       // Unset toToken if it's the same as the fromToken
       if (
         state.fromToken?.assetId &&
         state.toToken?.assetId &&
-        state.fromToken.assetId?.toLowerCase() ===
-          state.toToken.assetId?.toLowerCase()
+        state.fromToken.assetId.toLowerCase() ===
+          state.toToken.assetId.toLowerCase()
       ) {
         state.toToken = null;
       }

--- a/ui/hooks/bridge/__snapshots__/useBridgeQueryParams.test.ts.snap
+++ b/ui/hooks/bridge/__snapshots__/useBridgeQueryParams.test.ts.snap
@@ -158,7 +158,7 @@ exports[`useBridgeQueryParams should set src token after navigating from ERC20 a
     "name": "USDC",
     "symbol": "USDC",
   },
-  "fromTokenInputValue": undefined,
+  "fromTokenInputValue": null,
   "toChainId": null,
   "toToken": undefined,
 }

--- a/ui/hooks/bridge/useBridgeQueryParams.test.ts
+++ b/ui/hooks/bridge/useBridgeQueryParams.test.ts
@@ -135,16 +135,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.SOLANA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
-            },
-          },
+          ],
         },
       },
       metamaskStateOverrides: {
@@ -196,16 +191,16 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.SOLANA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(
+                ChainId.SOLANA,
+              ),
             },
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
     });
@@ -253,12 +248,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
       metamaskStateOverrides: {
@@ -306,12 +300,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
       metamaskStateOverrides: {
@@ -345,7 +338,7 @@ describe('useBridgeQueryParams', () => {
     expect(calcLatestSrcBalanceSpy.mock.calls).toMatchSnapshot();
   });
 
-  it('should not set inputs when there are no query params', async () => {
+  it.only('should not set inputs when there are no query params', async () => {
     const fetchAssetMetadataForAssetIdsSpy = jest.spyOn(
       assetUtils,
       'fetchAssetMetadataForAssetIds',
@@ -391,12 +384,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
       metamaskStateOverrides: {
@@ -446,12 +438,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
       metamaskStateOverrides: {
@@ -494,12 +485,11 @@ describe('useBridgeQueryParams', () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [ChainId.LINEA]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: bridgeControllerUtils.formatChainIdToCaip(ChainId.LINEA),
             },
-          },
+          ],
         },
       },
     });

--- a/ui/hooks/bridge/useBridging.test.ts
+++ b/ui/hooks/bridge/useBridging.test.ts
@@ -1,5 +1,8 @@
 import { toChecksumAddress } from 'ethereumjs-util';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import {
+  formatChainIdToCaip,
+  getNativeAssetForChainId,
+} from '@metamask/bridge-controller';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { MetaMetricsSwapsEventSource } from '../../../shared/constants/metametrics';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
@@ -77,9 +80,9 @@ describe('useBridging', () => {
         false,
       ],
       [
-        '/cross-chain/swaps/prepare-swap-page?from=eip155:1/slip44:60',
+        '/cross-chain/swaps/prepare-swap-page?',
         {
-          ...getNativeAssetForChainId(CHAIN_IDS.MAINNET),
+          ...getNativeAssetForChainId(CHAIN_IDS.SEI),
           chainId: 243,
         },
         MetaMetricsSwapsEventSource.TokenView,
@@ -131,12 +134,9 @@ describe('useBridging', () => {
                 refreshRate: 5000,
                 minimumVersion: '0.0.0',
                 maxRefreshCount: 5,
-                chains: {
-                  '1': {
-                    isActiveSrc: true,
-                    isActiveDest: false,
-                  },
-                },
+                chainRanking: [
+                  { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+                ],
               },
             },
             enabledNetworkMap: {
@@ -203,6 +203,9 @@ describe('useBridging', () => {
       ) => {
         const openTabSpy = jest.spyOn(global.platform, 'openTab');
         jest
+          .spyOn(bridgeSelectors, 'getLastSelectedChainId')
+          .mockReturnValueOnce(CHAIN_IDS.MAINNET);
+        jest
           .spyOn(bridgeSelectors, 'getFromChains')
           .mockReturnValueOnce([
             { chainId: CHAIN_IDS.MAINNET } as unknown as NetworkConfiguration,
@@ -226,16 +229,10 @@ describe('useBridging', () => {
                 refreshRate: 5000,
                 minimumVersion: '0.0.0',
                 maxRefreshCount: 5,
-                chains: {
-                  '1': {
-                    isActiveSrc: true,
-                    isActiveDest: true,
-                  },
-                  '10': {
-                    isActiveSrc: true,
-                    isActiveDest: true,
-                  },
-                },
+                chainRanking: [
+                  { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+                  { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+                ],
               },
             },
             enabledNetworkMap: {

--- a/ui/hooks/bridge/useTokenAlerts.test.ts
+++ b/ui/hooks/bridge/useTokenAlerts.test.ts
@@ -3,6 +3,7 @@ import { renderHookWithProvider } from '../../../test/lib/render-helpers';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { createBridgeMockStore } from '../../../test/data/bridge/mock-bridge-store';
+import { toAssetId } from '../../../shared/lib/asset-utils';
 import { useTokenAlerts } from './useTokenAlerts';
 
 const renderUseSolanaAlerts = (mockStoreState: object) =>
@@ -28,37 +29,37 @@ jest.mock(
   }),
 );
 
-// For now we have to mock toChain Solana, remove once it is truly implemented
-const mockGetToChain = { chainId: MultichainNetworks.SOLANA };
-jest.mock('../../ducks/bridge/selectors', () => ({
-  ...jest.requireActual('../../ducks/bridge/selectors'),
-  getToChain: () => mockGetToChain,
-}));
-
 describe('useTokenAlerts', () => {
   it('should set token alert when toChain is Solana', async () => {
     const mockStoreState = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [formatChainIdToCaip(ChainId.SOLANA)]: {
-              isActiveSrc: true,
-              isActiveDest: true,
+          chainRanking: [
+            {
+              chainId: formatChainIdToCaip(ChainId.SOLANA),
             },
-          },
+            {
+              chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET),
+            },
+          ],
         },
       },
       bridgeSliceOverrides: {
         fromToken: {
           address: '0x3fa807b6f8d4c407e6e605368f4372d14658b38c',
           chainId: CHAIN_IDS.MAINNET,
-        },
-        fromChain: {
-          chainId: CHAIN_IDS.MAINNET,
+          assetId: toAssetId(
+            '0x3fa807b6f8d4c407e6e605368f4372d14658b38c',
+            'eip155:1',
+          ),
         },
         toToken: {
           address: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
           chainId: MultichainNetworks.SOLANA,
+          assetId: toAssetId(
+            '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
+            MultichainNetworks.SOLANA,
+          ),
         },
         toChainId: MultichainNetworks.SOLANA,
       },

--- a/ui/pages/bridge/index.test.tsx
+++ b/ui/pages/bridge/index.test.tsx
@@ -90,12 +90,6 @@ describe('Bridge', () => {
           support: true,
           refreshRate: 5000,
           maxRefreshCount: 5,
-          chains: {
-            '1': {
-              isActiveSrc: true,
-              isActiveDest: false,
-            },
-          },
         },
       },
       metamaskStateOverrides: {

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -18,10 +18,10 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+          ],
         },
       },
       bridgeSliceOverrides: { fromTokenInputValue: '1' },
@@ -40,14 +40,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {
@@ -69,14 +66,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {
@@ -102,14 +96,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {
@@ -135,14 +126,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {
@@ -170,20 +158,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: {
-              isActiveSrc: true,
-              isActiveDest: false,
-            },
-            [CHAIN_IDS.OPTIMISM]: {
-              isActiveSrc: true,
-              isActiveDest: false,
-            },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {
@@ -228,20 +207,11 @@ describe('BridgeCTAButton', () => {
       const mockStore = createBridgeMockStore({
         featureFlagOverrides: {
           bridgeConfig: {
-            chains: {
-              [CHAIN_IDS.MAINNET]: {
-                isActiveSrc: true,
-                isActiveDest: false,
-              },
-              [CHAIN_IDS.OPTIMISM]: {
-                isActiveSrc: true,
-                isActiveDest: false,
-              },
-              [CHAIN_IDS.LINEA_MAINNET]: {
-                isActiveSrc: false,
-                isActiveDest: true,
-              },
-            },
+            chainRanking: [
+              { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+              { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+              { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+            ],
           },
         },
         bridgeSliceOverrides: {
@@ -283,20 +253,11 @@ describe('BridgeCTAButton', () => {
     const mockStore = createBridgeMockStore({
       featureFlagOverrides: {
         bridgeConfig: {
-          chains: {
-            [CHAIN_IDS.MAINNET]: {
-              isActiveSrc: true,
-              isActiveDest: false,
-            },
-            [CHAIN_IDS.OPTIMISM]: {
-              isActiveSrc: true,
-              isActiveDest: false,
-            },
-            [CHAIN_IDS.LINEA_MAINNET]: {
-              isActiveSrc: false,
-              isActiveDest: true,
-            },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
         },
       },
       bridgeSliceOverrides: {

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.test.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.test.tsx
@@ -4,6 +4,7 @@ import {
   QuoteResponse,
   RequestStatus,
   formatChainIdToCaip,
+  getNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import { zeroAddress } from 'ethereumjs-util';
 import { renderWithProvider } from '../../../../test/jest';
@@ -46,15 +47,23 @@ describe('MultichainBridgeQuoteCard', () => {
         bridgeConfig: {
           maxRefreshCount: 5,
           refreshRate: 30000,
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
-            [CHAIN_IDS.POLYGON]: { isActiveSrc: true, isActiveDest: true },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.POLYGON) },
+          ],
         },
       },
       bridgeSliceOverrides: {
         fromTokenInputValue: 1,
+        toToken: {
+          address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+          chainId: formatChainIdToCaip(CHAIN_IDS.POLYGON),
+          assetId: toAssetId(
+            '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+            formatChainIdToCaip(CHAIN_IDS.POLYGON),
+          ),
+        },
         toChainId: formatChainIdToCaip(CHAIN_IDS.POLYGON),
       },
       bridgeStateOverrides: {
@@ -123,15 +132,23 @@ describe('MultichainBridgeQuoteCard', () => {
         bridgeConfig: {
           maxRefreshCount: 5,
           refreshRate: 30000,
-          chains: {
-            [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: false },
-            [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
-            [CHAIN_IDS.POLYGON]: { isActiveSrc: true, isActiveDest: true },
-          },
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.POLYGON) },
+          ],
         },
       },
       bridgeSliceOverrides: {
         fromTokenInputValue: 1,
+        toToken: {
+          address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+          chainId: formatChainIdToCaip(CHAIN_IDS.POLYGON),
+          assetId: toAssetId(
+            '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+            formatChainIdToCaip(CHAIN_IDS.POLYGON),
+          ),
+        },
         toChainId: formatChainIdToCaip(CHAIN_IDS.POLYGON),
       },
       bridgeStateOverrides: {
@@ -224,6 +241,7 @@ describe('MultichainBridgeQuoteCard', () => {
       },
       bridgeSliceOverrides: {
         fromTokenInputValue: 1,
+        toToken: getNativeAssetForChainId(CHAIN_IDS.POLYGON),
         toChainId: formatChainIdToCaip(CHAIN_IDS.POLYGON),
         slippage: 1,
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Uses the `chainRanking` feature flag to sort swap and bridge networks

```
type ChainRanking = {
  chainId: caipChainId,
}[]
```

See BugBot section below for more details


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37679?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: sort bridge networks using chainRanking feature flag

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3232

## **Manual testing steps**

1. No user-facing changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use chainRanking feature flag to deterministically order bridge networks and update selectors, actions, UI, and tests accordingly, plus stricter asset utils and new network image mapping.
> 
> - **Bridge feature flags & selection (core/selectors):**
>   - Use `bridgeConfig.chainRanking` to sort `fromChains`/`toChains`; return ordered CAIP-keyed maps in `getAllBridgeableNetworks`.
>   - Default `getFromChain` to first ranked chain; `getToChain` honors user selection or source (swap) and Bitcoin BIP44 defaults.
>   - Add `getChainRanking` plumbing; remove prior enabled/active filtering logic in favor of ranking.
> - **Redux actions/state:**
>   - Add `setEvmBalances(chainId, tokenAddress?)` to fetch EVM token/native balances; refactor `setFromChain` to accept `chainId` (CAIP/hex/num), select native token by default.
>   - `setFromToken` now clears `fromTokenInputValue`; balance traces simplified.
> - **UI:**
>   - Bridge inputs and switch button logic updated to validate `toChain` against ranked/available `fromChains`.
>   - Asset picker button shows network avatar via new `BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP`.
>   - Query param handling simplified; balances fetched via `setEvmBalances`.
> - **Shared libs & constants:**
>   - `toAssetId` now throws on invalid inputs; `getAssetImageUrl` error handling tightened.
>   - Add `BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP` and expose `ALLOWED_BRIDGE_CHAIN_IDS_IN_CAIP`.
> - **Tests & mocks:**
>   - Broad test updates to assert ranking-driven ordering and behavior; SSE/flags mock generalized; snapshots updated; slippage tests include `assetId`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20ef93016e84fe3b87b2c670e33eabf37989b7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->