### PR TITLE
fix: flaky tests ` Sentry errors before initialization, after opting into metrics should...`

### DIFF
--- a/test/e2e/tests/metrics/errors.spec.ts
+++ b/test/e2e/tests/metrics/errors.spec.ts
@@ -211,6 +211,7 @@ describe('Sentry errors', function () {
   async function mockSentryMigratorError(mockServer: Mockttp) {
     return await mockServer
       .forPost(sentryRegEx)
+      .withBodyIncluding('{"type":"event"')
       .withBodyIncluding(migrationError)
       .thenCallback(() => {
         return {
@@ -316,8 +317,8 @@ describe('Sentry errors', function () {
     });
   });
 
-  describe.only('before initialization, after opting into metrics', function () {
-    it.only('should send error events in background', async function () {
+  describe('before initialization, after opting into metrics', function () {
+    it('should send error events in background', async function () {
       await withFixtures(
         {
           fixtures: {
@@ -347,19 +348,14 @@ describe('Sentry errors', function () {
           }, WAIT_FOR_SENTRY_MS);
 
           const [mockedRequest] = await mockedEndpoint.getSeenRequests();
-
-          console.log('mockedRequest============', mockedRequest);
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
-          console.log('mockJson Body ============', mockJsonBody);
-
           // Verify request
           const escapedMigrationError = migrationError.replace(
             /[.*+?^${}()|[\]\\]/gu,
             '\\$&',
           );
           const migrationErrorRegex = new RegExp(escapedMigrationError, 'u');
-          console.log('migrationErrorRegex============', migrationErrorRegex);
           assert.match(
             JSON.stringify(mockJsonBody.exception),
             migrationErrorRegex,

--- a/test/e2e/tests/metrics/errors.spec.ts
+++ b/test/e2e/tests/metrics/errors.spec.ts
@@ -316,8 +316,8 @@ describe('Sentry errors', function () {
     });
   });
 
-  describe('before initialization, after opting into metrics', function () {
-    it('should send error events in background', async function () {
+  describe.only('before initialization, after opting into metrics', function () {
+    it.only('should send error events in background', async function () {
       await withFixtures(
         {
           fixtures: {
@@ -347,14 +347,19 @@ describe('Sentry errors', function () {
           }, WAIT_FOR_SENTRY_MS);
 
           const [mockedRequest] = await mockedEndpoint.getSeenRequests();
+
+          console.log('mockedRequest============', mockedRequest);
           const mockTextBody = (await mockedRequest.body.getText()).split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
+          console.log('mockJson Body ============', mockJsonBody);
+
           // Verify request
           const escapedMigrationError = migrationError.replace(
             /[.*+?^${}()|[\]\\]/gu,
             '\\$&',
           );
           const migrationErrorRegex = new RegExp(escapedMigrationError, 'u');
+          console.log('migrationErrorRegex============', migrationErrorRegex);
           assert.match(
             JSON.stringify(mockJsonBody.exception),
             migrationErrorRegex,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There are 2 Sentry requests happening: one transaction type and one event type, that match with our mock.
The test is flaky as sometimes we get the transaction instead the event one (those can happen in any order), and it doesn't contain the expected properties (ie exception).

With this change, we make sure we are always grabbing the event type one, so then the properties we assert is always there

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37834?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filter mocked Sentry requests to event envelopes ("{"type":"event"}") to stabilize flaky Sentry error tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a6372898c490ecbed31d9599f06529ec799cdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->