### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
@@ -18,6 +18,7 @@ import {
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../../../helpers/constants/design-system';
 import { RecipientRow, TransactionDetails } from './transaction-details';
+import * as useUserPreferencedCurrencyModule from '../../../../../../../hooks/useUserPreferencedCurrency';
 
 jest.mock(
   '../../../../../../../components/app/alert-system/contexts/alertMetricsContext',
@@ -151,6 +152,36 @@ describe('Transaction Details', () => {
         expect(
           queryByTestId('transaction-details-amount-row'),
         ).not.toBeInTheDocument();
+      });
+
+      it('uses transaction chainId to determine currency symbol', () => {
+        const useUserPreferencedCurrencySpy = jest.spyOn(
+          useUserPreferencedCurrencyModule,
+          'useUserPreferencedCurrency',
+        );
+
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation({
+            chainId: CHAIN_IDS.POLYGON,
+          });
+        const state = getMockConfirmStateForTransaction(contractInteraction, {
+          metamask: {
+            preferences: {
+              showConfirmationAdvancedDetails: true,
+            },
+          },
+        });
+        const mockStore = configureMockStore(middleware)(state);
+        renderWithConfirmContextProvider(<TransactionDetails />, mockStore);
+
+        // Verify useUserPreferencedCurrency was called with the transaction's chainId
+        expect(useUserPreferencedCurrencySpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          CHAIN_IDS.POLYGON,
+        );
+
+        useUserPreferencedCurrencySpy.mockRestore();
       });
     });
 

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -118,7 +118,11 @@ export const MethodDataRow = () => {
 const AmountRow = () => {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
-  const { currency } = useUserPreferencedCurrency(PRIMARY);
+  const { currency } = useUserPreferencedCurrency(
+    PRIMARY,
+    {},
+    currentConfirmation?.chainId,
+  );
 
   const value = currentConfirmation?.txParams?.value;
 


### PR DESCRIPTION
Pass transaction chainId to `useUserPreferencedCurrency` to fix incorrect currency symbol and decimals for Polygon transactions.

Previously, the `AmountRow` component would default to the currently selected account's native currency if no `chainId` was provided to `useUserPreferencedCurrency`. This led to displaying 'SOL' instead of 'POL' for Polygon transactions when a Solana account was active.

---
<a href="https://cursor.com/background-agent?bcId=bc-c63b26e9-a404-47fa-afd6-19bea6c13b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c63b26e9-a404-47fa-afd6-19bea6c13b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

