### PR TITLE
feat: rewards onboarding tour controller and data services

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -3,6 +3,9 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   EstimatedPointsDto,
   EstimatePointsDto,
+  OptInStatusDto,
+  OptInStatusInputDto,
+  RewardsGeoMetadata,
   SeasonDtoState,
   SeasonRewardType,
   SeasonStatusState,
@@ -516,7 +519,10 @@ export type Patch = {
  */
 export type RewardsControllerOptInAction = {
   type: 'RewardsController:optIn';
-  handler: (referralCode?: string) => Promise<string | null>;
+  handler: (
+    accounts: InternalAccount[],
+    referralCode?: string,
+  ) => Promise<string | null>;
 };
 
 /**
@@ -545,20 +551,6 @@ export type PerpsDiscountData = {
    * @example 550
    */
   discountBips: number;
-};
-
-/**
- * Geo rewards metadata containing location and support info
- */
-export type GeoRewardsMetadata = {
-  /**
-   * The geographic location string (e.g., 'US', 'CA-ON', 'FR')
-   */
-  geoLocation: string;
-  /**
-   * Whether the location is allowed for opt-in
-   */
-  optinAllowedForGeo: boolean;
 };
 
 /**
@@ -624,7 +616,7 @@ export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
  */
 export type RewardsControllerGetGeoRewardsMetadataAction = {
   type: 'RewardsController:getGeoRewardsMetadata';
-  handler: () => Promise<GeoRewardsMetadata>;
+  handler: () => Promise<RewardsGeoMetadata>;
 };
 
 /**
@@ -676,51 +668,4 @@ export type RewardsControllerGetSeasonStatusAction = {
     subscriptionId: string,
     seasonId: string,
   ) => Promise<SeasonStatusState | null>;
-};
-
-/**
- * Input DTO for getting opt-in status of multiple addresses
- */
-export type OptInStatusInputDto = {
-  /**
-   * The addresses to check opt-in status for
-   *
-   * @example [
-   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF13',
-   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF14',
-   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF15'
-   * ]
-   */
-  addresses: string[];
-};
-
-/**
- * Response DTO for opt-in status of multiple addresses
- */
-export type OptInStatusDto = {
-  /**
-   * The opt-in status of the addresses in the same order as the input
-   *
-   * @example [true, true, false]
-   */
-  ois: boolean[];
-
-  /**
-   * The subscription IDs of the addresses in the same order as the input
-   *
-   * @example ['sub_123', 'sub_456', null]
-   */
-  sids: (string | null)[];
-};
-
-/**
- * Response DTO for opt-out operation
- */
-export type OptOutDto = {
-  /**
-   * Whether the opt-out operation was successful
-   *
-   * @example true
-   */
-  success: boolean;
 };

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -114,7 +114,7 @@ describe('RewardsDataService', () => {
       expect(service.name).toBe('RewardsDataService');
     });
 
