### PR TITLE
feat: sidepanel code clean up

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -23,9 +23,7 @@ import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_FULLSCREEN,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
   PLATFORM_FIREFOX,
   MESSAGE_TYPE,
 } from '../../shared/constants/app';
@@ -153,9 +151,7 @@ const isFirefox = getPlatform() === PLATFORM_FIREFOX;
 let openPopupCount = 0;
 let notificationIsOpen = false;
 let uiIsTriggering = false;
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 let sidePanelIsOpen = false;
-///: END:ONLY_INCLUDE_IF
 const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
 let controller;
@@ -1169,9 +1165,7 @@ export function setupController(
       openPopupCount > 0 ||
       Boolean(Object.keys(openMetamaskTabsIDs).length) ||
       notificationIsOpen ||
-      ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
       sidePanelIsOpen ||
-      ///: END:ONLY_INCLUDE_IF
       false
     );
   };
@@ -1259,7 +1253,6 @@ export function setupController(
         });
       }
 
-      ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
       if (processName === ENVIRONMENT_TYPE_SIDEPANEL) {
         sidePanelIsOpen = true;
         finished(portStream, () => {
@@ -1269,7 +1262,6 @@ export function setupController(
           onCloseEnvironmentInstances(isClientOpen, ENVIRONMENT_TYPE_SIDEPANEL);
         });
       }
-      ///: END:ONLY_INCLUDE_IF
 
       if (processName === ENVIRONMENT_TYPE_NOTIFICATION) {
         notificationIsOpen = true;
@@ -1615,9 +1607,7 @@ async function triggerUi() {
     !uiIsTriggering &&
     (isVivaldi || openPopupCount === 0) &&
     !currentlyActiveMetamaskTab &&
-    ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     !sidePanelIsOpen &&
-    ///: END:ONLY_INCLUDE_IF
     true
   ) {
     uiIsTriggering = true;
@@ -1682,7 +1672,6 @@ function onInstall() {
     platform.openExtensionInBrowser();
   }
 }
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 // Only register sidepanel context menu for browsers that support it (Chrome/Edge/Brave)
 // and when the feature flag is enabled
 if (
@@ -1704,7 +1693,6 @@ if (
     }
   });
 }
-///: END:ONLY_INCLUDE_IF
 
 // // On first install, open a new tab with MetaMask
 // async function onInstall() {
