### PR TITLE
fix: disable experimental code fence feature in non-experimental builds

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -17,7 +17,6 @@ buildTypes:
     id: 10
     features:
       - build-main
-      - build-experimental
       - keyring-snaps
       - multi-srp
       - multichain
@@ -35,7 +34,7 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.2.3/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_PROD_CLIENT_ID
       - APPLE_PROD_CLIENT_ID
@@ -51,7 +50,6 @@ buildTypes:
     id: 11
     features:
       - build-beta
-      - build-experimental
       - keyring-snaps
       - multichain
       - bitcoin
@@ -70,7 +68,7 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.2.3/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_BETA_CLIENT_ID
       - APPLE_BETA_CLIENT_ID
@@ -121,7 +119,6 @@ buildTypes:
     # will not be removed
     features:
       - build-flask
-      - build-experimental
       - keyring-snaps
       - bitcoin
       - tron
@@ -141,7 +138,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://metamask.github.io/snaps-directory-staging/main/account-management
       - EIP_4337_ENTRYPOINT: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_FLASK_CLIENT_ID
       - APPLE_FLASK_CLIENT_ID

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -225,7 +225,17 @@ export default function CreationSuccessful() {
           width={BlockSize.Full}
           onClick={onDone}
         >
-          {isSidePanelEnabled ? t('openWallet') : t('done')}
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
+            // Side Panel - only if feature flag is enabled
+            isSidePanelEnabled ? t('openWallet') : t('done')
+            ///: END:ONLY_INCLUDE_IF
+          }
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+            t('done')
+            ///: END:ONLY_INCLUDE_IF
+          }
         </Button>
       </Box>
     );

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -649,6 +649,7 @@ export default function Routes() {
     }
   }, [currentCurrency, dispatch]);
 
+  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   // Navigate to confirmations when there are pending approvals and user is on asset details page
   // This behavior is only enabled in sidepanel to avoid interfering with popup/extension flows
   useEffect(() => {
@@ -684,6 +685,7 @@ export default function Routes() {
       );
     }
   }, [isUnlocked, pendingApprovals, approvalFlows, history, location.pathname]);
+  ///: END:ONLY_INCLUDE_IF
 
   const renderRoutes = useCallback(() => {
     const RestoreVaultComponent = forgottenPassword ? Route : Initialized;


### PR DESCRIPTION
PR https://github.com/MetaMask/metamask-extension/commit/084e01dc2c33649cffc011ee8628097c47e6ef85 was meant to enable only the side panel feature, by enabling the `build-experimental` code-fence flag for all builds, but other features also use this same flag, and were erroneously turned on when this flag was enabled.

This PR temporarily turns it back off.

<!--

## **Description**

## **Changelog**

CHANGELOG entry: Automatically restart the extension after MM is updated in order to work around this chromium bug: https://issues.chromium.org/issues/40805401

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
 -->