### PR TITLE
fix: connect hardware wallet must open in expanded view

### DIFF
--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -32,7 +32,10 @@ import {
   IMPORT_SRP_ROUTE,
   ADD_WALLET_PAGE_ROUTE,
 } from '../../../helpers/constants/routes';
-import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../../../shared/constants/app';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
@@ -129,7 +132,10 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
 
     // Hardware wallet connections require expanded view
     if (option.id === 'hardware-wallet') {
-      if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
+      if (
+        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ||
+        getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL
+      ) {
         global.platform.openExtensionInBrowser?.(option.route);
       } else {
         history.push(option.route);


### PR DESCRIPTION
## **Description**

Adds back hardware wallet device selection on expanded view in the context of sidepanel

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37731?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added back hardware wallet device selection on expanded view in the context of sidepanel

## **Related issues**

Fixes:

## **Manual testing steps**

1. run the app under experimental mode (`yarn start --build-type experimental`)
2. add a new hardware wallet account
3. see that it opens the hardware wallet device selection page on expanded view instead of staying in the context of the sidepanel

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures hardware wallet connection opens in the expanded view when initiated from popup or sidepanel.
> 
> - **UI (Add Wallet Modal)**
>   - Hardware wallet option now opens in expanded view when environment is `ENVIRONMENT_TYPE_POPUP` or `ENVIRONMENT_TYPE_SIDEPANEL` (previously only popup).
>   - Imports `ENVIRONMENT_TYPE_SIDEPANEL` and updates `handleOptionClick` condition accordingly in `ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cceb244a1bf42a47a73b18686cf7dbe95e2a3f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->