@@ -1786,7 +1774,6 @@ function onNavigateToTab() {
   });
 }
 
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 // Sidepanel-specific functionality
 // Set initial side panel behavior based on user preference
 const initSidePanelBehavior = async () => {
@@ -1974,7 +1961,6 @@ browser.tabs.onUpdated.addListener(async (tabId) => {
 
   return {};
 });
-///: END:ONLY_INCLUDE_IF
 
 function setupSentryGetStateGlobal(store) {
   global.stateHooks.getSentryAppState = function () {

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -114,7 +114,7 @@ export type Preferences = {
     sortCallback: string;
   };
   useNativeCurrencyAsPrimaryCurrency: boolean;
-  useSidePanelAsDefault?: boolean; // Only available in build-experimental
+  useSidePanelAsDefault?: boolean;
 };
 
 // Omitting properties that already exist in the PreferencesState, as part of the preferences property.
@@ -222,9 +222,7 @@ export const getDefaultPreferencesControllerState =
         sortCallback: 'stringNumeric',
       },
       useNativeCurrencyAsPrimaryCurrency: true,
-      ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
       useSidePanelAsDefault: false,
-      ///: END:ONLY_INCLUDE_IF
     },
     securityAlertsEnabled: true,
     selectedAddress: '',

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -14,9 +14,7 @@ import {
   ENVIRONMENT_TYPE_BACKGROUND,
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
   ENVIRONMENT_TYPE_POPUP,
   PLATFORM_BRAVE,
   PLATFORM_CHROME,
@@ -41,11 +39,9 @@ const getEnvironmentTypeMemo = memoize((url) => {
   } else if (parsedUrl.pathname === '/notification.html') {
     return ENVIRONMENT_TYPE_NOTIFICATION;
   }
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   else if (parsedUrl.pathname === '/sidepanel.html') {
     return ENVIRONMENT_TYPE_SIDEPANEL;
   }
-  ///: END:ONLY_INCLUDE_IF
   return ENVIRONMENT_TYPE_BACKGROUND;
 });
 

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -38,8 +38,7 @@ const getEnvironmentTypeMemo = memoize((url) => {
     return ENVIRONMENT_TYPE_FULLSCREEN;
   } else if (parsedUrl.pathname === '/notification.html') {
     return ENVIRONMENT_TYPE_NOTIFICATION;
-  }
-  else if (parsedUrl.pathname === '/sidepanel.html') {
+  } else if (parsedUrl.pathname === '/sidepanel.html') {
     return ENVIRONMENT_TYPE_SIDEPANEL;
   }
   return ENVIRONMENT_TYPE_BACKGROUND;

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -40,9 +40,7 @@ import launchMetaMaskUi, {
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_POPUP,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
   PLATFORM_FIREFOX,
 } from '../../shared/constants/app';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
@@ -284,7 +282,6 @@ async function queryCurrentActiveTab(windowType) {
   }
 
   // Only popup queries the active tab
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   // Sidepanel uses appActiveTab from tab listeners instead
   if (
     windowType !== ENVIRONMENT_TYPE_POPUP &&
@@ -292,14 +289,6 @@ async function queryCurrentActiveTab(windowType) {
   ) {
     return {};
   }
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-  // Only popup queries the active tab
-  // Dialog/notification windows get their origin from approval metadata
-  if (windowType !== ENVIRONMENT_TYPE_POPUP) {
-    return {};
-  }
-  ///: END:ONLY_INCLUDE_IF
 
   const tabs = await browser.tabs
     .query({ active: true, currentWindow: true })

--- a/builds.yml
+++ b/builds.yml
@@ -17,7 +17,6 @@ buildTypes:
     id: 10
     features:
       - build-main
-      - build-experimental
       - keyring-snaps
       - multi-srp
       - multichain
@@ -51,7 +50,6 @@ buildTypes:
     id: 11
     features:
       - build-beta
-      - build-experimental
       - keyring-snaps
       - multichain
       - bitcoin
@@ -121,7 +119,6 @@ buildTypes:
     # will not be removed
     features:
       - build-flask
-      - build-experimental
       - keyring-snaps
       - bitcoin
       - tron

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -758,7 +758,6 @@ function createFactoredBuild({
               applyLavaMoat,
               scripts,
             });
-            ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
             renderHtmlFile({
               htmlName: 'sidepanel',
               browserPlatforms,
@@ -766,7 +765,6 @@ function createFactoredBuild({
               shouldIncludeSnow,
               scripts,
             });
-            ///: END:ONLY_INCLUDE_IF
             renderHtmlFile({
               htmlName: 'notification',
               browserPlatforms,

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -941,9 +941,7 @@ export enum MetaMetricsEventName {
   ExtensionPinned = 'Extension Pinned',
   // Extension Port Stream
   PortStreamChunked = 'Port Stream Chunked',
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ViewportSwitched = 'Viewport Switched',
-  ///: END:ONLY_INCLUDE_IF
   // Shield
   ShieldEntryModal = 'Shield Entry Modal',
   ShieldSubscriptionRequest = 'Shield Subscription Request',

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -29,9 +29,7 @@ import { toggleNetworkMenu } from '../../../store/actions';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import {
   ENVIRONMENT_TYPE_POPUP,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../../shared/constants/app';
 import { getIsUnlocked } from '../../../ducks/metamask/metamask';
 import { SEND_STAGES, getSendStage } from '../../../ducks/send';
@@ -58,9 +56,7 @@ export const AppHeader = ({ location }) => {
 
   const environmentType = getEnvironmentType();
   const popupStatus = environmentType === ENVIRONMENT_TYPE_POPUP;
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
-  ///: END:ONLY_INCLUDE_IF
 
   // Disable the network and account pickers if the user is in
   // a critical flow
@@ -130,9 +126,7 @@ export const AppHeader = ({ location }) => {
     <>
       {isUnlocked &&
       !popupStatus &&
-      ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
       !isSidepanel &&
-      ///: END:ONLY_INCLUDE_IF
       true ? (
         <MultichainMetaFoxLogo />
       ) : null}

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -124,10 +124,7 @@ export const AppHeader = ({ location }) => {
 
   return (
     <>
-      {isUnlocked &&
-      !popupStatus &&
-      !isSidepanel &&
-      true ? (
+      {isUnlocked && !popupStatus && !isSidepanel && true ? (
         <MultichainMetaFoxLogo />
       ) : null}
       <AppHeaderContainer isUnlocked={isUnlocked} popupStatus={popupStatus}>

--- a/ui/index.js
+++ b/ui/index.js
@@ -19,9 +19,7 @@ import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
 } from '../shared/constants/app';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { getBrowserName } from '../shared/modules/browser-runtime.utils';
-///: END:ONLY_INCLUDE_IF
 import { COPY_OPTIONS } from '../shared/constants/copy';
 import { switchDirection } from '../shared/lib/switch-direction';
 import { setupLocale } from '../shared/lib/error-utils';
@@ -247,7 +245,6 @@ async function startApp(metamaskState, opts) {
 async function runInitialActions(store) {
   const initialState = store.getState();
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   // Update browser environment with accurate browser detection from UI
   // This corrects the initial detection from background which can't detect Brave
   try {
@@ -263,7 +260,6 @@ async function runInitialActions(store) {
   } catch (error) {
     log.error('Failed to get browser name:', error);
   }
-  ///: END:ONLY_INCLUDE_IF
 
   // This block autoswitches chains based on the last chain used
   // for a given dapp, when there are no pending confimrations

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -1,9 +1,7 @@
 import React, { useCallback, useMemo, useContext } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { useDispatch, useSelector } from 'react-redux';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import browser from 'webextension-polyfill';
-///: END:ONLY_INCLUDE_IF
 import {
   Button,
   ButtonSize,
@@ -51,15 +49,11 @@ import { getIsPrimarySeedPhraseBackedUp } from '../../../ducks/metamask/metamask
 import {
   toggleExternalServices,
   setCompletedOnboarding,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   setCompletedOnboardingWithSidepanel,
   setUseSidePanelAsDefault,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../store/actions';
 import { LottieAnimation } from '../../../components/component-library/lottie-animation';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';
-///: END:ONLY_INCLUDE_IF
 import WalletReadyAnimation from './wallet-ready-animation';
 
 export default function CreationSuccessful() {
@@ -74,9 +68,7 @@ export default function CreationSuccessful() {
   const trackEvent = useContext(MetaMetricsContext);
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isTestEnvironment = Boolean(process.env.IN_TEST);
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   const isSidePanelEnabled = useSidePanelEnabled();
-  ///: END:ONLY_INCLUDE_IF
 
   const learnMoreLink =
     'https://support.metamask.io/stay-safe/safety-in-web3/basic-safety-and-security-tips-for-metamask/';
@@ -165,7 +157,6 @@ export default function CreationSuccessful() {
       toggleExternalServices(externalServicesOnboardingToggleState),
     );
 
-    ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     // Side Panel - only if feature flag is enabled
     if (isSidePanelEnabled) {
       try {
@@ -189,11 +180,6 @@ export default function CreationSuccessful() {
     }
     // Fallback to regular onboarding completion
     await dispatch(setCompletedOnboarding());
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-    // Regular onboarding completion for non-experimental builds
-    await dispatch(setCompletedOnboarding());
-    ///: END:ONLY_INCLUDE_IF
 
     navigate(DEFAULT_ROUTE);
   }, [
@@ -205,9 +191,7 @@ export default function CreationSuccessful() {
     trackEvent,
     firstTimeFlowType,
     isFromSettingsSecurity,
-    ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     isSidePanelEnabled,
-    ///: END:ONLY_INCLUDE_IF
   ]);
 
   const renderDoneButton = () => {

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.js
@@ -3,14 +3,10 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { useDispatch, useSelector } from 'react-redux';
 import { Carousel } from 'react-responsive-carousel';
 import classnames from 'classnames';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import browser from 'webextension-polyfill';
-///: END:ONLY_INCLUDE_IF
 import {
   setCompletedOnboarding,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   setCompletedOnboardingWithSidepanel,
-  ///: END:ONLY_INCLUDE_IF
   toggleExternalServices,
 } from '../../../store/actions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -48,9 +44,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';
-///: END:ONLY_INCLUDE_IF
 
 export default function OnboardingPinExtension() {
   const t = useI18nContext();
@@ -60,9 +54,7 @@ export default function OnboardingPinExtension() {
   const trackEvent = useContext(MetaMetricsContext);
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const currentKeyring = useSelector(getCurrentKeyring);
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   const isSidePanelEnabled = useSidePanelEnabled();
-  ///: END:ONLY_INCLUDE_IF
 
   const externalServicesOnboardingToggleState = useSelector(
     getExternalServicesOnboardingToggleState,
@@ -83,7 +75,6 @@ export default function OnboardingPinExtension() {
       },
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     // Side Panel - only if feature flag is enabled and not in test mode
     if (isSidePanelEnabled) {
       try {
@@ -106,11 +97,6 @@ export default function OnboardingPinExtension() {
     }
     // Fallback to regular onboarding completion
     await dispatch(setCompletedOnboarding());
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-    // Regular onboarding completion for non-experimental builds
-    await dispatch(setCompletedOnboarding());
-    ///: END:ONLY_INCLUDE_IF
   };
 
   useEffect(() => {

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
@@ -106,7 +106,7 @@ describe('Creation Successful Onboarding View', () => {
 
       await Promise.all(mockPromises);
       expect(toggleExternalServices).toHaveBeenCalledTimes(1);
-      expect(setCompletedOnboarding).toHaveBeenCalledTimes(2);
+      expect(setCompletedOnboarding).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -92,9 +92,7 @@ import {
   getPendingApprovals,
   getIsMultichainAccountsState1Enabled,
 } from '../../selectors';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { getApprovalFlows } from '../../selectors/approvals';
-///: END:ONLY_INCLUDE_IF
 
 import {
   hideImportNftsModal,
@@ -118,14 +116,10 @@ import {
 } from '../../ducks/metamask/metamask';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 import { navigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
-///: END:ONLY_INCLUDE_IF
 import {
   ENVIRONMENT_TYPE_POPUP,
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
   ///: END:ONLY_INCLUDE_IF
@@ -502,9 +496,7 @@ export default function Routes() {
   );
   const pendingApprovals = useAppSelector(getPendingApprovals);
   const transactionsMetadata = useAppSelector(getUnapprovedTransactions);
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   const approvalFlows = useAppSelector(getApprovalFlows);
-  ///: END:ONLY_INCLUDE_IF
 
   const textDirection = useAppSelector((state) => state.metamask.textDirection);
   const isUnlocked = useAppSelector(getIsUnlocked);
@@ -1131,18 +1123,14 @@ export default function Routes() {
     />
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   const isSidepanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
-  ///: END:ONLY_INCLUDE_IF
 
   return (
     <div
       className={classnames('app', {
         [`os-${os}`]: Boolean(os),
         [`browser-${browser}`]: Boolean(browser),
-        ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
         'group app--sidepanel': isSidepanel,
-        ///: END:ONLY_INCLUDE_IF
       })}
       dir={textDirection}
     >

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -414,7 +414,6 @@
   }
 }
 
-///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
 // Sidepanel-specific styles: apply popup layout regardless of viewport width
 .settings-page--sidepanel {
   .settings-page__header__title-container {
@@ -552,4 +551,3 @@
     }
   }
 }
-///: END:ONLY_INCLUDE_IF

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -169,9 +169,7 @@ class SettingsPage extends PureComponent {
     const isPopup =
       environmentType === ENVIRONMENT_TYPE_POPUP ||
       environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
-    ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
     const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
-    ///: END:ONLY_INCLUDE_IF
     const isSearchHidden =
       isRevealSrpListPage || isPasswordChangePage || isTransactionShieldPage;
 
@@ -181,9 +179,7 @@ class SettingsPage extends PureComponent {
           'main-container main-container--has-shadow settings-page',
           {
             'settings-page--selected': currentPath !== SETTINGS_ROUTE,
-            ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
             'settings-page--sidepanel': isSidepanel,
-            ///: END:ONLY_INCLUDE_IF
           },
         )}
       >

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -110,9 +110,7 @@ import { STATIC_MAINNET_TOKEN_LIST } from '../../shared/constants/tokens';
 import { DAY } from '../../shared/constants/time';
 import { TERMS_OF_USE_LAST_UPDATED } from '../../shared/constants/terms';
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   ENVIRONMENT_TYPE_SIDEPANEL,
-  ///: END:ONLY_INCLUDE_IF
   ENVIRONMENT_TYPE_POPUP,
 } from '../../shared/constants/app';
 import {
@@ -1867,13 +1865,11 @@ export function getAppActiveTab(state) {
 }
 
 export function getOriginOfCurrentTab(state) {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-experimental)
   // For sidepanel, always use appActiveTab
   if (getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL) {
     const appActiveTab = getAppActiveTab(state);
     return appActiveTab?.origin;
   }
-  ///: END:ONLY_INCLUDE_IF
   // For all other cases, use activeTab
   return state.activeTab.origin;
 }


### PR DESCRIPTION
This PR is to remove unused code fence

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37811?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension with yarn start
2. Check extension in sidepanel
3. Everything should work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes experimental code fences and enables sidepanel across builds, updating background/UI logic, onboarding flows, selectors/styles, build scripts, and tests.
> 
> - **Sidepanel promotion (remove experimental fences)**
>   - Always include `ENVIRONMENT_TYPE_SIDEPANEL` handling in `background.js`, `ui.js`, `lib/util.ts`, and UI components; track sidepanel open/close and client-open state.
>   - Add sidepanel context menu registration and dynamic sidepanel behavior/preferences in background unconditionally when `IS_SIDEPANEL=true`.
>   - Update onboarding flows to open sidepanel and use `setCompletedOnboardingWithSidepanel`, with fallback to `setCompletedOnboarding`.
>   - Simplify UI conditionals (e.g., header logo visibility, active tab querying) to account for sidepanel.
>   - Apply sidepanel-specific layout/classes/styles in Settings and Routes without fences.
> - **Build/config**
>   - `builds.yml`: remove `build-experimental` from main/beta/flask feature lists; set `IS_SIDEPANEL: true` for builds; keep experimental build type.
>   - Build scripts now always render `sidepanel.html`.
> - **Selectors/logic**
>   - Make `useSidePanelAsDefault` part of preferences defaults/state unconditionally.
>   - Selectors/use of `ENVIRONMENT_TYPE_SIDEPANEL` and `appActiveTab` always available; routes auto-navigate to confirmations in sidepanel.
>   - UI init always updates browser environment from UI.
> - **Metrics**
>   - Always include `ViewportSwitched` event name.
> - **Tests**
>   - Update onboarding pin-extension test to expect a single `setCompletedOnboarding` dispatch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfaa1fc1c18e608d4ae0d0535cccb9bbda8fbce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->