### PR TITLE
ci: allow faster test iteration by using previous builds

### DIFF
--- a/.github/scripts/identify-builds-from-run.sh
+++ b/.github/scripts/identify-builds-from-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# If the string `[builds-from-run: <run-id>]` is contained in the last commit message
+if [[ "$(git log -1 --pretty=%B)" =~ \[builds-from-run:[[:space:]]*([0-9]+)\] ]]; then
+  # Extract the <run-id> value from the commit message
+  builds_from_run="${BASH_REMATCH[1]}"
+  echo "Found builds-from-run directive in commit message: $builds_from_run"
+  echo "builds-from-run=$builds_from_run" >> "$GITHUB_OUTPUT"
+else
+  echo "No builds-from-run directive found in commit message."
+  # Default to the current run ID
+  echo "builds-from-run=${RUN_ID}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         env:
           SEMVER: ${{ inputs.semver-version }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           .github/scripts/resolve-previous-ref.sh
 

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -5,6 +5,11 @@ name: E2E Chrome
 
 on:
   workflow_call:
+    inputs:
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
     secrets:
       PR_COMMENT_TOKEN:
         required: true
@@ -26,6 +31,7 @@ jobs:
       build-artifact: build-test-browserify
       build-command: yarn build:test
       test-command: yarn test:e2e:chrome
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
@@ -44,6 +50,7 @@ jobs:
       build-artifact: build-test-webpack
       build-command: yarn build:test:webpack
       test-command: yarn test:e2e:chrome
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
@@ -54,6 +61,7 @@ jobs:
       build-artifact: build-test-browserify
       build-command: yarn build:test
       test-command: yarn test:e2e:chrome:multi-provider
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-chrome-rpc:
     uses: ./.github/workflows/run-e2e.yml
@@ -62,6 +70,7 @@ jobs:
       build-artifact: build-test-browserify
       build-command: yarn build:test
       test-command: yarn test:e2e:chrome:rpc
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-chrome-flask:
     uses: ./.github/workflows/run-e2e.yml
@@ -74,6 +83,7 @@ jobs:
       build-artifact: build-test-flask-browserify
       build-command: yarn build:test:flask
       test-command: yarn test:e2e:chrome:flask
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
@@ -85,6 +95,7 @@ jobs:
       test-suite-name: test-e2e-chrome-vault-decryption
       build-artifact: build-dist-browserify
       test-command: yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.ts --browser chrome
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-chrome-api-specs:
     uses: ./.github/workflows/run-e2e.yml
@@ -94,6 +105,7 @@ jobs:
       build-command: yarn build:test
       test-command: yarn test:api-specs
       test-artifacts-path: html-report
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-chrome-api-specs-alert-on-failure:
     needs:
@@ -135,6 +147,7 @@ jobs:
       build-command: yarn build:test:flask
       test-command: yarn test:api-specs-multichain
       test-artifacts-path: html-report-multichain
+      builds-from-run: ${{ inputs.builds-from-run }}
 
   test-e2e-chrome-api-specs-multichain-alert-on-failure:
     needs:

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -5,6 +5,11 @@ name: E2E Firefox
 
 on:
   workflow_call:
+    inputs:
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
     secrets:
       INFURA_PROJECT_ID:
         required: false
@@ -24,6 +29,7 @@ jobs:
       build-artifact: build-test-mv2-browserify
       build-command: yarn build:test:mv2
       test-command: yarn test:e2e:firefox
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
@@ -42,6 +48,7 @@ jobs:
       build-artifact: build-test-webpack
       build-command: yarn build:test:webpack
       test-command: yarn test:e2e:firefox
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 
@@ -56,6 +63,7 @@ jobs:
       build-artifact: build-test-flask-mv2-browserify
       build-command: yarn build:test:flask:mv2
       test-command: yarn test:e2e:firefox:flask
+      builds-from-run: ${{ inputs.builds-from-run }}
       matrix-index: ${{ matrix.index }}
       matrix-total: ${{ strategy.job-total }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
       - stable
       - release/*
-      - trigger-ci*
+      - trigger-ci-*
   pull_request:
     types:
       - opened
@@ -32,12 +32,34 @@ env:
   # For a `pull_request` event, the fork is `github.event.pull_request.head.repo.fork`.
   # For a `push` event, the fork is `github.event.repository.fork`.
   IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
+  # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
+  # For a `push` event, the head commit hash is `github.sha`.
+  HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
 
 permissions:
   contents: write # required for releases
   id-token: write # required for s3 uploads
 
 jobs:
+  identify-builds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      builds-from-run: ${{ steps.identify-builds.outputs.builds-from-run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # Specifying `ref` ensures that the head commit is checked out directly.
+          ref: ${{ env.HEAD_COMMIT_HASH }}
+
+      - name: 'Look for `[builds-from-run: <run>]` in the last commit message'
+        id: identify-builds
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: .github/scripts/identify-builds-from-run.sh
+
   prep-deps:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -100,91 +122,124 @@ jobs:
     uses: ./.github/workflows/validate-lavamoat-policies.yml
 
   build-dist-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-dist-browserify
       build-command: ${{ (github.head_ref || github.ref_name) == 'stable' && 'yarn build prod' || 'yarn build dist' }}
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-dist-mv2-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-dist-mv2-browserify
       build-command: ${{ (github.head_ref || github.ref_name) == 'stable' && 'yarn build prod' || 'yarn build dist' }}
       mozilla-lint: true
       enable-mv3: false
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-beta-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-beta-browserify
       build-command: yarn build --build-type beta dist
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-beta-mv2-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-beta-mv2-browserify
       build-command: yarn build --build-type beta dist
       mozilla-lint: false # Disabled as it is failing for some reason
       enable-mv3: false
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-flask-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-flask-browserify
       build-command: ${{ (github.head_ref || github.ref_name) == 'stable' && 'yarn build --build-type flask prod' || 'yarn build --build-type flask dist' }}
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-flask-mv2-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-flask-mv2-browserify
       build-command: ${{ (github.head_ref || github.ref_name) == 'stable' && 'yarn build --build-type flask prod' || 'yarn build --build-type flask dist' }}
       mozilla-lint: true
       enable-mv3: false
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-test-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-test-browserify
       build-command: yarn build:test
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-test-mv2-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-test-mv2-browserify
       build-command: yarn build:test:mv2
       mozilla-lint: false # Disabled as it is failing for some reason
       enable-mv3: false
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-test-flask-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-test-flask-browserify
       build-command: yarn build:test:flask
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-test-flask-mv2-browserify:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-test-flask-mv2-browserify
       build-command: yarn build:test:flask:mv2
       mozilla-lint: false # Disabled as it is failing for some reason
       enable-mv3: false
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   build-test-webpack:
+    needs:
+      - identify-builds
     uses: ./.github/workflows/run-build.yml
     with:
       build-name: build-test-webpack
       build-command: yarn build:test:webpack
       validate-source-maps: false # Disabled as webpack outputs are not supported by validate-source-maps
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets: inherit
 
   run-benchmarks:
@@ -192,9 +247,12 @@ jobs:
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-benchmarks.yml
     needs:
+      - identify-builds
       - prep-deps
       - build-test-browserify
       - build-test-webpack
+    with:
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
@@ -206,6 +264,7 @@ jobs:
 
   bundle-size:
     needs:
+      - identify-builds
       - build-dist-browserify
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -224,6 +283,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-dist-browserify
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ needs.identify-builds.outputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       - name: Measure bundle size
         run: yarn tsx test/e2e/mv3-perf-stats/bundle-size.ts --out test-artifacts/chrome
@@ -243,6 +304,7 @@ jobs:
 
   page-load-benchmark:
     needs:
+      - identify-builds
       - build-test-browserify
     uses: ./.github/workflows/page-load-benchmark.yml
     secrets:
@@ -250,6 +312,7 @@ jobs:
     with:
       browser-loads: 10
       page-loads: 10
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
 
   needs-e2e:
     needs:
@@ -258,6 +321,7 @@ jobs:
 
   e2e-chrome:
     needs:
+      - identify-builds
       - needs-e2e
       - build-test-browserify
       - build-test-webpack
@@ -265,18 +329,23 @@ jobs:
       - build-test-flask-browserify
     if: ${{ needs.needs-e2e.outputs.needs-e2e == 'true' }}
     uses: ./.github/workflows/e2e-chrome.yml
+    with:
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
   e2e-firefox:
     needs:
+      - identify-builds
       - needs-e2e
       - build-test-mv2-browserify
       - build-test-webpack
       - build-test-flask-mv2-browserify
     if: ${{ needs.needs-e2e.outputs.needs-e2e == 'true' }}
     uses: ./.github/workflows/e2e-firefox.yml
+    with:
+      builds-from-run: ${{ needs.identify-builds.outputs.builds-from-run }}
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
@@ -294,6 +363,7 @@ jobs:
 
   build-source-map-explorer:
     needs:
+      - identify-builds
       - prep-deps
       - build-dist-browserify
     runs-on: ubuntu-latest
@@ -310,6 +380,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-dist-browserify
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ needs.identify-builds.outputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       - run: ./development/source-map-explorer.sh
 
@@ -324,6 +396,7 @@ jobs:
 
   build-lavamoat-viz:
     needs:
+      - identify-builds
       - prep-deps
       - build-dist-browserify
     runs-on: ubuntu-latest
@@ -384,6 +457,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-dist-browserify
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ needs.identify-builds.outputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       - run: ./.github/scripts/create-lavamoat-viz.sh
         if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' }}
@@ -401,6 +476,7 @@ jobs:
     name: Publish prerelease
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     needs:
+      - identify-builds
       - build-dist-browserify
       - build-dist-mv2-browserify
       - build-beta-browserify
@@ -421,6 +497,7 @@ jobs:
     uses: ./.github/workflows/publish-prerelease.yml
     with:
       lavamoat-policy-changed: ${{ needs.build-lavamoat-viz.outputs.lavamoat-policy-changed == 'true' }}
+      post-new-builds: ${{ needs.identify-builds.outputs.builds-from-run == github.run_id }}
     secrets:
       PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
 
@@ -483,6 +560,7 @@ jobs:
       - needs-e2e
       - e2e-chrome
       - e2e-firefox
+      - identify-builds
     steps:
       - name: Check that all jobs have passed
         run: |
@@ -502,6 +580,13 @@ jobs:
               echo "E2E Firefox tests failed"
               exit 1
             fi
+          fi
+
+          # Check if the identify-builds output is the current run ID
+          if [[ "${{ needs.identify-builds.outputs.builds-from-run }}" != "${{ github.run_id }}" ]]; then
+            echo "Builds were used from a different GHA run: ${{ needs.identify-builds.outputs.builds-from-run }}"
+            echo "Right now you can use this feature to test and iterate faster, but to merge a PR, you have to disable it."
+            exit 1
           fi
 
           echo "All required jobs passed"

--- a/.github/workflows/needs-e2e.yml
+++ b/.github/workflows/needs-e2e.yml
@@ -17,6 +17,7 @@ jobs:
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
       # For a `push` event, the head commit hash is `github.sha`.
       HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+      BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +29,7 @@ jobs:
         id: skip-tag
         run: |
           echo "SKIP=false" >> "$GITHUB_OUTPUT"
-          if [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "merge_group" ]] || [[ "$BRANCH" == trigger-ci-* ]]; then
             if git show --format='%B' --no-patch "${HEAD_COMMIT_HASH}" | grep --fixed-strings --quiet '[skip-e2e]'; then
               echo "SKIP=true" >> "$GITHUB_OUTPUT"
               echo "-> SKIP=true due to [skip-e2e] tag in last commit message"
@@ -50,8 +51,8 @@ jobs:
           # Default to running E2E tests
           echo "NEEDS_E2E=true" >> "$GITHUB_OUTPUT"
 
-          # Only consider skipping for PRs and merge-queue events
-          if [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          # Only consider skipping for PRs, merge-queue events, or trigger-ci-* branches
+          if [[ "${{ steps.skip-tag.outputs.SKIP }}" == "true" ]] || [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "merge_group" ]]; then
 
             # Skip if [skip-e2e] tag found
             if [[ "${{ steps.skip-tag.outputs.SKIP }}" == "true" ]]; then

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       build-name: build-dist-browserify
       build-command: yarn build dist
+      builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
   build-dist-mv2-browserify:
@@ -25,6 +26,7 @@ jobs:
       build-command: yarn build dist
       mozilla-lint: true
       enable-mv3: false
+      builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
   build-experimental-browserify:
@@ -32,6 +34,7 @@ jobs:
     with:
       build-name: build-experimental-browserify
       build-command: yarn build --build-type experimental dist
+      builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
   build-experimental-mv2-browserify:
@@ -41,6 +44,7 @@ jobs:
       build-command: yarn build --build-type experimental dist
       mozilla-lint: true
       enable-mv3: false
+      builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
   post-nightly-builds:

--- a/.github/workflows/page-load-benchmark.yml
+++ b/.github/workflows/page-load-benchmark.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: number
         default: 10
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
     secrets:
       EXTENSION_BENCHMARK_STATS_TOKEN:
         required: true
@@ -44,6 +48,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-test-browserify
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ inputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       - name: Install Playwright browsers
         if: ${{ env.IS_PR_OR_MAIN }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,10 @@ on:
         description: 'Whether the Lavamoat policy files have changed'
         required: true
         type: boolean
+      post-new-builds:
+        description: 'Whether to post new builds from CloudFront to the comment'
+        required: true
+        type: boolean
 
 jobs:
   publish-prerelease:
@@ -31,6 +35,7 @@ jobs:
       CLOUDFRONT_REPO_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}
       HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
       LAVAMOAT_POLICY_CHANGED: ${{ inputs.lavamoat-policy-changed }}
+      POST_NEW_BUILDS: ${{ inputs.post-new-builds }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
     secrets:
       INFURA_PROJECT_ID:
         required: true
@@ -55,6 +60,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ inputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       - name: Run the benchmark
         # Choose a benchmark command from env.COMMANDS

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
         default: true
         description: Whether to enable MV3 or not
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
 
 jobs:
   run-build:
@@ -32,6 +36,7 @@ jobs:
     env:
       # Build parameter
       ENABLE_MV3: ${{ inputs.enable-mv3 }}
+      SHOULD_BUILD: ${{ inputs.builds-from-run == github.run_id }}
       # Environment variables not used in production builds
       APPLE_CLIENT_ID_FLASK_UAT: ${{ secrets.APPLE_CLIENT_ID_FLASK_UAT }}
       APPLE_CLIENT_ID_UAT: ${{ secrets.APPLE_CLIENT_ID_UAT }}
@@ -84,6 +89,7 @@ jobs:
       VAPID_KEY: ${{ secrets.VAPID_KEY }}
     steps:
       - name: Checkout and setup environment
+        if: ${{ env.SHOULD_BUILD == 'true' }}
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
@@ -91,17 +97,19 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Run build
+        if: ${{ env.SHOULD_BUILD == 'true' }}
         run: ${{ inputs.build-command }}
 
       - name: Validate source maps
-        if: ${{ inputs.validate-source-maps }}
+        if: ${{ env.SHOULD_BUILD == 'true' && inputs.validate-source-maps }}
         run: yarn validate-source-maps
 
       - name: Run mozilla-lint
-        if: ${{ inputs.mozilla-lint }}
+        if: ${{ env.SHOULD_BUILD == 'true' && inputs.mozilla-lint }}
         run: yarn mozilla-lint
 
       - name: Upload artifact '${{ inputs.build-name }}'
+        if: ${{ env.SHOULD_BUILD == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.build-name }}
@@ -110,7 +118,7 @@ jobs:
             dist
 
       - name: Upload 'builds' to S3
-        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        if: ${{ env.SHOULD_BUILD == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
         uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
         description: The test command to run
+      builds-from-run:
+        required: true
+        type: string
+        description: The run ID to get builds from
       test-timeout-minutes:
         type: number
         default: 30
@@ -97,6 +101,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build-artifact }}
+          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
+          run-id: ${{ inputs.builds-from-run }} # Download from whatever run the identify-builds job said.
 
       # if there is a build-command and there is no build artifact, or the specified artifact does not exist, we run the build command
       - run: ${{ inputs.build-command }}

--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ Different build types have different e2e tests sets. In order to run them look i
     "test:e2e:firefox": "SELENIUM_BROWSER=firefox node test/e2e/run-all.js",
 ```
 
+### Test and iterate on GitHub Actions more quickly
+
+Running the full workflow on GitHub Actions can take 30 minutes or more, but there are ways to speed it up for faster iteration
+
+- `[builds-from-run: <run-id>]` in the last commit message - If you didn't change any code that will change the builds, you can use this to speed up CI by about 10 minutes
+  - You probably want to use either the last completed run on branch `main` https://github.com/MetaMask/metamask-extension/actions/workflows/main.yml?query=branch%3Amain, or the last run on your feature branch. The run-id is at the end of the URL like https://github.com/MetaMask/metamask-extension/actions/runs/xxxxxxxx
+  - For security, you will be prevented from merging the PR in this test state.
+  - If this is popular (a lot of people using it in commit messages, praising it on Slack), we may be able to harden this state, trigger it more automatically, make the UX easier, and allow merges.
+- `[skip-e2e]` in the last commit message - Skips the E2E test suite
+- `[skip-unit]` in the last commit message _(command not working yet, coming soon)_ - Skips the unit test suite
+- `trigger-ci-*` as the branch name - This allows you to run the CI workflow without attaching it to a PR. This is useful if you need to test some things that you know will never be merged. Please clean up after yourself when you're done, and delete the branch.
+
 ### Changing dependencies
 
 Whenever you change dependencies (adding, removing, or updating, either in `package.json` or `yarn.lock`), there are various files that must be kept up-to-date.

--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -62,6 +62,7 @@ async function start(): Promise<void> {
     MERGE_BASE_COMMIT_HASH,
     HOST_URL,
     LAVAMOAT_POLICY_CHANGED,
+    POST_NEW_BUILDS,
   } = process.env as Record<string, string>;
 
   if (!PR_NUMBER) {
@@ -157,7 +158,12 @@ async function start(): Promise<void> {
 
   const allArtifactsUrl = `https://github.com/${OWNER}/${REPOSITORY}/actions/runs/${RUN_ID}#artifacts`;
 
-  const contentRows = [...buildContentRows];
+  const contentRows = [];
+
+  // Only post new Extension builds if this run is not using old builds
+  if (POST_NEW_BUILDS === 'true') {
+    contentRows.push(...buildContentRows);
+  }
 
   // Only show lavamoat build viz link if the policy files changed
   if (LAVAMOAT_POLICY_CHANGED === 'true') {


### PR DESCRIPTION
## **Description**

- Supports `[builds-from-run: <run-id>]` in the last commit message - If you didn't change any code that will change the builds, you can use this to speed up CI by about 10 minutes
- For security, you will be prevented from merging the PR in this test state
- Fixed `[skip-e2e]` to be compatible with `trigger-ci-*`
- Added instructions to README.md

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Manual version of MetaMask/MetaMask-planning#5922 (later PRs can make this more automatic)

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a commit-message directive to reuse build artifacts from a specified workflow run, wires it through build/test/benchmark workflows, and updates gating and docs.
> 
> - **CI/Workflows**
>   - **Artifact Reuse**: Add `identify-builds` job to parse `[builds-from-run: <run-id>]` from the last commit and expose `builds-from-run` for downstream jobs.
>   - **Build Jobs**: Update `run-build.yml` to accept `inputs.builds-from-run`; conditionally run steps via `SHOULD_BUILD` and upload artifacts/S3 only when building current run.
>   - **Consumers**: Pass `builds-from-run` to `e2e-*`, `run-benchmarks.yml`, `page-load-benchmark.yml`, `bundle-size`, `source-map-explorer`, `lavamoat-viz`, and artifact downloads via `actions/download-artifact` with `run-id` and `github-token`.
>   - **Gating**: In `all-jobs-pass`, fail if builds come from a different run; in `publish-prerelease`, only post new build links when using current run (`post-new-builds`).
>   - **Triggers/Filters**: Support `trigger-ci-*` branches; refine `[skip-e2e]` handling in `needs-e2e.yml`; update push branch pattern to `trigger-ci-*`.
>   - **Nightly/Release**: Nightly builds pass their own `run_id`; minor token fix in `create-release-pr.yml`.
> - **Scripts**
>   - Add `.github/scripts/identify-builds-from-run.sh` to extract `builds-from-run` from commit message or default to current run.
> - **Bot/Comments**
>   - Update `metamaskbot-build-announce.ts` to hide new build links when reusing old builds and include other artifact links as before.
> - **Docs**
>   - README: Add guidance on using `[builds-from-run: <run-id>]`, `[skip-e2e]`, and `trigger-ci-*` to speed up CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04038d1352190602f5dd9fe2d7f4f6b9ee50b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->