### PR TITLE
fix: Update onboarding to open in sidepanel

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4590,6 +4590,9 @@
   "openInBlockExplorer": {
     "message": "Open in block explorer"
   },
+  "openWallet": {
+    "message": "Open Wallet"
+  },
   "optional": {
     "message": "Optional"
   },

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -59,6 +59,8 @@ import { LottieAnimation } from '../../../components/component-library/lottie-an
 ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { getIsSidePanelFeatureEnabled } from '../../../../shared/modules/environment';
 ///: END:ONLY_INCLUDE_IF
+import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import WalletReadyAnimation from './wallet-ready-animation';
 
 export default function CreationSuccessful() {
@@ -73,6 +75,7 @@ export default function CreationSuccessful() {
   const trackEvent = useContext(MetaMetricsContext);
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isTestEnvironment = Boolean(process.env.IN_TEST);
+  const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
 
   const learnMoreLink =
     'https://support.metamask.io/stay-safe/safety-in-web3/basic-safety-and-security-tips-for-metamask/';
@@ -163,7 +166,7 @@ export default function CreationSuccessful() {
 
     ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     // Side Panel - only if feature flag is enabled
-    if (getIsSidePanelFeatureEnabled()) {
+    if (getIsSidePanelFeatureEnabled() && !isFirefox) {
       try {
         if (browser?.sidePanel?.open) {
           const tabs = await browser.tabs.query({
@@ -183,7 +186,9 @@ export default function CreationSuccessful() {
       }
     }
     // Fallback to regular onboarding completion
-    await dispatch(setCompletedOnboarding());
+    if (!isFirefox) {
+      await dispatch(setCompletedOnboarding());
+    }
     ///: END:ONLY_INCLUDE_IF
     ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
     // Regular onboarding completion for non-experimental builds
@@ -200,6 +205,7 @@ export default function CreationSuccessful() {
     trackEvent,
     firstTimeFlowType,
     isFromSettingsSecurity,
+    isFirefox,
   ]);
 
   const renderDoneButton = () => {
@@ -217,7 +223,9 @@ export default function CreationSuccessful() {
           width={BlockSize.Full}
           onClick={onDone}
         >
-          {t('done')}
+          {process.env.METAMASK_BUILD_TYPE === 'experimental'
+            ? t('openWallet')
+            : t('done')}
         </Button>
       </Box>
     );

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -223,7 +223,7 @@ export default function CreationSuccessful() {
           width={BlockSize.Full}
           onClick={onDone}
         >
-          {process.env.METAMASK_BUILD_TYPE === 'experimental'
+          {process.env.METAMASK_BUILD_TYPE === 'experimental' && !isFirefox
             ? t('openWallet')
             : t('done')}
         </Button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, For new users we open sidepanel by default upon onboarding completion. Used feature flag to only show this change when sidepanel is available for chrome and build type is experimental. Updated button on wallet creation successful page from 'Done' to 'Open wallet'.


Jira Link: https://consensyssoftware.atlassian.net/browse/SL-281

Figma Link: https://www.figma.com/design/YhI8pXtinRY4oZu4IYoAPt/Side-Panel-Extension?node-id=172-7522&t=mPG5UFWEZJEFOLIV-0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37722?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open extension
2. Create wallet at the end of flow i.e. Wallet Successful Page 
3. CTA changed to 'Open wallet' only for chrome extension and build type is 'experimental'
4. Validate the changes from the above Figma link.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

CHROME EXTENSION:

https://github.com/user-attachments/assets/ebcb797a-698c-4621-9c2a-e51c66015111

FIREFOX EXTENSION:

https://github.com/user-attachments/assets/fb20a01f-3d42-4b60-9b76-30eb9068e61a



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Opens the side panel by default after onboarding for experimental builds except on Firefox, and changes the completion CTA to “Open Wallet”; adds corresponding locale string.
> 
> - **Onboarding (CreationSuccessful)**:
>   - Gate side panel opening behind feature flag and browser check (`!isFirefox`), using `getBrowserName` and `PLATFORM_FIREFOX`.
>   - Fallback onboarding completion dispatch adjusted; maintain non-experimental path.
>   - Update completion button label to `t('openWallet')` for experimental builds on non-Firefox; otherwise use `t('done')`.
> - **Localization**:
>   - Add `openWallet` message key in `app/_locales/en/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 886706aa975007701d411c413023a935914dfa7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->