### PR TITLE
fix: hide account menu in dapp connection flow

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -751,6 +751,30 @@ describe('MultichainAccountList', () => {
         ),
       ).not.toBeInTheDocument();
     });
+
+    it('hides account menu (3 dots) when showAccountCheckbox is true', () => {
+      const { rerender } = renderComponent({
+        selectedAccountGroups: [walletOneGroupId],
+        showAccountCheckbox: false,
+      });
+
+      // With checkboxes disabled, menu buttons should be visible
+      let menuButtons = document.querySelectorAll(menuButtonSelector);
+      expect(menuButtons.length).toBe(2);
+
+      // Enable checkboxes
+      rerender(
+        <MultichainAccountList
+          wallets={mockWallets}
+          selectedAccountGroups={[walletOneGroupId]}
+          showAccountCheckbox={true}
+        />,
+      );
+
+      // With checkboxes enabled, menu buttons should be hidden
+      menuButtons = document.querySelectorAll(menuButtonSelector);
+      expect(menuButtons.length).toBe(0);
+    });
   });
 
   describe('Connection Status', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -293,13 +293,15 @@ export const MultichainAccountList = ({
               ) : undefined
             }
             endAccessory={
-              <MultichainAccountMenu
-                accountGroupId={groupId as AccountGroupId}
-                isRemovable={isRemovable}
-                handleAccountRenameAction={handleAccountRenameAction}
-                isOpen={openMenuAccountId === groupId}
-                onToggle={() => handleMenuToggle(groupId as AccountGroupId)}
-              />
+              showAccountCheckbox ? undefined : (
+                <MultichainAccountMenu
+                  accountGroupId={groupId as AccountGroupId}
+                  isRemovable={isRemovable}
+                  handleAccountRenameAction={handleAccountRenameAction}
+                  isOpen={openMenuAccountId === groupId}
+                  onToggle={() => handleMenuToggle(groupId as AccountGroupId)}
+                />
+              )
             }
           />
         </Box>

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -87,6 +87,8 @@ export const MultichainAccountList = ({
   showAccountCheckbox = false,
   showConnectionStatus = false,
 }: MultichainAccountListProps) => {
+  const showAccountMenu = !showAccountCheckbox;
+
   const dispatch = useDispatch();
   const history = useHistory();
   const trackEvent = useContext(MetaMetricsContext);
@@ -293,7 +295,7 @@ export const MultichainAccountList = ({
               ) : undefined
             }
             endAccessory={
-              showAccountCheckbox ? undefined : (
+              showAccountMenu ? (
                 <MultichainAccountMenu
                   accountGroupId={groupId as AccountGroupId}
                   isRemovable={isRemovable}
@@ -301,7 +303,7 @@ export const MultichainAccountList = ({
                   isOpen={openMenuAccountId === groupId}
                   onToggle={() => handleMenuToggle(groupId as AccountGroupId)}
                 />
-              )
+              ) : undefined
             }
           />
         </Box>


### PR DESCRIPTION
## **Description**

Fixes a bug where clicking the account details menu (3 dots) in the Connect to dapp screen does nothing. The menu should not be displayed in this flow since users are selecting accounts via checkboxes, not accessing account details.

**Changes:**
- Hide the account menu (`MultichainAccountMenu`) in `MultichainAccountList` when in account selection mode (`showAccountCheckbox` is true)
- Added test coverage to verify the menu is properly hidden during account selection

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37704?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed account details menu appearing in dapp connection account selection

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37604

## **Manual testing steps**

1. Go to the test dapp (https://metamask.github.io/test-dapp/)
2. Click "Connect" button
3. Click "Edit Accounts" in the connection modal
4. Verify that the 3 dots menu is **NOT** visible next to each account
5. Close the edit accounts modal
6. Open the main account menu from the extension
7. Verify that the 3 dots menu IS visible in the normal account list

## **Screenshots/Recordings**

### **Before**

Account menu (3 dots) was visible but non-functional in the edit accounts flow during dapp connection ([see bug](https://github.com/MetaMask/metamask-extension/issues/37604)).

### **After**

Account menu (3 dots) is now hidden in the edit accounts flow, only checkboxes are shown for account selection:

<img width="1166" height="870" alt="Screenshot 2025-11-11 at 13 28 08" src="https://github.com/user-attachments/assets/8d40621a-ad91-4010-b5a3-71dcccf906e2" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the per-account menu when `showAccountCheckbox` is true in `MultichainAccountList`, with tests verifying the menu is not rendered.
> 
> - **Frontend**
>   - **`ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx`**:
>     - Conditionally render `MultichainAccountMenu` only when `showAccountCheckbox` is false (`showAccountMenu = !showAccountCheckbox`).
> - **Tests**
>   - **`multichain-account-list.test.tsx`**:
>     - Add test to assert the 3-dots account menu is hidden when `showAccountCheckbox` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40b264c95eea728fe12f9c01102c381ea1b1f980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->