### PR TITLE
fix: subscription-error-message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5141,7 +5141,7 @@
     "message": "Your plan is now active."
   },
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
-    "message": "Your membership has been paused due to payment failure."
+    "message": "Your plan has been paused due to payment failure."
   },
   "pushNotificationShieldSubscriptionTitle": {
     "message": "MetaMask Transaction Shield"
@@ -6030,7 +6030,7 @@
     "message": "PENDING CLAIMS"
   },
   "shieldConfirmMembership": {
-    "message": "Confirm membership"
+    "message": "Confirm plan"
   },
   "shieldCoverageAlertCovered": {
     "message": "You're protected up to $2 with Metamask Transaction Shield. $1."
@@ -6045,7 +6045,7 @@
     "message": "Learn how coverage works"
   },
   "shieldCoverageAlertMessagePaused": {
-    "message": "There was an issue with your Transaction Shield membership payment. Please update your payment method to resume coverage."
+    "message": "There was an issue with your Transaction Shield plan payment. Please update your payment method to resume coverage."
   },
   "shieldCoverageAlertMessagePausedAcknowledgeButton": {
     "message": "Update payment method"
@@ -6087,7 +6087,7 @@
     "message": "Renew"
   },
   "shieldCoverageEndingDescription": {
-    "message": "Membership ends on $1.",
+    "message": "Plan ends on $1.",
     "description": "The $1 is the date"
   },
   "shieldCovered": {
@@ -6248,7 +6248,7 @@
     "message": "Priority support"
   },
   "shieldTxMembershipActive": {
-    "message": "Active membership"
+    "message": "Active plan"
   },
   "shieldTxMembershipBillingDetails": {
     "message": "Billing details"
@@ -6269,31 +6269,49 @@
     "message": "View billing history"
   },
   "shieldTxMembershipCancel": {
-    "message": "Cancel membership"
+    "message": "Cancel plan"
   },
   "shieldTxMembershipCancelNotification": {
-    "message": "Your membership will be cancelled on $1.",
+    "message": "Your plan will be cancelled on $1.",
     "description": "The $1 is the date"
   },
   "shieldTxMembershipErrorAddFunds": {
     "message": "Add funds"
   },
   "shieldTxMembershipErrorInsufficientFunds": {
-    "message": "Insufficient funds for your $1 renewal. Keep access active by adding funds.",
-    "description": "The $1 is the date"
+    "message": "Your plan ends on $1. Renew now to continue your benefits.",
+    "description": "The $1 is the date subscription ends"
   },
   "shieldTxMembershipErrorInsufficientToken": {
-    "message": "Insufficient $1",
-    "description": "The $1 is the token symbol"
+    "message": "Retry payment"
   },
   "shieldTxMembershipErrorPaused": {
-    "message": "Membership paused due to insufficient funds. Coverage will resume after payment update."
+    "message": "Plan paused due to insufficient funds. Coverage will resume after payment update."
+  },
+  "shieldTxMembershipErrorPausedCard": {
+    "message": "Your plan has been paused due to a failed card payment."
+  },
+  "shieldTxMembershipErrorPausedCardAction": {
+    "message": "Update card details"
   },
   "shieldTxMembershipErrorPausedCardTooltip": {
     "message": "Your payment was declined. Please update your payment method to continue your coverage."
   },
