### PR TITLE
ci: use a container and HEADLESS=false for running benchmarks

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -13,7 +13,7 @@ env:
   COMMANDS: |
     {
       standardHome: 'yarn tsx test/e2e/benchmarks/benchmark.ts --out test-artifacts/benchmarks/benchmark-{0}-{1}-standardHome.json --retries 2',
-      powerUserHome: 'yarn tsx test/e2e/benchmarks/benchmark.ts --persona powerUser --browserLoads 4 --pageLoads 4 --out test-artifacts/benchmarks/benchmark-{0}-{1}-powerUserHome.json --retries 2',
+      powerUserHome: 'yarn tsx test/e2e/benchmarks/benchmark.ts --persona powerUser --browserLoads 10 --pageLoads 10 --out test-artifacts/benchmarks/benchmark-{0}-{1}-powerUserHome.json --retries 2',
       userActions: 'yarn tsx test/e2e/benchmarks/user-actions-benchmark.ts --out test-artifacts/benchmarks/benchmark-{0}-{1}-userActions.json --retries 2',
     }
 
@@ -22,6 +22,11 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    container:
+      image: ghcr.io/metamask/metamask-extension-e2e-image:v24.11.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +36,7 @@ jobs:
     name: ${{ matrix.browser }}-${{ matrix.buildType }}-${{ matrix.pageType }}
     env:
       SELENIUM_BROWSER: ${{ matrix.browser }}
-      HEADLESS: true
+      HEADLESS: false
       ARTIFACT_NAME: build-test-${{ matrix.buildType }}
       OUTPUT_NAME: benchmark-${{ matrix.browser }}-${{ matrix.buildType }}-${{ matrix.pageType }}.json
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
@@ -62,6 +67,13 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
           run-id: ${{ inputs.builds-from-run }} # Download from whatever run the identify-builds job said.
+
+      - name: Configure Xvfb
+        run: Xvfb -ac :99 -screen 0 1280x1024x16 &
+
+      # TODO: Pre-install this in the container image
+      - name: Install AWS CLI (needed in the container)
+        run: sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
 
       - name: Run the benchmark
         # Choose a benchmark command from env.COMMANDS

--- a/app/scripts/controller-init/snaps/execution-service-init.test.ts
+++ b/app/scripts/controller-init/snaps/execution-service-init.test.ts
@@ -69,7 +69,6 @@ describe('ExecutionServiceInit', () => {
       messenger: expect.any(Object),
       offscreenPromise: expect.any(Promise),
       setupSnapProvider: expect.any(Function),
-      pingTimeout: process.env.IN_TEST ? 60000 : 5000, // see https://github.com/MetaMask/metamask-extension/issues/36935
     });
   });
 });

--- a/app/scripts/controller-init/snaps/execution-service-init.ts
+++ b/app/scripts/controller-init/snaps/execution-service-init.ts
@@ -56,7 +56,6 @@ export const ExecutionServiceInit: ControllerInitFunction<
         messenger: controllerMessenger,
         setupSnapProvider,
         offscreenPromise,
-        pingTimeout: process.env.IN_TEST ? 60000 : 5000, // see https://github.com/MetaMask/metamask-extension/issues/36935
       }),
     };
   }
@@ -71,7 +70,6 @@ export const ExecutionServiceInit: ControllerInitFunction<
       messenger: controllerMessenger,
       iframeUrl: new URL(iframeUrl),
       setupSnapProvider,
-      pingTimeout: process.env.IN_TEST ? 60000 : 5000, // see https://github.com/MetaMask/metamask-extension/issues/36935
     }),
   };
 };


### PR DESCRIPTION
## **Description**

Previously, benchmarks would crash if you ran them too many times.  The solution here is to use a container and run them `HEADLESS=false`, just like the E2E tests run.

Also undo the `pingTimeout` change.

The container did not have the AWS CLI installed, so we had to install it.  TODO is pre-install this in the container.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #36935

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs benchmarks in a container with HEADLESS=false and removes the `pingTimeout` option from Snaps execution service (and its tests).
> 
> - **CI / Benchmarks (`.github/workflows/run-benchmarks.yml`)**
>   - Run in container `ghcr.io/metamask/metamask-extension-e2e-image:v24.11.0` with credentials.
>   - Set `HEADLESS=false`; configure Xvfb for display.
>   - Install AWS CLI inside container.
>   - Increase `powerUserHome` loads: `--browserLoads 10 --pageLoads 10`.
> - **Snaps Execution Service**
>   - Remove `pingTimeout` from `OffscreenExecutionService` and `IframeExecutionService` initialization in `app/scripts/controller-init/snaps/execution-service-init.ts`.
>   - Update test `execution-service-init.test.ts` to drop `pingTimeout` expectation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d9eeb53a6c45c80091af6ab6cc8410cc32752c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->