### PR TITLE
chore: fix sidepanel settings styles

### DIFF
--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -26,6 +26,10 @@
       opacity: 1;
     }
 
+    @include design-system.screen-sm-min {
+      max-height: 50px;
+    }
+
     &__selected-indicator {
       width: 4px;
       height: calc(100% - 8px);

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -248,18 +248,6 @@
         flex: 0 0 40%;
         max-width: 197px;
       }
-
-      .tab-bar__tab {
-        @include design-system.screen-sm-min {
-          max-height: 50px;
-        }
-
-        &__caret {
-          @include design-system.screen-sm-min {
-            display: none;
-          }
-        }
-      }
     }
 
     &__modules {
@@ -507,8 +495,31 @@
       flex: 1 1 auto;
 
       .tab-bar__tab {
+        @include design-system.screen-sm-min {
+          @include design-system.H4;
+          max-height: none;
+        }
+
+        &__selected-indicator {
+          display: none;
+        }
+
         &__caret {
           display: block;
+        }
+
+        &__content {
+          &__title {
+            @include design-system.screen-sm-min {
+              @include design-system.H4;
+            }
+          }
+        }
+
+        &--active {
+          @include design-system.screen-sm-min {
+            background-color: unset;
+          }
         }
       }
     }

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -497,6 +497,7 @@
       .tab-bar__tab {
         @include design-system.screen-sm-min {
           @include design-system.H4;
+
           max-height: none;
         }
 

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -194,11 +194,7 @@ class SettingsPage extends PureComponent {
           />
         )}
         {isSeedlessPasswordOutdated && <PasswordOutdatedModal />}
-        <Box
-          className="settings-page__header"
-          padding={4}
-          paddingBottom={2}
-        >
+        <Box className="settings-page__header" padding={4} paddingBottom={2}>
           <div
             className={classnames('settings-page__header__title-container', {
               'settings-page__header__title-container--hide-search':

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -197,7 +197,7 @@ class SettingsPage extends PureComponent {
         <Box
           className="settings-page__header"
           padding={4}
-          paddingBottom={[2, 4]}
+          paddingBottom={2}
         >
           <div
             className={classnames('settings-page__header__title-container', {


### PR DESCRIPTION
## **Description**

Sidepanel settings previously used a breakpoint at 575px where the items would then take on the styles seen in the full screen expanded view. We want to keep the settings styles in sidepanel view the same as popup, regardless of how expanded the sidepanel is.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37747?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-376

## **Manual testing steps**

1. Run extension in experimental: `yarn start --build-type experimental` and open Sidepanel view
2. Click on Settings
3. Resize the window and observe that styles don't change regardless of window size
4. Validate that expanded view Settings page remains unchanged

## **Screenshots/Recordings**

### **Before**

<img width="888" height="776" alt="image" src="https://github.com/user-attachments/assets/9544b350-431b-475e-b546-1cf750191e4a" />

### **After**

<img width="1006" height="776" alt="image" src="https://github.com/user-attachments/assets/e852204a-b0df-4768-89e4-db7c176f0224" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keeps sidepanel Settings using popup styles at all widths by adding a sidepanel mode and SCSS overrides, plus minor tab-bar/style tweaks.
> 
> - **Styles (Settings sidepanel)**:
>   - Add `settings-page--sidepanel` mode (experimental build) to force popup layout regardless of viewport.
>   - Override header grid, show back/close/logo controls, hide app-header logo, and hide subheaders.
>   - In `settings-page__content__tabs`, adjust `.tab-bar__tab` for sidepanel: use `H4`, remove max-height, hide `__selected-indicator`, show `__caret`, set active background to `unset`; hide modules by default and swap visibility when `--selected`.
>   - Ensure content rows wrap and items use initial heights/max-widths for sidepanel.
> - **Tab Bar**:
>   - On `screen-sm-min`, set `.tab-bar__tab` `max-height: 50px`.
> - **Settings (general tweaks)**:
>   - Remove previous inline tab overrides under `settings-page__content__tabs` (moved to sidepanel-specific section).
>   - Minor header padding adjustment in `settings.component.js` and apply `settings-page--sidepanel` class when in sidepanel environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3818f3d689fba3542d779117bb1a04a0d179c3d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->