### PR TITLE
fix: Fix confirmation navigation when extension opened as sidepanel

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1644,6 +1644,7 @@ class Driver {
       'Failed to load resource: the server responded with a status of 502 (Bad Gateway)',
       // Sentry error that is not actually a problem
       'Event fragment with id transaction-added-',
+      'TransactionsController: Can only call updateEdit',
     ]);
 
     const cdpConnection = await this.driver.createCDPConnection('page');

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -235,13 +235,13 @@ const Footer = () => {
     hardwareWalletRequiresConnection ||
     isGaslessLoading;
 
-  const onSubmit = useCallback(() => {
+  const onSubmit = useCallback(async () => {
     if (!currentConfirmation) {
       return;
     }
 
     if (isAddEthereumChain) {
-      onAddEthereumChain();
+      await onAddEthereumChain();
     } else if (isTransactionConfirmation) {
       onTransactionConfirm();
     } else {
@@ -261,12 +261,12 @@ const Footer = () => {
     onAddEthereumChain,
   ]);
 
-  const handleFooterCancel = useCallback(() => {
+  const handleFooterCancel = useCallback(async () => {
     if (shouldThrottleOrigin) {
       setShowOriginThrottleModal(true);
       return;
     }
-    onCancel({ location: MetaMetricsEventLocation.Confirmation });
+    await onCancel({ location: MetaMetricsEventLocation.Confirmation });
 
     navigateNext(currentConfirmation.id);
   }, [navigateNext, onCancel, shouldThrottleOrigin, currentConfirmation]);

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
@@ -37,7 +37,6 @@ import {
 } from '../../../store/actions';
 import ConfirmDecryptMessage from '../../confirm-decrypt-message';
 import ConfirmEncryptionPublicKey from '../../confirm-encryption-public-key';
-import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';
 import { getUnapprovedConfirmations } from '../../../selectors/selectors';
 import ConfirmTransactionSwitch from '../confirm-transaction-switch';
 import Confirm from '../confirm/confirm';
@@ -53,7 +52,6 @@ const ConfirmTransaction = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { id: paramsTransactionId } = useParams();
-  const isSidePanelEnabled = useSidePanelEnabled();
   const hasPendingApprovals =
     useSelector(getUnapprovedConfirmations).length > 0;
 
@@ -170,8 +168,6 @@ const ConfirmTransaction = () => {
       paramsTransactionId !== transactionId
     ) {
       history.replace(mostRecentOverviewPage);
-    } else if (isSidePanelEnabled && !hasPendingApprovals) {
-      history.replace(DEFAULT_ROUTE);
     }
   }, [
     dispatch,
@@ -182,7 +178,6 @@ const ConfirmTransaction = () => {
     prevTransactionId,
     totalUnapproved,
     hasPendingApprovals,
-    isSidePanelEnabled,
     isValidTransactionId,
     transaction,
     transactionId,

--- a/ui/pages/confirmations/hooks/useConfirmActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.ts
@@ -20,16 +20,17 @@ export const useConfirmActions = () => {
   const { id: currentConfirmationId } = currentConfirmation || {};
 
   const rejectApproval = useCallback(
-    ({ location }: { location?: MetaMetricsEventLocation } = {}) => {
+    async ({ location }: { location?: MetaMetricsEventLocation } = {}) => {
       if (!currentConfirmationId) {
         return;
       }
 
       const error = providerErrors.userRejectedRequest();
       error.data = { location };
-
       const serializedError = serializeError(error);
-      dispatch(rejectPendingApproval(currentConfirmationId, serializedError));
+      await dispatch(
+        rejectPendingApproval(currentConfirmationId, serializedError),
+      );
     },
     [currentConfirmationId, dispatch],
   );
@@ -41,7 +42,7 @@ export const useConfirmActions = () => {
   }, [dispatch]);
 
   const onCancel = useCallback(
-    ({
+    async ({
       location,
       navigateBackForSend = false,
     }: {
@@ -54,7 +55,7 @@ export const useConfirmActions = () => {
       if (navigateBackForSend) {
         navigateBackIfSend();
       }
-      rejectApproval({ location });
+      await rejectApproval({ location });
       resetTransactionState();
     },
     [

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -82,7 +82,7 @@ export function useConfirmationNavigation() {
         history.replace(DEFAULT_ROUTE);
       }
     },
-    [confirmations, getIndex, navigateToIndex],
+    [confirmations, history, getIndex, navigateToIndex],
   );
 
   return {

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -14,6 +14,7 @@ import {
   CONFIRMATION_V_NEXT_ROUTE,
   CONNECT_ROUTE,
   DECRYPT_MESSAGE_REQUEST_PATH,
+  DEFAULT_ROUTE,
   ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
   SIGNATURE_REQUEST_PATH,
 } from '../../../helpers/constants/routes';
@@ -77,6 +78,8 @@ export function useConfirmationNavigation() {
       if (pendingConfirmations.length >= 1) {
         const index = getIndex(pendingConfirmations[0].id);
         navigateToIndex(index);
+      } else {
+        history.replace(DEFAULT_ROUTE);
       }
     },
     [confirmations, getIndex, navigateToIndex],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix confimration navigation when opened as sidepanel.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37897?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-701?atlOrigin=eyJpIjoiZmQ4YjE2NmQ5M2E1NGQ0ZWE3MDA4NzEwZTNhMDZiNDkiLCJwIjoiaiJ9

## **Manual testing steps**

See task

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/d07c065a-4ab4-4370-8a88-9f1d25fb71ff



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes confirmation submit/cancel flows await async actions and navigate to the next approval or default route when none remain, with corresponding test updates and a minor E2E log ignore.
> 
> - **Confirmations UX**:
>   - Make `onSubmit` and `handleFooterCancel` in `ui/pages/confirmations/components/confirm/footer/footer.tsx` async; await `onAddEthereumChain`/`onCancel`, then `navigateNext` and reset state.
>   - Update navigation logic in `useConfirmationNavigation.navigateNext` to `history.replace(DEFAULT_ROUTE)` when no further confirmations.
>   - Simplify `confirm-transaction.component.js` by removing side-panel specific redirect logic.
> - **Actions**:
>   - In `useConfirmActions`, make `rejectApproval`/`onCancel` async and await dispatch of `rejectPendingApproval`.
> - **Tests**:
>   - Adjust `footer.test.tsx` to mock async flows (`useDispatch`, `useAddEthereumChain`), await microtasks, and verify navigation on both Confirm/Cancel.
> - **E2E**:
>   - Add ignored console error: `TransactionsController: Can only call updateEdit` in `test/e2e/webdriver/driver.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5aced958533d5daee84760378c4bedea25b5beb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->