### PR TITLE
feat: Track when RPC update from network banner is completed

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -764,6 +764,7 @@ export enum MetaMetricsEventName {
   NavPermissionsOpened = 'Permissions Opened',
   NetworkConnectionBannerShown = 'Network Connection Banner Shown',
   NetworkConnectionBannerUpdateRpcClicked = 'Network Connection Banner Update RPC Clicked',
+  NetworkConnectionBannerRpcUpdated = 'Network Connection Banner RPC Updated',
   UpdatePermissionedNetworks = 'Update Permissioned Networks',
   UpdatePermissionedAccounts = 'Update Permissioned Accounts',
   ViewPermissionedNetworks = 'View Permissioned Networks',

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -105,7 +105,10 @@ describe('NetworkConnectionBanner', () => {
         );
         fireEvent.click(getByText('Update RPC'));
 
-        expect(mockSetEditedNetwork).toHaveBeenCalledWith({ chainId: '0x1' });
+        expect(mockSetEditedNetwork).toHaveBeenCalledWith({
+          chainId: '0x1',
+          trackRpcUpdateFromBanner: true,
+        });
         expect(navigateMock).toHaveBeenCalledWith('/settings/networks');
       });
 
@@ -212,7 +215,10 @@ describe('NetworkConnectionBanner', () => {
         );
         fireEvent.click(getByText('update RPC'));
 
-        expect(mockSetEditedNetwork).toHaveBeenCalledWith({ chainId: '0x1' });
+        expect(mockSetEditedNetwork).toHaveBeenCalledWith({
+          chainId: '0x1',
+          trackRpcUpdateFromBanner: true,
+        });
         expect(navigateMock).toHaveBeenCalledWith('/settings/networks');
       });
 

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -190,7 +190,12 @@ export const NetworkConnectionBanner = () => {
         networkClientId: networkConnectionBanner.networkClientId,
       });
 
-      dispatch(setEditedNetwork({ chainId: networkConnectionBanner.chainId }));
+      dispatch(
+        setEditedNetwork({
+          chainId: networkConnectionBanner.chainId,
+          trackRpcUpdateFromBanner: true,
+        }),
+      );
       navigate(NETWORKS_ROUTE);
     }
   }, [networkConnectionBanner, dispatch, navigate]);

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -184,8 +184,11 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
     getMultichainNetworkConfigurationsByChainId,
   );
   const currentChainId = useSelector(getSelectedMultichainNetworkChainId);
-  const { chainId: editingChainId, editCompleted } =
-    useSelector(getEditedNetwork) ?? {};
+  const {
+    chainId: editingChainId,
+    editCompleted,
+    trackRpcUpdateFromBanner,
+  } = useSelector(getEditedNetwork) ?? {};
   const permittedChainIds = useSelector((state) =>
     getPermittedEVMChainsForSelectedTab(state, selectedTabOrigin),
   );
@@ -735,6 +738,7 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
         <NetworksForm
           networkFormState={networkFormState}
           existingNetwork={editedNetwork}
