### PR TITLE
test: Mitigate flaky ToS test

### DIFF
--- a/test/e2e/tests/settings/terms-of-use.spec.ts
+++ b/test/e2e/tests/settings/terms-of-use.spec.ts
@@ -18,6 +18,10 @@ describe('Terms of use', function (this: Suite) {
       },
       async ({ driver }) => {
         await loginWithoutBalanceValidation(driver);
+
+        // Delay click to mitigate flakiness
+        await driver.delay(1_000);
+
         // accept updated terms of use
         const updateTermsOfUseModal = new TermsOfUseUpdateModal(driver);
         await updateTermsOfUseModal.checkPageIsLoaded();


### PR DESCRIPTION
## **Description**

Mitigate the flaky "accepts the updated terms of use" E2E test by adding a delay before clicking the "Scroll to bottom" button.

This test started failing _very frequently_ today for no apparent reason.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37817?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 1s delay before interacting with the Terms of Use update modal in the E2E test to mitigate flakiness.
> 
> - **Tests (E2E)**:
>   - Update `test/e2e/tests/settings/terms-of-use.spec.ts`:
>     - After `loginWithoutBalanceValidation(driver)`, add `await driver.delay(1_000);` to stabilize the "accepts the updated terms of use" flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4354256ee02140816b68368466ba37c50617deb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->