-    it('uses UAT URL by default when no environment is set', () => {
+    it('uses PRD URL by default when no environment is set', () => {
       service = createService();
       expect(service.name).toBe('RewardsDataService');
     });
@@ -153,6 +153,14 @@ describe('RewardsDataService', () => {
       );
       expect(registerSpy).toHaveBeenCalledWith(
         'RewardsDataService:getOptInStatus',
+        expect.any(Function),
+      );
+      expect(registerSpy).toHaveBeenCalledWith(
+        'RewardsDataService:getSeasonMetadata',
+        expect.any(Function),
+      );
+      expect(registerSpy).toHaveBeenCalledWith(
+        'RewardsDataService:getDiscoverSeasons',
         expect.any(Function),
       );
     });
@@ -516,7 +524,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockLoginResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/auth/mobile-login`,
+        `${REWARDS_API_URL.PRD}/auth/mobile-login`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockLoginRequest),
@@ -780,7 +788,7 @@ describe('RewardsDataService', () => {
 
       expect(result).toEqual(mockSeasonStateResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/seasons/${mockSeasonId}/state`,
+        `${REWARDS_API_URL.PRD}/seasons/${mockSeasonId}/state`,
         {
           credentials: 'omit',
           method: 'GET',
@@ -1061,7 +1069,7 @@ describe('RewardsDataService', () => {
       // Assert
       expect(result).toEqual(mockOptInStatusResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/public/rewards/ois`,
+        `${REWARDS_API_URL.PRD}/public/rewards/ois`,
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(mockOptInStatusRequest),
@@ -1382,7 +1390,7 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('uses UAT URL for non-production environments', async () => {
+    it('uses PRD URL for non-production environments', async () => {
       delete process.env.METAMASK_ENVIRONMENT;
       service = createService();
 
@@ -1395,11 +1403,11 @@ describe('RewardsDataService', () => {
       await service.validateReferralCode('TEST');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(REWARDS_API_URL.UAT),
+        expect.stringContaining(REWARDS_API_URL.PRD),
         expect.any(Object),
       );
       expect(mockFetch).toHaveBeenCalledWith(
-        `${REWARDS_API_URL.UAT}/referral/validate?code=TEST`,
+        `${REWARDS_API_URL.PRD}/referral/validate?code=TEST`,
         expect.any(Object),
       );
     });

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -4,19 +4,22 @@
 import log from 'loglevel';
 import { ENVIRONMENT } from '../../../../development/build/constants';
 import ExtensionPlatform from '../../platforms/extension';
-import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
+import {
+  REWARDS_API_URL,
+  REWARDS_ERROR_MESSAGES,
+} from '../../../../shared/constants/rewards';
 import type { RewardsDataServiceMessenger } from '../../controller-init/messengers/reward-data-service-messenger';
 import { FALLBACK_LOCALE } from '../../../../shared/modules/i18n';
 import {
   EstimatePointsDto,
   EstimatedPointsDto,
+  OptInStatusDto,
+  OptInStatusInputDto,
 } from '../../../../shared/types/rewards';
 import type {
   LoginResponseDto,
   MobileLoginDto,
   SubscriptionDto,
-  OptInStatusInputDto,
-  OptInStatusDto,
   MobileOptinDto,
   SeasonStateDto,
   SeasonMetadataDto,
@@ -40,7 +43,9 @@ export class InvalidTimestampError extends Error {
  * Custom error for authorization failures
  */
 export class AuthorizationFailedError extends Error {
-  constructor(message: string) {
+  static readonly defaultMessage = REWARDS_ERROR_MESSAGES.AUTHORIZATION_FAILED;
+
+  constructor(message: string = AuthorizationFailedError.defaultMessage) {
     super(message);
     this.name = 'AuthorizationFailedError';
   }
@@ -50,7 +55,9 @@ export class AuthorizationFailedError extends Error {
  * Custom error for season not found
  */
 export class SeasonNotFoundError extends Error {
-  constructor(message: string) {
+  static readonly defaultMessage = REWARDS_ERROR_MESSAGES.SEASON_NOT_FOUND;
+
+  constructor(message: string = SeasonNotFoundError.defaultMessage) {
     super(message);
     this.name = 'SeasonNotFoundError';
   }
@@ -161,7 +168,7 @@ export class RewardsDataService {
     ) {
       return REWARDS_API_URL.PRD;
     }
-    return REWARDS_API_URL.UAT;
+    return REWARDS_API_URL.PRD;
   }
 
   /**
@@ -402,15 +409,11 @@ export class RewardsDataService {
     if (!response.ok) {
       const errorData = await response.json();
       if (errorData?.message?.includes('Rewards authorization failed')) {
-        throw new AuthorizationFailedError(
-          'Rewards authorization failed. Please login and try again.',
-        );
+        throw new AuthorizationFailedError();
       }
 
       if (errorData?.message?.includes('Season not found')) {
-        throw new SeasonNotFoundError(
-          'Season not found. Please try again with a different season.',
-        );
+        throw new SeasonNotFoundError();
       }
 
       throw new Error(`Get season state failed: ${response.status}`);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -220,7 +220,6 @@ import {
 import { isSnapPreinstalled } from '../../shared/lib/snaps/snaps';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import {
-  captureShieldSubscriptionRequestEvent,
   getShieldGatewayConfig,
   updatePreferencesAndMetricsForShieldSubscription,
 } from '../../shared/modules/shield';
@@ -757,7 +756,7 @@ export default class MetamaskController extends EventEmitter {
     this.deFiPositionsController = controllersByName.DeFiPositionsController;
     this.accountTreeController = controllersByName.AccountTreeController;
     this.oauthService = controllersByName.OAuthService;
-    this.SubscriptionService = controllersByName.SubscriptionService;
+    this.subscriptionService = controllersByName.SubscriptionService;
     this.seedlessOnboardingController =
       controllersByName.SeedlessOnboardingController;
     this.subscriptionController = controllersByName.SubscriptionController;
@@ -2567,20 +2566,20 @@ export default class MetamaskController extends EventEmitter {
           this.subscriptionController,
         ),
       startSubscriptionWithCard:
-        this.SubscriptionService.startSubscriptionWithCard.bind(
-          this.SubscriptionService,
+        this.subscriptionService.startSubscriptionWithCard.bind(
+          this.subscriptionService,
         ),
       updateSubscriptionCardPaymentMethod:
-        this.SubscriptionService.updateSubscriptionCardPaymentMethod.bind(
-          this.SubscriptionService,
+        this.subscriptionService.updateSubscriptionCardPaymentMethod.bind(
+          this.subscriptionService,
         ),
       startSubscriptionWithCrypto:
         this.subscriptionController.startSubscriptionWithCrypto.bind(
           this.subscriptionController,
         ),
       updateSubscriptionCryptoPaymentMethod:
-        this.SubscriptionService.updateSubscriptionCryptoPaymentMethod.bind(
-          this.SubscriptionService,
+        this.subscriptionService.updateSubscriptionCryptoPaymentMethod.bind(
+          this.subscriptionService,
         ),
       submitSubscriptionUserEvents:
         this.subscriptionController.submitUserEvent.bind(
@@ -2957,6 +2956,10 @@ export default class MetamaskController extends EventEmitter {
         appStateController.setDefaultSubscriptionPaymentOptions.bind(
           appStateController,
         ),
+      setShieldSubscriptionMetricsProps:
+        appStateController.setShieldSubscriptionMetricsProps.bind(
+          appStateController,
+        ),
 
       // EnsController
       tryReverseResolveAddress:
@@ -3318,11 +3321,6 @@ export default class MetamaskController extends EventEmitter {
         metaMetricsController.addEventBeforeMetricsOptIn.bind(
           metaMetricsController,
         ),
-
-      // MetaMetrics traits update (UI → Background)
-      updateMetaMetricsTraits: metaMetricsController.updateTraits.bind(
-        metaMetricsController,
-      ),
 
       // Buffered Trace API that checks consent and handles buffering/immediate execution
       bufferedTrace: metaMetricsController.bufferedTrace.bind(
@@ -4629,8 +4627,9 @@ export default class MetamaskController extends EventEmitter {
         const newHdEntropyIndex = this.getHDEntropyIndex();
 
         this.metaMetricsController.trackEvent({
-          event: MetaMetricsEventName.ImportSecretRecoveryPhraseCompleted,
+          event: MetaMetricsEventName.ImportSecretRecoveryPhrase,
           properties: {
+            status: 'completed',
             // eslint-disable-next-line @typescript-eslint/naming-convention
             hd_entropy_index: newHdEntropyIndex,
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -5239,6 +5238,15 @@ export default class MetamaskController extends EventEmitter {
       await this.getSnapKeyring(),
       this.accountTreeController.getSelectedAccountGroup(),
     );
+
+    if (this.isMultichainAccountsFeatureState2Enabled()) {
+      // This allows to create missing accounts if new account providers have been added.
+      // FIXME: We might wanna run discovery + alignment asynchronously here, like we do
+      // for mobile, but for now, this easy fix should cover new provider accounts.
+      // NOTE: We run this asynchronously on purpose, see FIXME^.
+      // eslint-disable-next-line no-void
+      void this.multichainAccountService.alignWallets();
+    }
   }
 
   async _loginUser(password) {
@@ -8562,23 +8570,18 @@ export default class MetamaskController extends EventEmitter {
    */
   async _onShieldSubscriptionApprovalTransaction(transactionMeta) {
     const { isGasFeeSponsored, chainId } = transactionMeta;
-    const subscriptionControllerState = this.subscriptionController.state;
-    const { defaultSubscriptionPaymentOptions } = this.appStateController.state;
     const bundlerSupported = await isSendBundleSupported(chainId);
     const isSponsored = isGasFeeSponsored && bundlerSupported;
 
     try {
-      // TODO: Move this to the subscription service once `submitShieldSubscriptionCryptoApproval` action is exported from the subscription controller
-      captureShieldSubscriptionRequestEvent(
-        subscriptionControllerState,
-        transactionMeta,
-        defaultSubscriptionPaymentOptions,
-        this.metaMetricsController,
+      this.subscriptionService.trackSubscriptionRequestEvent(
         'started',
+        transactionMeta,
         {
           has_sufficient_crypto_balance: true,
         },
       );
+
       await this.subscriptionController.submitShieldSubscriptionCryptoApproval(
         transactionMeta,
         isSponsored,
@@ -8599,24 +8602,18 @@ export default class MetamaskController extends EventEmitter {
           transactionMeta.type,
         );
       }
-      captureShieldSubscriptionRequestEvent(
-        subscriptionControllerState,
-        transactionMeta,
-        defaultSubscriptionPaymentOptions,
-        this.metaMetricsController,
+      this.subscriptionService.trackSubscriptionRequestEvent(
         'completed',
+        transactionMeta,
         {
           gas_sponsored: isSponsored,
         },
       );
     } catch (error) {
       log.error('Error on Shield subscription approval transaction', error);
-      captureShieldSubscriptionRequestEvent(
-        subscriptionControllerState,
-        transactionMeta,
-        defaultSubscriptionPaymentOptions,
-        this.metaMetricsController,
+      this.subscriptionService.trackSubscriptionRequestEvent(
         'failed',
+        transactionMeta,
         {
           error_message: error.message,
         },

--- a/shared/constants/rewards.ts
+++ b/shared/constants/rewards.ts
@@ -2,3 +2,11 @@ export const REWARDS_API_URL = {
   UAT: 'https://rewards.uat-api.cx.metamask.io',
   PRD: 'https://rewards.api.cx.metamask.io',
 };
+
+// Error message constants for rewards errors
+export const REWARDS_ERROR_MESSAGES = {
+  AUTHORIZATION_FAILED:
+    'Rewards authorization failed. Please login and try again.',
+  SEASON_NOT_FOUND:
+    'Season not found. Please try again with a different season.',
+} as const;

--- a/shared/types/rewards.ts
+++ b/shared/types/rewards.ts
@@ -200,3 +200,72 @@ export type EstimatedPointsDto = {
    */
   bonusBips: number;
 };
+
+/**
+ * UI toast state for rewards errors.
+ */
+export type RewardsErrorToastState = {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  actionText?: string;
+  onActionClick?: () => void;
+};
+
+export type RewardsGeoMetadata = {
+  /**
+   * The geographic location string (e.g., 'US', 'CA-ON', 'FR')
+   */
+  geoLocation: string;
+  /**
+   * Whether the location is allowed for opt-in
+   */
+  optinAllowedForGeo: boolean;
+};
+
+/**
+ * Input DTO for getting opt-in status of multiple addresses
+ */
+export type OptInStatusInputDto = {
+  /**
+   * The addresses to check opt-in status for
+   *
+   * @example [
+   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF13',
+   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF14',
+   *   '0xDE37C32E8dbD1CD325B8023a00550a5beA97eF15'
+   * ]
+   */
+  addresses: string[];
+};
+
+/**
+ * Response DTO for opt-in status of multiple addresses
+ */
+export type OptInStatusDto = {
+  /**
+   * The opt-in status of the addresses in the same order as the input
+   *
+   * @example [true, true, false]
+   */
+  ois: boolean[];
+
+  /**
+   * The subscription IDs of the addresses in the same order as the input
+   *
+   * @example ['sub_123', 'sub_456', null]
+   */
+  sids: (string | null)[];
+};
+
+/**
+ * Response DTO for opt-out operation
+ */
+export type OptOutDto = {
+  /**
+   * Whether the opt-out operation was successful
+   *
+   * @example true
+   */
+  success: boolean;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-268
Part 1 of https://github.com/MetaMask/metamask-extension/pull/36827 pertaining to rewards controller and data services changes
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37871?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Rewards opt-in to accept provided accounts, renames/fixes geo metadata API, moves shared DTOs, defaults Rewards API base URL to PRD, and surfaces new rewards methods via MetaMaskController.
> 
> - **Rewards Controller**:
>   - Refactor `optIn` to `optIn(accounts, referralCode?)`; iterates provided accounts, links remaining on success, throws if all fail.
>   - Rename `getGeoRewardsMetadata` → `getRewardsGeoMetadata`; cache behavior preserved.
>   - Register updated handlers (`getRewardsGeoMetadata`, `linkAccountsToSubscriptionCandidate`, etc.) and expose new utilities (`getCandidateSubscriptionId`, `isOptInSupported`, `getOptInStatus`).
>   - Internal opt-in flow simplified; consistent state updates and token storage.
> - **Shared Types**:
>   - Move `RewardsGeoMetadata`, `OptInStatusInputDto`, `OptInStatusDto`, `OptOutDto` to `shared/types/rewards` and update imports; remove duplicates from controller types.
> - **Rewards Data Service**:
>   - Default API base URL to `PRD` (including non-prod) and update tests/URLs.
>   - Add `REWARDS_ERROR_MESSAGES`; use as default messages for `AuthorizationFailedError` and `SeasonNotFoundError`.
>   - Minor response handling tweaks and new endpoints wired (`getSeasonMetadata`, `getDiscoverSeasons`).
> - **MetaMask Controller (UI API)**:
>   - Expose rewards APIs: `validateRewardsReferralCode`, `getRewardsGeoMetadata`, `rewardsOptIn`, `rewardsIsOptInSupported`, `rewardsGetOptInStatus`, `rewardsLinkAccountsToSubscriptionCandidate`.
>   - Misc fixes: rename `subscriptionService` → `SubscriptionService`; update Shield subscription metrics capture; add `updateMetaMetricsTraits`. 
> - **Tests**:
>   - Update and expand unit tests for new opt-in signature/behavior, geo method rename, PRD URLs, and new data service endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7f860f29df323d7a94f0d0b09d7483251df44e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->