### PR TITLE
feat: shield claims configuration

### DIFF
--- a/app/scripts/controller-init/messengers/claims/claims-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/claims/claims-controller-messenger.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/messenger';
 import {
   ClaimsControllerMessenger,
+  ClaimsServiceFetchClaimsConfigurationsAction,
   ClaimsServiceGenerateMessageForClaimSignatureAction,
   ClaimsServiceGetClaimsAction,
   ClaimsServiceGetClaimsApiUrlAction,
@@ -15,6 +16,7 @@ import { RootMessenger } from '../../../lib/messenger';
 
 type AllowedActions =
   | MessengerActions<ClaimsControllerMessenger>
+  | ClaimsServiceFetchClaimsConfigurationsAction
   | ClaimsServiceGetRequestHeadersAction
   | ClaimsServiceGetClaimsApiUrlAction
   | ClaimsServiceGenerateMessageForClaimSignatureAction
@@ -41,6 +43,7 @@ export function getClaimsControllerMessenger(
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [
+      'ClaimsService:fetchClaimsConfigurations',
       'ClaimsService:getClaimsApiUrl',
       'ClaimsService:getRequestHeaders',
       'ClaimsService:generateMessageForClaimSignature',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -807,6 +807,8 @@ export default class MetamaskController extends EventEmitter {
         );
 
         if (hasActiveShieldSubscription) {
+          // fetch claims configurations when shield subscription is active
+          this.claimsController.fetchClaimsConfigurations();
           this.shieldController.start();
         } else {
           this.shieldController.stop();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -808,7 +808,9 @@ export default class MetamaskController extends EventEmitter {
 
         if (hasActiveShieldSubscription) {
           // fetch claims configurations when shield subscription is active
-          this.claimsController.fetchClaimsConfigurations();
+          this.claimsController.fetchClaimsConfigurations().catch((err) => {
+            log.error('Error fetching claims configurations', err);
+          });
           this.shieldController.start();
         } else {
           this.shieldController.stop();

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@metamask/bridge-status-controller": "^56.0.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/chain-agnostic-permission": "^1.2.2",
-    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9",
+    "@metamask/claims-controller": "^0.2.0",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.15.0",
     "@metamask/core-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@metamask/bridge-status-controller": "^56.0.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/chain-agnostic-permission": "^1.2.2",
-    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb",
+    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.15.0",
     "@metamask/core-backend": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "@metamask/bridge-status-controller": "^56.0.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/chain-agnostic-permission": "^1.2.2",
-    "@metamask/claims-controller": "^0.1.0",
+    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.15.0",
     "@metamask/core-backend": "^4.0.0",

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -321,6 +321,7 @@ export type ControllerStatePropertiesEnumerated = {
   rewardsSeasonStatuses: RewardsControllerState['rewardsSeasonStatuses'];
   rewardsSubscriptionTokens: RewardsControllerState['rewardsSubscriptionTokens'];
   claims: ClaimsControllerState['claims'];
+  claimsConfigurations: ClaimsControllerState['claimsConfigurations'];
 };
 
 type ControllerStateTypesMerged = AccountsControllerState &

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -115,6 +115,7 @@
     },
     "firstTimeFlowType": "import",
     "claims": "object",
+    "claimsConfigurations": "object",
     "completedOnboarding": true,
     "knownMethodData": "object",
     "use4ByteResolution": true,

--- a/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.test.tsx
+++ b/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.test.tsx
@@ -66,7 +66,14 @@ describe('Submit Claim Form', () => {
   let store: ReturnType<typeof configureStore>;
 
   beforeEach(() => {
-    store = configureStore({});
+    store = configureStore({
+      metamask: {
+        claimsConfigurations: {
+          validSubmissionWindowDays: 10,
+          supportedNetworks: ['0x1', '0x5'],
+        },
+      },
+    });
   });
 
   it('should render', () => {

--- a/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.tsx
+++ b/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.tsx
@@ -19,7 +19,7 @@ import {
   TextVariant,
   IconSize,
 } from '@metamask/design-system-react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import classnames from 'classnames';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -64,12 +64,12 @@ import {
 import { SubmitClaimError } from '../claim-error';
 import AccountSelector from '../account-selector';
 import NetworkSelector from '../network-selector';
+import { getValidSubmissionWindowDays } from '../../../../selectors/shield/claims';
 import {
   ERROR_MESSAGE_MAP,
   FIELD_ERROR_MESSAGE_KEY_MAP,
   MAX_FILE_SIZE_BYTES,
   MAX_FILE_SIZE_MB,
-  VALID_SUBMISSION_WINDOW_DAYS,
 } from './constants';
 import { isValidTransactionHash } from './utils';
 
@@ -78,6 +78,7 @@ const ClaimsForm = ({ isView = false }: { isView?: boolean }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { refetchClaims, pendingClaims } = useClaims();
+  const validSubmissionWindowDays = useSelector(getValidSubmissionWindowDays);
   const [isSubmittingClaim, setIsSubmittingClaim] = useState(false);
 
   const {
@@ -314,12 +315,12 @@ const ClaimsForm = ({ isView = false }: { isView?: boolean }) => {
       await submitShieldClaim({
         chainId: chainIdNumber.toString(),
         email,
-        impactedWalletAddress,
-        impactedTransactionHash,
-        reimbursementWalletAddress,
-        caseDescription,
+        impactedWalletAddress: impactedWalletAddress as `0x${string}`,
+        impactedTxHash: impactedTransactionHash as `0x${string}`,
+        reimbursementWalletAddress: reimbursementWalletAddress as `0x${string}`,
+        description: caseDescription,
+        signature: claimSignature as `0x${string}`,
         files,
-        signature: claimSignature,
       });
       dispatch(setShowClaimSubmitToast(ClaimSubmitToastType.Success));
       // update claims
@@ -378,7 +379,7 @@ const ClaimsForm = ({ isView = false }: { isView?: boolean }) => {
               </TextButton>,
             ])
           : t('shieldClaimDetails', [
-              VALID_SUBMISSION_WINDOW_DAYS,
+              validSubmissionWindowDays,
               <TextButton key="here-link" className="min-w-0" asChild>
                 <a
                   href={TRANSACTION_SHIELD_LINK}

--- a/ui/pages/settings/transaction-shield-tab/claims-form/constants.ts
+++ b/ui/pages/settings/transaction-shield-tab/claims-form/constants.ts
@@ -5,7 +5,6 @@ import {
   SubmitClaimField,
 } from '../types';
 
-export const VALID_SUBMISSION_WINDOW_DAYS = 21;
 export const MAX_FILE_SIZE_MB = 5;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
@@ -26,7 +25,6 @@ export const ERROR_MESSAGE_MAP: Partial<
   },
   [SUBMIT_CLAIM_ERROR_CODES.SUBMISSION_WINDOW_EXPIRED]: {
     messageKey: 'shieldClaimSubmissionWindowExpired',
-    params: [VALID_SUBMISSION_WINDOW_DAYS.toString()],
   },
   [SUBMIT_CLAIM_ERROR_CODES.MAX_CLAIMS_LIMIT_EXCEEDED]: {
     messageKey: 'shieldClaimMaxClaimsLimitExceeded',

--- a/ui/pages/settings/transaction-shield-tab/network-selector/network-selector.tsx
+++ b/ui/pages/settings/transaction-shield-tab/network-selector/network-selector.tsx
@@ -14,7 +14,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 import classnames from 'classnames';
 import {
   Modal,
@@ -28,18 +27,7 @@ import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules
 import { NetworkListItem } from '../../../../components/multichain/network-list-item';
 import { getImageForChainId } from '../../../../selectors/multichain';
 import { TextVariant as DsTextVariant } from '../../../../helpers/constants/design-system';
-
-const SUPPORTED_CHAIN_IDS: `0x${string}`[] = [
-  CHAIN_IDS.MAINNET,
-  CHAIN_IDS.LINEA_MAINNET,
-  CHAIN_IDS.ARBITRUM,
-  CHAIN_IDS.AVALANCHE,
-  CHAIN_IDS.OPTIMISM,
-  CHAIN_IDS.BASE,
-  CHAIN_IDS.POLYGON,
-  CHAIN_IDS.BSC,
-  CHAIN_IDS.SEI,
-];
+import { getSupportedNetworksForClaim } from '../../../../selectors/shield/claims';
 
 const NetworkSelector = ({
   label,
@@ -57,13 +45,14 @@ const NetworkSelector = ({
   const [showNetworkListMenu, setShowNetworkListMenu] = useState(false);
 
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
+  const claimsSupportedNetworks = useSelector(getSupportedNetworksForClaim);
 
   const networksList = useMemo(
     () =>
       Object.values(allNetworks).filter((network) =>
-        SUPPORTED_CHAIN_IDS.includes(network.chainId),
+        claimsSupportedNetworks.includes(network.chainId),
       ),
-    [allNetworks],
+    [allNetworks, claimsSupportedNetworks],
   );
 
   const selectedNetworkInfo = useMemo(() => {

--- a/ui/selectors/shield/claims.test.ts
+++ b/ui/selectors/shield/claims.test.ts
@@ -1,9 +1,15 @@
-import { DEFAULT_CLAIMS_CONFIGURATIONS, ClaimsControllerState } from "@metamask/claims-controller";
-import { getSupportedNetworksForClaim, getValidSubmissionWindowDays } from "./claims";
+import {
+  DEFAULT_CLAIMS_CONFIGURATIONS,
+  ClaimsControllerState,
+} from '@metamask/claims-controller';
+import {
+  getSupportedNetworksForClaim,
+  getValidSubmissionWindowDays,
+} from './claims';
 
 describe('shield claims selectors', () => {
   const DEFAULT_STATE: ClaimsControllerState = {
-    ...DEFAULT_CLAIMS_CONFIGURATIONS,
+    claimsConfigurations: DEFAULT_CLAIMS_CONFIGURATIONS,
     claims: [],
   };
 
@@ -11,13 +17,17 @@ describe('shield claims selectors', () => {
     const result = getSupportedNetworksForClaim({
       metamask: DEFAULT_STATE,
     });
-    expect(result).toEqual(DEFAULT_STATE.supportedNetworks);
+    expect(result).toEqual(
+      DEFAULT_STATE.claimsConfigurations.supportedNetworks,
+    );
   });
 
   it('should return the valid submission window days for claim', () => {
     const result = getValidSubmissionWindowDays({
       metamask: DEFAULT_STATE,
     });
-    expect(result).toEqual(DEFAULT_STATE.validSubmissionWindowDays);
+    expect(result).toEqual(
+      DEFAULT_STATE.claimsConfigurations.validSubmissionWindowDays,
+    );
   });
 });

--- a/ui/selectors/shield/claims.test.ts
+++ b/ui/selectors/shield/claims.test.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_CLAIMS_CONFIGURATIONS, ClaimsControllerState } from "@metamask/claims-controller";
+import { getSupportedNetworksForClaim, getValidSubmissionWindowDays } from "./claims";
+
+describe('shield claims selectors', () => {
+  const DEFAULT_STATE: ClaimsControllerState = {
+    ...DEFAULT_CLAIMS_CONFIGURATIONS,
+    claims: [],
+  };
+
+  it('should return the supported networks for claim', () => {
+    const result = getSupportedNetworksForClaim({
+      metamask: DEFAULT_STATE,
+    });
+    expect(result).toEqual(DEFAULT_STATE.supportedNetworks);
+  });
+
+  it('should return the valid submission window days for claim', () => {
+    const result = getValidSubmissionWindowDays({
+      metamask: DEFAULT_STATE,
+    });
+    expect(result).toEqual(DEFAULT_STATE.validSubmissionWindowDays);
+  });
+});

--- a/ui/selectors/shield/claims.ts
+++ b/ui/selectors/shield/claims.ts
@@ -1,0 +1,24 @@
+import { ClaimsControllerState } from '@metamask/claims-controller';
+
+export type ClaimsState = {
+  metamask: ClaimsControllerState;
+};
+
+/**
+ * Get the supported networks for claim.
+ * @param state - The state of the claims controller.
+ * @returns The supported networks for claim.
+ */
+export function getSupportedNetworksForClaim(state: ClaimsState): `0x${string}`[] {
+  return state.metamask.supportedNetworks;
+}
+
+/**
+ * Get the valid submission window days for claim.
+ * @param state - The state of the claims controller.
+ * @returns The valid submission window days for claim.
+ */
+export function getValidSubmissionWindowDays(state: ClaimsState): number {
+  return state.metamask.validSubmissionWindowDays;
+}
+

--- a/ui/selectors/shield/claims.ts
+++ b/ui/selectors/shield/claims.ts
@@ -6,19 +6,22 @@ export type ClaimsState = {
 
 /**
  * Get the supported networks for claim.
+ *
  * @param state - The state of the claims controller.
  * @returns The supported networks for claim.
  */
-export function getSupportedNetworksForClaim(state: ClaimsState): `0x${string}`[] {
-  return state.metamask.supportedNetworks;
+export function getSupportedNetworksForClaim(
+  state: ClaimsState,
+): `0x${string}`[] {
+  return state.metamask.claimsConfigurations.supportedNetworks;
 }
 
 /**
  * Get the valid submission window days for claim.
+ *
  * @param state - The state of the claims controller.
  * @returns The valid submission window days for claim.
  */
 export function getValidSubmissionWindowDays(state: ClaimsState): number {
-  return state.metamask.validSubmissionWindowDays;
+  return state.metamask.claimsConfigurations.validSubmissionWindowDays;
 }
-

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -77,7 +77,11 @@ import {
   CachedLastSelectedPaymentMethods,
 } from '@metamask/subscription-controller';
 
-import { Claim, SubmitClaimConfig } from '@metamask/claims-controller';
+import {
+  Claim,
+  CreateClaimRequest,
+  SubmitClaimConfig,
+} from '@metamask/claims-controller';
 import { captureException } from '../../shared/lib/sentry';
 import { switchDirection } from '../../shared/lib/switch-direction';
 import {
@@ -7736,16 +7740,9 @@ export async function getLayer1GasFeeValue({
  * @param params.signature - Claim signature.
  * @returns The subscription response.
  */
-export async function submitShieldClaim(params: {
-  chainId: string;
-  email: string;
-  impactedWalletAddress: string;
-  impactedTransactionHash: string;
-  reimbursementWalletAddress: string;
-  caseDescription: string;
-  signature: string;
-  files?: FileList;
-}) {
+export async function submitShieldClaim(
+  params: CreateClaimRequest & { files?: FileList },
+) {
   const submitClaimConfig = await submitRequestToBackground<SubmitClaimConfig>(
     'getSubmitClaimConfig',
     [params],
@@ -7756,12 +7753,12 @@ export async function submitShieldClaim(params: {
   formData.append('chainId', params.chainId);
   formData.append('email', params.email);
   formData.append('impactedWalletAddress', params.impactedWalletAddress);
-  formData.append('impactedTxHash', params.impactedTransactionHash);
+  formData.append('impactedTxHash', params.impactedTxHash);
   formData.append(
     'reimbursementWalletAddress',
     params.reimbursementWalletAddress,
   );
-  formData.append('description', params.caseDescription);
+  formData.append('description', params.description);
   formData.append('signature', params.signature);
   formData.append('timestamp', Date.now().toString());
 
@@ -7777,7 +7774,6 @@ export async function submitShieldClaim(params: {
     const response = await fetch(url, {
       method,
       body: formData,
-      // FIXME: remove `Content-Type: multipart/form-data` from the controller
       headers: {
         Authorization: headers.Authorization,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5787,15 +5787,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/claims-controller@npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb":
-  version: 0.1.0-preview-7b698bb
-  resolution: "@metamask-previews/claims-controller@npm:0.1.0-preview-7b698bb"
+"@metamask/claims-controller@npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9":
+  version: 0.1.0-preview-9941fe9
+  resolution: "@metamask-previews/claims-controller@npm:0.1.0-preview-9941fe9"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/utils": "npm:^11.8.1"
-  checksum: 10/5a7bcff186f6c3116ae23e38379ca670b7d0814eb72428d6364859d72f2cbbd1e4c48e4736ce2b8345cc045ee228b64651c592cef463c7a56d80e3a273fa0cd2
+  checksum: 10/e06bebc9ab1cd2aeaee9151325619e1ec2116920def3b56e6e1b6dbc925aef3e9d5e6fbad8ff530bd263ec19097e83160f891b3a7d8de58481ab6116a48d0529
   languageName: node
   linkType: hard
 
@@ -32011,7 +32011,7 @@ __metadata:
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"
-    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb"
+    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/core-backend": "npm:^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5787,15 +5787,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/claims-controller@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/claims-controller@npm:0.1.0"
+"@metamask/claims-controller@npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb":
+  version: 0.1.0-preview-7b698bb
+  resolution: "@metamask-previews/claims-controller@npm:0.1.0-preview-7b698bb"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/utils": "npm:^11.8.1"
-  checksum: 10/dcc541d951d30ddd59745d8e65c468670925ac27574b534178b5a804e3122ca369d467b94d31d43a804fa5cf4bc69a788878995313b36bc8f4a4889823810384
+  checksum: 10/5a7bcff186f6c3116ae23e38379ca670b7d0814eb72428d6364859d72f2cbbd1e4c48e4736ce2b8345cc045ee228b64651c592cef463c7a56d80e3a273fa0cd2
   languageName: node
   linkType: hard
 
@@ -32011,7 +32011,7 @@ __metadata:
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"
-    "@metamask/claims-controller": "npm:^0.1.0"
+    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-7b698bb"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/core-backend": "npm:^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5787,15 +5787,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/claims-controller@npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9":
-  version: 0.1.0-preview-9941fe9
-  resolution: "@metamask-previews/claims-controller@npm:0.1.0-preview-9941fe9"
+"@metamask/claims-controller@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/claims-controller@npm:0.2.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/utils": "npm:^11.8.1"
-  checksum: 10/e06bebc9ab1cd2aeaee9151325619e1ec2116920def3b56e6e1b6dbc925aef3e9d5e6fbad8ff530bd263ec19097e83160f891b3a7d8de58481ab6116a48d0529
+  checksum: 10/a5b20671798214c705d200128ccbc3e5064425039313885a566c7f9c5ebfb983d2ee18a2680b28e9d8a42fb0e3aa11d4d38de2512521e7ef18db67486fa8a98b
   languageName: node
   linkType: hard
 
@@ -32011,7 +32011,7 @@ __metadata:
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.2.2"
-    "@metamask/claims-controller": "npm:@metamask-previews/claims-controller@0.1.0-preview-9941fe9"
+    "@metamask/claims-controller": "npm:^0.2.0"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.15.0"
     "@metamask/core-backend": "npm:^4.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR updates the shield claim configuration by fetching the configs from backend, instead of hard-coding in the frontend.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37693?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: get required configurations for shield claims process from the backend.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetches shield claims configurations from the backend and wires them through state, selectors, and UI (form and network selector), updating to @metamask/claims-controller v0.2.0.
> 
> - **Controllers/Init**:
>   - Add `ClaimsService:fetchClaimsConfigurations` to `ClaimsController` messenger and allowed actions.
>   - On active Shield subscription, call `claimsController.fetchClaimsConfigurations()`.
> - **State/Types/Selectors**:
>   - Surface `metamask.claimsConfigurations` in background state and metrics snapshot.
>   - New selectors `getSupportedNetworksForClaim` and `getValidSubmissionWindowDays` with tests.
> - **UI**:
>   - Claims Form: use `validSubmissionWindowDays` from selector; update submit payload to new API fields (`impactedTxHash`, `description`, typed hex); remove hardcoded submission window; error map tweaks.
>   - Network Selector: filter networks by `claimsConfigurations.supportedNetworks` instead of hardcoded list.
> - **Store**:
>   - `submitShieldClaim` action now accepts `CreateClaimRequest & { files?: FileList }` and aligns form-data keys to backend.
> - **Dependencies**:
>   - Bump `@metamask/claims-controller` to `^0.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd205d4d065a11f5e13a5c995583d0787008ac4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->