### PR TITLE
fix: force account alignment on unlock cp-13.9.0

### DIFF
--- a/app/scripts/controller-init/messengers/accounts/snap-keyring-builder-messenger.ts
+++ b/app/scripts/controller-init/messengers/accounts/snap-keyring-builder-messenger.ts
@@ -49,6 +49,7 @@ export function getSnapKeyringBuilderMessenger(
       'SnapController:get',
       'SnapController:isMinimumPlatformVersion',
       'PreferencesController:getState',
+      'RemoteFeatureFlagController:getState',
     ],
   });
   return keyringMessenger;

--- a/app/scripts/lib/snap-keyring/snap-keyring.test.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.test.ts
@@ -23,6 +23,7 @@ import {
   SnapKeyringBuilderAllowActions,
   SnapKeyringBuilderMessenger,
 } from './types';
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
 const mockAddRequest = jest.fn();
 const mockStartFlow = jest.fn();
@@ -43,6 +44,7 @@ const mockLocale = 'en';
 const mockPreferencesControllerGetState = jest.fn();
 const mockSnapControllerGet = jest.fn();
 const mockSnapControllerHandleRequest = jest.fn();
+const mockRemoteFeatureFlagsGetStateRequest = jest.fn();
 
 const mockFlowId = '123';
 const address = '0x2a4d4b667D5f12C3F9Bf8F14a7B9f8D8d9b8c8fA';
@@ -114,6 +116,7 @@ const createControllerMessenger = ({
       'PreferencesController:getState',
       'SnapController:get',
       'SnapController:handleRequest',
+      'RemoteFeatureFlagController:getState',
     ],
   });
 
@@ -171,6 +174,9 @@ const createControllerMessenger = ({
       case 'SnapController:handleRequest':
         return mockSnapControllerHandleRequest(params);
 
+      case 'RemoteFeatureFlagController:getState':
+        return mockRemoteFeatureFlagsGetStateRequest(params);
+
       default:
         throw new Error(
           `MOCK_FAIL - unsupported messenger call: ${actionType}`,
@@ -190,6 +196,11 @@ const createSnapKeyringBuilder = ({
 } = {}) => {
   jest.mocked(isSnapPreinstalled).mockReturnValue(snapPreinstalled);
   jest.mocked(getSnapName).mockReturnValue(snapName);
+
+  // Needed now to know if state 2 is enabled or not.
+  mockRemoteFeatureFlagsGetStateRequest.mockReturnValue({
+    remoteFeatureFlags: {},
+  } as RemoteFeatureFlagControllerState);
 
   return snapKeyringBuilder(createControllerMessenger(), {
     persistKeyringHelper: mockPersistKeyringHelper,

--- a/app/scripts/lib/snap-keyring/snap-keyring.test.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SnapId } from '@metamask/snaps-sdk';
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { getRootMessenger } from '../messenger';
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import {
@@ -23,7 +24,6 @@ import {
   SnapKeyringBuilderAllowActions,
   SnapKeyringBuilderMessenger,
 } from './types';
-import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
 const mockAddRequest = jest.fn();
 const mockStartFlow = jest.fn();

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -379,10 +379,11 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
           );
         }
 
-        // HACK: This account name we have might have conflicts (race-condition), and
-        // we still have unique names constraint on the `AccountsController`, so for
-        // now, we just omit renaming the account since those names are no longer in use
-        // with the multichain accounts new state 2 UI.
+        // HACK: In state 2, account creations can run in parallel, thus, `accountName`
+        // sometimes conflict with other concurrent renaming. Since we don't rely on those
+        // account names anymore, we just omit this part and make this race-free.
+        // FIXME: We still rely on the old behavior in some e2e, so we cannot remove this
+        // entirely.
         if (!this.#isMultichainAccountsFeatureState2Enabled()) {
           if (accountName) {
             this.#messenger.call(

--- a/app/scripts/lib/snap-keyring/types.ts
+++ b/app/scripts/lib/snap-keyring/types.ts
@@ -23,6 +23,7 @@ import {
   IsMinimumPlatformVersion,
 } from '@metamask/snaps-controllers';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 
 export type SnapKeyringBuilderAllowActions =
@@ -44,7 +45,8 @@ export type SnapKeyringBuilderAllowActions =
   | HandleSnapRequest
   | GetSnap
   | PreferencesControllerGetStateAction
-  | IsMinimumPlatformVersion;
+  | IsMinimumPlatformVersion
+  | RemoteFeatureFlagControllerGetStateAction;
 
 export type SnapKeyringBuilderMessenger = Messenger<
   'SnapKeyring',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5208,7 +5208,9 @@ export default class MetamaskController extends EventEmitter {
       // This allows to create missing accounts if new account providers have been added.
       // FIXME: We might wanna run discovery + alignment asynchronously here, like we do
       // for mobile, but for now, this easy fix should cover new provider accounts.
-      await this.multichainAccountService.alignWallets();
+      // NOTE: We run this asynchronously on purpose, see FIXME^.
+      // eslint-disable-next-line no-void
+      void this.multichainAccountService.alignWallets();
     }
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5203,6 +5203,13 @@ export default class MetamaskController extends EventEmitter {
       await this.getSnapKeyring(),
       this.accountTreeController.getSelectedAccountGroup(),
     );
+
+    if (this.isMultichainAccountsFeatureState2Enabled()) {
+      // This allows to create missing accounts if new account providers have been added.
+      // FIXME: We might wanna run discovery + alignment asynchronously here, like we do
+      // for mobile, but for now, this easy fix should cover new provider accounts.
+      await this.multichainAccountService.alignWallets();
+    }
   }
 
   async _loginUser(password) {


### PR DESCRIPTION
## **Description**

Force account alignment on unlock to cover new account providers being added.

> [!NOTE]
> Normally, we should run discovery + alignment asynchronously for a better UX, but this involves a lot more work. For now, this will cover new account providers being added to the extension.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37762?quickstart=1)

## **Changelog**

CHANGELOG entry: Automatically create new account types on wallet unlock

## **Related issues**

N/A

## **Manual testing steps**

- Go to branch `v13.7.0`
  * Build the extension with: `yarn build --build-type main dist`
- Go to this branch
  * Build the extension with: `yarn build --build-type main dist`
- Make a folder `_local` and `cd` into it
- Run `cp ../builds/metamask-chrome-13.7.0.zip . && unzip *.zip`
- Load and start the extension
- Create a new SRP
- Import another SRP
- Create some accounts on both SRP
- Stop the extension
- Run `cp ../builds/metamask-chrome-13.10.0.zip . && unzip *.zip` (build for this branch)
- Reload the extension
- You should see some `Running ... migration` message
- Check all your multichain accounts, you should now see Bitcoin accounts for all of them.

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/29ab83b2-520a-4331-8e8f-0f5b92490b69

https://github.com/user-attachments/assets/788b3518-9826-45a8-a3d5-62cd239e733f

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 38d98a254ac9f41a612be1642484db73dc167ce7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->