### PR TITLE
fix: Revert `6286882567a0520732be6d70f5af264d839ec26c` cp-13.10.0

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../../../../test/data/confirmations/personal_sign';
 import { permitSignatureMsg } from '../../../../../../test/data/confirmations/typed_sign';
 import mockState from '../../../../../../test/data/mock-state.json';
-import { fireEvent } from '../../../../../../test/jest';
+import { fireEvent, waitFor } from '../../../../../../test/jest';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -38,9 +38,23 @@ import Footer from './footer';
 jest.mock('../../../hooks/gas/useIsGaslessLoading');
 jest.mock('../../../hooks/alerts/transactions/useInsufficientBalanceAlerts');
 jest.mock('../../../hooks/gas/useIsGaslessSupported');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockStore: any = null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDispatch: any = jest.fn((action: unknown) => {
+  if (typeof action === 'function') {
+    // Thunk actions need both dispatch and getState
+    const mockGetState = mockStore ? mockStore.getState : jest.fn(() => ({}));
+    return action(mockDispatch, mockGetState);
+  }
+  return action;
+});
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useDispatch: () => jest.fn(),
+  useDispatch: () => mockDispatch,
 }));
 jest.mock('../../../hooks/useConfirmationNavigation', () => ({
   useConfirmationNavigation: jest.fn(() => ({
@@ -60,7 +74,26 @@ jest.mock(
 );
 
 jest.mock('../../../hooks/useOriginThrottling');
+
 jest.mock('../../../../../hooks/subscription/useSubscription');
+jest.mock('../../../hooks/useAddEthereumChain', () => ({
+  useAddEthereumChain: jest.fn(() => ({
+    onSubmit: jest.fn().mockResolvedValue(undefined),
+  })),
+  isAddEthereumChainType: jest.fn(
+    (confirmation) => confirmation?.type === 'wallet_addEthereumChain',
+  ),
+}));
+jest.mock('../../../hooks/transactions/useTransactionConfirm', () => ({
+  useTransactionConfirm: jest.fn(() => ({
+    onTransactionConfirm: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock('../../../hooks/useConfirmSendNavigation', () => ({
+  useConfirmSendNavigation: jest.fn(() => ({
+    navigateBackIfSend: jest.fn(),
+  })),
+}));
 
 jest.mock('react-router-dom-v5-compat', () => ({
   useNavigate: jest.fn(),
@@ -68,6 +101,7 @@ jest.mock('react-router-dom-v5-compat', () => ({
 
 const render = (args?: Record<string, unknown>) => {
   const store = configureStore(args ?? getMockPersonalSignConfirmState());
+  mockStore = store;
 
   return renderWithConfirmContextProvider(<Footer />, store);
 };
@@ -91,6 +125,10 @@ describe('ConfirmFooter', () => {
   const useUserSubscriptionsMock = jest.mocked(useUserSubscriptions);
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockDispatch.mockClear();
+    mockStore = null;
+
     mockUseOriginThrottling.mockReturnValue({
       shouldThrottleOrigin: false,
     });
@@ -244,50 +282,62 @@ describe('ConfirmFooter', () => {
     });
   });
 
-  it('invoke required actions when cancel button is clicked', () => {
+  it('invoke required actions when cancel button is clicked', async () => {
     const { getAllByRole } = render();
     const cancelButton = getAllByRole('button')[0];
     const rejectSpy = jest
       .spyOn(Actions, 'rejectPendingApproval')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockImplementation(() => Promise.resolve() as any);
     const updateCustomNonceSpy = jest
       .spyOn(Actions, 'updateCustomNonce')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockReturnValue({} as any);
     const setNextNonceSpy = jest
       .spyOn(Actions, 'setNextNonce')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockReturnValue({} as any);
+
     fireEvent.click(cancelButton);
-    expect(rejectSpy).toHaveBeenCalled();
+
+    // Wait for async onCancel to complete
+    await waitFor(() => {
+      expect(rejectSpy).toHaveBeenCalled();
+    });
+
     expect(updateCustomNonceSpy).toHaveBeenCalledWith('');
     expect(setNextNonceSpy).toHaveBeenCalledWith('');
   });
 
-  it('invoke required actions when submit button is clicked', () => {
+  it('invoke required actions when submit button is clicked', async () => {
     const { getAllByRole } = render();
     const submitButton = getAllByRole('button')[1];
     const resolveSpy = jest
       .spyOn(Actions, 'resolvePendingApproval')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockImplementation(() => Promise.resolve() as any);
     const updateCustomNonceSpy = jest
       .spyOn(Actions, 'updateCustomNonce')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockReturnValue({} as any);
     const setNextNonceSpy = jest
       .spyOn(Actions, 'setNextNonce')
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => ({}) as any);
+      .mockReturnValue({} as any);
+
     fireEvent.click(submitButton);
-    expect(resolveSpy).toHaveBeenCalled();
+
+    // Wait for async onSubmit to complete
+    await waitFor(() => {
+      expect(resolveSpy).toHaveBeenCalled();
+    });
+
     expect(updateCustomNonceSpy).toHaveBeenCalledWith('');
     expect(setNextNonceSpy).toHaveBeenCalledWith('');
   });
@@ -488,7 +538,7 @@ describe('ConfirmFooter', () => {
       // @ts-expect-error This is missing from the Mocha type definitions
       it.each(['Confirm', 'Cancel'])(
         'on %s button click',
-        (buttonText: string) => {
+        async (buttonText: string) => {
           const navigateNextMock = jest.fn();
           useConfirmationNavigationMock.mockReturnValue({
             navigateNext: navigateNextMock,
@@ -498,17 +548,21 @@ describe('ConfirmFooter', () => {
           const mockStateWithContractInteractionConfirmation =
             getMockContractInteractionConfirmState();
 
+          // Get the actual transaction from the transactions array
+          const contractInteractionConfirmation =
+            mockStateWithContractInteractionConfirmation.metamask
+              .transactions[0];
+
           mockStateWithContractInteractionConfirmation.metamask.pendingApprovals =
             {
-              [addEthereumChainApproval.id]: addEthereumChainApproval,
               ...mockStateWithContractInteractionConfirmation.metamask
                 .pendingApprovals,
+              [addEthereumChainApproval.id]: addEthereumChainApproval,
             };
           mockStateWithContractInteractionConfirmation.metamask.pendingApprovalCount = 2;
 
-          // Current confirmation is add ethereum chain
           jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
-            currentConfirmation: addEthereumChainApproval,
+            currentConfirmation: contractInteractionConfirmation,
             isScrollToBottomCompleted: true,
             setIsScrollToBottomCompleted: () => undefined,
           });
@@ -519,10 +573,13 @@ describe('ConfirmFooter', () => {
           const button = getByText(buttonText);
           fireEvent.click(button);
 
-          // It will navigate to transaction confirmation
-          expect(navigateNextMock).toHaveBeenCalledTimes(1);
+          // Wait for async operations to complete
+          await waitFor(() => {
+            expect(navigateNextMock).toHaveBeenCalledTimes(1);
+          });
+
           expect(navigateNextMock).toHaveBeenCalledWith(
-            addEthereumChainApproval.id,
+            contractInteractionConfirmation.id,
           );
         },
       );

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -5,6 +5,7 @@ import {
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { PRODUCT_TYPES } from '@metamask/subscription-controller';
+import { useHistory } from 'react-router-dom';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
 import { isCorrectDeveloperTransactionType } from '../../../../../../shared/lib/confirmation.utils';
 import { ConfirmAlertModal } from '../../../../../components/app/alert-system/confirm-alert-modal';
@@ -22,6 +23,7 @@ import {
   FlexDirection,
   Severity,
 } from '../../../../../helpers/constants/design-system';
+import { DEFAULT_ROUTE } from '../../../../../helpers/constants/routes';
 import useAlerts from '../../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { doesAddressRequireLedgerHidConnection } from '../../../../../selectors';
@@ -201,6 +203,7 @@ const CancelButton = ({
 
 const Footer = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { onTransactionConfirm } = useTransactionConfirm();
   const { navigateNext } = useConfirmationNavigation();
   const { onSubmit: onAddEthereumChain } = useAddEthereumChain();
@@ -235,41 +238,56 @@ const Footer = () => {
     hardwareWalletRequiresConnection ||
     isGaslessLoading;
 
-  const onSubmit = useCallback(() => {
+  const onSubmit = useCallback(async () => {
     if (!currentConfirmation) {
       return;
     }
 
     if (isAddEthereumChain) {
-      onAddEthereumChain();
+      await onAddEthereumChain();
+      history.push(DEFAULT_ROUTE);
     } else if (isTransactionConfirmation) {
-      onTransactionConfirm();
+      await onTransactionConfirm();
+      navigateNext(currentConfirmation.id);
     } else {
-      dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
+      await dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
+      navigateNext(currentConfirmation.id);
     }
 
-    navigateNext(currentConfirmation.id);
     resetTransactionState();
   }, [
     currentConfirmation,
     dispatch,
+    history,
     isTransactionConfirmation,
+    isAddEthereumChain,
     navigateNext,
     onTransactionConfirm,
     resetTransactionState,
-    isAddEthereumChain,
     onAddEthereumChain,
   ]);
 
-  const handleFooterCancel = useCallback(() => {
+  const handleFooterCancel = useCallback(async () => {
     if (shouldThrottleOrigin) {
       setShowOriginThrottleModal(true);
       return;
     }
-    onCancel({ location: MetaMetricsEventLocation.Confirmation });
 
-    navigateNext(currentConfirmation.id);
-  }, [navigateNext, onCancel, shouldThrottleOrigin, currentConfirmation]);
+    await onCancel({ location: MetaMetricsEventLocation.Confirmation });
+
+    if (isAddEthereumChain) {
+      history.push(DEFAULT_ROUTE);
+    } else {
+      navigateNext(currentConfirmation.id);
+    }
+  }, [
+    navigateNext,
+    onCancel,
+    shouldThrottleOrigin,
+    currentConfirmation,
+    isAddEthereumChain,
+    history,
+  ]);
 
   const { isEnabled, isPaused } = useEnableShieldCoverageChecks();
   const isShowShieldFooterCoverageIndicator = isEnabled || isPaused;

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
@@ -37,8 +37,6 @@ import {
 } from '../../../store/actions';
 import ConfirmDecryptMessage from '../../confirm-decrypt-message';
 import ConfirmEncryptionPublicKey from '../../confirm-encryption-public-key';
-import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';
-import { getUnapprovedConfirmations } from '../../../selectors/selectors';
 import ConfirmTransactionSwitch from '../confirm-transaction-switch';
 import Confirm from '../confirm/confirm';
 import useCurrentConfirmation from '../hooks/useCurrentConfirmation';
@@ -53,9 +51,6 @@ const ConfirmTransaction = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { id: paramsTransactionId } = useParams();
-  const isSidePanelEnabled = useSidePanelEnabled();
-  const hasPendingApprovals =
-    useSelector(getUnapprovedConfirmations).length > 0;
 
   const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
   const sendTo = useSelector(getSendTo);
@@ -170,8 +165,6 @@ const ConfirmTransaction = () => {
       paramsTransactionId !== transactionId
     ) {
       history.replace(mostRecentOverviewPage);
-    } else if (isSidePanelEnabled && !hasPendingApprovals) {
-      history.replace(DEFAULT_ROUTE);
     }
   }, [
     dispatch,
@@ -181,9 +174,6 @@ const ConfirmTransaction = () => {
     prevParamsTransactionId,
     prevTransactionId,
     totalUnapproved,
-    hasPendingApprovals,
-    isSidePanelEnabled,
-    isValidTransactionId,
     transaction,
     transactionId,
     use4ByteResolution,

--- a/ui/pages/confirmations/hooks/useConfirmActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.ts
@@ -20,7 +20,7 @@ export const useConfirmActions = () => {
   const { id: currentConfirmationId } = currentConfirmation || {};
 
   const rejectApproval = useCallback(
-    ({ location }: { location?: MetaMetricsEventLocation } = {}) => {
+    async ({ location }: { location?: MetaMetricsEventLocation } = {}) => {
       if (!currentConfirmationId) {
         return;
       }
@@ -29,7 +29,9 @@ export const useConfirmActions = () => {
       error.data = { location };
 
       const serializedError = serializeError(error);
-      dispatch(rejectPendingApproval(currentConfirmationId, serializedError));
+      await dispatch(
+        rejectPendingApproval(currentConfirmationId, serializedError),
+      );
     },
     [currentConfirmationId, dispatch],
   );
@@ -41,7 +43,7 @@ export const useConfirmActions = () => {
   }, [dispatch]);
 
   const onCancel = useCallback(
-    ({
+    async ({
       location,
       navigateBackForSend = false,
     }: {
@@ -54,7 +56,7 @@ export const useConfirmActions = () => {
       if (navigateBackForSend) {
         navigateBackIfSend();
       }
-      rejectApproval({ location });
+      await rejectApproval({ location });
       resetTransactionState();
     },
     [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR reverts https://github.com/MetaMask/metamask-extension/pull/37778 as it introduced regression on sidepanel.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37898?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:  https://consensyssoftware.atlassian.net/browse/CEUX-701?atlOrigin=eyJpIjoiZmQ4YjE2NmQ5M2E1NGQ0ZWE3MDA4NzEwZTNhMDZiNDkiLCJwIjoiaiJ9

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes confirmation actions async, routes addEthereumChain to home and otherwise advances to next confirmation, removes sidepanel-specific redirect, and updates tests accordingly.
> 
> - **Confirmations UI**:
>   - `ui/pages/confirmations/components/confirm/footer/footer.tsx`
>     - Make `onSubmit`/`handleFooterCancel` async and await actions.
>     - For `wallet_addEthereumChain`, navigate to `DEFAULT_ROUTE` after confirm/cancel; otherwise call `navigateNext(currentConfirmation.id)`.
>     - Await `onTransactionConfirm`/`resolvePendingApproval` and reset transaction state.
> - **Confirm Actions**:
>   - `ui/pages/confirmations/hooks/useConfirmActions.ts`
>     - Make `rejectApproval` and `onCancel` async; await `rejectPendingApproval` and then reset state.
> - **Confirm Transaction Flow**:
>   - `ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js`
>     - Remove sidepanel-related redirect logic and associated hooks/selectors.
> - **Tests**:
>   - `ui/pages/confirmations/components/confirm/footer/footer.test.tsx`
>     - Mock thunk-aware `dispatch`; add async `waitFor` assertions.
>     - Mock `useAddEthereumChain`, `useTransactionConfirm`, and navigation; update expectations to use the current confirmation id.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a537b7b87a4cc917755139deeb4c9ed4c3a219. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->