### PR TITLE
feat: display account full name on billing account

### DIFF
--- a/ui/components/app/confirm/info/row/address.tsx
+++ b/ui/components/app/confirm/info/row/address.tsx
@@ -18,10 +18,16 @@ export type ConfirmInfoRowAddressProps = {
   address: string;
   chainId: string;
   isSnapUsingThis?: boolean;
+  showFullName?: boolean;
 };
 
 export const ConfirmInfoRowAddress = memo(
-  ({ address, chainId, isSnapUsingThis }: ConfirmInfoRowAddressProps) => {
+  ({
+    address,
+    chainId,
+    isSnapUsingThis,
+    showFullName = false,
+  }: ConfirmInfoRowAddressProps) => {
     const { displayName, hexAddress } = useFallbackDisplayName(address);
     const [isNicknamePopoverShown, setIsNicknamePopoverShown] = useState(false);
     const handleDisplayNameClick = () => setIsNicknamePopoverShown(true);
@@ -70,6 +76,7 @@ export const ConfirmInfoRowAddress = memo(
               type={NameType.ETHEREUM_ADDRESS}
               preferContractSymbol
               variation={chainId}
+              showFullName={showFullName}
             />
           )
         }

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -45,6 +45,11 @@ export type NameProps = {
    * The fallback value to display if the name is not found or cannot be resolved.
    */
   fallbackName?: string;
+
+  /**
+   * Whether to show the full name.
+   */
+  showFullName?: boolean;
 };
 
 const Name = memo(

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -875,6 +875,7 @@ const TransactionShield = () => {
                       chainId={
                         displayedShieldSubscription.paymentMethod.crypto.chainId
                       }
+                      showFullName
                     />
                   ) : (
                     ''


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Show Shield Settings billing account name in full

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37797?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show Shield Settings billing account name in full

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="650" height="63" alt="Screenshot 2025-11-13 at 10 35 46 PM" src="https://github.com/user-attachments/assets/214c169a-2278-4e3b-823d-db3e0b050313" />


<!-- [screenshots/recordings] -->

### **After**
<img width="651" height="60" alt="Screenshot 2025-11-13 at 10 34 03 PM" src="https://github.com/user-attachments/assets/37eae7ab-dc68-4fbc-8ee2-fa6653158641" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays the full account name for the Shield billing account by adding and wiring a `showFullName` prop through `ConfirmInfoRowAddress` to `Name`.
> 
> - **Settings — Shield Billing Details**:
>   - Show full account name for crypto billing account by rendering `ConfirmInfoRowAddress` with `showFullName` in `ui/pages/settings/transaction-shield-tab/transaction-shield.tsx`.
> - **Components**:
>   - `ui/components/app/confirm/info/row/address.tsx`:
>     - Add optional `showFullName` prop to `ConfirmInfoRowAddress` and pass it to `Name`.
>   - `ui/components/app/name/name.tsx`:
>     - Extend `NameProps` with `showFullName` to support full-name rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7df426f367ba6bcaf01fef39de153c5d030cd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->