### PR TITLE
fix: updated cta for sidepanel

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4592,6 +4592,9 @@
   "openInBlockExplorer": {
     "message": "Open in block explorer"
   },
+  "openWallet": {
+    "message": "Open wallet"
+  },
   "optional": {
     "message": "Optional"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4592,6 +4592,9 @@
   "openInBlockExplorer": {
     "message": "Open in block explorer"
   },
+  "openWallet": {
+    "message": "Open wallet"
+  },
   "optional": {
     "message": "Optional"
   },

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -223,7 +223,7 @@ export default function CreationSuccessful() {
           width={BlockSize.Full}
           onClick={onDone}
         >
-          {t('done')}
+          {isSidePanelEnabled ? t('openWallet') : t('done')}
         </Button>
       </Box>
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, For new users we open sidepanel by default upon onboarding completion. Used feature flag to only show this change when sidepanel flag is enabled for chrome. Updated button on wallet creation successful page from 'Done' to 'Open wallet'.

Jira Link: https://consensyssoftware.atlassian.net/browse/SL-281

Figma Link: https://www.figma.com/design/YhI8pXtinRY4oZu4IYoAPt/Side-Panel-Extension?node-id=172-7522&t=mPG5UFWEZJEFOLIV-0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37722?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Used feature flag to only show this change when sidepanel flag is enabled for chrome. Updated button on wallet creation successful page from 'Done' to 'Open wallet'.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open extension
2. Create wallet at the end of flow i.e. Wallet Successful Page 
3. CTA changed to 'Open wallet' only for chrome extension and build type is 'experimental'
4. Validate the changes from the above Figma link.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

CHROME EXTENSION:

https://github.com/user-attachments/assets/ebcb797a-698c-4621-9c2a-e51c66015111

FIREFOX EXTENSION:

https://github.com/user-attachments/assets/fb20a01f-3d42-4b60-9b76-30eb9068e61a



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes the onboarding completion button to “Open wallet” when the side panel feature is enabled and adds the required locale string.
> 
> - **UI (onboarding)**:
>   - Update CTA in `ui/pages/onboarding-flow/creation-successful/creation-successful.js` to show `t('openWallet')` when `isSidePanelEnabled` is true; otherwise use `t('done')`.
> - **i18n**:
>   - Add `openWallet` message to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ad6d9c00cff15fdd81b3d3a782e8f2fbada972. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->