### PR TITLE
fix: handle 'title' as an alias for 'name' in asset sorting

### DIFF
--- a/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.test.ts
@@ -50,6 +50,26 @@ describe('sortAssetsWithPriority', () => {
     ]);
   });
 
+  it('sorts by name when key is "title"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'title',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset B',
+      'Asset Z',
+    ]);
+  });
+
   it('sorts by fiat balance when key is "tokenFiatAmount"', () => {
     const assets = [
       createMockAsset({ name: 'Asset B', fiatBalance: 400 }),

--- a/ui/components/app/assets/util/sortAssetsWithPriority.ts
+++ b/ui/components/app/assets/util/sortAssetsWithPriority.ts
@@ -11,7 +11,7 @@ export function sortAssetsWithPriority(
   array: Asset[],
   criteria: SortCriteria,
 ): Asset[] {
-  if (criteria.key === 'name') {
+  if (criteria.key === 'name' || criteria.key === 'title') {
     return sortAssets(array, {
       key: 'name',
       order: 'asc',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This fixes an issue where sorting assets by "Token name" was not working because the sort key was being passed as 'title' instead of 'name'. The `sortAssetsWithPriority` function in `ui/components/app/assets/util/sortAssetsWithPriority.ts` has been updated to treat 'title' as an alias for 'name'.

A new test case has been added to `ui/components/app/assets/util/sortAssetsWithPriority.test.ts` to verify that sorting by 'title' works as expected.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37900?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix token asset sorting

## **Related issues**

Fixes: #37687

## **Manual testing steps**

See issue

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/5b74edf6097b455bae03ab2d9d2eee3c

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats `criteria.key: 'title'` the same as `'name'` for asset sorting and adds a test to validate it.
> 
> - **Assets sorting**:
>   - Update `ui/components/app/assets/util/sortAssetsWithPriority.ts` to treat `criteria.key: 'title'` like `'name'`, delegating to `sortAssets` with alpha-numeric ascending by `name`.
> - **Tests**:
>   - Add test in `ui/components/app/assets/util/sortAssetsWithPriority.test.ts` verifying sorting by `'title'` mirrors name-based sorting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dca2d65cf4a662e60c0959eb2798945321c7e6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->