### PR TITLE
fix: flaky test `Phishing Detection Via Iframe... NoSuchWindowError: Browsing context has been discarded `

### DIFF
--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -158,7 +158,7 @@ describe('Phishing Detection', function (this: Suite) {
           await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
           await phishingWarningPage.checkPageIsLoaded();
           await phishingWarningPage.clickProceedAnywayButton();
-          await driver.wait(until.titleIs(WINDOW_TITLES.TestDApp), 10000);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         },
       );
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a race condition where we get this error:

`<failure message="Browsing context has been discarded" type="NoSuchWindowError"><! CDATA[NoSuchWindowError: Browsing context has been discarded``

The problem seems that whenever we click Open warning in a new tab, this should automatically open a new window, switch to it and load the test dapp. So we click and then we wait for the page title to be Test Dapp.
However, if we happen to look for the title **before** the window has switched, then we get `browsing context has been discarded`, as the window where we were looking for the title has now changed.

To prevent that, and have a more robust approach, after clicking the element we actively try to switch to the page with window title Test Dapp -> this will result on changing to that window once it's there, implicitly checking the window title, avoiding browser context being discarded ever.

Side: after the fix, this spec has ben run 1+5 extra times on each build (24 times). I've seen 1 ocurrence of a different failure `TimeoutError: Waiting for element to be located By(xpath, //*[contains(text(), "Open this warning in a new tab")])
Wait timed out after 12910ms`. This can be investigated separately, as it's not related to the first issue we are fixing here.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37772?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace flaky title wait with explicit window switch in phishing iframe E2E test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 631a16adfa5d54962699e628ca7744a57a59ac63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->