### PR TITLE
fix: add specific error message for duplicate SRP imports

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6864,6 +6864,9 @@
   "srpDetailsTitle": {
     "message": "What’s a Secret Recovery Phrase?"
   },
+  "srpImportDuplicateAccountError": {
+    "message": "The account you are trying to import is a duplicate."
+  },
   "srpInputNumberOfWords": {
     "message": "I have a $1-word phrase",
     "description": "This is the text for each option in the dropdown where a user selects how many words their secret recovery phrase has during import. The $1 is the number of words (either 12, 15, 18, 21, or 24)."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6864,6 +6864,9 @@
   "srpDetailsTitle": {
     "message": "What’s a Secret Recovery Phrase?"
   },
+  "srpImportDuplicateAccountError": {
+    "message": "The account you are trying to import is a duplicate."
+  },
   "srpInputNumberOfWords": {
     "message": "I have a $1-word phrase",
     "description": "This is the text for each option in the dropdown where a user selects how many words their secret recovery phrase has during import. The $1 is the number of words (either 12, 15, 18, 21, or 24)."

--- a/ui/pages/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { userEvent } from '@testing-library/user-event';
-import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+// eslint-disable-next-line import/no-restricted-paths
+import messages from '../../../../app/_locales/en/messages.json';
 import mockState from '../../../../test/data/mock-state.json';
-import { importMnemonicToVault } from '../../../store/actions';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { setShowNewSrpAddedToast } from '../../../components/app/toast-master/utils';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { importMnemonicToVault } from '../../../store/actions';
 import { ImportSrp } from './import-srp';
 
 jest.mock('../../../store/actions', () => ({
@@ -93,6 +95,67 @@ describe('ImportSrp', () => {
       // Verify that navigation happened after import
       expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
       expect(setShowNewSrpAddedToast).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('error handling', () => {
+    const testImportError = async (
+      errorMessage: string,
+      expectedErrorMessage: string,
+    ) => {
+      const mockStore = configureMockStore([thunk])(mockState);
+
+      // Mock importMnemonicToVault to reject with the specified error
+      (importMnemonicToVault as jest.Mock).mockReturnValueOnce(
+        jest.fn().mockRejectedValue(new Error(errorMessage)),
+      );
+
+      const { queryByTestId, getByText } = renderWithProvider(
+        <ImportSrp />,
+        mockStore,
+      );
+
+      const srpNote = queryByTestId('srp-input-import__srp-note');
+      expect(srpNote).toBeInTheDocument();
+
+      srpNote?.focus();
+
+      if (srpNote) {
+        await userEvent.type(srpNote, TEST_SEED);
+      }
+
+      const confirmSrpButton = queryByTestId('import-srp-confirm');
+      expect(confirmSrpButton).not.toBeDisabled();
+
+      if (confirmSrpButton) {
+        fireEvent.click(confirmSrpButton);
+      }
+
+      // Wait for error to be displayed
+      await waitFor(() => {
+        expect(getByText(expectedErrorMessage)).toBeInTheDocument();
+      });
+
+      // Verify the button is now disabled due to error
+      expect(confirmSrpButton).toBeDisabled();
+
+      // Verify navigation did not happen
+      expect(mockNavigate).not.toHaveBeenCalledWith(DEFAULT_ROUTE);
+      expect(setShowNewSrpAddedToast).not.toHaveBeenCalled();
+    };
+
+    it('should display duplicate account error when trying to import a duplicate account', async () => {
+      await testImportError(
+        'KeyringController - The account you are trying to import is a duplicate',
+        messages.srpImportDuplicateAccountError.message,
+      );
+    });
+
+    it('should display already imported error for any other import error', async () => {
+      await testImportError(
+        'Some other error',
+        messages.srpAlreadyImportedError.message,
+      );
     });
   });
 });

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -68,7 +68,14 @@ export const ImportSrp = () => {
       navigate(DEFAULT_ROUTE);
       dispatch(setShowNewSrpAddedToast(true));
     } catch (error) {
-      setSrpError(t('srpAlreadyImportedError'));
+      switch ((error as Error)?.message) {
+        case 'KeyringController - The account you are trying to import is a duplicate':
+          setSrpError(t('srpImportDuplicateAccountError'));
+          break;
+        default:
+          setSrpError(t('srpAlreadyImportedError'));
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37743?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix error message when trying to import an SRP with an account that is already imported via private key

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-491

## **Manual testing steps**

1. Import private key account
2. Import SRP that includes this private key account
3. Verify that the error message "The account you are trying to import is a duplicate." is shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="925" height="903" alt="image" src="https://github.com/user-attachments/assets/77abb409-feac-4ba4-92bd-387d122928dd" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show a specific error when an imported SRP contains a duplicate account, with new i18n strings and tests validating behavior.
> 
> - **Import SRP UI (`ui/pages/multi-srp/import-srp/import-srp.tsx`)**:
>   - Handle duplicate-account import errors explicitly by mapping controller error to `t('srpImportDuplicateAccountError')`; fall back to `srpAlreadyImportedError`.
> - **i18n (`app/_locales/en/messages.json`, `app/_locales/en_GB/messages.json`)**:
>   - Add `srpImportDuplicateAccountError` message: "The account you are trying to import is a duplicate."
> - **Tests (`ui/pages/multi-srp/import-srp/import-srp.test.tsx`)**:
>   - Add error-handling tests covering duplicate-account vs generic import errors; ensure button disables, no navigation, and no toast on error.
>   - Minor import updates to support test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7adca3241972e7b8bc5fe89bd6a9bdd28d6b0ce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->