### PR TITLE
feat: shield-last-subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
   },
   "resolutions": {
     "http-cache-semantics": "^4.1.1",
+    "@metamask/subscription-controller@^3.3.0": "npm:@metamask-previews/subscription-controller@3.3.0-preview-6b23dd6",
     "semver-regex": "^3.1.4",
     "base-x@^3.0.x": "^3.0.11",
     "base-x@3.0.9": "^3.0.11",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
   },
   "resolutions": {
     "http-cache-semantics": "^4.1.1",
-    "@metamask/subscription-controller@^3.3.0": "npm:@metamask-previews/subscription-controller@3.3.0-preview-6b23dd6",
     "semver-regex": "^3.1.4",
     "base-x@^3.0.x": "^3.0.11",
     "base-x@3.0.9": "^3.0.11",
@@ -364,7 +363,7 @@
     "@metamask/solana-wallet-snap": "^2.4.6",
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/streams": "^0.4.0",
-    "@metamask/subscription-controller": "^3.3.0",
+    "@metamask/subscription-controller": "^4.0.0",
     "@metamask/transaction-controller": "^61.0.0",
     "@metamask/tron-wallet-snap": "^1.7.1",
     "@metamask/user-operation-controller": "^40.0.0",

--- a/shared/lib/shield.ts
+++ b/shared/lib/shield.ts
@@ -8,7 +8,7 @@ import { DAY } from '../constants/time';
 
 const SUBSCRIPTION_ENDING_SOON_DAYS = DAY;
 
-function getShieldSubscription(
+export function getShieldSubscription(
   subscriptions: Subscription | Subscription[],
 ): Subscription | undefined {
   let shieldSubscription: Subscription | undefined;

--- a/shared/modules/shield/shield.test.ts
+++ b/shared/modules/shield/shield.test.ts
@@ -36,6 +36,7 @@ const MOCK_SUBSCRIPTION: Subscription = {
       last4: '1234',
     },
   },
+  isEligibleForSupport: true,
 };
 
 const setup = ({

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -40,14 +40,20 @@ import {
   useSubscriptionPricing,
 } from './useSubscriptionPricing';
 
+/**
+ * get user subscriptions information
+ *
+ * @param options - The options for the hook.
+ * @param options.refetch - whether to refetch the subscriptions
+ * @returns user subscriptions information
+ */
 export const useUserSubscriptions = (
   { refetch }: { refetch?: boolean } = { refetch: false },
 ) => {
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const isSignedIn = useSelector(selectIsSignedIn);
   const isUnlocked = useSelector(getIsUnlocked);
-  const { customerId, subscriptions, trialedProducts, lastSubscription } =
-    useSelector(getUserSubscriptions);
+  const userSubscriptions = useSelector(getUserSubscriptions);
 
   const result = useAsyncResult(async () => {
     if (!isSignedIn || !refetch || !isUnlocked) {
@@ -57,15 +63,19 @@ export const useUserSubscriptions = (
   }, [refetch, dispatch, isSignedIn, isUnlocked]);
 
   return {
-    customerId,
-    subscriptions,
-    trialedProducts,
-    lastSubscription,
+    ...userSubscriptions,
     loading: result.pending,
     error: result.error,
   };
 };
 
+/**
+ * get user subscription by product from list of subscriptions
+ *
+ * @param product - The product to get the subscription for.
+ * @param subscriptions - The subscriptions to get the subscription from.
+ * @returns The subscription for the product.
+ */
 export const useUserSubscriptionByProduct = (
   product: ProductType,
   subscriptions?: Subscription[],
@@ -76,6 +86,26 @@ export const useUserSubscriptionByProduct = (
         subscription.products.some((p) => p.name === product),
       ),
     [subscriptions, product],
+  );
+};
+
+/**
+ * get user last subscription by product
+ *
+ * @param product - The product to get the subscription for.
+ * @param lastSubscription - The last subscription to get the subscription from.
+ * @returns The subscription for the product.
+ */
+export const useUserLastSubscriptionByProduct = (
+  product: ProductType,
+  lastSubscription?: Subscription,
+): Subscription | undefined => {
+  return useMemo(
+    () =>
+      lastSubscription?.products.some((p) => p.name === product)
+        ? lastSubscription
+        : undefined,
+    [lastSubscription, product],
   );
 };
 

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -46,7 +46,7 @@ export const useUserSubscriptions = (
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const isSignedIn = useSelector(selectIsSignedIn);
   const isUnlocked = useSelector(getIsUnlocked);
-  const { customerId, subscriptions, trialedProducts } =
+  const { customerId, subscriptions, trialedProducts, lastSubscription } =
     useSelector(getUserSubscriptions);
 
   const result = useAsyncResult(async () => {
@@ -60,6 +60,7 @@ export const useUserSubscriptions = (
     customerId,
     subscriptions,
     trialedProducts,
+    lastSubscription,
     loading: result.pending,
     error: result.error,
   };

--- a/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.test.tsx
+++ b/ui/pages/settings/transaction-shield-tab/cancel-membership-modal.test.tsx
@@ -23,6 +23,7 @@ const mockSubscription: Subscription = {
       displayBrand: 'Visa',
     },
   },
+  isEligibleForSupport: true,
 };
 
 describe('Cancel Membership Modal', () => {

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.test.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.test.tsx
@@ -52,6 +52,7 @@ describe('Transaction Shield Page', () => {
               displayBrand: 'Visa',
             },
           },
+          isEligibleForSupport: true,
         } satisfies Subscription,
       ],
     },

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -126,14 +126,15 @@ const TransactionShield = () => {
   const {
     customerId,
     subscriptions,
+    lastSubscription,
     loading: subscriptionsLoading,
   } = useUserSubscriptions({
     refetch: !shouldWaitForSubscriptionCreation, // always fetch latest subscriptions state in settings screen unless we are waiting for subscription creation (subscription is refetch in background)
   });
-  const shieldSubscription = useUserSubscriptionByProduct(
-    PRODUCT_TYPES.SHIELD,
-    subscriptions,
-  );
+  // show current active shield subscription or last subscription if no active subscription
+  const shieldSubscription =
+    useUserSubscriptionByProduct(PRODUCT_TYPES.SHIELD, subscriptions) ??
+    lastSubscription;
 
   const [timeoutCancelled, setTimeoutCancelled] = useState(false);
   useEffect(() => {
@@ -788,7 +789,7 @@ const TransactionShield = () => {
           'shield-detail-view-benefits-button',
         )}
         {/* TODO: implement logic to allow submitting case until after 21 days of last active subscription */}
-        {!isCancelled &&
+        {shieldSubscription?.isEligibleForSupport &&
           buttonRow(
             t('shieldTxMembershipSubmitCase'),
             () => {
@@ -849,7 +850,7 @@ const TransactionShield = () => {
             <>
               {billingDetails(
                 t('shieldTxMembershipBillingDetailsNextBilling'),
-                shieldSubscription?.cancelAtPeriodEnd
+                isCancelled || shieldSubscription?.cancelAtPeriodEnd
                   ? '-'
                   : getShortDateFormatterV2().format(
                       new Date(shieldSubscription.currentPeriodEnd),

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -52,6 +52,7 @@ import {
   useSubscriptionCryptoApprovalTransaction,
   useUnCancelSubscription,
   useUpdateSubscriptionCardPaymentMethod,
+  useUserLastSubscriptionByProduct,
   useUserSubscriptionByProduct,
   useUserSubscriptions,
 } from '../../../hooks/subscription/useSubscription';
@@ -131,10 +132,17 @@ const TransactionShield = () => {
   } = useUserSubscriptions({
     refetch: !shouldWaitForSubscriptionCreation, // always fetch latest subscriptions state in settings screen unless we are waiting for subscription creation (subscription is refetch in background)
   });
+  const currentShieldSubscription = useUserSubscriptionByProduct(
+    PRODUCT_TYPES.SHIELD,
+    subscriptions,
+  );
+  const lastShieldSubscription = useUserLastSubscriptionByProduct(
+    PRODUCT_TYPES.SHIELD,
+    lastSubscription,
+  );
   // show current active shield subscription or last subscription if no active subscription
-  const shieldSubscription =
-    useUserSubscriptionByProduct(PRODUCT_TYPES.SHIELD, subscriptions) ??
-    lastSubscription;
+  const displayedShieldSubscription =
+    currentShieldSubscription ?? lastShieldSubscription;
 
   const [timeoutCancelled, setTimeoutCancelled] = useState(false);
   useEffect(() => {
@@ -145,10 +153,10 @@ const TransactionShield = () => {
   }, []);
   useEffect(() => {
     // cancel timeout when subscription is created
-    if (shieldSubscription) {
+    if (currentShieldSubscription) {
       setTimeoutCancelled(true);
     }
-  }, [shieldSubscription]);
+  }, [currentShieldSubscription]);
 
   const startSubscriptionCreationTimeout = useTimeout(
     () => {
@@ -179,33 +187,36 @@ const TransactionShield = () => {
   );
 
   const isCancelled =
-    shieldSubscription?.status === SUBSCRIPTION_STATUSES.canceled;
+    displayedShieldSubscription?.status === SUBSCRIPTION_STATUSES.canceled;
   const isPaused = getIsShieldSubscriptionPaused(subscriptions);
   const isMembershipInactive = isCancelled || isPaused;
   const isSubscriptionEndingSoon =
     getIsShieldSubscriptionEndingSoon(subscriptions);
 
   // user can cancel subscription if not canceled and not cancel at period end
-  const canCancel = !isCancelled && !shieldSubscription?.cancelAtPeriodEnd;
+  const canCancel =
+    !isCancelled && !displayedShieldSubscription?.cancelAtPeriodEnd;
 
   const isCryptoPayment =
-    shieldSubscription?.paymentMethod &&
-    isCryptoPaymentMethod(shieldSubscription?.paymentMethod);
+    displayedShieldSubscription?.paymentMethod &&
+    isCryptoPaymentMethod(displayedShieldSubscription?.paymentMethod);
 
   const productInfo = useMemo(
     () =>
-      shieldSubscription?.products.find((p) => p.name === PRODUCT_TYPES.SHIELD),
-    [shieldSubscription],
+      displayedShieldSubscription?.products.find(
+        (p) => p.name === PRODUCT_TYPES.SHIELD,
+      ),
+    [displayedShieldSubscription],
   );
 
   const [executeCancelSubscription, cancelSubscriptionResult] =
     useCancelSubscription({
-      subscriptionId: shieldSubscription?.id,
+      subscriptionId: currentShieldSubscription?.id,
     });
 
   const [executeUnCancelSubscription, unCancelSubscriptionResult] =
     useUnCancelSubscription({
-      subscriptionId: shieldSubscription?.id,
+      subscriptionId: currentShieldSubscription?.id,
     });
 
   const [
@@ -217,12 +228,12 @@ const TransactionShield = () => {
     executeUpdateSubscriptionCardPaymentMethod,
     updateSubscriptionCardPaymentMethodResult,
   ] = useUpdateSubscriptionCardPaymentMethod({
-    subscriptionId: shieldSubscription?.id,
-    recurringInterval: shieldSubscription?.interval,
+    subscriptionId: currentShieldSubscription?.id,
+    recurringInterval: currentShieldSubscription?.interval,
   });
 
   const isWaitingForSubscriptionCreation =
-    shouldWaitForSubscriptionCreation && !shieldSubscription;
+    shouldWaitForSubscriptionCreation && !currentShieldSubscription;
 
   const loading =
     cancelSubscriptionResult.pending ||
@@ -235,8 +246,9 @@ const TransactionShield = () => {
     subscriptionsLoading ||
     subscriptionPricingLoading;
 
+  // set security alerts enabled, phishing detection, and transaction simulations to true if not already set
   useEffect(() => {
-    if (shieldSubscription) {
+    if (currentShieldSubscription) {
       // set security alerts enabled to true
       if (!securityAlertsEnabled) {
         trackEvent({
@@ -259,19 +271,25 @@ const TransactionShield = () => {
       if (!useTransactionSimulations) {
         setUseTransactionSimulations(true);
       }
-    } else if (!shouldWaitForSubscriptionCreation) {
-      // redirect to shield plan page if user doesn't have a subscription
-      navigate(SHIELD_PLAN_ROUTE);
     }
   }, [
-    shouldWaitForSubscriptionCreation,
-    navigate,
-    shieldSubscription,
+    currentShieldSubscription,
     securityAlertsEnabled,
     usePhishDetect,
     useTransactionSimulations,
     dispatch,
     trackEvent,
+  ]);
+
+  // redirect to shield plan page if user doesn't have a subscription
+  useEffect(() => {
+    if (!shouldWaitForSubscriptionCreation && !displayedShieldSubscription) {
+      navigate(SHIELD_PLAN_ROUTE);
+    }
+  }, [
+    shouldWaitForSubscriptionCreation,
+    navigate,
+    displayedShieldSubscription,
   ]);
 
   const [isCancelMembershipModalOpen, setIsCancelMembershipModalOpen] =
@@ -300,27 +318,29 @@ const TransactionShield = () => {
 
   const currentToken = useMemo((): TokenPaymentInfo | undefined => {
     if (
-      !shieldSubscription ||
-      !isCryptoPaymentMethod(shieldSubscription.paymentMethod)
+      !displayedShieldSubscription ||
+      !isCryptoPaymentMethod(displayedShieldSubscription.paymentMethod)
     ) {
       return undefined;
     }
     const chainPaymentInfo = cryptoPaymentMethod?.chains?.find(
       (chain) =>
         chain.chainId ===
-        (shieldSubscription.paymentMethod as SubscriptionCryptoPaymentMethod)
-          .crypto.chainId,
+        (
+          displayedShieldSubscription.paymentMethod as SubscriptionCryptoPaymentMethod
+        ).crypto.chainId,
     );
 
     const token = chainPaymentInfo?.tokens.find(
       (paymentToken) =>
         paymentToken.symbol ===
-        (shieldSubscription.paymentMethod as SubscriptionCryptoPaymentMethod)
-          .crypto.tokenSymbol,
+        (
+          displayedShieldSubscription.paymentMethod as SubscriptionCryptoPaymentMethod
+        ).crypto.tokenSymbol,
     );
 
     return token;
-  }, [cryptoPaymentMethod, shieldSubscription]);
+  }, [cryptoPaymentMethod, displayedShieldSubscription]);
 
   const buttonRow = (label: string, onClick: () => void, id?: string) => {
     return (
@@ -379,46 +399,47 @@ const TransactionShield = () => {
     );
   };
   const isInsufficientFundsCrypto =
-    shieldSubscription &&
-    isCryptoPaymentMethod(shieldSubscription.paymentMethod) &&
-    shieldSubscription.paymentMethod.crypto.error === 'insufficient_balance';
+    currentShieldSubscription &&
+    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
+    currentShieldSubscription.paymentMethod.crypto.error ===
+      'insufficient_balance';
   const isAllowanceNeededCrypto =
-    shieldSubscription &&
-    isCryptoPaymentMethod(shieldSubscription.paymentMethod) &&
-    (shieldSubscription.paymentMethod.crypto.error ===
+    currentShieldSubscription &&
+    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
+    (currentShieldSubscription.paymentMethod.crypto.error ===
       CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_ALLOWANCE ||
-      shieldSubscription?.paymentMethod.crypto.error ===
+      currentShieldSubscription?.paymentMethod.crypto.error ===
         CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_TOO_OLD ||
-      shieldSubscription?.paymentMethod.crypto.error ===
+      currentShieldSubscription?.paymentMethod.crypto.error ===
         CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_REVERTED ||
-      shieldSubscription?.paymentMethod.crypto.error ===
+      currentShieldSubscription?.paymentMethod.crypto.error ===
         CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_MAX_VERIFICATION_ATTEMPTS_REACHED);
 
   const { value: subscriptionCryptoApprovalAmount } =
     useAsyncResult(async () => {
       if (
         !currentToken ||
-        !shieldSubscription ||
-        !isCryptoPaymentMethod(shieldSubscription.paymentMethod)
+        !displayedShieldSubscription ||
+        !isCryptoPaymentMethod(displayedShieldSubscription.paymentMethod)
       ) {
         return undefined;
       }
       const amount = await getSubscriptionCryptoApprovalAmount({
-        chainId: shieldSubscription.paymentMethod.crypto.chainId,
+        chainId: displayedShieldSubscription.paymentMethod.crypto.chainId,
         paymentTokenAddress: currentToken.address,
         productType: PRODUCT_TYPES.SHIELD,
-        interval: shieldSubscription.interval,
+        interval: displayedShieldSubscription.interval,
       });
 
       return amount;
-    }, [currentToken, shieldSubscription]);
+    }, [currentToken, displayedShieldSubscription]);
 
   const paymentToken = useMemo(() => {
     if (
-      !shieldSubscription ||
+      !displayedShieldSubscription ||
       !currentToken ||
-      !isCryptoPaymentMethod(shieldSubscription.paymentMethod) ||
-      !shieldSubscription.endDate ||
+      !isCryptoPaymentMethod(displayedShieldSubscription.paymentMethod) ||
+      !displayedShieldSubscription.endDate ||
       !productInfo ||
       !subscriptionCryptoApprovalAmount
     ) {
@@ -426,19 +447,20 @@ const TransactionShield = () => {
     }
 
     return {
-      chainId: shieldSubscription.paymentMethod.crypto.chainId,
+      chainId: displayedShieldSubscription.paymentMethod.crypto.chainId,
       address: currentToken.address,
       approvalAmount: {
         approveAmount: subscriptionCryptoApprovalAmount.approveAmount,
-        chainId: shieldSubscription.paymentMethod.crypto.chainId,
-        paymentAddress: shieldSubscription.paymentMethod.crypto.payerAddress,
+        chainId: displayedShieldSubscription.paymentMethod.crypto.chainId,
+        paymentAddress:
+          displayedShieldSubscription.paymentMethod.crypto.payerAddress,
         paymentTokenAddress: currentToken.address,
       },
     };
   }, [
     productInfo,
     currentToken,
-    shieldSubscription,
+    displayedShieldSubscription,
     subscriptionCryptoApprovalAmount,
   ]);
 
@@ -450,8 +472,8 @@ const TransactionShield = () => {
       // go to shield plan page to renew subscription for cancelled subscription
       navigate(SHIELD_PLAN_ROUTE);
     } else if (
-      shieldSubscription &&
-      isCryptoPaymentMethod(shieldSubscription.paymentMethod)
+      currentShieldSubscription &&
+      isCryptoPaymentMethod(currentShieldSubscription.paymentMethod)
     ) {
       if (isInsufficientFundsCrypto) {
         // TODO: handle add funds crypto
@@ -472,7 +494,7 @@ const TransactionShield = () => {
   }, [
     isCancelled,
     navigate,
-    shieldSubscription,
+    currentShieldSubscription,
     isInsufficientFundsCrypto,
     isAllowanceNeededCrypto,
     executeUpdateSubscriptionCardPaymentMethod,
@@ -496,12 +518,12 @@ const TransactionShield = () => {
         />
       );
     }
-    if (isSubscriptionEndingSoon && shieldSubscription) {
+    if (isSubscriptionEndingSoon && currentShieldSubscription) {
       return (
         <BannerAlert
           description={t('shieldTxMembershipErrorInsufficientFunds', [
             getShortDateFormatterV2().format(
-              new Date(shieldSubscription.currentPeriodEnd),
+              new Date(currentShieldSubscription.currentPeriodEnd),
             ),
           ])}
           severity={BannerAlertSeverity.Warning}
@@ -520,7 +542,7 @@ const TransactionShield = () => {
   }, [
     isPaused,
     isSubscriptionEndingSoon,
-    shieldSubscription,
+    currentShieldSubscription,
     t,
     isCryptoPayment,
     isInsufficientFundsCrypto,
@@ -529,7 +551,7 @@ const TransactionShield = () => {
   ]);
 
   const paymentMethod = useMemo(() => {
-    if (!shieldSubscription) {
+    if (!displayedShieldSubscription) {
       return '';
     }
     if (isPaused) {
@@ -555,8 +577,10 @@ const TransactionShield = () => {
                 ? 'shieldTxMembershipErrorInsufficientToken'
                 : 'shieldTxMembershipErrorUpdateCard',
               [
-                isCryptoPaymentMethod(shieldSubscription?.paymentMethod)
-                  ? shieldSubscription.paymentMethod.crypto.tokenSymbol
+                isCryptoPaymentMethod(
+                  displayedShieldSubscription?.paymentMethod,
+                )
+                  ? displayedShieldSubscription.paymentMethod.crypto.tokenSymbol
                   : '',
               ],
             )}
@@ -564,7 +588,7 @@ const TransactionShield = () => {
         </Tooltip>
       );
     }
-    if (isSubscriptionEndingSoon && shieldSubscription) {
+    if (isSubscriptionEndingSoon && displayedShieldSubscription) {
       return (
         <ButtonLink
           className="warning-button"
@@ -576,15 +600,15 @@ const TransactionShield = () => {
           color={TextColor.warningDefault}
           onClick={handlePaymentError}
         >
-          {isCryptoPaymentMethod(shieldSubscription.paymentMethod)
-            ? shieldSubscription.paymentMethod.crypto.tokenSymbol
+          {isCryptoPaymentMethod(displayedShieldSubscription.paymentMethod)
+            ? displayedShieldSubscription.paymentMethod.crypto.tokenSymbol
             : ''}
         </ButtonLink>
       );
     }
 
-    if (isCryptoPaymentMethod(shieldSubscription.paymentMethod)) {
-      const tokenInfo = shieldSubscription.paymentMethod.crypto;
+    if (isCryptoPaymentMethod(displayedShieldSubscription.paymentMethod)) {
+      const tokenInfo = displayedShieldSubscription.paymentMethod.crypto;
       const tokenAddress = cryptoPaymentMethod?.chains
         ?.find((chain) => chain.chainId === tokenInfo.chainId)
         ?.tokens.find(
@@ -605,10 +629,10 @@ const TransactionShield = () => {
       );
     }
 
-    return `${shieldSubscription.paymentMethod.card.brand.charAt(0).toUpperCase() + shieldSubscription.paymentMethod.card.brand.slice(1)} - ${shieldSubscription.paymentMethod.card.last4}`; // display card info for card payment method;
+    return `${displayedShieldSubscription.paymentMethod.card.brand.charAt(0).toUpperCase() + displayedShieldSubscription.paymentMethod.card.brand.slice(1)} - ${displayedShieldSubscription.paymentMethod.card.last4}`; // display card info for card payment method;
   }, [
     isPaused,
-    shieldSubscription,
+    displayedShieldSubscription,
     isCryptoPayment,
     isSubscriptionEndingSoon,
     t,
@@ -624,7 +648,7 @@ const TransactionShield = () => {
       flexDirection={FlexDirection.Column}
       padding={4}
     >
-      {shieldSubscription?.cancelAtPeriodEnd && (
+      {currentShieldSubscription?.cancelAtPeriodEnd && (
         <Box
           className="transaction-shield-page__notification-banner"
           backgroundColor={BackgroundColor.warningMuted}
@@ -640,7 +664,7 @@ const TransactionShield = () => {
           <Text variant={TextVariant.bodySm}>
             {t('shieldTxMembershipCancelNotification', [
               getShortDateFormatterV2().format(
-                new Date(shieldSubscription.currentPeriodEnd),
+                new Date(currentShieldSubscription.currentPeriodEnd),
               ),
             ])}
           </Text>
@@ -688,7 +712,7 @@ const TransactionShield = () => {
                     ? t('shieldTxMembershipInactive')
                     : t('shieldTxMembershipActive')}
                 </Text>
-                {shieldSubscription?.status ===
+                {currentShieldSubscription?.status ===
                   SUBSCRIPTION_STATUSES.trialing && (
                   <Tag
                     label={t('shieldTxMembershipFreeTrial')}
@@ -793,8 +817,7 @@ const TransactionShield = () => {
           },
           'shield-detail-view-benefits-button',
         )}
-        {/* TODO: implement logic to allow submitting case until after 21 days of last active subscription */}
-        {shieldSubscription?.isEligibleForSupport &&
+        {displayedShieldSubscription?.isEligibleForSupport &&
           buttonRow(
             t('shieldTxMembershipSubmitCase'),
             () => {
@@ -803,7 +826,7 @@ const TransactionShield = () => {
             'shield-detail-submit-case-button',
           )}
         {!isMembershipInactive &&
-          shieldSubscription?.cancelAtPeriodEnd &&
+          currentShieldSubscription?.cancelAtPeriodEnd &&
           buttonRow(
             t('shieldTxMembershipResubscribe'),
             () => {
@@ -822,14 +845,7 @@ const TransactionShield = () => {
         {isCancelled &&
           buttonRow(
             t('shieldTxMembershipRenew'),
-            async () => {
-              if (isCryptoPayment) {
-                // TODO: handle renew membership crypto
-                console.log('renew membership');
-              } else {
-                await executeUpdateSubscriptionCardPaymentMethod();
-              }
-            },
+            handlePaymentError,
             'shield-detail-renew-button',
           )}
       </Box>
@@ -851,39 +867,44 @@ const TransactionShield = () => {
               {t('shieldTxMembershipBillingDetails')}
             </Text>
           )}
-          {shieldSubscription ? (
+          {displayedShieldSubscription ? (
             <>
               {billingDetails(
                 t('shieldTxMembershipBillingDetailsNextBilling'),
-                isCancelled || shieldSubscription?.cancelAtPeriodEnd
+                isCancelled || displayedShieldSubscription?.cancelAtPeriodEnd
                   ? '-'
                   : getShortDateFormatterV2().format(
-                      new Date(shieldSubscription.currentPeriodEnd),
+                      new Date(displayedShieldSubscription.currentPeriodEnd),
                     ),
                 'shield-detail-next-billing',
               )}
               {billingDetails(
                 t('shieldTxMembershipBillingDetailsCharges'),
                 isCryptoPayment
-                  ? `${getProductPrice(productInfo as Product)} ${productInfo?.currency.toUpperCase()} (${shieldSubscription.interval === RECURRING_INTERVALS.year ? t('shieldPlanAnnual') : t('shieldPlanMonthly')})`
+                  ? `${getProductPrice(productInfo as Product)} ${productInfo?.currency.toUpperCase()} (${displayedShieldSubscription.interval === RECURRING_INTERVALS.year ? t('shieldPlanAnnual') : t('shieldPlanMonthly')})`
                   : `${formatCurrency(
                       getProductPrice(productInfo as Product),
                       productInfo?.currency.toUpperCase(),
                       {
                         maximumFractionDigits: 0,
                       },
-                    )} (${shieldSubscription.interval === RECURRING_INTERVALS.year ? t('shieldPlanAnnual') : t('shieldPlanMonthly')})`,
+                    )} (${displayedShieldSubscription.interval === RECURRING_INTERVALS.year ? t('shieldPlanAnnual') : t('shieldPlanMonthly')})`,
                 'shield-detail-charges',
               )}
               {isCryptoPayment &&
                 billingDetails(
                   t('shieldTxMembershipBillingDetailsBillingAccount'),
-                  isCryptoPaymentMethod(shieldSubscription.paymentMethod) ? (
+                  isCryptoPaymentMethod(
+                    displayedShieldSubscription.paymentMethod,
+                  ) ? (
                     <ConfirmInfoRowAddress
                       address={
-                        shieldSubscription.paymentMethod.crypto.payerAddress
+                        displayedShieldSubscription.paymentMethod.crypto
+                          .payerAddress
                       }
-                      chainId={shieldSubscription.paymentMethod.crypto.chainId}
+                      chainId={
+                        displayedShieldSubscription.paymentMethod.crypto.chainId
+                      }
                     />
                   ) : (
                     ''
@@ -900,35 +921,38 @@ const TransactionShield = () => {
             <Skeleton width="60%" height={24} />
           )}
         </Box>
-        {shieldSubscription?.status !== SUBSCRIPTION_STATUSES.provisional &&
+        {displayedShieldSubscription?.status !==
+          SUBSCRIPTION_STATUSES.provisional &&
           buttonRow(
             t('shieldTxMembershipBillingDetailsViewBillingHistory'),
             executeOpenGetSubscriptionBillingPortal,
             'shield-detail-view-billing-history-button',
           )}
       </Box>
-      {shieldSubscription && isCancelMembershipModalOpen && (
+      {currentShieldSubscription && isCancelMembershipModalOpen && (
         <CancelMembershipModal
           onClose={() => setIsCancelMembershipModalOpen(false)}
           onConfirm={async () => {
             setIsCancelMembershipModalOpen(false);
             await executeCancelSubscription();
           }}
-          subscription={shieldSubscription}
+          subscription={currentShieldSubscription}
         />
       )}
       {loading && <LoadingScreen />}
       {currentToken &&
         isAddFundsModalOpen &&
-        shieldSubscription &&
-        isCryptoPaymentMethod(shieldSubscription.paymentMethod) && (
+        currentShieldSubscription &&
+        isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) && (
           <AddFundsModal
             onClose={() => {
               setIsAddFundsModalOpen(false);
             }}
             token={currentToken}
-            chainId={shieldSubscription.paymentMethod.crypto.chainId}
-            payerAddress={shieldSubscription.paymentMethod.crypto.payerAddress}
+            chainId={currentShieldSubscription.paymentMethod.crypto.chainId}
+            payerAddress={
+              currentShieldSubscription.paymentMethod.crypto.payerAddress
+            }
           />
         )}
     </Box>

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -446,7 +446,10 @@ const TransactionShield = () => {
     useSubscriptionCryptoApprovalTransaction(paymentToken);
 
   const handlePaymentError = useCallback(async () => {
-    if (
+    if (isCancelled) {
+      // go to shield plan page to renew subscription for cancelled subscription
+      navigate(SHIELD_PLAN_ROUTE);
+    } else if (
       shieldSubscription &&
       isCryptoPaymentMethod(shieldSubscription.paymentMethod)
     ) {
@@ -467,6 +470,8 @@ const TransactionShield = () => {
       await executeUpdateSubscriptionCardPaymentMethod();
     }
   }, [
+    isCancelled,
+    navigate,
     shieldSubscription,
     isInsufficientFundsCrypto,
     isAllowanceNeededCrypto,

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -193,9 +193,9 @@ const TransactionShield = () => {
   const isSubscriptionEndingSoon =
     getIsShieldSubscriptionEndingSoon(subscriptions);
 
-  // user can cancel subscription if not canceled and not cancel at period end
+  // user can cancel subscription if not canceled and current subscription not cancel at period end
   const canCancel =
-    !isCancelled && !displayedShieldSubscription?.cancelAtPeriodEnd;
+    !isCancelled && !currentShieldSubscription?.cancelAtPeriodEnd;
 
   const isCryptoPayment =
     displayedShieldSubscription?.paymentMethod &&

--- a/ui/selectors/subscription/subscription.ts
+++ b/ui/selectors/subscription/subscription.ts
@@ -24,11 +24,13 @@ export function getUserSubscriptions(state: SubscriptionState): {
   customerId?: string;
   subscriptions: Subscription[];
   trialedProducts: ProductType[];
+  lastSubscription?: Subscription;
 } {
   return {
     customerId: state.metamask.customerId,
     subscriptions: state.metamask.subscriptions,
     trialedProducts: state.metamask.trialedProducts,
+    lastSubscription: state.metamask.lastSubscription,
   };
 }
 

--- a/ui/selectors/subscription/subscription.ts
+++ b/ui/selectors/subscription/subscription.ts
@@ -6,7 +6,10 @@ import {
   Subscription,
   SubscriptionControllerState,
 } from '@metamask/subscription-controller';
-import { getIsShieldSubscriptionActive } from '../../../shared/lib/shield';
+import {
+  getIsShieldSubscriptionActive,
+  getShieldSubscription,
+} from '../../../shared/lib/shield';
 
 export type SubscriptionState = {
   metamask: SubscriptionControllerState & {
@@ -53,6 +56,13 @@ export function getLastUsedShieldSubscriptionPaymentDetails(
 }
 
 export function getHasSubscribedToShield(state: SubscriptionState): boolean {
-  const hasSubscribedToShield = state.metamask.customerId;
-  return Boolean(hasSubscribedToShield);
+  const currentShieldSubscription = getShieldSubscription(
+    state.metamask.subscriptions,
+  );
+  const lastShieldSubscription =
+    state.metamask.lastSubscription &&
+    getShieldSubscription(state.metamask.lastSubscription);
+  const hasSubscribedToShield =
+    !currentShieldSubscription && !lastShieldSubscription;
+  return hasSubscribedToShield;
 }

--- a/ui/selectors/subscription/subscription.ts
+++ b/ui/selectors/subscription/subscription.ts
@@ -63,6 +63,6 @@ export function getHasSubscribedToShield(state: SubscriptionState): boolean {
     state.metamask.lastSubscription &&
     getShieldSubscription(state.metamask.lastSubscription);
   const hasSubscribedToShield =
-    !currentShieldSubscription && !lastShieldSubscription;
+    Boolean(currentShieldSubscription) || Boolean(lastShieldSubscription);
   return hasSubscribedToShield;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7890,9 +7890,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/subscription-controller@npm:@metamask-previews/subscription-controller@3.3.0-preview-6b23dd6":
-  version: 3.3.0-preview-6b23dd6
-  resolution: "@metamask-previews/subscription-controller@npm:3.3.0-preview-6b23dd6"
+"@metamask/subscription-controller@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/subscription-controller@npm:4.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.15.0"
@@ -7903,7 +7903,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
   peerDependencies:
     "@metamask/profile-sync-controller": ^26.0.0
-  checksum: 10/c21a9713675bd745944c22916843d15b6523735e4cb092c38d162a2e50341cb13925c019831acf9964fb3712176401df7d7e37b57c523994fc1c311f6b327378
+  checksum: 10/6dfe9ade5776661aa279239345fff8b9e16e01180a219feb924153ca55305f15fa6a231018795796bf7dd3b04bb144584571335b42f81ff6d4430716a9b06b96
   languageName: node
   linkType: hard
 
@@ -32110,7 +32110,7 @@ __metadata:
     "@metamask/solana-wallet-snap": "npm:^2.4.6"
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@metamask/streams": "npm:^0.4.0"
-    "@metamask/subscription-controller": "npm:^3.3.0"
+    "@metamask/subscription-controller": "npm:^4.0.0"
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7890,9 +7890,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/subscription-controller@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@metamask/subscription-controller@npm:3.3.0"
+"@metamask/subscription-controller@npm:@metamask-previews/subscription-controller@3.3.0-preview-6b23dd6":
+  version: 3.3.0-preview-6b23dd6
+  resolution: "@metamask-previews/subscription-controller@npm:3.3.0-preview-6b23dd6"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.15.0"
@@ -7903,7 +7903,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
   peerDependencies:
     "@metamask/profile-sync-controller": ^26.0.0
-  checksum: 10/0fe72a78e8cb8c49975c55eee906ec7e15dc343656895ff7810fe30805702406694bc5142b67aa7262efee21f6f5f305b6eea2be1762f9dc5b63a119363df822
+  checksum: 10/c21a9713675bd745944c22916843d15b6523735e4cb092c38d162a2e50341cb13925c019831acf9964fb3712176401df7d7e37b57c523994fc1c311f6b327378
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Handle user shield last subscription data
Keep transaction claimable after cancel if still within eligible time
Navigate back to shield plan if showing cancelled subscription and user press renew
Correct `getHasSubscribedToShield` check

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37700?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: keep shield transaction claimable after subscription cancelled
CHANGELOG entry: navigate back to shield plan if showing cancelled subscription and user press renew

## **Related issues**

Fixes:

## **Manual testing steps**

1. Subscribe to shield
2. Cancel subscription
3. After cancelled within 21 days user should still be able to access shield settings and submit claim

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="599" height="725" alt="Screenshot 2025-11-11 at 18 59 50" src="https://github.com/user-attachments/assets/ef40e2c9-819a-41ef-bdbe-a089388548ff" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows the last Shield subscription when no active one exists, updates settings flows (renew/cancel, billing, support eligibility), fixes subscription checks, and bumps @metamask/subscription-controller to v4.
> 
> - **Shield Settings (UI)**:
>   - Use `currentShieldSubscription` or fallback to `lastSubscription` for display and billing details.
>   - Adjust renew/cancel flows: navigate to plan on renew when canceled; allow uncancel; compute actions based on current vs. displayed subscription.
>   - Show support action only when `isEligibleForSupport`; refine error banners and payment method rendering; skeleton/loading and redirects updated.
> - **Hooks**:
>   - `useUserSubscriptions` returns full user subscription state (incl. `lastSubscription`).
>   - Add `useUserLastSubscriptionByProduct(product, lastSubscription)`.
> - **Selectors**:
>   - `getUserSubscriptions` now includes `lastSubscription`.
>   - `getHasSubscribedToShield` checks current or last Shield subscription via exported `getShieldSubscription`.
> - **Shared**:
>   - Export `getShieldSubscription` from `shared/lib/shield` for reuse.
> - **Tests**:
>   - Update tests to include `isEligibleForSupport` and new flows in Shield pages/modals.
> - **Dependencies**:
>   - Bump `@metamask/subscription-controller` to `^4.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 488730d875e9ccdf091caac5da1cbfb035fdfdb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->