### PR TITLE
Analyse issue and suggest code changes

### DIFF
--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -7,7 +7,10 @@ import React, { memo, useMemo } from 'react';
 import { TokenStandard } from '../../../../../../shared/constants/transaction';
 import GeneralAlert from '../../../../../components/app/alert-system/general-alert/general-alert';
 import { Box, Text } from '../../../../../components/component-library';
+import { Skeleton } from '../../../../../components/component-library/skeleton';
 import {
+  Display,
+  JustifyContent,
   TextAlign,
   TextColor,
   TextVariant,
@@ -297,6 +300,31 @@ const ConfirmTitle: React.FC = memo(() => {
 
   if (!currentConfirmation) {
     return null;
+  }
+
+  // Show skeleton loaders while data is loading
+  if (spendingCapPending) {
+    return (
+      <>
+        <ConfirmBannerAlert ownerId={currentConfirmation.id} />
+        <Box
+          paddingTop={4}
+          paddingBottom={2}
+          display={Display.Flex}
+          justifyContent={JustifyContent.center}
+        >
+          <Skeleton height={32} width="60%" />
+        </Box>
+        <NestedTransactionTag />
+        <Box
+          paddingBottom={4}
+          display={Display.Flex}
+          justifyContent={JustifyContent.center}
+        >
+          <Skeleton height={20} width="70%" />
+        </Box>
+      </>
+    );
   }
 
   return (

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -25,6 +25,7 @@ import {
   IconSize,
   Text,
 } from '../../../../components/component-library';
+import { Skeleton } from '../../../../components/component-library/skeleton';
 import Preloader from '../../../../components/ui/icon/preloader/preloader-icon.component';
 import Tooltip from '../../../../components/ui/tooltip';
 import {
@@ -72,9 +73,23 @@ export type SimulationDetailsProps = {
  */
 const LoadingIndicator: React.FC = () => {
   return (
-    <div role="progressbar">
-      <Preloader size={20} />
-    </div>
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      gap={2}
+      role="progressbar"
+    >
+      {/* Simulate outgoing section */}
+      <Box>
+        <Skeleton height={16} width="40%" marginBottom={1} />
+        <Skeleton height={48} width="100%" />
+      </Box>
+      {/* Simulate incoming section */}
+      <Box>
+        <Skeleton height={16} width="40%" marginBottom={1} />
+        <Skeleton height={48} width="100%" />
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Add skeleton loaders to confirmation screens to prevent content jumping during loading.

This change improves the user experience by reserving space for dynamically loaded content (title, description, and simulation details) before it appears, eliminating layout shifts, particularly noticeable in Uniswap Shield transactions.

---
[Slack Thread](https://consensys.slack.com/archives/C070G0RCX0T/p1763037834636589?thread_ts=1763037834.636589&cid=C070G0RCX0T)

<a href="https://cursor.com/background-agent?bcId=bc-617e5c23-2a4e-4661-bed2-c9e23daff048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-617e5c23-2a4e-4661-bed2-c9e23daff048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

