### PR TITLE
fix: shield-cta cp-13.10.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6213,6 +6213,9 @@
   "shieldStartNowCTA": {
     "message": "Start now"
   },
+  "shieldStartNowCTAWithTrial": {
+    "message": "Start free trial"
+  },
   "shieldTx": {
     "message": "Transaction Shield"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6213,6 +6213,9 @@
   "shieldStartNowCTA": {
     "message": "Start now"
   },
+  "shieldStartNowCTAWithTrial": {
+    "message": "Start free trial"
+  },
   "shieldTx": {
     "message": "Transaction Shield"
   },

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -32,6 +32,7 @@ import { useIsGaslessSupported } from '../../../hooks/gas/useIsGaslessSupported'
 import { useInsufficientBalanceAlerts } from '../../../hooks/alerts/transactions/useInsufficientBalanceAlerts';
 import { useIsGaslessLoading } from '../../../hooks/gas/useIsGaslessLoading';
 import { useConfirmationNavigation } from '../../../hooks/useConfirmationNavigation';
+import { useUserSubscriptions } from '../../../../../hooks/subscription/useSubscription';
 import Footer from './footer';
 
 jest.mock('../../../hooks/gas/useIsGaslessLoading');
@@ -59,6 +60,7 @@ jest.mock(
 );
 
 jest.mock('../../../hooks/useOriginThrottling');
+jest.mock('../../../../../hooks/subscription/useSubscription');
 
 jest.mock('react-router-dom-v5-compat', () => ({
   useNavigate: jest.fn(),
@@ -86,6 +88,7 @@ describe('ConfirmFooter', () => {
   );
   const useIsGaslessLoadingMock = jest.mocked(useIsGaslessLoading);
   const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
+  const useUserSubscriptionsMock = jest.mocked(useUserSubscriptions);
 
   beforeEach(() => {
     mockUseOriginThrottling.mockReturnValue({
@@ -99,6 +102,13 @@ describe('ConfirmFooter', () => {
 
     useIsGaslessLoadingMock.mockReturnValue({
       isGaslessLoading: false,
+    });
+
+    useUserSubscriptionsMock.mockReturnValue({
+      trialedProducts: [],
+      loading: false,
+      subscriptions: [],
+      error: undefined,
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -4,6 +4,7 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
 import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
 import { ConfirmAlertModal } from '../../../../../components/app/alert-system/confirm-alert-modal';
@@ -38,6 +39,7 @@ import {
 } from '../../../hooks/useAddEthereumChain';
 import { isSignatureTransactionType } from '../../../utils';
 import { getConfirmationSender } from '../utils';
+import { useUserSubscriptions } from '../../../../../hooks/subscription/useSubscription';
 import OriginThrottleModal from './origin-throttle-modal';
 import ShieldFooterAgreement from './shield-footer-agreement';
 import ShieldFooterCoverageIndicator from './shield-footer-coverage-indicator/shield-footer-coverage-indicator';
@@ -117,6 +119,9 @@ const ConfirmButton = ({
     setConfirmModalVisible(true);
   }, []);
 
+  const { trialedProducts } = useUserSubscriptions();
+  const isShieldTrialed = trialedProducts?.includes(PRODUCT_TYPES.SHIELD);
+
   return (
     <>
       {confirmModalVisible && (
@@ -157,7 +162,11 @@ const ConfirmButton = ({
         >
           {currentConfirmation?.type ===
           TransactionType.shieldSubscriptionApprove
-            ? t('shieldStartNowCTA')
+            ? t(
+                isShieldTrialed
+                  ? 'shieldStartNowCTA'
+                  : 'shieldStartNowCTAWithTrial',
+              )
             : t('confirm')}
         </Button>
       )}

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/estimated-changes.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/estimated-changes.tsx
@@ -39,8 +39,8 @@ export const EstimatedChanges = ({
           isYearlySubscription
             ? null
             : t('shieldEstimatedChangesMonthlyTooltipText', [
-                `$${approvalAmount}`,
                 `$${Number(approvalAmount) / 12}`,
+                `$${approvalAmount}`,
               ])
         }
       />

--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -146,6 +146,7 @@ const ShieldPlan = () => {
       productType: PRODUCT_TYPES.SHIELD,
     });
   const hasAvailableToken = availableTokenBalances.length > 0;
+
   const [selectedPaymentMethod, setSelectedPaymentMethod] =
     useState<PaymentType>(() => {
       // always default to card if no token is available
@@ -157,6 +158,7 @@ const ShieldPlan = () => {
       }
       return PAYMENT_TYPES.byCrypto;
     });
+
   // default options for the new subscription request
   const defaultOptions = useMemo(() => {
     const paymentType =
@@ -224,6 +226,8 @@ const ShieldPlan = () => {
     // if the last used payment method is not crypto, don't set default method
     if (selectedToken && lastUsedPaymentMethod !== PAYMENT_TYPES.byCard) {
       setSelectedPaymentMethod(PAYMENT_TYPES.byCrypto);
+    } else {
+      setSelectedPaymentMethod(PAYMENT_TYPES.byCard);
     }
   }, [selectedToken, setSelectedPaymentMethod, lastUsedPaymentDetails]);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Fix payment method select card if no crypto available between plan change
- Fix copy text in confirmation tooltip and start now button

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37860?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the Shield confirm CTA show “Start free trial” unless the user has already trialed, fixes the monthly tooltip copy order, and defaults payment method to card when crypto isn’t selected/available; updates locales and tests.
> 
> - **Confirmations UI**:
>   - **Footer CTA**: For `TransactionType.shieldSubscriptionApprove`, choose `t('shieldStartNowCTAWithTrial')` unless the user has already trialed `PRODUCT_TYPES.SHIELD`, then use `t('shieldStartNowCTA')`.
>   - Integrates `useUserSubscriptions` to read `trialedProducts`.
> - **Shield Plan**:
>   - **Payment Method Default**: Ensure selection defaults to `card` when no crypto token is available/selected or last used method is `card`.
> - **Confirm Info (Shield Subscription Approve)**:
>   - **Monthly Tooltip**: Swap params to display per-month first, then total in `shieldEstimatedChangesMonthlyTooltipText`.
> - **i18n**:
>   - Add `shieldStartNowCTAWithTrial` message in `app/_locales/en/messages.json` and `en_GB/messages.json`.
> - **Tests**:
>   - Update `footer.test.tsx` to mock `useUserSubscriptions` and reflect CTA logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbee7cc4a7ef621b729ca34e03c8a37aea14cb73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->