### PR TITLE
fix: subscription last payment method card

### DIFF
--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -148,10 +148,14 @@ const ShieldPlan = () => {
   const hasAvailableToken = availableTokenBalances.length > 0;
   const [selectedPaymentMethod, setSelectedPaymentMethod] =
     useState<PaymentType>(() => {
+      // always default to card if no token is available
+      if (!hasAvailableToken) {
+        return PAYMENT_TYPES.byCard;
+      }
       if (lastUsedPaymentDetails?.type) {
         return lastUsedPaymentDetails.type;
       }
-      return hasAvailableToken ? PAYMENT_TYPES.byCrypto : PAYMENT_TYPES.byCard;
+      return PAYMENT_TYPES.byCrypto;
     });
   // default options for the new subscription request
   const defaultOptions = useMemo(() => {

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -216,10 +216,12 @@ const ShieldPlan = () => {
 
   // set default selected payment method to crypto if selected token available
   useEffect(() => {
-    if (selectedToken) {
+    const lastUsedPaymentMethod = lastUsedPaymentDetails?.type;
+    // if the last used payment method is not crypto, don't set default method
+    if (selectedToken && lastUsedPaymentMethod !== PAYMENT_TYPES.byCard) {
       setSelectedPaymentMethod(PAYMENT_TYPES.byCrypto);
     }
-  }, [selectedToken, setSelectedPaymentMethod]);
+  }, [selectedToken, setSelectedPaymentMethod, lastUsedPaymentDetails]);
 
   const tokensSupported = useMemo(() => {
     const chainsAndTokensSupported = cryptoPaymentMethod?.chains ?? [];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Previously after user submit card payment method subscription and go back to shield plan, they still see default to crypto payment method. This fix it and would default to card if user selected it last time.
- Fix problem if user select crypto payment method then switch to account without enough fund then incorrect payment method selected.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37774?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix subscription default card payment method not saved

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to shield plan
2. Try to subscribe with card
3. Back to shield plan should default to card payment method

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defaults payment method to last used (card vs crypto), avoiding auto-switch to crypto when a token is available and card was used last.
> 
> - **Shield Plan page (`ui/pages/shield-plan/shield-plan.tsx`)**:
>   - Adjust default payment method logic: set to `PAYMENT_TYPES.byCrypto` only if a `selectedToken` exists and last used method is not `byCard`.
>   - Update effect dependencies to include `lastUsedPaymentDetails` to reflect latest user choice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a8fc5e3e04f4966e84e118e8c54e056d935a1cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->