### PR TITLE
test: wait for balance `Terms of use accepts the updated terms of use`

### DIFF
--- a/test/e2e/tests/settings/terms-of-use.spec.ts
+++ b/test/e2e/tests/settings/terms-of-use.spec.ts
@@ -2,7 +2,7 @@ import { Suite } from 'mocha';
 import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixture-builder';
 import TermsOfUseUpdateModal from '../../page-objects/pages/dialog/terms-of-use-update-modal';
-import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
 describe('Terms of use', function (this: Suite) {
   it('accepts the updated terms of use', async function () {
@@ -17,10 +17,7 @@ describe('Terms of use', function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
-        await loginWithoutBalanceValidation(driver);
-
-        // Delay click to mitigate flakiness
-        await driver.delay(1_000);
+        await loginWithBalanceValidation(driver);
 
         // accept updated terms of use
         const updateTermsOfUseModal = new TermsOfUseUpdateModal(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This test was flaky as right after login in, we clicked on the terms of use arrow and accept the terms of use. Sometimes the click took no effect.

This was fixed by adding a delay.
Hypothesis: we click and then the balance component is updated making the click take no effect due to a rerender?.
We can wait for the balance to be loaded in the UI so nothing else is re-rendered in the Ui, so then the click is always effective.

Side: the recommended practice is to always wait for the balance to be rendered in the UI before proceeding with any action. This has proven to stabilize tests in multiple areas (ie starting txs without balance loaded can lead to unexpected results etc), so in general we'll always want to login with balance validation


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37831?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
