### PR TITLE
chore: qr code view to download mobile

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5679,6 +5679,12 @@
     "message": "Rewards Points",
     "description": "Alt text for the rewards points icon"
   },
+  "rewardsQRCodeDescription": {
+    "message": "You'll need the app to track your progress and redeem rewards. Scan this QR code and we'll help you import your accounts."
+  },
+  "rewardsQRCodeTitle": {
+    "message": "Get the mobile app"
+  },
   "rewardsSignUp": {
     "message": "Sign up for Rewards"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5679,6 +5679,12 @@
     "message": "Rewards Points",
     "description": "Alt text for the rewards points icon"
   },
+  "rewardsQRCodeDescription": {
+    "message": "You'll need the app to track your progress and redeem rewards. Scan this QR code and we'll help you import your accounts."
+  },
+  "rewardsQRCodeTitle": {
+    "message": "Get the mobile app"
+  },
   "rewardsSignUp": {
     "message": "Sign up for Rewards"
   },

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -146,6 +146,9 @@ describe('RewardsPointsBalance', () => {
       if (selector === selectOnboardingModalRendered) {
         return onboardingModalRendered;
       }
+      if (selector === selectSeasonStatusError) {
+        return seasonStatusError;
+      }
       return undefined;
     });
 

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -160,6 +160,7 @@ export const RewardsPointsBalance = () => {
       <RewardsBadge
         formattedPoints={formattedPoints}
         boxClassName="gap-1 px-1.5 bg-background-muted rounded"
+        onClick={openRewardsOnboardingModal}
       />
     );
   }

--- a/ui/components/app/rewards/RewardsQRCode.test.tsx
+++ b/ui/components/app/rewards/RewardsQRCode.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { setOnboardingModalOpen } from '../../../ducks/rewards';
+import { getSocialLoginType } from '../../../selectors/seedless-onboarding/social-sync';
+import RewardsQRCode from './RewardsQRCode';
+
+// Mock react-redux hooks
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(() => jest.fn()),
+}));
+
+// Mock i18n to return readable strings
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => {
+    if (key === 'rewardsQRCodeTitle') {
+      return 'Scan this QR code to continue';
+    }
+    if (key === 'rewardsQRCodeDescription') {
+      return 'Use your mobile app to complete onboarding.';
+    }
+    if (key === 'gotIt') {
+      return 'Got it';
+    }
+    return key;
+  }),
+}));
+
+// Mock ModalBody to a simple container preserving test id and children
+jest.mock('../../component-library/modal-body/modal-body', () => ({
+  ModalBody: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+// Mock QR code generator to expose the encoded data in the DOM
+// so we can assert the component passes the correct value
+jest.mock('qrcode-generator', () => {
+  return jest.fn(() => {
+    let storedData = '';
+    return {
+      addData: (data: string) => {
+        storedData = data;
+      },
+      make: jest.fn(),
+      createTableTag: jest.fn(() => `<div data-qr="${storedData}">QR</div>`),
+    };
+  });
+});
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+
+describe('RewardsQRCode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the container and logo image', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getSocialLoginType) {
+        return undefined;
+      }
+      return undefined;
+    });
+
+    render(<RewardsQRCode />);
+
+    expect(
+      screen.getByTestId('rewards-onboarding-qrcode-container'),
+    ).toBeInTheDocument();
+    expect(screen.getByAltText('Logo')).toBeInTheDocument();
+    expect(mockUseSelector).toHaveBeenCalledWith(getSocialLoginType);
+  });
+
+  it('encodes socialType in QR data when provided', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getSocialLoginType) {
+        return 'google';
+      }
+      return undefined;
+    });
+
+    render(<RewardsQRCode />);
+
+    const qrImageContainer = screen.getByTestId('qr-code-image');
+    expect(qrImageContainer).toBeInTheDocument();
+    // The inner HTML is produced by our qr generator mock and includes data-qr
+    expect(qrImageContainer.innerHTML).toContain(
+      'data-qr="https://link.metamask.io/onboarding?type=google&amp;existing=true"',
+    );
+  });
+
+  it('defaults to SRP flow in QR data when socialType is absent', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getSocialLoginType) {
+        return undefined;
+      }
+      return undefined;
+    });
+
+    render(<RewardsQRCode />);
+
+    const qrImageContainer = screen.getByTestId('qr-code-image');
+    expect(qrImageContainer).toBeInTheDocument();
+    expect(qrImageContainer.innerHTML).toContain(
+      'data-qr="https://link.metamask.io/onboarding?type=srp"',
+    );
+  });
+
+  it('dispatches close action when clicking Got it', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getSocialLoginType) {
+        return undefined;
+      }
+      return undefined;
+    });
+    const dispatchMock = jest.fn();
+    mockUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<RewardsQRCode />);
+
+    const closeButton = screen.getByRole('button', { name: 'Got it' });
+    expect(closeButton).toBeInTheDocument();
+    fireEvent.click(closeButton);
+
+    expect(dispatchMock).toHaveBeenCalledWith(setOnboardingModalOpen(false));
+  });
+});

