### PR TITLE
fix: Show token balance for gas tokens if fiat balance is disabled in settings

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
@@ -48,7 +48,7 @@ describe('GasFeeTokenListItem', () => {
     expect(result.getByText('Bal: $2,345.00 USD')).toBeInTheDocument();
   });
 
-  it('hides balance and fiat amount when currency rate check is disabled', () => {
+  it('shows token balance when currency rate check is disabled', () => {
     const storeWithoutCurrencyRateCheck = configureStore(
       getMockConfirmStateForTransaction(
         genUnapprovedContractInteractionConfirmation({
@@ -72,12 +72,12 @@ describe('GasFeeTokenListItem', () => {
       storeWithoutCurrencyRateCheck,
     );
 
-    // Should not show balance text with "Bal:"
-    expect(result.queryByText(/Bal:/u)).not.toBeInTheDocument();
+    // Should show balance with token amount instead of fiat
+    expect(result.getByText(/Bal:/u)).toBeInTheDocument();
+    // Should show token balance with symbol (e.g., "Bal: 2.345 TEST")
+    expect(result.getByText(/Bal: .*TEST/u)).toBeInTheDocument();
     // Should not show "undefined" text anywhere
     expect(result.queryByText(/undefined/iu)).not.toBeInTheDocument();
-    // Should still show token symbol
-    expect(result.getByText('TEST')).toBeInTheDocument();
   });
 
   it('renders token amount', () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.test.tsx
@@ -48,6 +48,38 @@ describe('GasFeeTokenListItem', () => {
     expect(result.getByText('Bal: $2,345.00 USD')).toBeInTheDocument();
   });
 
+  it('hides balance and fiat amount when currency rate check is disabled', () => {
+    const storeWithoutCurrencyRateCheck = configureStore(
+      getMockConfirmStateForTransaction(
+        genUnapprovedContractInteractionConfirmation({
+          address: FROM_MOCK,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        }),
+        {
+          metamask: {
+            preferences: {
+              showFiatInTestnets: true,
+            },
+            useCurrencyRateCheck: false,
+          },
+        },
+      ),
+    );
+
+    const result = renderWithConfirmContextProvider(
+      <GasFeeTokenListItem tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,
+      storeWithoutCurrencyRateCheck,
+    );
+
+    // Should not show balance text with "Bal:"
+    expect(result.queryByText(/Bal:/u)).not.toBeInTheDocument();
+    // Should not show "undefined" text anywhere
+    expect(result.queryByText(/undefined/iu)).not.toBeInTheDocument();
+    // Should still show token symbol
+    expect(result.getByText('TEST')).toBeInTheDocument();
+  });
+
   it('renders token amount', () => {
     const result = renderWithConfirmContextProvider(
       <GasFeeTokenListItem tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
@@ -3,6 +3,7 @@ import { GasFeeToken } from '@metamask/transaction-controller';
 import classnames from 'classnames';
 import { Hex } from '@metamask/utils';
 import { useSelector } from 'react-redux';
+import { BigNumber } from 'bignumber.js';
 
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../../shared/constants/transaction';
 import {
@@ -29,6 +30,8 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { useGasFeeToken } from '../../hooks/useGasFeeToken';
 import { getCurrentCurrency } from '../../../../../../../ducks/metamask/metamask';
 import { GasFeeTokenIcon, GasFeeTokenIconSize } from '../gas-fee-token-icon';
+import { formatAmount } from '../../../../simulation-details/formatAmount';
+import { getIntlLocale } from '../../../../../../../ducks/locale/locale';
 
 export type GasFeeTokenListItemProps = {
   isSelected?: boolean;
@@ -48,17 +51,31 @@ export function GasFeeTokenListItem({
   const t = useI18nContext();
   const gasFeeToken = useGasFeeToken({ tokenAddress });
   const currentCurrency = useSelector(getCurrentCurrency);
+  const locale = useSelector(getIntlLocale);
 
   if (!gasFeeToken) {
     return null;
   }
 
-  const { amountFiat, amountFormatted, balanceFiat, symbol } = gasFeeToken;
+  const {
+    amountFiat,
+    amountFormatted,
+    balanceFiat,
+    symbol,
+    balance,
+    decimals,
+  } = gasFeeToken;
 
-  // Only show balance text when balanceFiat is defined
+  // Format balance as token amount when fiat is not available
+  const balanceFormatted = formatAmount(
+    locale,
+    new BigNumber(balance).shift(-decimals),
+  );
+
+  // Show fiat balance if available, otherwise show token balance
   const balanceText = balanceFiat
     ? `${t('confirmGasFeeTokenBalance')} ${balanceFiat} ${currentCurrency.toUpperCase()}`
-    : '';
+    : `${t('confirmGasFeeTokenBalance')} ${balanceFormatted} ${symbol}`;
 
   return (
     <ListItem

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
@@ -69,7 +69,7 @@ export function GasFeeTokenListItem({
   // Format balance as token amount when fiat is not available
   const balanceFormatted = formatAmount(
     locale,
-    new BigNumber(balance).shift(-decimals),
+    new BigNumber(balance ?? '0x0').shift(-decimals),
   );
 
   // Show fiat balance if available, otherwise show token balance

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
@@ -55,6 +55,11 @@ export function GasFeeTokenListItem({
 
   const { amountFiat, amountFormatted, balanceFiat, symbol } = gasFeeToken;
 
+  // Only show balance text when balanceFiat is defined
+  const balanceText = balanceFiat
+    ? `${t('confirmGasFeeTokenBalance')} ${balanceFiat} ${currentCurrency.toUpperCase()}`
+    : '';
+
   return (
     <ListItem
       image={
@@ -65,10 +70,8 @@ export function GasFeeTokenListItem({
       }
       isSelected={isSelected}
       leftPrimary={symbol}
-      leftSecondary={`${t(
-        'confirmGasFeeTokenBalance',
-      )} ${balanceFiat} ${currentCurrency.toUpperCase()}`}
-      rightPrimary={amountFiat}
+      leftSecondary={balanceText}
+      rightPrimary={amountFiat || ''}
       rightSecondary={`${amountFormatted} ${symbol}`}
       warning={warning && <WarningIndicator text={warning} />}
       onClick={() => onClick?.(gasFeeToken)}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.test.tsx
@@ -63,6 +63,32 @@ function getState({
         preferences: {
           showFiatInTestnets: true,
         },
+        internalAccounts: {
+          accounts: {
+            'mock-account-id': {
+              address: '0x2e0d7e8c45221fca00d74a3609a0f7097035d09b',
+              id: 'mock-account-id',
+              metadata: {
+                importTime: 0,
+                name: 'Test Account',
+                keyring: {
+                  type: 'HD Key Tree',
+                },
+              },
+              options: {},
+              methods: [],
+              type: 'eip155:eoa',
+            },
+          },
+          selectedAccount: 'mock-account-id',
+        },
+        accountsByChainId: {
+          '0x5': {
+            '0x2e0d7e8c45221fca00d74a3609a0f7097035d09b': {
+              balance: '0xde0b6b3a7640000',
+            },
+          },
+        },
       },
     },
   );


### PR DESCRIPTION
## **Description**
When a user turns off the `Show balance and token price checker` setting, we will show token balance instead of undefined fiat balance for gas tokens.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37738?quickstart=1)

## **Changelog**

CHANGELOG entry: Shows token balance for gas tokens if fiat balance is disabled in settings

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37620

## **Manual testing steps**

Fiat values off
1. Disable `Show balance and token price checker` in Settings
2. Click on Send on Ethereum mainnet when you also have some stablecoin balances, which can be used to pay for gas
3. Enter amount and destination address
4. On the next page in the `Network fee` row click on the ticker, which opens the `Select a token` modal. You will see token balances there

Fiat values on
1. Enable `Show balance and token price checker` in Settings
2. Click on Send on Ethereum mainnet when you also have some stablecoin balances, which can be used to pay for gas
3. Enter amount and destination address
4. On the next page in the `Network fee` row click on the ticker, which opens the `Select a token` modal. You will see fiat balances there

## **Screenshots/Recordings**
### **Before**
<img width="256" height="262" alt="image" src="https://github.com/user-attachments/assets/b2a84b26-a33e-449d-931e-009455fc100f" />


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display token balance (localized) for gas fee tokens when fiat balance is unavailable/disabled, and update tests/mocks accordingly.
> 
> - **UI**:
>   - `gas-fee-token-list-item`: Render token balance with symbol when `balanceFiat` is absent; retain fiat when present. Localize using `formatAmount` and `getIntlLocale`; convert with `BigNumber` and decimals. Prevent "undefined" by defaulting `rightPrimary` to empty string.
> - **Tests**:
>   - `gas-fee-token-list-item.test.tsx`: Add spec to verify token balance shown when currency rate check is disabled.
>   - `gas-fee-token-modal.test.tsx`: Add account state (`internalAccounts`, `accountsByChainId`) to mocks for rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1931df3c9df0cd52366fae6eaacceefb20ddc29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->