### PR TITLE
feat: update localizations for Shield notifications

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5131,17 +5131,20 @@
   "pushNotificationShieldClaimStatusUpdatedTitle": {
     "message": "Claim updated"
   },
-  "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
-    "message": "Welcome to MetaMask Transaction Shield! Explore benefits"
+  "pushNotificationShieldLearnMoreCta": {
+    "message": "Learn more"
   },
-  "pushNotificationShieldSubscriptionCreatedTitle": {
-    "message": "MetaMask Transaction Shield activated"
+  "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
+    "message": "Your plan is now active."
   },
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
-    "message": "Membership is inactive due to payment issue. Update your payment to restore coverage"
+    "message": "Your membership has been paused due to payment failure."
   },
-  "pushNotificationShieldSubscriptionPaymentFailedTitle": {
-    "message": "MetaMask Transaction Shield paused"
+  "pushNotificationShieldSubscriptionTitle": {
+    "message": "MetaMask Transaction Shield"
+  },
+  "pushNotificationShieldUpdatePaymentCta": {
+    "message": "Update payment"
   },
   "pushNotificationStopLossTriggeredDescriptionLong": {
     "message": "Your $1 long closed at your stop loss.",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5131,17 +5131,20 @@
   "pushNotificationShieldClaimStatusUpdatedTitle": {
     "message": "Claim updated"
   },
-  "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
-    "message": "Welcome to MetaMask Transaction Shield! Explore benefits"
+  "pushNotificationShieldLearnMoreCta": {
+    "message": "Learn more"
   },
-  "pushNotificationShieldSubscriptionCreatedTitle": {
-    "message": "MetaMask Transaction Shield activated"
+  "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
+    "message": "Your plan is now active."
   },
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
-    "message": "Membership is inactive due to payment issue. Update your payment to restore coverage"
+    "message": "Your membership has been paused due to payment failure."
   },
-  "pushNotificationShieldSubscriptionPaymentFailedTitle": {
-    "message": "MetaMask Transaction Shield paused"
+  "pushNotificationShieldSubscriptionTitle": {
+    "message": "MetaMask Transaction Shield"
+  },
+  "pushNotificationShieldUpdatePaymentCta": {
+    "message": "Update payment"
   },
   "pushNotificationStopLossTriggeredDescriptionLong": {
     "message": "Your $1 long closed at your stop loss.",

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -4854,30 +4854,6 @@
   "pushNotificationPositionLiquidatedTitle": {
     "message": "Post leachtaithe"
   },
-  "pushNotificationShieldClaimCreatedDescriptionShort": {
-    "message": "Tá d'éileamh cruthaithe"
-  },
-  "pushNotificationShieldClaimCreatedTitle": {
-    "message": "Éileamh cruthaithe"
-  },
-  "pushNotificationShieldClaimStatusUpdatedDescriptionShort": {
-    "message": "Tá d'éileamh nuashonraithe"
-  },
-  "pushNotificationShieldClaimStatusUpdatedTitle": {
-    "message": "Éileamh nuashonraithe"
-  },
-  "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
-    "message": "Fáilte go Sciath Idirbhirt MetaMask! Féach ar na buntáistí"
-  },
-  "pushNotificationShieldSubscriptionCreatedTitle": {
-    "message": "Sciath Idirbhirt MetaMask gníomhachaithe"
-  },
-  "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
-    "message": "Tá an bhallraíocht neamhghníomhach mar gheall ar fhadhb íocaíochta. Nuashonraigh d'íocaíocht chun clúdach a atosú"
-  },
-  "pushNotificationShieldSubscriptionPaymentFailedTitle": {
-    "message": "Sciath Idirbhirt MetaMask curtha ar sos"
-  },
   "pushNotificationStopLossTriggeredDescriptionLong": {
     "message": "Dhún do $1 fada ag do stad-chaillteanas.",
     "description": "$1 is the asset symbol"

--- a/app/scripts/controllers/push-notifications/get-notification-message.ts
+++ b/app/scripts/controllers/push-notifications/get-notification-message.ts
@@ -85,14 +85,14 @@ const perpsTranslations = {
 };
 
 const shieldTranslations = {
-  ShieldSubscriptionCreatedTitle: () =>
-    t('pushNotificationShieldSubscriptionCreatedTitle'),
+  ShieldSubscriptionTitle: () => t('pushNotificationShieldSubscriptionTitle'),
   ShieldSubscriptionCreatedDescriptionShort: () =>
     t('pushNotificationShieldSubscriptionCreatedDescriptionShort'),
-  ShieldSubscriptionPaymentFailedTitle: () =>
-    t('pushNotificationShieldSubscriptionPaymentFailedTitle'),
   ShieldSubscriptionPaymentFailedDescriptionShort: () =>
     t('pushNotificationShieldSubscriptionPaymentFailedDescriptionShort'),
+  ShieldSubscriptionUpdatePaymentCta: () =>
+    t('pushNotificationShieldUpdatePaymentCta'),
+  ShieldSubscriptionLearnMoreCta: () => t('pushNotificationShieldLearnMoreCta'),
   ShieldClaimCreatedTitle: () => t('pushNotificationShieldClaimCreatedTitle'),
   ShieldClaimCreatedDescriptionShort: () =>
     t('pushNotificationShieldClaimCreatedDescriptionShort'),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Update localizations of Transaction Shield notifications:
- Subscribed event
MetaMask Transaction Shield
Your plan is now active. 
<CTA: Learn more>. *-> goes to landing page

- Payment failure event
MetaMask Transaction Shield
Your membership has been paused due to payment failure.
<CTA: Update payment>   -> Membership settings page

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37794?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Shield notification localization strings (en/en_GB), removes outdated ga entries, and refactors notification mapping to new title/CTA keys.
> 
> - **Localization (i18n)**
>   - **en, en_GB**: Add `pushNotificationShieldLearnMoreCta`, `pushNotificationShieldSubscriptionTitle`, `pushNotificationShieldUpdatePaymentCta`; update `pushNotificationShieldSubscriptionCreatedDescriptionShort` and `pushNotificationShieldSubscriptionPaymentFailedDescriptionShort` copy.
>   - **ga**: Remove outdated Shield keys for claim/subscription created and payment failed.
> - **Push notification mapping** (`app/scripts/controllers/push-notifications/get-notification-message.ts`):
>   - Replace `ShieldSubscriptionCreatedTitle`/`ShieldSubscriptionPaymentFailedTitle` with `ShieldSubscriptionTitle`.
>   - Add CTA mappings `ShieldSubscriptionUpdatePaymentCta` and `ShieldSubscriptionLearnMoreCta`.
>   - Keep claim-related mappings; align keys with new locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e49861b09b2858aa102bf44a9162744e1929618. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->