### PR TITLE
fix: Display correct native asset and its amount

### DIFF
--- a/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
@@ -47,28 +47,3 @@ exports[`ConfirmInfoRowCurrency should display value in user preferred currency 
 </div>
 `;
 
-exports[`ConfirmInfoRowCurrency should display with chainId prop 1`] = `
-<div>
-  <div
-    class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
-    style="column-gap: 8px;"
-  >
-    <div
-      class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
-      title="0.148619 POL"
-    >
-      <span
-        class="mm-box mm-text currency-display-component__text cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-        data-testid="account-value-and-suffix"
-      >
-        0.148619
-      </span>
-      <span
-        class="mm-box mm-text currency-display-component__suffix cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
-      >
-        POL
-      </span>
-    </div>
-  </div>
-</div>
-`;

--- a/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
@@ -46,3 +46,29 @@ exports[`ConfirmInfoRowCurrency should display value in user preferred currency 
   </div>
 </div>
 `;
+
+exports[`ConfirmInfoRowCurrency should display with chainId prop 1`] = `
+<div>
+  <div
+    class="mm-box mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
+    style="column-gap: 8px;"
+  >
+    <div
+      class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
+      title="0.148619 POL"
+    >
+      <span
+        class="mm-box mm-text currency-display-component__text cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
+        data-testid="account-value-and-suffix"
+      >
+        0.148619
+      </span>
+      <span
+        class="mm-box mm-text currency-display-component__suffix cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
+      >
+        POL
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/components/app/confirm/info/row/currency.test.tsx
+++ b/ui/components/app/confirm/info/row/currency.test.tsx
@@ -30,4 +30,9 @@ describe('ConfirmInfoRowCurrency', () => {
     const { container } = render({ currency: 'usd' });
     expect(container).toMatchSnapshot();
   });
+
+  it('should display with chainId prop', () => {
+    const { container } = render({ currency: 'POL', chainId: '0x89' });
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/ui/components/app/confirm/info/row/currency.test.tsx
+++ b/ui/components/app/confirm/info/row/currency.test.tsx
@@ -32,7 +32,14 @@ describe('ConfirmInfoRowCurrency', () => {
   });
 
   it('should display with chainId prop', () => {
-    const { container } = render({ currency: 'POL', chainId: '0x89' });
-    expect(container).toMatchSnapshot();
+    const { container, getByText } = render({
+      currency: 'POL',
+      chainId: '0x89',
+    });
+    expect(
+      container.querySelector('.currency-display-component'),
+    ).toBeInTheDocument();
+    expect(getByText(/0.148619/u)).toBeInTheDocument();
+    expect(getByText(/POL/u)).toBeInTheDocument();
   });
 });

--- a/ui/components/app/confirm/info/row/currency.tsx
+++ b/ui/components/app/confirm/info/row/currency.tsx
@@ -14,6 +14,7 @@ export type ConfirmInfoRowCurrencyProps = {
   currency?: string;
   'data-testid'?: string;
   className?: string;
+  chainId?: string;
 };
 
 // todo: the component currently takes care of displaying value in the currency passed
@@ -25,6 +26,7 @@ export const ConfirmInfoRowCurrency = ({
   currency,
   'data-testid': dataTestId,
   className,
+  chainId,
 }: ConfirmInfoRowCurrencyProps) => (
   <Box
     display={Display.Flex}
@@ -41,6 +43,7 @@ export const ConfirmInfoRowCurrency = ({
         currency={currency}
         value={`${value}`}
         className={className}
+        chainId={chainId}
       />
     ) : (
       <UserPreferencedCurrencyDisplay

--- a/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
+++ b/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
@@ -49,27 +49,6 @@ exports[`CurrencyDisplay Component should render text with a prefix 1`] = `
 </div>
 `;
 
-exports[`CurrencyDisplay Component should render with chainId prop 1`] = `
-<div>
-  <div
-    class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
-    title="0.1 POL"
-  >
-    <span
-      class="mm-box mm-text currency-display-component__text cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-      data-testid="account-value-and-suffix"
-    >
-      0.1
-    </span>
-    <span
-      class="mm-box mm-text currency-display-component__suffix cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
-    >
-      POL
-    </span>
-  </div>
-</div>
-`;
-
 exports[`CurrencyDisplay Component should render with title (tooltip) 1`] = `
 <div>
   <div
@@ -100,3 +79,4 @@ exports[`CurrencyDisplay Component should render without title (tooltip) 1`] = `
   </div>
 </div>
 `;
+

--- a/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
+++ b/ui/components/ui/currency-display/__snapshots__/currency-display.component.test.js.snap
@@ -49,6 +49,27 @@ exports[`CurrencyDisplay Component should render text with a prefix 1`] = `
 </div>
 `;
 
+exports[`CurrencyDisplay Component should render with chainId prop 1`] = `
+<div>
+  <div
+    class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
+    title="0.1 POL"
+  >
+    <span
+      class="mm-box mm-text currency-display-component__text cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
+      data-testid="account-value-and-suffix"
+    >
+      0.1
+    </span>
+    <span
+      class="mm-box mm-text currency-display-component__suffix cursor-pointer transition-colors duration-200 hover:text-text-alternative mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"
+    >
+      POL
+    </span>
+  </div>
+</div>
+`;
+
 exports[`CurrencyDisplay Component should render with title (tooltip) 1`] = `
 <div>
   <div

--- a/ui/components/ui/currency-display/currency-display.component.d.ts
+++ b/ui/components/ui/currency-display/currency-display.component.d.ts
@@ -14,6 +14,7 @@ export type CurrencyDisplayProps = OverridingUnion<
     prefix?: string;
     suffix?: string | boolean;
     value?: string;
+    chainId?: string;
 
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -33,19 +33,24 @@ export default function CurrencyDisplay({
   isAggregatedFiatOverviewBalance = false,
   privacyMode = false,
   onClick,
+  chainId,
   ...props
 }) {
-  const [title, parts] = useCurrencyDisplay(value, {
-    account,
-    displayValue,
-    prefix,
-    numberOfDecimals,
-    hideLabel,
-    denomination,
-    currency,
-    suffix,
-    isAggregatedFiatOverviewBalance,
-  });
+  const [title, parts] = useCurrencyDisplay(
+    value,
+    {
+      account,
+      displayValue,
+      prefix,
+      numberOfDecimals,
+      hideLabel,
+      denomination,
+      currency,
+      suffix,
+      isAggregatedFiatOverviewBalance,
+    },
+    chainId,
+  );
 
   return (
     <Box
@@ -114,6 +119,7 @@ const CurrencyDisplayPropTypes = {
   isAggregatedFiatOverviewBalance: PropTypes.bool,
   privacyMode: PropTypes.bool,
   onClick: PropTypes.func,
+  chainId: PropTypes.string,
 };
 
 CurrencyDisplay.propTypes = CurrencyDisplayPropTypes;

--- a/ui/components/ui/currency-display/currency-display.component.test.js
+++ b/ui/components/ui/currency-display/currency-display.component.test.js
@@ -76,11 +76,15 @@ describe('CurrencyDisplay Component', () => {
       chainId: '0x89',
     };
 
-    const { container } = renderWithProvider(
+    const { container, getByText } = renderWithProvider(
       <CurrencyDisplay {...props} />,
       mockStore,
     );
 
-    expect(container).toMatchSnapshot();
+    expect(
+      container.querySelector('.currency-display-component'),
+    ).toBeInTheDocument();
+    expect(getByText(/0.1/u)).toBeInTheDocument();
+    expect(getByText(/POL/u)).toBeInTheDocument();
   });
 });

--- a/ui/components/ui/currency-display/currency-display.component.test.js
+++ b/ui/components/ui/currency-display/currency-display.component.test.js
@@ -68,4 +68,19 @@ describe('CurrencyDisplay Component', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('should render with chainId prop', () => {
+    const props = {
+      value: '0x16345785d8a0000',
+      currency: 'POL',
+      chainId: '0x89',
+    };
+
+    const { container } = renderWithProvider(
+      <CurrencyDisplay {...props} />,
+      mockStore,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -16,6 +16,7 @@ import {
 } from '../../shared/constants/network';
 import { Numeric } from '../../shared/modules/Numeric';
 import { EtherDenomination } from '../../shared/constants/common';
+import { isEvmChainId } from '../../shared/lib/asset-utils';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import { getCurrencyRates } from '../ducks/metamask/metamask';
 import { useFormatters } from './useFormatters';
@@ -156,12 +157,15 @@ export function useCurrencyDisplay(
     currency === nativeCurrency ||
     currency === CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId];
 
+  // Check if the transaction's chain is EVM, not just the account
+  const isTransactionOnEvmChain = chainId ? isEvmChainId(chainId) : isEvm;
+
   const value = useMemo(() => {
     if (displayValue) {
       return displayValue;
     }
 
-    if (!isEvm && !isAggregatedFiatOverviewBalance) {
+    if (!isTransactionOnEvmChain && !isAggregatedFiatOverviewBalance) {
       return formatNonEvmAssetCurrencyDisplay({
         tokenSymbol: nativeCurrency,
         isNativeCurrency,
@@ -203,7 +207,7 @@ export function useCurrencyDisplay(
     });
   }, [
     displayValue,
-    isEvm,
+    isTransactionOnEvmChain,
     isNativeCurrency,
     isUserPreferredCurrency,
     currency,

--- a/ui/hooks/useCurrencyDisplay.test.js
+++ b/ui/hooks/useCurrencyDisplay.test.js
@@ -156,4 +156,68 @@ describe('useCurrencyDisplay', () => {
       });
     });
   });
+
+  describe('when chainId is provided', () => {
+    it('should format native currency correctly for EVM chains', () => {
+      const state = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          completedOnboarding: true,
+          currentCurrency: 'usd',
+          currencyRates: { ETH: { conversionRate: 280.45 } },
+        },
+      };
+
+      const wrapper = ({ children }) => (
+        <Provider store={configureStore(state)}>{children}</Provider>
+      );
+
+      const { result } = renderHook(
+        () =>
+          useCurrencyDisplay(
+            '0x16345785d8a0000', // 0.1 in Wei
+            { currency: 'POL', numberOfDecimals: 4 },
+            '0x89', // Polygon chainId
+          ),
+        { wrapper },
+      );
+
+      const [displayValue, parts] = result.current;
+      expect(parts.value).toStrictEqual('0.1');
+      expect(parts.suffix).toStrictEqual('POL');
+      expect(displayValue).toStrictEqual('0.1 POL');
+    });
+
+    it('should use EVM formatting for transactions on EVM chains even with non-EVM accounts', () => {
+      const state = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          completedOnboarding: true,
+          currentCurrency: 'usd',
+          currencyRates: { ETH: { conversionRate: 280.45 } },
+        },
+      };
+
+      const wrapper = ({ children }) => (
+        <Provider store={configureStore(state)}>{children}</Provider>
+      );
+
+      // Polygon chainId (EVM)
+      const { result } = renderHook(
+        () =>
+          useCurrencyDisplay(
+            '0xde0b6b3a7640000', // 1 in Wei
+            { currency: 'POL' },
+            '0x89',
+          ),
+        { wrapper },
+      );
+
+      const [displayValue, parts] = result.current;
+      expect(parts.value).toStrictEqual('1');
+      expect(parts.suffix).toStrictEqual('POL');
+    });
+  });
 });

--- a/ui/hooks/useCurrencyDisplay.test.js
+++ b/ui/hooks/useCurrencyDisplay.test.js
@@ -216,6 +216,7 @@ describe('useCurrencyDisplay', () => {
       );
 
       const [displayValue, parts] = result.current;
+      expect(displayValue).toStrictEqual('1 POL');
       expect(parts.value).toStrictEqual('1');
       expect(parts.suffix).toStrictEqual('POL');
     });

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../../../../../test/data/confirmations/batch-transaction';
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../../../helpers/constants/design-system';
+import * as useUserPreferencedCurrencyModule from '../../../../../../../hooks/useUserPreferencedCurrency';
 import { RecipientRow, TransactionDetails } from './transaction-details';
 
 jest.mock(
@@ -151,6 +152,36 @@ describe('Transaction Details', () => {
         expect(
           queryByTestId('transaction-details-amount-row'),
         ).not.toBeInTheDocument();
+      });
+
+      it('uses transaction chainId to determine currency symbol', () => {
+        const useUserPreferencedCurrencySpy = jest.spyOn(
+          useUserPreferencedCurrencyModule,
+          'useUserPreferencedCurrency',
+        );
+
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation({
+            chainId: CHAIN_IDS.POLYGON,
+          });
+        const state = getMockConfirmStateForTransaction(contractInteraction, {
+          metamask: {
+            preferences: {
+              showConfirmationAdvancedDetails: true,
+            },
+          },
+        });
+        const mockStore = configureMockStore(middleware)(state);
+        renderWithConfirmContextProvider(<TransactionDetails />, mockStore);
+
+        // Verify useUserPreferencedCurrency was called with the transaction's chainId
+        expect(useUserPreferencedCurrencySpy).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          CHAIN_IDS.POLYGON,
+        );
+
+        useUserPreferencedCurrencySpy.mockRestore();
       });
     });
 

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
@@ -183,6 +183,28 @@ describe('Transaction Details', () => {
 
         useUserPreferencedCurrencySpy.mockRestore();
       });
+
+      it('passes chainId to ConfirmInfoRowCurrency for proper formatting', () => {
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation({
+            chainId: CHAIN_IDS.POLYGON,
+          });
+        const state = getMockConfirmStateForTransaction(contractInteraction, {
+          metamask: {
+            preferences: {
+              showConfirmationAdvancedDetails: true,
+            },
+          },
+        });
+        const mockStore = configureMockStore(middleware)(state);
+        const { getByTestId } = renderWithConfirmContextProvider(
+          <TransactionDetails />,
+          mockStore,
+        );
+
+        const amountRow = getByTestId('transaction-details-amount-row');
+        expect(amountRow).toBeInTheDocument();
+      });
     });
 
     it('display network info if there is an alert on that field', () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -136,7 +136,11 @@ const AmountRow = () => {
         data-testid="transaction-details-amount-row"
         label={t('amount')}
       >
-        <ConfirmInfoRowCurrency value={value} currency={currency} />
+        <ConfirmInfoRowCurrency
+          value={value}
+          currency={currency}
+          chainId={currentConfirmation?.chainId}
+        />
       </ConfirmInfoRow>
     </ConfirmInfoSection>
   );

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -118,7 +118,11 @@ export const MethodDataRow = () => {
 const AmountRow = () => {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
-  const { currency } = useUserPreferencedCurrency(PRIMARY);
+  const { currency } = useUserPreferencedCurrency(
+    PRIMARY,
+    {},
+    currentConfirmation?.chainId,
+  );
 
   const value = currentConfirmation?.txParams?.value;
 


### PR DESCRIPTION
## **Description**
Displays correct native asset and the right amount in the Amount row.

## **Changelog**

CHANGELOG entry: Displays correct native asset and the right amount in the Amount row on the Confirmation page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/34762

## **Manual testing steps**

0. In the MM wallet make sure to select Solana
1. Go to https://app.1inch.io/swap?src=137:POL&dst=137:DEFIT
2. Connect with MM
3. Swap POL -> DEFIT (Polygon transaction), it will open the extension
4. You will see the right native asset and amount in the Amount row

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="370" height="577" alt="image" src="https://github.com/user-attachments/assets/907cf562-dc2e-4c58-88ea-cc5d0083d1b2" />

### **After**
<img width="492" height="754" alt="image" src="https://github.com/user-attachments/assets/086fb312-16fc-458b-a2bc-6965e0c1aad4" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the transaction chainId to determine native currency symbol/formatting in the Amount row, plumbing chainId through CurrencyDisplay and useCurrencyDisplay with new tests.
> 
> - **Confirmations UI**:
>   - Amount row now derives currency via `useUserPreferencedCurrency(PRIMARY, {}, currentConfirmation?.chainId)` and passes `chainId` to `ConfirmInfoRowCurrency`.
> - **Components**:
>   - `ConfirmInfoRowCurrency`: accepts optional `chainId` and forwards it to `CurrencyDisplay`.
>   - `CurrencyDisplay`: adds `chainId` prop; passes it to `useCurrencyDisplay`.
> - **Hooks**:
>   - `useCurrencyDisplay`: now accepts `chainId`; uses `isEvmChainId(chainId)` to choose EVM vs non‑EVM formatting and resolves native ticker via `CHAIN_ID_TO_CURRENCY_SYMBOL_MAP`.
> - **Tests**:
>   - Add tests verifying formatting with `chainId` for Polygon and that `useUserPreferencedCurrency` is called with the transaction `chainId`.
>   - Update snapshots accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a5792b05d5f9f8bb775a3a08e44df6057131042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->