### PR TITLE
fix(predict): cp-13.10.0 Update predict deep link to redirect to /prediction-markets

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2005,7 +2005,7 @@
     "message": "the perps page"
   },
   "deepLink_thePredictPage": {
-    "message": "the predict page"
+    "message": "the prediction markets page"
   },
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2005,7 +2005,7 @@
     "message": "the perps page"
   },
   "deepLink_thePredictPage": {
-    "message": "the predict page"
+    "message": "the prediction markets page"
   },
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -5,7 +5,7 @@ export default new Route({
   pathname: '/predict',
   getTitle: (_: URLSearchParams) => 'deepLink_thePredictPage',
   handler: function handler(params: URLSearchParams) {
-    const predictUrl = new URL('/predict', BaseUrl.MetaMask);
+    const predictUrl = new URL('/prediction-markets', BaseUrl.MetaMask);
     params.forEach((value, key) => predictUrl.searchParams.append(key, value));
     return {
       redirectTo: predictUrl,

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -274,7 +274,7 @@ and we'll take you to the right place.`
         // test signed flow
         await driver.openNewURL(signedUrl);
 
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/predict` });
+        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/prediction-markets` });
 
         await driver.navigate();
         await homePage.checkPageIsLoaded();
@@ -282,7 +282,7 @@ and we'll take you to the right place.`
         // test unsigned flow
         await driver.openNewURL(rawUrl);
 
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/predict` });
+        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/prediction-markets` });
       },
     );
   });

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -274,7 +274,9 @@ and we'll take you to the right place.`
         // test signed flow
         await driver.openNewURL(signedUrl);
 
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/prediction-markets` });
+        await driver.waitForUrl({
+          url: `${BaseUrl.MetaMask}/prediction-markets`,
+        });
 
         await driver.navigate();
         await homePage.checkPageIsLoaded();
@@ -282,7 +284,9 @@ and we'll take you to the right place.`
         // test unsigned flow
         await driver.openNewURL(rawUrl);
 
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/prediction-markets` });
+        await driver.waitForUrl({
+          url: `${BaseUrl.MetaMask}/prediction-markets`,
+        });
       },
     );
   });


### PR DESCRIPTION
# Pull Request Description

## **Description**

This PR adds a deep link handler for the Predict page, enabling redirection from `https://link.metamask.io/predict` to `https://metamask.io/prediction-markets` with query parameter preservation.

https://github.com/user-attachments/assets/eeb114aa-2b2e-4f9c-bb94-46bd68fca626

## **Changelog**

CHANGELOG entry: Update Predict deeplink handler

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to `https://link.metamask.io/predict`
2. Should be routed to `https://metamask.io/prediction-markets`
3. Test with query parameters: `https://link.metamask.io/predict?param=value`
4. Verify parameters are preserved in the redirect: `https://metamask.io/prediction-markets?param=value`

## **Screenshots/Recordings**

### **Before**

N/A - New feature

### **After**

N/A - Redirect functionality (no UI changes)

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Changed

1. **`shared/lib/deep-links/routes/predict.ts`** (modified)
   - Route handler for `/predict` path
   - Redirects to `https://metamask.io/prediction-markets`
   - Preserves all query parameters from original URL

2. **`test/e2e/tests/deep-link/deep-link.spec.ts`** (modified)
   - Updated E2E test: `handles /predict route redirect`
   - Tests both signed and unsigned deep link flows
   - Verifies redirect to `https://metamask.io/prediction-markets`

3. **`app/_locales/en/messages.json`** (modified)
   - Updated `deepLink_thePredictPage` localization key
   - Message: "the prediction markets page"

4. **`app/_locales/en_GB/messages.json`** (modified)
   - Updated `deepLink_thePredictPage` localization key
   - Message: "the prediction markets page"

### Implementation Pattern

This implementation follows the same pattern as the existing perps deep link handler (PR #35817):

- Uses the `Route` class with pathname, title, and handler
- Leverages `BaseUrl.MetaMask` constant for redirect target
- Preserves query parameters using `URLSearchParams`
- Includes comprehensive E2E test coverage

### Test Coverage

The E2E test verifies:
- ✅ Signed deep link flow redirects correctly
- ✅ Unsigned deep link flow redirects correctly
- ✅ Target URL matches expected `https://metamask.io/prediction-markets`
- ✅ User can access the page after authentication

## **Notes for Reviewers**

- This is a straightforward deep link redirect similar to the perps handler
- No new dependencies added
- No breaking changes
- Query parameters are preserved in the redirect
- Localization keys follow existing naming convention


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redirects the `/predict` deep link to `MetaMask/prediction-markets` with query params preserved, updating i18n text and e2e tests.
> 
> - **Deep Links**:
>   - Update route in `shared/lib/deep-links/routes/predict.ts` to redirect `/predict` -> `/prediction-markets` (preserves query params).
> - **Tests**:
>   - Adjust e2e expectations in `test/e2e/tests/deep-link/deep-link.spec.ts` to wait for `${BaseUrl.MetaMask}/prediction-markets` for both signed and unsigned flows.
> - **Localization**:
>   - Update `deepLink_thePredictPage` message to "the prediction markets page" in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32ff11b7ea48f4e40da79f1a8d43332728b8d86e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->