+  "shieldTxMembershipErrorPausedCryptoInsufficientFunds": {
+    "message": "Plan paused due to insufficient funds. Payment updates may take up to $1hours.",
+    "description": "The $1 is the number of hours"
+  },
+  "shieldTxMembershipErrorPausedCryptoInsufficientFundsAction": {
+    "message": "Add funds"
+  },
   "shieldTxMembershipErrorPausedCryptoTooltip": {
-    "message": "Insufficient token balance in your wallet. Top up to resume coverage."
+    "message": "Insufficient token balance in your wallet. Click retry after funding your wallet."
+  },
+  "shieldTxMembershipErrorPausedUnexpected": {
+    "message": "Plan paused due to an unexpected error."
+  },
+  "shieldTxMembershipErrorPausedUnexpectedAction": {
+    "message": "Contact support"
   },
   "shieldTxMembershipErrorUpdateCard": {
     "message": "Update card details"
@@ -6308,16 +6326,16 @@
     "message": "Member ID"
   },
   "shieldTxMembershipInactive": {
-    "message": "Inactive membership"
+    "message": "Inactive plan"
   },
   "shieldTxMembershipPaused": {
     "message": "Paused"
   },
   "shieldTxMembershipRenew": {
-    "message": "Renew membership"
+    "message": "Renew plan"
   },
   "shieldTxMembershipResubscribe": {
-    "message": "Restart membership"
+    "message": "Restart plan"
   },
   "shieldTxMembershipSubmitCase": {
     "message": "Submit a claim"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6122,14 +6122,32 @@
   "shieldPaused": {
     "message": "Paused"
   },
-  "shieldPaymentDeclined": {
-    "message": "Shield payment declined"
-  },
   "shieldPaymentDeclinedAction": {
     "message": "Add funds"
   },
   "shieldPaymentDeclinedDescription": {
     "message": "Insufficient token balance. Please try again to resume coverage."
+  },
+  "shieldPaymentPaused": {
+    "message": "Transaction Shield paused"
+  },
+  "shieldPaymentPausedActionCardPayment": {
+    "message": "Update"
+  },
+  "shieldPaymentPausedActionCryptoPayment": {
+    "message": "Update"
+  },
+  "shieldPaymentPausedActionUnexpectedError": {
+    "message": "View"
+  },
+  "shieldPaymentPausedDescriptionCardPayment": {
+    "message": "Card payment failed."
+  },
+  "shieldPaymentPausedDescriptionCryptoPayment": {
+    "message": "Insufficient token balance."
+  },
+  "shieldPaymentPausedDescriptionUnexpectedError": {
+    "message": "An unexpected error occurred."
   },
   "shieldPlanAnnual": {
     "message": "Annual"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5141,7 +5141,7 @@
     "message": "Your plan is now active."
   },
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
-    "message": "Your membership has been paused due to payment failure."
+    "message": "Your plan has been paused due to payment failure."
   },
   "pushNotificationShieldSubscriptionTitle": {
     "message": "MetaMask Transaction Shield"
@@ -6030,7 +6030,7 @@
     "message": "PENDING CLAIMS"
   },
   "shieldConfirmMembership": {
-    "message": "Confirm membership"
+    "message": "Confirm plan"
   },
   "shieldCoverageAlertCovered": {
     "message": "You're protected up to $2 with Metamask Transaction Shield. $1."
@@ -6045,7 +6045,7 @@
     "message": "Learn how coverage works"
   },
   "shieldCoverageAlertMessagePaused": {
-    "message": "There was an issue with your Transaction Shield membership payment. Please update your payment method to resume coverage."
+    "message": "There was an issue with your Transaction Shield plan payment. Please update your payment method to resume coverage."
   },
   "shieldCoverageAlertMessagePausedAcknowledgeButton": {
     "message": "Update payment method"
@@ -6087,7 +6087,7 @@
     "message": "Renew"
   },
   "shieldCoverageEndingDescription": {
-    "message": "Membership ends on $1.",
+    "message": "Plan ends on $1.",
     "description": "The $1 is the date"
   },
   "shieldCovered": {
@@ -6248,7 +6248,7 @@
     "message": "Priority support"
   },
   "shieldTxMembershipActive": {
-    "message": "Active membership"
+    "message": "Active plan"
   },
   "shieldTxMembershipBillingDetails": {
     "message": "Billing details"
@@ -6269,31 +6269,49 @@
     "message": "View billing history"
   },
   "shieldTxMembershipCancel": {
-    "message": "Cancel membership"
+    "message": "Cancel plan"
   },
   "shieldTxMembershipCancelNotification": {
-    "message": "Your membership will be cancelled on $1.",
+    "message": "Your plan will be cancelled on $1.",
     "description": "The $1 is the date"
   },
   "shieldTxMembershipErrorAddFunds": {
     "message": "Add funds"
   },
   "shieldTxMembershipErrorInsufficientFunds": {
-    "message": "Insufficient funds for your $1 renewal. Keep access active by adding funds.",
-    "description": "The $1 is the date"
+    "message": "Your plan ends on $1. Renew now to continue your benefits.",
+    "description": "The $1 is the date subscription ends"
   },
   "shieldTxMembershipErrorInsufficientToken": {
-    "message": "Insufficient $1",
-    "description": "The $1 is the token symbol"
+    "message": "Retry payment"
   },
   "shieldTxMembershipErrorPaused": {
-    "message": "Membership paused due to insufficient funds. Coverage will resume after payment update."
+    "message": "Plan paused due to insufficient funds. Coverage will resume after payment update."
+  },
+  "shieldTxMembershipErrorPausedCard": {
+    "message": "Your plan has been paused due to a failed card payment."
+  },
+  "shieldTxMembershipErrorPausedCardAction": {
+    "message": "Update card details"
   },
   "shieldTxMembershipErrorPausedCardTooltip": {
     "message": "Your payment was declined. Please update your payment method to continue your coverage."
   },