--- a/ui/components/app/rewards/RewardsQRCode.tsx
+++ b/ui/components/app/rewards/RewardsQRCode.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import qrCode from 'qrcode-generator';
+import { useDispatch, useSelector } from 'react-redux';
+import { getSocialLoginType } from '../../../selectors/seedless-onboarding/social-sync';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { setOnboardingModalOpen } from '../../../ducks/rewards';
+import { ModalBody } from '../../component-library/modal-body/modal-body';
+
+const QrCodeView = ({ data }: { data: string }) => {
+  const qrImage = qrCode(0, 'M');
+  qrImage.addData(data);
+  qrImage.make();
+
+  return (
+    <Box className="qr-code__wrapper my-2">
+      <Box
+        data-testid="qr-code-image"
+        className="qr-code__image"
+        dangerouslySetInnerHTML={{
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          __html: qrImage.createTableTag(5, 16),
+        }}
+      />
+      <Box className="qr-code__logo">
+        <img src="images/logo/metamask-fox.svg" alt="Logo" />
+      </Box>
+    </Box>
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default function RewardsQRCode() {
+  const socialType = useSelector(getSocialLoginType);
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+
+  const handleClose = useCallback(() => {
+    dispatch(setOnboardingModalOpen(false));
+  }, [dispatch]);
+
+  const dataToEncode = useMemo(() => {
+    if (socialType) {
+      return `https://link.metamask.io/onboarding?type=${socialType}&existing=true`;
+    }
+
+    return `https://link.metamask.io/onboarding?type=srp`;
+  }, [socialType]);
+
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid="rewards-onboarding-qrcode-container"
+    >
+      <Box className="flex flex-1 flex-col items-center justify-center gap-4">
+        <Text variant={TextVariant.HeadingSm} className="text-center">
+          {t('rewardsQRCodeTitle')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          className="text-center text-alternative"
+        >
+          {t('rewardsQRCodeDescription')}
+        </Text>
+        <QrCodeView data={dataToEncode} />
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onClick={handleClose}
+          className="w-full my-2"
+        >
+          {t('gotIt')}
+        </Button>
+      </Box>
+    </ModalBody>
+  );
+}

--- a/ui/components/app/rewards/onboarding/OnboardingModal.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.test.tsx
@@ -47,6 +47,11 @@ jest.mock('../RewardsErrorToast', () => () => (
   <div data-testid="rewards-error-toast">Toast</div>
 ));
 
+// Mock QR code to a simple marker for content assertions
+jest.mock('../RewardsQRCode', () => () => (
+  <div data-testid="rewards-qr">QR Code</div>
+));
+
 const mockedUseSelector = useSelector as jest.Mock;
 const mockedUseDispatch = useDispatch as jest.Mock;
 
@@ -120,6 +125,11 @@ describe('OnboardingModal', () => {
     mockedUseDispatch.mockReturnValue(dispatchMock);
 
     render(<OnboardingModal />);
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    const closeButton = header.querySelector('button.absolute.z-10');
+    expect(closeButton).toBeTruthy();
+    // Click the close button to trigger handleClose
+    closeButton && (closeButton as HTMLButtonElement).click();
 
     await waitFor(() => {
       expect(dispatchMock).toHaveBeenCalledWith(setOnboardingModalOpen(false));

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -25,6 +25,7 @@ import {
 import { OnboardingStep } from '../../../../ducks/rewards/types';
 import { useTheme } from '../../../../hooks/useTheme';
 import RewardsErrorToast from '../RewardsErrorToast';
+import RewardsQRCode from '../RewardsQRCode';
 import OnboardingIntroStep from './OnboardingIntroStep';
 import OnboardingStep1 from './OnboardingStep1';
 import OnboardingStep2 from './OnboardingStep2';
@@ -52,8 +53,7 @@ export default function OnboardingModal() {
       candidateSubscriptionId !== 'pending' &&
       candidateSubscriptionId !== 'retry'
     ) {
-      // TODO: render mobile QR code
-      return null;
+      return <RewardsQRCode />;
     }
 
     switch (onboardingStep) {
@@ -75,17 +75,6 @@ export default function OnboardingModal() {
   useEffect(() => {
     dispatch(setOnboardingModalRendered(true));
   }, [dispatch]);
-
-  useEffect(() => {
-    if (
-      candidateSubscriptionId &&
-      candidateSubscriptionId !== 'error' &&
-      candidateSubscriptionId !== 'pending' &&
-      candidateSubscriptionId !== 'retry'
-    ) {
-      handleClose();
-    }
-  }, [candidateSubscriptionId, handleClose]);
 
   return (
     <Modal
@@ -117,7 +106,10 @@ export default function OnboardingModal() {
               top: '24px',
               right: '12px',
               display:
-                onboardingStep === OnboardingStep.INTRO ? 'none' : 'block',
+                !candidateSubscriptionId &&
+                onboardingStep === OnboardingStep.INTRO
+                  ? 'none'
+                  : 'block',
             },
           }}
           paddingBottom={0}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

https://consensyssoftware.atlassian.net/browse/RWDS-275
Implement the QrCode View to download MM Mobile

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37718?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Implement the QrCode View to download MM Mobile after Rewards onboarding

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="396" height="598" alt="Screenshot 2025-11-11 at 4 41 50 PM" src="https://github.com/user-attachments/assets/00519978-151a-45a0-bac2-9d06b11a23dd" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a QR code view for mobile onboarding, shows it in the rewards onboarding modal when a valid subscription is detected, and makes the points badge open the onboarding modal; includes i18n and tests.
> 
> - **Rewards UI**:
>   - **QR Code View**: New `RewardsQRCode` component renders a MetaMask Mobile onboarding QR (`ui/components/app/rewards/RewardsQRCode.tsx`).
>   - **Onboarding Modal Integration**: `OnboardingModal` now displays `RewardsQRCode` when `candidateSubscriptionId` is valid (not `error/pending/retry`) and adjusts close-button visibility logic (`ui/components/app/rewards/onboarding/OnboardingModal.tsx`).
>   - **Points Badge Interaction**: `RewardsPointsBalance` adds `onClick` to open the onboarding modal and refines signup/error states (`ui/components/app/rewards/RewardsPointsBalance.tsx`).
> - **i18n**:
>   - Add `rewardsQRCodeTitle` and `rewardsQRCodeDescription` to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Add `RewardsQRCode.test.tsx` and update `OnboardingModal.test.tsx` and `RewardsPointsBalance.test.tsx` to cover new QR flow and interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4058ec5796f32b51bc0eae4b48fe902e93810ad7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->