### PR TITLE
fix(lattice): reuse cached credentials in offscreen keyring

### DIFF
--- a/app/scripts/lib/offscreen-bridge/lattice-offscreen-keyring.ts
+++ b/app/scripts/lib/offscreen-bridge/lattice-offscreen-keyring.ts
@@ -28,15 +28,18 @@ class LatticeKeyringOffscreen extends LatticeKeyring {
     super(opts);
   }
 
-  async _getCreds(): Promise<{
-    deviceID: string;
-    password: string;
-    endpoint: string;
-  } | undefined> {
+  async _getCreds(): Promise<
+    | {
+        deviceID: string;
+        password: string;
+        endpoint?: string;
+      }
+    | undefined
+  > {
     try {
       // If we already have credentials cached
       if (this._hasCreds()) {
-        return;
+        return undefined;
       }
 
       // If we are not aware of what Lattice we should be talking to,
@@ -50,7 +53,7 @@ class LatticeKeyringOffscreen extends LatticeKeyring {
       const creds = await new Promise<{
         deviceID: string;
         password: string;
-        endpoint: string;
+        endpoint?: string;
       }>((resolve, reject) => {
         chrome.runtime.sendMessage(
           {

--- a/types/eth-lattice-keyring.d.ts
+++ b/types/eth-lattice-keyring.d.ts
@@ -6,10 +6,12 @@ declare module 'eth-lattice-keyring' {
 
     constructor(opts);
 
+    _hasCreds(): boolean;
+
     _getCreds(): Promise<{
       deviceID: string;
       password: string;
       endpoint: string;
-    }>;
+    } | undefined>;
   }
 }

--- a/types/eth-lattice-keyring.d.ts
+++ b/types/eth-lattice-keyring.d.ts
@@ -8,10 +8,13 @@ declare module 'eth-lattice-keyring' {
 
     _hasCreds(): boolean;
 
-    _getCreds(): Promise<{
-      deviceID: string;
-      password: string;
-      endpoint: string;
-    } | undefined>;
+    _getCreds(): Promise<
+      | {
+          deviceID: string;
+          password: string;
+          endpoint?: string;
+        }
+      | undefined
+    >;
   }
 }


### PR DESCRIPTION
## **Description**

- Address an MV3 regression where the offscreen Lattice keyring repeatedly prompted for credentials despite having them cached.
- Short-circuit `_getCreds` when `eth-lattice-keyring` already has credentials, improve error handling around `chrome.runtime.sendMessage`, and align the type declaration with the runtime behavior.
- Mirrors the existing guard in the upstream [keyring implementation](https://github.com/GridPlus/eth-lattice-keyring/blob/5732011bffe88d2125eaa9e373e2619e63f6f13d/index.js#L466)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37781?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed the Lattice hardware wallet flow to reuse cached credentials instead of asking users to reconnect every time.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Connect a Lattice device and pair it with MetaMask in the extension.
2. Reopen the extension and initiate another signing action that uses the Lattice keyring.
3. Confirm the connector window is not re-opened and the cached credential flow proceeds without errors.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

https://www.loom.com/share/20586b3a36a24eca83642f968122cb5d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable *(existing test harnesses do not cover offscreen runtime APIs; manual validation described above)*
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Short-circuits Lattice offscreen credential flow when creds are cached, adds robust sendMessage error handling and validation, and updates type definitions (optional endpoint, undefined return, _hasCreds).
> 
> - **Lattice Offscreen Keyring (`app/scripts/lib/offscreen-bridge/lattice-offscreen-keyring.ts`)**:
>   - Short-circuit `_getCreds` by returning `undefined` when `_hasCreds()` is true to reuse cached credentials.
>   - Improve `chrome.runtime.sendMessage` handling: check `chrome.runtime.lastError`, optional-chain `response`, and return `response?.result`.
>   - Validate returned creds and throw on missing `deviceID`/`password`.
>   - Make `endpoint` optional in returned creds and allow `_getCreds` to return `undefined`.
> - **Types (`types/eth-lattice-keyring.d.ts`)**:
>   - Add `_hasCreds(): boolean`.
>   - Update `_getCreds` signature to reflect optional `endpoint` and possible `undefined` return.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e39fef0aef866cd59c4504ad89ace024f4908a48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->