### PR TITLE
fix: prevent double permission request submission

### DIFF
--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -49,6 +49,7 @@ export default class PermissionPageContainer extends Component {
     }),
     navigate: PropTypes.func.isRequired,
     connectPath: PropTypes.string.isRequired,
+    isSubmitting: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -57,6 +58,7 @@ export default class PermissionPageContainer extends Component {
     selectedAccounts: [],
     allAccountsSelected: false,
     currentPermissions: {},
+    isSubmitting: false,
   };
 
   static contextTypes = {
@@ -144,7 +146,13 @@ export default class PermissionPageContainer extends Component {
       rejectPermissionsRequest,
       selectedAccounts,
       requestedChainIds,
+      isSubmitting,
     } = this.props;
+
+    // Prevent double submission (guard is also in parent, but keep for safety)
+    if (isSubmitting) {
+      return;
+    }
 
     const approvedAccounts = selectedAccounts.map(
       (selectedAccount) => selectedAccount.address,
@@ -243,10 +251,13 @@ export default class PermissionPageContainer extends Component {
             onCancel={() => this.onLeftFooterClick()}
             cancelText={footerLeftActionText}
             onSubmit={() => this.onSubmit()}
-            disabled={containsEthPermissionsAndNonEvmAccount(
-              selectedAccounts,
-              requestedPermissions,
-            )}
+            disabled={
+              this.props.isSubmitting ||
+              containsEthPermissionsAndNonEvmAccount(
+                selectedAccounts,
+                requestedPermissions,
+              )
+            }
           />
         </Box>
       </TemplateAlertContextProvider>

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx
@@ -111,6 +111,7 @@ export type MultichainConnectPageProps = {
     origin: string;
     subjectType: string;
   };
+  isSubmitting?: boolean;
 };
 
 export enum MultichainAccountsConnectPageMode {
@@ -126,6 +127,7 @@ export const MultichainAccountsConnectPage: React.FC<
   rejectPermissionsRequest,
   approveConnection,
   targetSubjectMetadata,
+  isSubmitting = false,
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
@@ -463,6 +465,11 @@ export const MultichainAccountsConnectPage: React.FC<
   }, [permissionsRequestId, rejectPermissionsRequest]);
 
   const onConfirm = useCallback(() => {
+    // Prevent double submission (guard is also in parent, but keep for safety)
+    if (isSubmitting) {
+      return;
+    }
+
     const _request = {
       ...request,
       permissions: {
@@ -481,6 +488,7 @@ export const MultichainAccountsConnectPage: React.FC<
     selectedCaipAccountIds,
     selectedChainIds,
     approveConnection,
+    isSubmitting,
   ]);
 
   const title = transformOriginToTitle(targetSubjectMetadata.origin);
@@ -712,6 +720,7 @@ export const MultichainAccountsConnectPage: React.FC<
               size={ButtonSize.Lg}
               onClick={onConfirm}
               disabled={
+                isSubmitting ||
                 selectedAccountGroupIds.length === 0 ||
                 selectedChainIds.length === 0
               }

--- a/ui/pages/permissions-connect/connect-page/connect-page.tsx
+++ b/ui/pages/permissions-connect/connect-page/connect-page.tsx
@@ -119,6 +119,7 @@ export type ConnectPageProps = {
     origin: string;
     subjectType: string;
   };
+  isSubmitting?: boolean;
 };
 
 export const ConnectPage: React.FC<ConnectPageProps> = ({
@@ -127,6 +128,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
   rejectPermissionsRequest,
   approveConnection,
   targetSubjectMetadata,
+  isSubmitting = false,
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
@@ -428,6 +430,11 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
   }, [permissionsRequestId, rejectPermissionsRequest]);
 
   const onConfirm = useCallback(() => {
+    // Prevent double submission (guard is also in parent, but keep for safety)
+    if (isSubmitting) {
+      return;
+    }
+
     const _request = {
       ...request,
       permissions: {
@@ -446,6 +453,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
     selectedCaipAccountAddresses,
     selectedChainIds,
     approveConnection,
+    isSubmitting,
   ]);
 
   const title = transformOriginToTitle(targetSubjectMetadata.origin);
@@ -693,6 +701,7 @@ export const ConnectPage: React.FC<ConnectPageProps> = ({
               size={ButtonSize.Lg}
               onClick={onConfirm}
               disabled={
+                isSubmitting ||
                 selectedCaipAccountAddresses.length === 0 ||
                 selectedChainIds.length === 0
               }

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -514,16 +514,7 @@ export default class PermissionConnect extends Component {
               element={
                 <PermissionPageContainer
                   request={permissionsRequest || {}}
-                  approvePermissionsRequest={(...args) => {
-                    // Prevent double submission
-                    if (this.state.isSubmitting) {
-                      return;
-                    }
-
-                    this.setState({ isSubmitting: true });
-                    approvePermissionsRequest(...args);
-                    this.redirect(true);
-                  }}
+                  approvePermissionsRequest={this.approveConnection}
                   rejectPermissionsRequest={(requestId) =>
                     this.cancelPermissionsRequest(requestId)
                   }

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -157,6 +157,7 @@ export default class PermissionConnect extends Component {
     origin: this.props.origin,
     targetSubjectMetadata: this.props.targetSubjectMetadata || {},
     snapsInstallPrivacyWarningShown: this.props.snapsInstallPrivacyWarningShown,
+    isSubmitting: false,
   };
 
   componentDidMount() {
@@ -393,6 +394,7 @@ export default class PermissionConnect extends Component {
       permissionsRequestId: this.props.permissionsRequestId,
       approveConnection: this.approveConnection,
       targetSubjectMetadata: this.props.targetSubjectMetadata,
+      isSubmitting: this.state.isSubmitting,
     };
 
     return <ConnectPage {...connectPageProps} />;
@@ -407,6 +409,7 @@ export default class PermissionConnect extends Component {
       permissionsRequestId: this.props.permissionsRequestId,
       approveConnection: this.approveConnection,
       targetSubjectMetadata: this.props.targetSubjectMetadata,
+      isSubmitting: this.state.isSubmitting,
     };
 
     return <MultichainAccountsConnectPage {...connectPageProps} />;
@@ -437,6 +440,13 @@ export default class PermissionConnect extends Component {
   }
 
   approveConnection = (...args) => {
+    // Prevent double submission
+    if (this.state.isSubmitting) {
+      return;
+    }
+
+    this.setState({ isSubmitting: true });
+
     const { approvePermissionsRequest } = this.props;
     approvePermissionsRequest(...args);
     this.redirect(true);
@@ -505,6 +515,12 @@ export default class PermissionConnect extends Component {
                 <PermissionPageContainer
                   request={permissionsRequest || {}}
                   approvePermissionsRequest={(...args) => {
+                    // Prevent double submission
+                    if (this.state.isSubmitting) {
+                      return;
+                    }
+
+                    this.setState({ isSubmitting: true });
                     approvePermissionsRequest(...args);
                     this.redirect(true);
                   }}
@@ -526,6 +542,7 @@ export default class PermissionConnect extends Component {
                   setSnapsInstallPrivacyWarningShownStatus={
                     setSnapsInstallPrivacyWarningShownStatus
                   }
+                  isSubmitting={this.state.isSubmitting}
                 />
               }
             />

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -464,7 +464,6 @@ export default class PermissionConnect extends Component {
       approvePendingApproval,
       rejectPendingApproval,
       setSnapsInstallPrivacyWarningShownStatus,
-      approvePermissionsRequest,
       navigate,
       location,
     } = this.props;

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -62,13 +62,17 @@ export default function SnapsConnect({
   }, [request, rejectConnection]);
 
   const onConnect = useCallback(() => {
-    try {
-      setIsLoading(true);
-      approveConnection(request);
-    } finally {
-      setIsLoading(false);
+    // Prevent double submission - guard is also in parent, but keep for safety
+    if (isLoading) {
+      return;
     }
-  }, [request, approveConnection]);
+
+    setIsLoading(true);
+    approveConnection(request);
+    // Note: isLoading will remain true until component unmounts or user navigates away
+    // This is intentional to prevent double submission since approveConnection is async
+    // but doesn't return a promise we can await
+  }, [request, approveConnection, isLoading]);
 
   const SnapsConnectContent = () => {
     let trimmedOrigin = (useOriginMetadata(origin) || {})?.hostname;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
## Prevent double submission of permission requests

### Problem
Rapid clicks on submit could (theoretically) call `acceptPermissionsRequest` multiple times with the same request. The underlying controller throws `PermissionsRequestNotFoundError` for duplicates, but the UI still allowed multiple submissions. This is a potential cause [for a high frequency sentry error.](https://metamask.sentry.io/issues/3987548717/?groupId=3987548717&pageEnd=2025-11-04T22%3A36%3A19.488&pageStart=2025-11-03T22%3A36%3A19.488&project=273505&source=issue_details) Once this fix goes live we will monitor whether there are any improvements in the sentry issues and evaluate other possible causes from there.

### Solution
- Centralized loading state: added `isSubmitting` state in the parent `PermissionConnect` component to track submission status across all child components
- Guard checks: added early returns in submit handlers (`onSubmit`, `onConfirm`, `onConnect`) when already submitting
- Button disabling: submit buttons are disabled immediately when `isSubmitting` is true
- Fixed `SnapsConnect`: removed ineffective try/finally pattern that reset loading state too early

### Changes
- Added `isSubmitting` state to `permissions-connect.component.js` and passed it down to child components
- Updated `PermissionPageContainer`, `ConnectPage`, and `MultichainAccountsConnectPage` to accept and use the `isSubmitting` prop
- Fixed `SnapsConnect` to maintain loading state until component unmounts
- Unified `PermissionPageContainer` to use the same `approveConnection` method as other components

Fixes (difficult to repro) race conditions that could cause duplicate permission approvals.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: N/A

## **Related issues**

(Hopefully) Fixes: https://github.com/MetaMask/metamask-extension/issues/37714

## **Manual testing steps**
n/a

## **Screenshots/Recordings**
n/a

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate permission approvals by centralizing submitting state and disabling submit actions across connect and snaps flows.
> 
> - **Permissions flow**
>   - Add centralized `isSubmitting` state in `ui/pages/permissions-connect/permissions-connect.component.js`; pass to `ConnectPage`, `MultichainAccountsConnectPage`, and `PermissionPageContainer`.
>   - Use parent `approveConnection` for `PermissionPageContainer` to unify approval handling.
>   - Add guard clauses to prevent re-submission in `onSubmit` (`permission-page-container.component.js`), `onConfirm` (`connect-page.tsx`, `multichain-accounts-connect-page.tsx`).
>   - Disable submit buttons when `isSubmitting` or when required selections are empty.
> - **Snaps**
>   - Update `snaps-connect.js` to block double clicks via `isLoading` guard and persist loading state until navigation; footer submit disabled while loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee83d57c3bc3761b2d14267f3c81ee4891d29ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->