### PR TITLE
Fix(sort): Handle 'title' as an alias for 'name' in asset sorting

### DIFF
--- a/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
@@ -50,6 +50,26 @@ describe('sortAssetsWithPriority', () => {
     ]);
   });
 
+  it('sorts by name when key is "title"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'title',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset B',
+      'Asset Z',
+    ]);
+  });
+
   it('sorts by fiat balance when key is "tokenFiatAmount"', () => {
     const assets = [
       createMockAsset({ name: 'Asset B', fiatBalance: 400 }),

--- a/ui/components/app/assets/util/sortAssetsWithPriority.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.ts
@@ -11,7 +11,7 @@ export function sortAssetsWithPriority(
   array: Asset[],
   criteria: SortCriteria,
 ): Asset[] {
-  if (criteria.key === 'name') {
+  if (criteria.key === 'name' || criteria.key === 'title') {
     return sortAssets(array, {
       key: 'name',
       order: 'asc',


### PR DESCRIPTION
## **Description**

This commit fixes an issue where sorting assets by "Token name" was not working because the sort key was being passed as 'title' instead of 'name'. The `sortAssetsWithPriority` function in `ui/components/app/assets/util/sortAssetsWithPriority.ts` has been updated to treat 'title' as an alias for 'name'.

A new test case has been added to `ui/components/app/assets/util/sortAssetsWithPriority.test.ts` to verify that sorting by 'title' works as expected.

Fixes #37687

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37899?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

See issue: #37687

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
