### PR TITLE
fix: handle user cancellation in AddWalletPage

### DIFF
--- a/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.test.tsx
+++ b/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.test.tsx
@@ -23,7 +23,7 @@ jest.mock(
     ImportAccount: ({
       onActionComplete,
     }: {
-      onActionComplete: (success: boolean) => void;
+      onActionComplete: (success?: boolean) => void;
     }) => (
       <div>
         <button onClick={() => onActionComplete(true)}>
@@ -32,6 +32,7 @@ jest.mock(
         <button onClick={() => onActionComplete(false)}>
           Mock Import Failure
         </button>
+        <button onClick={() => onActionComplete()}>Mock Cancel</button>
       </div>
     ),
   }),
@@ -90,5 +91,16 @@ describe('AddWalletPage', () => {
     fireEvent.click(failureButton);
 
     expect(mockHistoryGoBack).not.toHaveBeenCalled();
+  });
+
+  it('navigates back when user cancels', () => {
+    renderComponent();
+
+    const cancelButton = screen.getByRole('button', {
+      name: 'Mock Cancel',
+    });
+    fireEvent.click(cancelButton);
+
+    expect(mockHistoryGoBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
+++ b/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
@@ -27,8 +27,10 @@ export const AddWalletPage = () => {
   const history = useHistory();
 
   const onActionComplete = useCallback(
-    async (confirmed: boolean) => {
-      if (confirmed) {
+    async (confirmed?: boolean) => {
+      // Navigate back if import succeeded (true) or user cancelled (undefined)
+      // Stay on page if import failed (false) to allow retry
+      if (confirmed !== false) {
         history.goBack();
       }
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed a bug where clicking Cancel on the Import Private Key page did nothing.  
The `onActionComplete` callback now correctly navigates back when the user cancels or when import succeeds, but stays on the page when import fails (to allow retry).

## **Changelog**

Fixed Cancel button on Import Private Key page not returning to previous page

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37605

## **Manual testing steps**

1. Click Account Menu
2. Click Create Account
3. Click Import Private Key
4. Click Cancel -> verify it navigates back to the previous page
5. Click Import Private Key again
6. Enter an invalid private key and click Import -> verify it stays on page showing error
7. Enter a valid private key and click Import -> verify it navigates back after successful import

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See recordings in attached [bug](https://github.com/MetaMask/metamask-extension/issues/37605).

### **After**

https://github.com/user-attachments/assets/dce0a621-b040-46fd-b767-d8fbcb5ee338



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates AddWalletPage to navigate back on cancel or success and adds tests for cancel behavior; `onActionComplete` now accepts an optional boolean.
> 
> - **UI**
>   - Update `AddWalletPage` `onActionComplete(confirmed?: boolean)` to navigate back when `confirmed` is `true` or `undefined` (cancel), and stay when `false` (failure).
> - **Tests**
>   - Modify `ImportAccount` mock to accept optional boolean and add a "Mock Cancel" action.
>   - Add test asserting navigation on cancel; keep existing success/failure tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a62e976955ae99a5de548747586f32ac486229. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->