+  "shieldTxMembershipErrorPausedCryptoInsufficientFunds": {
+    "message": "Plan paused due to insufficient funds. Payment updates may take up to $1hours.",
+    "description": "The $1 is the number of hours"
+  },
+  "shieldTxMembershipErrorPausedCryptoInsufficientFundsAction": {
+    "message": "Add funds"
+  },
   "shieldTxMembershipErrorPausedCryptoTooltip": {
-    "message": "Insufficient token balance in your wallet. Top up to resume coverage."
+    "message": "Insufficient token balance in your wallet. Click retry after funding your wallet."
+  },
+  "shieldTxMembershipErrorPausedUnexpected": {
+    "message": "Plan paused due to an unexpected error."
+  },
+  "shieldTxMembershipErrorPausedUnexpectedAction": {
+    "message": "Contact support"
   },
   "shieldTxMembershipErrorUpdateCard": {
     "message": "Update card details"
@@ -6308,16 +6326,16 @@
     "message": "Member ID"
   },
   "shieldTxMembershipInactive": {
-    "message": "Inactive membership"
+    "message": "Inactive plan"
   },
   "shieldTxMembershipPaused": {
     "message": "Paused"
   },
   "shieldTxMembershipRenew": {
-    "message": "Renew membership"
+    "message": "Renew plan"
   },
   "shieldTxMembershipResubscribe": {
-    "message": "Restart membership"
+    "message": "Restart plan"
   },
   "shieldTxMembershipSubmitCase": {
     "message": "Submit a claim"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6122,14 +6122,32 @@
   "shieldPaused": {
     "message": "Paused"
   },
-  "shieldPaymentDeclined": {
-    "message": "Shield payment declined"
-  },
   "shieldPaymentDeclinedAction": {
     "message": "Add funds"
   },
   "shieldPaymentDeclinedDescription": {
     "message": "Insufficient token balance. Please try again to resume coverage."
+  },
+  "shieldPaymentPaused": {
+    "message": "Transaction Shield paused"
+  },
+  "shieldPaymentPausedActionCardPayment": {
+    "message": "Update"
+  },
+  "shieldPaymentPausedActionCryptoPayment": {
+    "message": "Update"
+  },
+  "shieldPaymentPausedActionUnexpectedError": {
+    "message": "View"
+  },
+  "shieldPaymentPausedDescriptionCardPayment": {
+    "message": "Card payment failed."
+  },
+  "shieldPaymentPausedDescriptionCryptoPayment": {
+    "message": "Insufficient token balance."
+  },
+  "shieldPaymentPausedDescriptionUnexpectedError": {
+    "message": "An unexpected error occurred."
   },
   "shieldPlanAnnual": {
     "message": "Annual"

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -72,6 +72,10 @@ import {
   getIsShieldSubscriptionPaused,
 } from '../../../../shared/lib/shield';
 import {
+  isCardPaymentMethod,
+  isCryptoPaymentMethod,
+} from '../../../pages/settings/transaction-shield-tab/types';
+import {
   selectNftDetectionEnablementToast,
   selectShowConnectAccountToast,
   selectShowPrivacyPolicyToast,
@@ -622,14 +626,34 @@ function ShieldPausedToast() {
 
   const isPaused = getIsShieldSubscriptionPaused(shieldSubscription);
 
+  const isCardPayment =
+    shieldSubscription &&
+    isCardPaymentMethod(shieldSubscription?.paymentMethod);
+  const isCryptoPaymentWithError =
+    shieldSubscription &&
+    isCryptoPaymentMethod(shieldSubscription.paymentMethod) &&
+    Boolean(shieldSubscription.paymentMethod.crypto.error);
+
+  // default text to unexpected error case
+  let descriptionText = 'shieldPaymentPausedDescriptionUnexpectedError';
+  let actionText = 'shieldPaymentPausedActionUnexpectedError';
+  if (isCardPayment) {
+    descriptionText = 'shieldPaymentPausedDescriptionCardPayment';
+    actionText = 'shieldPaymentPausedActionCardPayment';
+  }
+  if (isCryptoPaymentWithError) {
+    descriptionText = 'shieldPaymentPausedDescriptionCryptoPayment';
+    actionText = 'shieldPaymentPausedActionCryptoPayment';
+  }
+
   return (
     Boolean(isPaused) &&
     showShieldPausedToast && (
       <Toast
         key="shield-payment-declined-toast"
-        text={t('shieldPaymentDeclined')}
-        description={t('shieldPaymentDeclinedDescription')}
-        actionText={t('shieldPaymentDeclinedAction')}
+        text={t('shieldPaymentPaused')}
+        description={t(descriptionText)}
+        actionText={t(actionText)}
         onActionClick={async () => {
           setShieldPausedToastLastClickedOrClosed(Date.now());
           navigate(TRANSACTION_SHIELD_ROUTE);

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -35,7 +35,10 @@ import {
 } from '../../store/actions';
 import { useAsyncCallback, useAsyncResult } from '../useAsync';
 import { MetaMaskReduxDispatch } from '../../store/store';
-import { selectIsSignedIn } from '../../selectors/identity/authentication';
+import {
+  selectIsSignedIn,
+  selectSessionData,
+} from '../../selectors/identity/authentication';
 import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import {
   getIsShieldSubscriptionActive,
@@ -47,6 +50,7 @@ import { decimalToHex } from '../../../shared/modules/conversion.utils';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../helpers/constants/routes';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
 import {
+  getMetaMetricsId,
   getModalTypeForShieldEntryModal,
   selectNetworkConfigurationByChainId,
 } from '../../selectors';
@@ -55,6 +59,8 @@ import { CaptureShieldSubscriptionRequestParams } from '../shield/metrics/types'
 import { EntryModalSourceEnum } from '../../../shared/constants/subscriptions';
 import { DefaultSubscriptionPaymentOptions } from '../../../shared/types';
 import { getLatestSubscriptionStatus } from '../../../shared/modules/shield';
+import { openWindow } from '../../helpers/utils/window';
+import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 import {
   TokenWithApprovalAmount,
   useSubscriptionPricing,
@@ -530,5 +536,39 @@ export const useHandleSubscription = ({
   return {
     handleSubscription,
     subscriptionResult,
+  };
+};
+
+export const useHandleSubscriptionSupportAction = () => {
+  const version = process.env.METAMASK_VERSION as string;
+  const sessionData = useSelector(selectSessionData);
+  const profileId = sessionData?.profile?.profileId;
+  const metaMetricsId = useSelector(getMetaMetricsId);
+  const { customerId: shieldCustomerId } = useUserSubscriptions();
+
+  const handleClickContactSupport = useCallback(() => {
+    let supportLinkWithUserId = SUPPORT_LINK as string;
+    const queryParams = new URLSearchParams();
+    queryParams.append('metamask_version', version);
+    if (profileId) {
+      queryParams.append('metamask_profile_id', profileId);
+    }
+    if (metaMetricsId) {
+      queryParams.append('metamask_metametrics_id', metaMetricsId);
+    }
+    if (shieldCustomerId) {
+      queryParams.append('shield_id', shieldCustomerId);
+    }
+
+    const queryString = queryParams.toString();
+    if (queryString) {
+      supportLinkWithUserId += `?${queryString}`;
+    }
+
+    openWindow(supportLinkWithUserId);
+  }, [version, profileId, metaMetricsId, shieldCustomerId]);
+
+  return {
+    handleClickContactSupport,
   };
 };

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -347,7 +347,7 @@ const TransactionShield = () => {
     currentShieldSubscription &&
     isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
     currentShieldSubscription.paymentMethod.crypto.error ===
-      'insufficient_balance';
+      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_BALANCE;
   const isAllowanceNeededCrypto =
     currentShieldSubscription &&
     isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -41,6 +41,7 @@ import { Skeleton } from '../../../components/component-library/skeleton';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   useCancelSubscription,
+  useHandleSubscriptionSupportAction,
   useOpenGetSubscriptionBillingPortal,
   useSubscriptionCryptoApprovalTransaction,
   useUnCancelSubscription,
@@ -83,7 +84,7 @@ import {
 } from '../../../../shared/constants/subscriptions';
 import { ThemeType } from '../../../../shared/constants/preferences';
 import CancelMembershipModal from './cancel-membership-modal';
-import { isCryptoPaymentMethod } from './types';
+import { isCardPaymentMethod, isCryptoPaymentMethod } from './types';
 
 const TransactionShield = () => {
   const t = useI18nContext();
@@ -343,22 +344,6 @@ const TransactionShield = () => {
       </Box>
     );
   };
-  const isInsufficientFundsCrypto =
-    currentShieldSubscription &&
-    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
-    currentShieldSubscription.paymentMethod.crypto.error ===
-      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_BALANCE;
-  const isAllowanceNeededCrypto =
-    currentShieldSubscription &&
-    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
-    (currentShieldSubscription.paymentMethod.crypto.error ===
-      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_ALLOWANCE ||
-      currentShieldSubscription?.paymentMethod.crypto.error ===
-        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_TOO_OLD ||
-      currentShieldSubscription?.paymentMethod.crypto.error ===
-        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_REVERTED ||
-      currentShieldSubscription?.paymentMethod.crypto.error ===
-        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_MAX_VERIFICATION_ATTEMPTS_REACHED);
 
   const { value: subscriptionCryptoApprovalAmount } =
     useAsyncResult(async () => {
@@ -412,10 +397,39 @@ const TransactionShield = () => {
   const { execute: executeSubscriptionCryptoApprovalTransaction } =
     useSubscriptionCryptoApprovalTransaction(paymentToken);
 
+  const isCardPayment =
+    currentShieldSubscription &&
+    isCardPaymentMethod(currentShieldSubscription.paymentMethod);
+  const isUnexpectedErrorCryptoPayment =
+    currentShieldSubscription &&
+    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
+    Boolean(currentShieldSubscription.paymentMethod.crypto.error);
+  const isInsufficientFundsCrypto =
+    currentShieldSubscription &&
+    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
+    currentShieldSubscription.paymentMethod.crypto.error ===
+      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_BALANCE;
+  const isAllowanceNeededCrypto =
+    currentShieldSubscription &&
+    isCryptoPaymentMethod(currentShieldSubscription.paymentMethod) &&
+    (currentShieldSubscription.paymentMethod.crypto.error ===
+      CRYPTO_PAYMENT_METHOD_ERRORS.INSUFFICIENT_ALLOWANCE ||
+      currentShieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_TOO_OLD ||
+      currentShieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_REVERTED ||
+      currentShieldSubscription?.paymentMethod.crypto.error ===
+        CRYPTO_PAYMENT_METHOD_ERRORS.APPROVAL_TRANSACTION_MAX_VERIFICATION_ATTEMPTS_REACHED);
+
+  const { handleClickContactSupport } = useHandleSubscriptionSupportAction();
+
   const handlePaymentError = useCallback(async () => {
     if (isCancelled) {
       // go to shield plan page to renew subscription for cancelled subscription
       navigate(SHIELD_PLAN_ROUTE);
+    } else if (isUnexpectedErrorCryptoPayment) {
+      // handle support action
+      handleClickContactSupport();
     } else if (
       currentShieldSubscription &&
       isCryptoPaymentMethod(currentShieldSubscription.paymentMethod)
@@ -437,6 +451,8 @@ const TransactionShield = () => {
       await executeUpdateSubscriptionCardPaymentMethod();
     }
   }, [
+    handleClickContactSupport,
+    isUnexpectedErrorCryptoPayment,
     isCancelled,
     navigate,
     currentShieldSubscription,
@@ -448,22 +464,32 @@ const TransactionShield = () => {
   ]);
 
   const membershipErrorBanner = useMemo(() => {
+    // This is the number of hours it might takes for the payment to be updated
+    const PAYMENT_UPDATE_HOURS = 24;
     if (isPaused) {
+      // default text to unexpected error case
+      let descriptionText = 'shieldTxMembershipErrorPausedUnexpected';
+      let actionButtonLabel = 'shieldTxMembershipErrorPausedUnexpectedAction';
+      if (isCryptoPayment) {
+        descriptionText =
+          'shieldTxMembershipErrorPausedCryptoInsufficientFunds';
+        actionButtonLabel =
+          'shieldTxMembershipErrorPausedCryptoInsufficientFundsAction';
+      } else if (isCardPayment) {
+        descriptionText = 'shieldTxMembershipErrorPausedCard';
+        actionButtonLabel = 'shieldTxMembershipErrorPausedCardAction';
+      }
       return (
         <BannerAlert
-          description={t('shieldTxMembershipErrorPaused')}
+          description={t(descriptionText, [PAYMENT_UPDATE_HOURS])}
           severity={BannerAlertSeverity.Danger}
           marginBottom={4}
-          actionButtonLabel={t(
-            isCryptoPayment && isInsufficientFundsCrypto
-              ? 'shieldTxMembershipErrorAddFunds'
-              : 'shieldTxMembershipErrorUpdatePayment',
-          )}
+          actionButtonLabel={t(actionButtonLabel)}
           actionButtonOnClick={handlePaymentError}
         />
       );
     }
-    if (isSubscriptionEndingSoon && currentShieldSubscription) {
+    if (currentShieldSubscription && isSubscriptionEndingSoon) {
       return (
         <BannerAlert
           description={t('shieldTxMembershipErrorInsufficientFunds', [
@@ -473,11 +499,7 @@ const TransactionShield = () => {
           ])}
           severity={BannerAlertSeverity.Warning}
           marginBottom={4}
-          actionButtonLabel={
-            isAllowanceNeededCrypto
-              ? t('shieldTxMembershipRenew')
-              : t('shieldTxMembershipErrorAddFunds')
-          }
+          actionButtonLabel={t('shieldTxMembershipRenew')}
           actionButtonOnClick={handlePaymentError}
         />
       );
@@ -489,9 +511,8 @@ const TransactionShield = () => {
     isSubscriptionEndingSoon,
     currentShieldSubscription,
     t,
+    isCardPayment,
     isCryptoPayment,
-    isInsufficientFundsCrypto,
-    isAllowanceNeededCrypto,
     handlePaymentError,
   ]);
 
@@ -499,16 +520,20 @@ const TransactionShield = () => {
     if (!displayedShieldSubscription) {
       return '';
     }
-    if (isPaused) {
+    if (isPaused && !isUnexpectedErrorCryptoPayment) {
+      let tooltipText = '';
+      let buttonText = '';
+      if (isCryptoPayment) {
+        tooltipText = 'shieldTxMembershipErrorPausedCryptoTooltip';
+        buttonText = 'shieldTxMembershipErrorInsufficientToken';
+      } else {
+        // card payment error case
+        tooltipText = 'shieldTxMembershipErrorPausedCardTooltip';
+        buttonText = 'shieldTxMembershipErrorUpdateCard';
+      }
+
       return (
-        <Tooltip
-          position="top"
-          title={t(
-            isCryptoPayment
-              ? 'shieldTxMembershipErrorPausedCryptoTooltip'
-              : 'shieldTxMembershipErrorPausedCardTooltip',
-          )}
-        >
+        <Tooltip position="top" title={t(tooltipText)}>
           <ButtonLink
             startIconName={IconName.Danger}
             startIconProps={{
@@ -517,18 +542,11 @@ const TransactionShield = () => {
             onClick={handlePaymentError}
             danger
           >
-            {t(
-              isCryptoPayment
-                ? 'shieldTxMembershipErrorInsufficientToken'
-                : 'shieldTxMembershipErrorUpdateCard',
-              [
-                isCryptoPaymentMethod(
-                  displayedShieldSubscription?.paymentMethod,
-                )
-                  ? displayedShieldSubscription.paymentMethod.crypto.tokenSymbol
-                  : '',
-              ],
-            )}
+            {t(buttonText, [
+              isCryptoPaymentMethod(displayedShieldSubscription?.paymentMethod)
+                ? displayedShieldSubscription.paymentMethod.crypto.tokenSymbol
+                : '',
+            ])}
           </ButtonLink>
         </Tooltip>
       );
@@ -577,6 +595,7 @@ const TransactionShield = () => {
     return `${displayedShieldSubscription.paymentMethod.card.brand.charAt(0).toUpperCase() + displayedShieldSubscription.paymentMethod.card.brand.slice(1)} - ${displayedShieldSubscription.paymentMethod.card.last4}`; // display card info for card payment method;
   }, [
     isPaused,
+    isUnexpectedErrorCryptoPayment,
     displayedShieldSubscription,
     isCryptoPayment,
     isSubscriptionEndingSoon,

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -191,9 +191,7 @@ const TransactionShield = () => {
     useCancelSubscription(currentShieldSubscription);
 
   const [executeUnCancelSubscription, unCancelSubscriptionResult] =
-    useUnCancelSubscription({
-      subscriptionId: currentShieldSubscription?.id,
-    });
+    useUnCancelSubscription(currentShieldSubscription);
 
   const [
     executeOpenGetSubscriptionBillingPortal,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Correct subscription paused toast and shield settings error message.
- Handle unexpected error message contact support action.
Figma: https://www.figma.com/design/HTAO1SrmixV4ppv7qIvLoa/Metamask-Transaction-Shield?node-id=14631-57069&p=f&t=AcoJzS3JF4yuRexs-0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37836?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: correct subscription error message in toast and settings screen

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Shield paused/payment error UX: new localized messages, context-aware toast and settings actions for card/crypto/unexpected errors, and a support contact handler with user context.
> 
> - **UI/UX (Transaction Shield)**:
>   - **Paused Toast**: Switches to `shieldPaymentPaused` with dynamic description/action based on payment method (`card`, `crypto`, `unexpected`).
>   - **Settings Page** (`transaction-shield.tsx`):
>     - Context-aware error banner/tooltips and CTA labels for paused states (card/crypto/unexpected) and ending-soon renewal.
>     - Handles crypto-specific flows (add funds, approval tx) and card update; opens support on unexpected errors.
>     - Minor API tweaks (use `useUnCancelSubscription(current)`; refine payment method rendering).
> - **Hooks**:
>   - Adds `useHandleSubscriptionSupportAction()` to open support with appended `metamask_version`, profile, MetaMetrics, and Shield customer IDs.
> - **Localization** (`app/_locales/en`, `en_GB`):
>   - Adds new `shieldPaymentPaused*` and detailed `shieldTxMembershipErrorPaused*` keys; updates renewal/insufficient funds copy; removes deprecated `shieldPaymentDeclined` text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f6e8ff0b1976a7417374c343254f7fed21a82d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->