### PR TITLE
feat: handle shield deep link open entry modal

### DIFF
--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -10,6 +10,7 @@ export {
   DEEP_LINK_ROUTE,
   NOTIFICATIONS_ROUTE,
   SHIELD_PLAN_ROUTE,
+  SETTINGS_ROUTE,
 } from '../../../../ui/helpers/constants/routes';
 
 /**

--- a/shared/lib/deep-links/routes/shield.ts
+++ b/shared/lib/deep-links/routes/shield.ts
@@ -13,7 +13,7 @@ export default new Route({
 
     if (shouldShowShieldEntryModal) {
       // link to settings page and show the shield entry modal
-      const query = new URLSearchParams();
+      const query = new URLSearchParams(params);
       query.set(SHIELD_QUERY_PARAMS.showShieldEntryModal, 'true');
       return {
         path: SETTINGS_ROUTE,

--- a/shared/lib/deep-links/routes/shield.ts
+++ b/shared/lib/deep-links/routes/shield.ts
@@ -1,9 +1,26 @@
-import { Route, SHIELD_PLAN_ROUTE } from './route';
+import { Route, SETTINGS_ROUTE, SHIELD_PLAN_ROUTE } from './route';
+
+export const SHIELD_QUERY_PARAMS = {
+  showShieldEntryModal: 'showShieldEntryModal',
+};
 
 export default new Route({
   pathname: '/shield',
   getTitle: (_: URLSearchParams) => 'deepLink_theTransactionShieldPage',
   handler: function handler(params: URLSearchParams) {
+    const shouldShowShieldEntryModal =
+      params.get(SHIELD_QUERY_PARAMS.showShieldEntryModal) === 'true';
+
+    if (shouldShowShieldEntryModal) {
+      // link to settings page and show the shield entry modal
+      const query = new URLSearchParams();
+      query.set(SHIELD_QUERY_PARAMS.showShieldEntryModal, 'true');
+      return {
+        path: SETTINGS_ROUTE,
+        query: params,
+      };
+    }
+
     return {
       path: SHIELD_PLAN_ROUTE,
       query: params,

--- a/shared/lib/deep-links/routes/shield.ts
+++ b/shared/lib/deep-links/routes/shield.ts
@@ -13,8 +13,6 @@ export default new Route({
 
     if (shouldShowShieldEntryModal) {
       // link to settings page and show the shield entry modal
-      const query = new URLSearchParams(params);
-      query.set(SHIELD_QUERY_PARAMS.showShieldEntryModal, 'true');
       return {
         path: SETTINGS_ROUTE,
         query: params,

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -131,11 +131,18 @@ class SettingsPage extends PureComponent {
   componentDidMount() {
     this.handleConversionDate();
 
-    if (
-      this.props.shouldShowShieldEntryModal &&
-      !this.props.hasSubscribedToShield
-    ) {
-      this.setState({ showShieldEntryModal: true });
+    if (this.props.shouldShowShieldEntryModal) {
+      // if user has subscribed to shield, navigate to shield page
+      // otherwise, show shield entry modal
+      if (this.props.hasSubscribedToShield) {
+        // componentDidMount is rendered after useEffect() so we need setTimeout to ensure the navigation work
+        // TODO: use navigate normally when refactor ot use functional component
+        setTimeout(() => {
+          this.props.navigate(TRANSACTION_SHIELD_ROUTE);
+        });
+      } else {
+        this.setState({ showShieldEntryModal: true });
+      }
     }
   }
 

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -110,6 +110,7 @@ class SettingsPage extends PureComponent {
     navigate: PropTypes.func.isRequired,
     pathnameI18nKey: PropTypes.string,
     settingsPageSnaps: PropTypes.array,
+    shouldShowShieldEntryModal: PropTypes.bool,
     snapSettingsTitle: PropTypes.string,
     toggleNetworkMenu: PropTypes.func.isRequired,
     useExternalServices: PropTypes.bool,
@@ -129,6 +130,13 @@ class SettingsPage extends PureComponent {
 
   componentDidMount() {
     this.handleConversionDate();
+
+    if (
+      this.props.shouldShowShieldEntryModal &&
+      !this.props.hasSubscribedToShield
+    ) {
+      this.setState({ showShieldEntryModal: true });
+    }
   }
 
   componentDidUpdate() {

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -50,6 +50,7 @@ import { decodeSnapIdFromPathname } from '../../helpers/utils/snaps';
 import { getIsSeedlessPasswordOutdated } from '../../ducks/metamask/metamask';
 import { getIsMetaMaskShieldFeatureEnabled } from '../../../shared/modules/environment';
 import { getHasSubscribedToShield } from '../../selectors/subscription/subscription';
+import { SHIELD_QUERY_PARAMS } from '../../../shared/lib/deep-links/routes/shield';
 import Settings from './settings.component';
 
 const ROUTES_TO_I18N_KEYS = {
@@ -77,7 +78,7 @@ const ROUTES_TO_I18N_KEYS = {
 
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  const { pathname } = location;
+  const { pathname, search } = location;
   const { ticker } = getProviderConfig(state);
   const {
     metamask: { currencyRates, socialLoginEmail },
@@ -85,6 +86,11 @@ const mapStateToProps = (state, ownProps) => {
   const settingsPageSnapsIds = getSettingsPageSnapsIds(state);
   const snapsMetadata = getSnapsMetadata(state);
   const conversionDate = currencyRates[ticker]?.conversionDate;
+
+  const searchParams = new URLSearchParams(search);
+  // param to check and show shield entry modal at start
+  const shouldShowShieldEntryModal =
+    searchParams.get(SHIELD_QUERY_PARAMS.showShieldEntryModal) === 'true';
 
   const pathNameTail = pathname.match(/[^/]+$/u)?.[0] || '';
   const isAddressEntryPage = pathNameTail.includes('0x');
@@ -188,6 +194,7 @@ const mapStateToProps = (state, ownProps) => {
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     pathnameI18nKey,
     settingsPageSnaps,
+    shouldShowShieldEntryModal,
     snapSettingsTitle,
     useExternalServices,
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Add params handle to shield deep link for `link.metamask.io/shield?showShieldEntryModal=true` which show shield entry modal in settings screen if user not subscribed yet

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37846?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add shield deep link `showShieldEntryModal` param handle

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `/shield?showShieldEntryModal=true` deep link that routes to Settings and either opens the Shield entry modal or navigates to the Shield page if subscribed.
> 
> - **Deep links**
>   - Add `SHIELD_QUERY_PARAMS.showShieldEntryModal` and handle in `shared/lib/deep-links/routes/shield.ts`.
>   - When `showShieldEntryModal=true`, redirect to `SETTINGS_ROUTE` with original query; otherwise go to `SHIELD_PLAN_ROUTE`.
>   - Export `SETTINGS_ROUTE` from `shared/lib/deep-links/routes/route.ts`.
> - **Settings page**
>   - Parse `showShieldEntryModal` from URL in `settings.container.js` and pass `shouldShowShieldEntryModal` prop.
>   - In `settings.component.js` `componentDidMount`, if `shouldShowShieldEntryModal`:
>     - If `hasSubscribedToShield`, navigate to `TRANSACTION_SHIELD_ROUTE`.
>     - Else, show `ShieldEntryModal`.
>   - Add `shouldShowShieldEntryModal` to PropTypes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519b088ad610cfd5e64a2300d5473e4c06d4dab5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->