### PR TITLE
feat: show inline alert state as neutral when subscription is paused

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
@@ -58,7 +58,7 @@ const ShieldFooterCoverageIndicator = () => {
       // the existing
       style={{ boxShadow: '0 -4px 16px -8px var(--color-shadow-default)' }}
     >
-      <Box marginTop={2}>
+      <Box marginTop={1}>
         <ShieldIconAnimation
           severity={animationSeverity}
           playAnimation={!isPaused}

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -178,17 +178,19 @@ export function useShieldCoverageAlert(): Alert[] {
       ? t('shieldCoverageAlertMessageTitlePaused')
       : t('shieldCoverageAlertMessageTitle');
     let inlineAlertTextBackgroundColor;
-    switch (status) {
-      case 'covered':
-        severity = Severity.Success;
-        inlineAlertText = t('shieldCovered');
-        modalTitle = t('shieldCoverageAlertMessageTitleCovered');
-        break;
-      case 'malicious':
-        severity = Severity.Danger;
-        inlineAlertTextBackgroundColor = BackgroundColor.errorMuted;
-        break;
-      default:
+    if (!isPaused) {
+      switch (status) {
+        case 'covered':
+          severity = Severity.Success;
+          inlineAlertText = t('shieldCovered');
+          modalTitle = t('shieldCoverageAlertMessageTitleCovered');
+          break;
+        case 'malicious':
+          severity = Severity.Danger;
+          inlineAlertTextBackgroundColor = BackgroundColor.errorMuted;
+          break;
+        default:
+      }
     }
 
     return [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Update UI for Shield coverage inline alert status when subscription is in paused state.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37729?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update UI for Shield coverage inline alert status when subscription is in paused state.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="409" height="626" alt="Screenshot 2025-11-12 at 3 39 19 PM" src="https://github.com/user-attachments/assets/b4ead63e-63de-4db5-889e-229f6e79cb8a" />


<!-- [screenshots/recordings] -->

### **After**
<img width="409" height="629" alt="Screenshot 2025-11-12 at 3 42 02 PM" src="https://github.com/user-attachments/assets/678addf0-3419-4858-9cb8-524a2a62b6ba" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat paused Shield subscriptions as neutral (disabled) in the inline alert and slightly reduce the footer icon top margin.
> 
> - **Confirmations UI**:
>   - **Alerts**: In `useShieldCoverageAlert`, apply status-based severities/backgrounds only when `!isPaused`, yielding neutral (disabled) severity with paused copy when paused.
> - **Styling**:
>   - Reduce `marginTop` for `ShieldIconAnimation` container in `shield-footer-coverage-indicator.tsx` from `2` to `1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21201a5f3d6a9180d62cd257ba65979cc56da8ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->