+          trackRpcUpdateFromBanner={trackRpcUpdateFromBanner}
           onRpcAdd={() => setActionMode(ACTION_MODE.ADD_RPC)}
           onBlockExplorerAdd={() => setActionMode(ACTION_MODE.ADD_EXPLORER_URL)}
         />

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -112,6 +112,7 @@ type AppState = {
         nickname?: string;
         editCompleted?: boolean;
         newNetwork?: boolean;
+        trackRpcUpdateFromBanner?: boolean;
       }
     | undefined;
   newNetworkAddedConfigurationId: string;

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -482,6 +482,18 @@ describe('NetworkForm Component', () => {
       <MetaMetricsContext.Provider value={mockTrackEvent}>
         <NetworksForm
           {...propNetworkDisplay}
+          networkFormState={{
+            ...propNetworkDisplay.networkFormState,
+            rpcUrls: {
+              defaultRpcEndpointIndex: 0,
+              rpcEndpoints: [
+                {
+                  url: 'https://monad-mainnet.infura.io/v3/',
+                  type: 'custom',
+                },
+              ],
+            },
+          }}
           existingNetwork={{
             chainId: '0x64',
             name: 'Ethereum',
@@ -509,7 +521,8 @@ describe('NetworkForm Component', () => {
         event: 'Network Connection Banner RPC Updated',
         properties: {
           chain_id_caip: 'eip155:100',
-          rpc_endpoint_url: 'mainnet.infura.io',
+          from_rpc_domain: 'mainnet.infura.io',
+          to_rpc_domain: 'monad-mainnet.infura.io',
         },
       });
     });
@@ -627,7 +640,8 @@ describe('NetworkForm Component', () => {
         event: 'Network Connection Banner RPC Updated',
         properties: {
           chain_id_caip: 'eip155:100',
-          rpc_endpoint_url: 'custom',
+          from_rpc_domain: 'custom',
+          to_rpc_domain: 'custom',
         },
       });
     });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -88,11 +88,7 @@ describe('NetworkForm Component', () => {
   });
 
   beforeEach(() => {
-    // Clear mock call history to ensure test isolation and accurate assertions
-    // Each test verifies these actions are called with specific arguments
-    updateNetwork.mockClear(); // Reset calls from network update tests
-    addNetwork.mockClear(); // Reset calls from network creation tests
-    setTokenNetworkFilter.mockClear(); // Reset calls from token filter tests
+    jest.clearAllMocks();
 
     nock('https://chainid.network:443', { encodedQueryParams: true })
       .get('/chains.json')

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -320,7 +320,7 @@ export const NetworksForm = ({
                 networkPayload.defaultRpcEndpointIndex
               ];
             const oldRpcEndpoint =
-              existingNetwork.rpcEndpoints[
+              existingNetwork.rpcEndpoints?.[
                 existingNetwork.defaultRpcEndpointIndex ?? 0
               ];
 
@@ -338,7 +338,9 @@ export const NetworksForm = ({
               /* eslint-disable @typescript-eslint/naming-convention */
               properties: {
                 chain_id_caip: `eip155:${chainIdAsDecimal}`,
-                from_rpc_domain: sanitizeRpcUrl(oldRpcEndpoint.url),
+                from_rpc_domain: oldRpcEndpoint?.url
+                  ? sanitizeRpcUrl(oldRpcEndpoint.url)
+                  : 'unknown',
                 to_rpc_domain: sanitizeRpcUrl(newRpcEndpoint.url),
               },
               /* eslint-enable @typescript-eslint/naming-convention */

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -5,7 +5,7 @@ import {
   type UpdateNetworkFields,
   RpcEndpointType,
 } from '@metamask/network-controller';
-import { Hex, isStrictHexString } from '@metamask/utils';
+import { Hex, isStrictHexString, hexToNumber } from '@metamask/utils';
 import { NETWORKS_BYPASSING_VALIDATION } from '@metamask/controller-utils';
 import {
   MetaMetricsEventCategory,
@@ -27,6 +27,7 @@ import {
   isSafeChainId,
 } from '../../../../../shared/modules/network.utils';
 import { jsonRpcRequest } from '../../../../../shared/modules/rpc.utils';
+import { isPublicEndpointUrl } from '../../../../../shared/lib/network-utils';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules/selectors/networks';
@@ -81,6 +82,7 @@ import { useNetworkFormState } from './networks-form-state';
 export const NetworksForm = ({
   networkFormState,
   existingNetwork,
+  trackRpcUpdateFromBanner,
   onRpcAdd,
   onBlockExplorerAdd,
   toggleNetworkMenuAfterSubmit = true,
@@ -89,6 +91,7 @@ export const NetworksForm = ({
 }: {
   networkFormState: ReturnType<typeof useNetworkFormState>;
   existingNetwork?: UpdateNetworkFields;
+  trackRpcUpdateFromBanner?: boolean;
   onRpcAdd: () => void;
   onBlockExplorerAdd: () => void;
   toggleNetworkMenuAfterSubmit?: boolean;
@@ -308,6 +311,35 @@ export const NetworksForm = ({
               }),
             );
             await dispatch(setEnabledNetworks(existingNetwork.chainId));
+          }
+
+          // Track RPC update from network connection banner
+          if (trackRpcUpdateFromBanner) {
+            const selectedRpcEndpoint =
+              networkPayload.rpcEndpoints?.[
+                networkPayload.defaultRpcEndpointIndex
+              ];
+            const chainIdAsDecimal = hexToNumber(chainIdHex);
+            const sanitizedRpcUrl =
+              selectedRpcEndpoint &&
+              isPublicEndpointUrl(
+                selectedRpcEndpoint.url,
+                infuraProjectId ?? '',
+              )
+                ? onlyKeepHost(selectedRpcEndpoint.url)
+                : 'custom';
+
+            trackEvent({
+              category: MetaMetricsEventCategory.Network,
+              event: MetaMetricsEventName.NetworkConnectionBannerRpcUpdated,
+              // The names of Segment properties have a particular case.
+              /* eslint-disable @typescript-eslint/naming-convention */
+              properties: {
+                chain_id_caip: `eip155:${chainIdAsDecimal}`,
+                rpc_endpoint_url: sanitizedRpcUrl,
+              },
+              /* eslint-enable @typescript-eslint/naming-convention */
+            });
           }
         } else {
           await dispatch(addNetwork(networkPayload));

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -316,18 +316,16 @@ export const NetworksForm = ({
           // Track RPC update from network connection banner
           if (trackRpcUpdateFromBanner) {
             const selectedRpcEndpoint =
-              networkPayload.rpcEndpoints?.[
+              networkPayload.rpcEndpoints[
                 networkPayload.defaultRpcEndpointIndex
               ];
             const chainIdAsDecimal = hexToNumber(chainIdHex);
-            const sanitizedRpcUrl =
-              selectedRpcEndpoint &&
-              isPublicEndpointUrl(
-                selectedRpcEndpoint.url,
-                infuraProjectId ?? '',
-              )
-                ? onlyKeepHost(selectedRpcEndpoint.url)
-                : 'custom';
+            const sanitizedRpcUrl = isPublicEndpointUrl(
+              selectedRpcEndpoint.url,
+              infuraProjectId ?? '',
+            )
+              ? onlyKeepHost(selectedRpcEndpoint.url)
+              : 'custom';
 
             trackEvent({
               category: MetaMetricsEventCategory.Network,

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.tsx
@@ -315,17 +315,21 @@ export const NetworksForm = ({
 
           // Track RPC update from network connection banner
           if (trackRpcUpdateFromBanner) {
-            const selectedRpcEndpoint =
+            const newRpcEndpoint =
               networkPayload.rpcEndpoints[
                 networkPayload.defaultRpcEndpointIndex
               ];
+            const oldRpcEndpoint =
+              existingNetwork.rpcEndpoints[
+                existingNetwork.defaultRpcEndpointIndex ?? 0
+              ];
+
             const chainIdAsDecimal = hexToNumber(chainIdHex);
-            const sanitizedRpcUrl = isPublicEndpointUrl(
-              selectedRpcEndpoint.url,
-              infuraProjectId ?? '',
-            )
-              ? onlyKeepHost(selectedRpcEndpoint.url)
-              : 'custom';
+
+            const sanitizeRpcUrl = (url: string) =>
+              isPublicEndpointUrl(url, infuraProjectId ?? '')
+                ? onlyKeepHost(url)
+                : 'custom';
 
             trackEvent({
               category: MetaMetricsEventCategory.Network,
@@ -334,7 +338,8 @@ export const NetworksForm = ({
               /* eslint-disable @typescript-eslint/naming-convention */
               properties: {
                 chain_id_caip: `eip155:${chainIdAsDecimal}`,
-                rpc_endpoint_url: sanitizedRpcUrl,
+                from_rpc_domain: sanitizeRpcUrl(oldRpcEndpoint.url),
+                to_rpc_domain: sanitizeRpcUrl(newRpcEndpoint.url),
               },
               /* eslint-enable @typescript-eslint/naming-convention */
             });

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -221,7 +221,7 @@ export function getNewNetworkAdded(state) {
 
 /**
  * @param state
- * @returns {{ chainId: import('@metamask/utils').Hex; nickname: string; editCompleted: boolean} | undefined}
+ * @returns {{ chainId: import('@metamask/utils').Hex; nickname?: string; editCompleted?: boolean; newNetwork?: boolean; trackRpcUpdateFromBanner?: boolean} | undefined}
  */
 export function getEditedNetwork(state) {
   return state.appState.editedNetwork;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -5719,6 +5719,7 @@ export function setEditedNetwork(
         nickname?: string;
         editCompleted?: boolean;
         newNetwork?: boolean;
+        trackRpcUpdateFromBanner?: boolean;
       }
     | undefined = undefined,
 ): PayloadAction<object> {


### PR DESCRIPTION
## **Description**

### Track RPC Update Completion from Network Banner

### Summary

Adds `NetworkConnectionBannerRpcUpdated` event to track when users **complete** the RPC update flow initiated from the network connection banner.

### Changes

- **New MetaMetrics event**: `NetworkConnectionBannerRpcUpdated`
- **Tracked on**: Network form submission when `trackRpcUpdateFromBanner` flag is set
- **Properties**:
  - `chain_id_caip`: CAIP-2 format (e.g., `eip155:1`)
  - `from_rpc_domain`: Original RPC domain being switched from (hostname for public RPCs, `'custom'` for private)
  - `to_rpc_domain`: New RPC domain being switched to (hostname for public RPCs, `'custom'` for private)

### Why

Currently we track when users **click** "Update RPC" (`NetworkConnectionBannerUpdateRpcClicked`), but not when they **complete** the update.

```mermaid
sequenceDiagram
    participant User
    participant Banner as Network Banner
    participant Form as Network Form
    participant Analytics

    Note over Banner: Network issue detected
    Banner->>User: Show "degraded" or "unavailable" banner
    Note over Analytics: 📊 NetworkConnectionBannerShown

    User->>Banner: Click "Update RPC"
    Banner->>Analytics: 📊 NetworkConnectionBannerUpdateRpcClicked
    Note right of Analytics: Existing event<br/>Tracks user INTENT

    Banner->>Form: Navigate to network settings
    User->>Form: Edit RPC endpoint
    User->>Form: Click "Save"

    Form->>Analytics: 📊 NetworkConnectionBannerRpcUpdated
    Note right of Analytics: NEW event (this PR)<br/>Tracks COMPLETION

    Form->>User: Network updated ✅
```

### Related

- Segment schema PR: https://github.com/Consensys/segment-schema/pull/366, https://github.com/Consensys/segment-schema/pull/381

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37751?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-172

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `NetworkConnectionBannerRpcUpdated` event and wires a banner->form flag to track completed RPC updates with CAIP chain ID and RPC domain metadata.
> 
> - **Analytics (MetaMetrics)**:
>   - Add `MetaMetricsEventName.NetworkConnectionBannerRpcUpdated`.
> - **State & Actions**:
>   - Extend `setEditedNetwork`/`editedNetwork` with `trackRpcUpdateFromBanner`.
>   - Update `getEditedNetwork` selector types accordingly.
> - **UI Flow**:
>   - `network-connection-banner`: on "Update RPC", dispatch `setEditedNetwork({ chainId, trackRpcUpdateFromBanner: true })` and navigate to `NETWORKS_ROUTE`.
>   - `network-list-menu`: pass `trackRpcUpdateFromBanner` to `NetworksForm`.
>   - `NetworksForm`: on Save (when editing) and flag is set, track `Network Connection Banner RPC Updated` with:
>     - `chain_id_caip` (`eip155:<decimal>`),
>     - `from_rpc_domain`/`to_rpc_domain` (public host or `custom`/`unknown`).
>   - Utilize `hexToNumber`, `isPublicEndpointUrl`, `onlyKeepHost` for payload.
> - **Tests**:
>   - Update banner tests to assert the new flag in `setEditedNetwork`.
>   - Add form tests covering event emission, absence when flag not set, custom endpoints, and missing `rpcEndpoints` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07049764571edabca83d8a715d12e69bf49ea92a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->