### PR TITLE
feat: rewards hooks

### DIFF
--- a/ui/hooks/rewards/useGeoRewardsMetadata.test.ts
+++ b/ui/hooks/rewards/useGeoRewardsMetadata.test.ts
@@ -1,0 +1,262 @@
+import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { RewardsGeoMetadata } from '../../../shared/types/rewards';
+import { useGeoRewardsMetadata } from './useGeoRewardsMetadata';
+
+// Mock store actions used by the hook
+jest.mock('../../store/actions', () => ({
+  getRewardsGeoMetadata: jest.fn(() => async () => null),
+}));
+
+const { getRewardsGeoMetadata } = jest.requireMock('../../store/actions') as {
+  getRewardsGeoMetadata: jest.Mock;
+};
+
+// Helper to assert store is defined and returns a typed slice
+type RewardsSliceForTest = {
+  geoLocation: string | null;
+  optinAllowedForGeo: boolean | null;
+  optinAllowedForGeoLoading: boolean;
+  optinAllowedForGeoError: boolean;
+};
+
+const getRewardsSlice = (store: unknown): RewardsSliceForTest => {
+  const typed = store as {
+    getState: () => { rewards: RewardsSliceForTest };
+  };
+  if (!typed || typeof typed.getState !== 'function') {
+    throw new Error('Store is undefined');
+  }
+  return typed.getState().rewards;
+};
+
+describe('useGeoRewardsMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initial State', () => {
+    it('exposes fetch function and state starts unchanged', () => {
+      const { result, store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: false }),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      expect(typeof result.current.fetchGeoRewardsMetadata).toBe('function');
+      const rewardsState = getRewardsSlice(store);
+      expect(rewardsState.geoLocation).toBeNull();
+      expect(rewardsState.optinAllowedForGeo).toBeNull();
+      expect(rewardsState.optinAllowedForGeoError).toBe(false);
+      expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+    });
+  });
+
+  describe('Conditional fetching via useEffect', () => {
+    it('fetches and updates state when enabled', async () => {
+      const mockMetadata: RewardsGeoMetadata = {
+        geoLocation: 'US',
+        optinAllowedForGeo: true,
+      };
+
+      (getRewardsGeoMetadata as jest.Mock).mockImplementation(
+        () => async () => mockMetadata,
+      );
+
+      const { store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: true }),
+        {
+          metamask: {
+            isUnlocked: true,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      await waitFor(() => {
+        // Action should be called by useEffect
+        expect(getRewardsGeoMetadata).toHaveBeenCalled();
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+        expect(rewardsState.optinAllowedForGeoError).toBe(false);
+        expect(rewardsState.geoLocation).toBe('US');
+        expect(rewardsState.optinAllowedForGeo).toBe(true);
+      });
+    });
+
+    it('sets loading=true during fetch then false after resolve', async () => {
+      let resolveMetadata!: (value: RewardsGeoMetadata | null) => void;
+      (getRewardsGeoMetadata as jest.Mock).mockImplementation(
+        () => async () =>
+          new Promise<RewardsGeoMetadata | null>((resolve) => {
+            resolveMetadata = resolve;
+          }),
+      );
+
+      const { store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: true }),
+        {
+          metamask: {
+            isUnlocked: true,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      // Loading should be true while fetch is in-flight
+      await waitFor(() => {
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(true);
+      });
+
+      // Resolve mocked action
+      act(() => {
+        resolveMetadata({ geoLocation: 'CA-ON', optinAllowedForGeo: true });
+      });
+
+      // After resolution, loading returns to false and metadata updates
+      await waitFor(() => {
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+        expect(rewardsState.geoLocation).toBe('CA-ON');
+        expect(rewardsState.optinAllowedForGeo).toBe(true);
+        expect(rewardsState.optinAllowedForGeoError).toBe(false);
+      });
+    });
+
+    it('does not call action and resets when disabled', async () => {
+      const { store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: false }),
+        {
+          metamask: {
+            isUnlocked: true,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      // Enabled=false: hook dispatches reset state on mount and does not call action
+      await waitFor(() => {
+        expect(getRewardsGeoMetadata).not.toHaveBeenCalled();
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.geoLocation).toBeNull();
+        expect(rewardsState.optinAllowedForGeo).toBeNull();
+        expect(rewardsState.optinAllowedForGeoError).toBe(false);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+      });
+    });
+  });
+
+  describe('fetchGeoRewardsMetadata function', () => {
+    it('updates state when action resolves (without disabled auto-effect)', async () => {
+      (getRewardsGeoMetadata as jest.Mock).mockImplementation(
+        () => async () => ({ geoLocation: 'UK', optinAllowedForGeo: false }),
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: true }),
+        {
+          metamask: {
+            isUnlocked: false, // no effect on this hook, but keeps parity with other tests
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchGeoRewardsMetadata();
+      });
+
+      expect(getRewardsGeoMetadata).toHaveBeenCalled();
+      const rewardsState = getRewardsSlice(store);
+      expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+      expect(rewardsState.geoLocation).toBe('UK');
+      expect(rewardsState.optinAllowedForGeo).toBe(false);
+      expect(rewardsState.optinAllowedForGeoError).toBe(false);
+    });
+
+    it('sets error=true when action throws', async () => {
+      const mockError = new Error('Network Error');
+      (getRewardsGeoMetadata as jest.Mock).mockImplementation(
+        () => async () => {
+          throw mockError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: true }),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchGeoRewardsMetadata();
+      });
+
+      expect(getRewardsGeoMetadata).toHaveBeenCalled();
+      const rewardsState = getRewardsSlice(store);
+      expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+      expect(rewardsState.optinAllowedForGeoError).toBe(true);
+    });
+
+    it('prevents duplicate calls while loading', async () => {
+      let resolveMetadata!: (value: RewardsGeoMetadata | null) => void;
+      (getRewardsGeoMetadata as jest.Mock).mockImplementation(
+        () => async () =>
+          new Promise<RewardsGeoMetadata | null>((resolve) => {
+            resolveMetadata = resolve;
+          }),
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useGeoRewardsMetadata({ enabled: true }),
+        {
+          metamask: {
+            isUnlocked: true,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+          },
+        },
+      );
+
+      // Trigger a manual fetch while auto-effect fetch is in-flight
+      act(() => {
+        result.current.fetchGeoRewardsMetadata();
+      });
+
+      // Ensure only a single call was made to the action while loading
+      await waitFor(() => {
+        expect(getRewardsGeoMetadata).toHaveBeenCalledTimes(1);
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(true);
+      });
+
+      // Resolve the first (in-flight) request
+      act(() => {
+        resolveMetadata({ geoLocation: 'FR', optinAllowedForGeo: true });
+      });
+
+      await waitFor(() => {
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.optinAllowedForGeoLoading).toBe(false);
+        expect(rewardsState.geoLocation).toBe('FR');
+        expect(rewardsState.optinAllowedForGeo).toBe(true);
+      });
+    });
+  });
+});

--- a/ui/hooks/rewards/useGeoRewardsMetadata.ts
+++ b/ui/hooks/rewards/useGeoRewardsMetadata.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  setRewardsGeoMetadata,
+  setRewardsGeoMetadataError,
+  setRewardsGeoMetadataLoading,
+} from '../../ducks/rewards';
+import { getRewardsGeoMetadata } from '../../store/actions';
+import { RewardsGeoMetadata } from '../../../shared/types/rewards';
+
+type UseGeoRewardsMetadataProps = {
+  enabled?: boolean;
+};
+
+type UseGeoRewardsMetadataReturn = {
+  fetchGeoRewardsMetadata: () => Promise<void>;
+};
+
+/*
+ * useGeoRewardsMetadata
+ *
+ * A custom hook that returns the geo rewards metadata for the current user.
+ */
+export const useGeoRewardsMetadata = ({
+  enabled = true,
+}: UseGeoRewardsMetadataProps): UseGeoRewardsMetadataReturn => {
+  const dispatch = useDispatch();
+  const isLoadingRef = useRef(false);
+
+  const fetchGeoRewardsMetadata = useCallback(async (): Promise<void> => {
+    // Skip fetch if already loading (prevents duplicate requests)
+    if (isLoadingRef.current || !enabled) {
+      if (!enabled) {
+        dispatch(setRewardsGeoMetadataError(false));
+        dispatch(setRewardsGeoMetadataLoading(false));
+        dispatch(setRewardsGeoMetadata(null));
+      }
+      return;
+    }
+    isLoadingRef.current = true;
+    dispatch(setRewardsGeoMetadataLoading(true));
+    dispatch(setRewardsGeoMetadataError(false));
+
+    try {
+      const metadata = (await dispatch(
+        getRewardsGeoMetadata(),
+      )) as unknown as RewardsGeoMetadata | null;
+
+      dispatch(setRewardsGeoMetadata(metadata));
+    } catch (err) {
+      dispatch(setRewardsGeoMetadataError(true));
+    } finally {
+      isLoadingRef.current = false;
+      dispatch(setRewardsGeoMetadataLoading(false));
+    }
+  }, [dispatch, enabled]);
+
+  // Initial data fetch
+  useEffect(() => {
+    fetchGeoRewardsMetadata();
+  }, [fetchGeoRewardsMetadata]);
+
+  return { fetchGeoRewardsMetadata };
+};

--- a/ui/hooks/rewards/useLinkAccountGroup.test.tsx
+++ b/ui/hooks/rewards/useLinkAccountGroup.test.tsx
@@ -1,0 +1,298 @@
+import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+import {
+  AccountGroupId,
+  AccountWalletType,
+  AccountGroupType,
+  AccountWalletStatus,
+} from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { MetaMetricsContext } from '../../contexts/metametrics';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
+import { createMockMultichainAccountsState } from '../../selectors/multichain-accounts/test-utils';
+import { AccountTreeWallets } from '../../selectors/multichain-accounts/account-tree.types';
+import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { useLinkAccountGroup } from './useLinkAccountGroup';
+
+// Mock store actions used by the hook
+jest.mock('../../store/actions', () => ({
+  rewardsIsOptInSupported: jest.fn(() => () => true),
+  rewardsGetOptInStatus: jest.fn(() => async () => ({ ois: [] })),
+  rewardsLinkAccountsToSubscriptionCandidate: jest.fn(
+    () => async () => [] as { account: InternalAccount; success: boolean }[],
+  ),
+}));
+
+const {
+  rewardsIsOptInSupported,
+  rewardsGetOptInStatus,
+  rewardsLinkAccountsToSubscriptionCandidate,
+} = jest.requireMock('../../store/actions') as {
+  rewardsIsOptInSupported: jest.Mock;
+  rewardsGetOptInStatus: jest.Mock;
+  rewardsLinkAccountsToSubscriptionCandidate: jest.Mock;
+};
+
+// Simple container to provide MetaMetrics context
+const mockTrackEvent = jest.fn();
+const Container = ({ children }: { children: React.ReactNode }) => (
+  <MetaMetricsContext.Provider value={mockTrackEvent}>
+    {children}
+  </MetaMetricsContext.Provider>
+);
+
+// Helpers to build minimal state with a wallet and group
+const WALLET_ID = 'entropy:test';
+const GROUP_ID = 'entropy:test/0' as AccountGroupId;
+
+const buildStateWithAccounts = (accounts: InternalAccount[]) => {
+  const wallets: AccountTreeWallets = {
+    [WALLET_ID]: {
+      id: WALLET_ID,
+      type: AccountWalletType.Entropy,
+      metadata: {
+        name: 'Test Wallet',
+        entropy: { id: 'test' },
+      },
+      // Status is present in many wallet objects across tests; include to satisfy type narrowing
+      status: 'ready' as AccountWalletStatus,
+      groups: {
+        [GROUP_ID]: {
+          id: GROUP_ID,
+          type: AccountGroupType.MultichainAccount,
+          metadata: {
+            name: 'Group',
+            pinned: false,
+            hidden: false,
+            entropy: { groupIndex: 0 },
+          },
+          accounts: accounts.map((a) => a.id),
+        },
+      },
+    },
+  } as unknown as AccountTreeWallets;
+
+  return createMockMultichainAccountsState(
+    {
+      wallets,
+      selectedAccountGroup: GROUP_ID,
+    },
+    {
+      accounts: accounts.reduce<Record<string, InternalAccount>>((acc, a) => {
+        acc[a.id] = a;
+        return acc;
+      }, {}),
+      selectedAccount: accounts[0]?.id ?? '',
+    },
+  );
+};
+
+describe('useLinkAccountGroup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initial State', () => {
+    it('exposes link function and initial state is not loading or error', () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const state = buildStateWithAccounts([a1]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      expect(typeof result.current.linkAccountGroup).toBe('function');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+  });
+
+  describe('No eligible accounts', () => {
+    it('returns failure and sets error when group has no accounts', async () => {
+      const state = buildStateWithAccounts([]);
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsIsOptInSupported).toHaveBeenCalledTimes(0);
+      expect(rewardsGetOptInStatus).toHaveBeenCalledTimes(0);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledTimes(
+        0,
+      );
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(report).toEqual({ success: false, byAddress: {} });
+    });
+  });
+
+  describe('Already opted-in', () => {
+    it('does not link and returns success when all accounts are opted-in', async () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const a2 = createMockInternalAccount({ id: 'acc-2', address: '0x222' });
+      const state = buildStateWithAccounts([a1, a2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [true, true] }),
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsIsOptInSupported).toHaveBeenCalledTimes(2);
+      expect(rewardsGetOptInStatus).toHaveBeenCalledTimes(1);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0x111': true, '0x222': true },
+      });
+    });
+  });
+
+  describe('Linking accounts and metrics', () => {
+    it('links accounts and tracks started/completed/failed events', async () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const a2 = createMockInternalAccount({ id: 'acc-2', address: '0x222' });
+      const state = buildStateWithAccounts([a1, a2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: a1, success: true },
+        { account: a2, success: false },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsIsOptInSupported).toHaveBeenCalledTimes(2);
+      expect(rewardsGetOptInStatus).toHaveBeenCalledTimes(1);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledTimes(
+        1,
+      );
+
+      // Metrics: started for both, then completed for one, failed for one
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalled();
+      });
+      const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+      const eventNames = calls.map(
+        (c: { event: MetaMetricsEventName }) => c.event,
+      );
+      const startedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      ).length;
+      const completedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      ).length;
+      const failedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      ).length;
+
+      expect(startedCount).toBe(2);
+      expect(completedCount).toBe(1);
+      expect(failedCount).toBe(1);
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0x111': true, '0x222': false },
+      });
+    });
+
+    it('handles link action error by marking all accounts failed and tracking failures', async () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const a2 = createMockInternalAccount({ id: 'acc-2', address: '0x222' });
+      const state = buildStateWithAccounts([a1, a2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('linking failed');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Started events for both, then failed for both
+      const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+      const eventNames = calls.map(
+        (c: { event: MetaMetricsEventName }) => c.event,
+      );
+      const startedCount = eventNames.filter(
+        (e) => e === 'REWARDS_ACCOUNT_LINKING_STARTED',
+      ).length;
+      const completedCount = eventNames.filter(
+        (e) => e === 'REWARDS_ACCOUNT_LINKING_COMPLETED',
+      ).length;
+      const failedCount = eventNames.filter(
+        (e) => e === 'REWARDS_ACCOUNT_LINKING_FAILED',
+      ).length;
+
+      expect(startedCount).toBe(2);
+      expect(completedCount).toBe(0);
+      expect(failedCount).toBe(2);
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0x111': false, '0x222': false },
+      });
+    });
+  });
+});

--- a/ui/hooks/rewards/useLinkAccountGroup.ts
+++ b/ui/hooks/rewards/useLinkAccountGroup.ts
@@ -1,0 +1,179 @@
+import { useCallback, useContext, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AccountGroupId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { MetaMetricsContext } from '../../contexts/metametrics';
+import { getInternalAccountsFromGroupById } from '../../selectors/multichain-accounts/account-tree';
+import {
+  rewardsGetOptInStatus,
+  rewardsIsOptInSupported,
+  rewardsLinkAccountsToSubscriptionCandidate,
+} from '../../store/actions';
+import { OptInStatusDto } from '../../../shared/types/rewards';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../shared/constants/metametrics';
+import { getAccountTypeCategory } from '../../pages/multichain-accounts/account-details/account-type-utils';
+
+type LinkStatusReport = {
+  success: boolean;
+  byAddress: Record<string, boolean>;
+};
+
+type UseLinkAccountGroupResult = {
+  linkAccountGroup: () => Promise<LinkStatusReport>;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+export const useLinkAccountGroup = (
+  accountGroupId?: AccountGroupId,
+): UseLinkAccountGroupResult => {
+  const dispatch = useDispatch();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const internalAccountsForGroup = useSelector((state) =>
+    accountGroupId
+      ? getInternalAccountsFromGroupById(state, accountGroupId)
+      : [],
+  );
+
+  const trackEvent = useContext(MetaMetricsContext);
+
+  const triggerAccountLinkingEvent = useCallback(
+    (event: MetaMetricsEventName, account: InternalAccount) => {
+      const accountMetricProps = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        account_type: getAccountTypeCategory(account),
+      };
+      trackEvent({
+        category: MetaMetricsEventCategory.Rewards,
+        event,
+        properties: accountMetricProps,
+      });
+    },
+    [trackEvent],
+  );
+
+  const linkAccountGroup = useCallback(async (): Promise<LinkStatusReport> => {
+    if (!internalAccountsForGroup) {
+      return {
+        success: false,
+        byAddress: {},
+      };
+    }
+
+    setIsLoading(true);
+    setIsError(false);
+
+    const byAddress: Record<string, boolean> = {};
+    try {
+      // Determine supported accounts by awaiting async support checks
+      const supportChecks = await Promise.all(
+        internalAccountsForGroup.map(
+          (account) =>
+            dispatch(
+              rewardsIsOptInSupported({ account }),
+            ) as unknown as Promise<boolean>,
+        ),
+      );
+
+      const supportedAccounts = internalAccountsForGroup.filter(
+        (_account, index) => Boolean(supportChecks[index]),
+      );
+
+      if (supportedAccounts.length === 0) {
+        setIsError(true);
+        return {
+          success: false,
+          byAddress,
+        };
+      }
+
+      // Initialize all accounts as not linked
+      supportedAccounts.forEach((account) => {
+        byAddress[account.address] = false;
+      });
+
+      // Only process eligible accounts for opt-in status check
+      const addresses = supportedAccounts.map((account) => account.address);
+      const optInResponse: OptInStatusDto = (await dispatch(
+        rewardsGetOptInStatus({ addresses }),
+      )) as unknown as OptInStatusDto;
+
+      // Map opt-in status for eligible accounts only
+      supportedAccounts.forEach((account, index) => {
+        if (optInResponse.ois[index]) {
+          byAddress[account.address] = true;
+        }
+      });
+
+      const accountsToLink = supportedAccounts.filter(
+        (_, index) => optInResponse.ois[index] === false,
+      );
+
+      if (accountsToLink.length === 0) {
+        return { success: true, byAddress };
+      }
+
+      // Emit started events for all accounts before calling the function
+      for (const account of accountsToLink) {
+        triggerAccountLinkingEvent(
+          MetaMetricsEventName.RewardsAccountLinkingStarted,
+          account,
+        );
+      }
+
+      try {
+        const results = (await dispatch(
+          rewardsLinkAccountsToSubscriptionCandidate(accountsToLink),
+        )) as unknown as { account: InternalAccount; success: boolean }[];
+
+        // Process results and emit completion/failure events
+        for (const result of results) {
+          byAddress[result.account.address] = result.success;
+          if (result.success) {
+            triggerAccountLinkingEvent(
+              MetaMetricsEventName.RewardsAccountLinkingCompleted,
+              result.account,
+            );
+          } else {
+            triggerAccountLinkingEvent(
+              MetaMetricsEventName.RewardsAccountLinkingFailed,
+              result.account,
+            );
+          }
+        }
+      } catch (err) {
+        // Mark all accounts as failed and emit failure events
+        for (const account of accountsToLink) {
+          byAddress[account.address] = false;
+          triggerAccountLinkingEvent(
+            MetaMetricsEventName.RewardsAccountLinkingFailed,
+            account,
+          );
+        }
+      }
+
+      const fullySucceeded = Object.values(byAddress).every((status) => status);
+      if (fullySucceeded) {
+        return { success: true, byAddress };
+      }
+
+      setIsError(true);
+      return { success: false, byAddress };
+    } catch {
+      setIsError(true);
+      return { success: false, byAddress: {} };
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dispatch, internalAccountsForGroup, triggerAccountLinkingEvent]);
+
+  return {
+    linkAccountGroup,
+    isLoading,
+    isError,
+  };
+};

--- a/ui/hooks/rewards/useOptIn.test.tsx
+++ b/ui/hooks/rewards/useOptIn.test.tsx
@@ -1,0 +1,460 @@
+import { act } from '@testing-library/react-hooks';
+import React from 'react';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { MetaMetricsContext } from '../../contexts/metametrics';
+import {
+  MetaMetricsEventName,
+  MetaMetricsUserTrait,
+} from '../../../shared/constants/metametrics';
+import { useOptIn } from './useOptIn';
+
+// Mocks
+jest.mock('../../store/actions', () => ({
+  rewardsOptIn: jest.fn(() => async () => 'sub-123'),
+  rewardsLinkAccountsToSubscriptionCandidate: jest.fn(() => async () => [
+    { account: {} as InternalAccount, success: true },
+  ]),
+  updateMetaMetricsTraits: jest.fn(() => async () => {
+    // noop
+  }),
+}));
+
+jest.mock('../../selectors', () => {
+  const actual = jest.requireActual('../../selectors');
+  return {
+    ...actual,
+    getSelectedAccount: jest.fn(() => ({ address: '0x111' })),
+  };
+});
+
+const mockSideEffectAccounts: InternalAccount[] = [
+  {
+    id: 'acc-1',
+    address: '0x111',
+    metadata: {
+      name: 'Account 1',
+      keyring: { type: 'HD Key Tree' },
+      importTime: Date.now(),
+    },
+    options: {},
+    methods: [],
+    type: 'eip155:eoa',
+    scopes: ['eip155:1'],
+  },
+];
+
+const mockActiveGroupAccounts: InternalAccount[] = [
+  {
+    id: 'acc-0',
+    address: '0x000',
+    metadata: {
+      name: 'Account 0',
+      keyring: { type: 'HD Key Tree' },
+      importTime: Date.now(),
+    },
+    options: {},
+    methods: [],
+    type: 'eip155:eoa',
+    scopes: [],
+  },
+];
+
+jest.mock('../../selectors/multichain-accounts/account-tree', () => {
+  const actual = jest.requireActual(
+    '../../selectors/multichain-accounts/account-tree',
+  );
+  return {
+    ...actual,
+    getSelectedAccountGroup: jest.fn(() => 'entropy:test/0'),
+    getWalletIdAndNameByAccountAddress: jest.fn(() => ({
+      id: 'entropy:test',
+      name: 'Test Wallet',
+    })),
+    getMultichainAccountsByWalletId: jest.fn(() => ({
+      'entropy:test/1': {
+        id: 'entropy:test/1',
+        type: 'MultichainAccount',
+        metadata: {
+          name: 'Group 1',
+          pinned: false,
+          hidden: false,
+          entropy: { groupIndex: 1 },
+        },
+        accounts: ['acc-1'],
+      },
+      'entropy:test/0': {
+        id: 'entropy:test/0',
+        type: 'MultichainAccount',
+        metadata: {
+          name: 'Group 0',
+          pinned: false,
+          hidden: false,
+          entropy: { groupIndex: 0 },
+        },
+        accounts: ['acc-0'],
+      },
+    })),
+    getInternalAccountsFromGroupById: jest.fn((_state, groupId: string) => {
+      if (groupId === 'entropy:test/1') {
+        return mockSideEffectAccounts;
+      }
+      if (groupId === 'entropy:test/0') {
+        return mockActiveGroupAccounts;
+      }
+      return [];
+    }),
+  };
+});
+
+jest.mock('../../ducks/rewards', () => ({
+  setCandidateSubscriptionId: jest.fn((sid: string) => ({
+    type: 'SET_SID',
+    payload: sid,
+  })),
+}));
+
+jest.mock(
+  '../../components/app/rewards/utils/handleRewardsErrorMessage',
+  () => ({
+    handleRewardsErrorMessage: jest.fn(() => 'mock error'),
+  }),
+);
+
+const { rewardsOptIn } = jest.requireMock('../../store/actions') as {
+  rewardsOptIn: jest.Mock;
+};
+const { rewardsLinkAccountsToSubscriptionCandidate } = jest.requireMock(
+  '../../store/actions',
+) as { rewardsLinkAccountsToSubscriptionCandidate: jest.Mock };
+const { updateMetaMetricsTraits } = jest.requireMock('../../store/actions') as {
+  updateMetaMetricsTraits: jest.Mock;
+};
+const { setCandidateSubscriptionId } = jest.requireMock(
+  '../../ducks/rewards',
+) as { setCandidateSubscriptionId: jest.Mock };
+const { getSelectedAccountGroup } = jest.requireMock(
+  '../../selectors/multichain-accounts/account-tree',
+) as { getSelectedAccountGroup: jest.Mock };
+const { getInternalAccountsFromGroupById } = jest.requireMock(
+  '../../selectors/multichain-accounts/account-tree',
+) as { getInternalAccountsFromGroupById: jest.Mock };
+
+// MetaMetrics provider container
+const mockTrackEvent = jest.fn();
+const Container = ({ children }: { children: React.ReactNode }) => (
+  <MetaMetricsContext.Provider value={mockTrackEvent}>
+    {children}
+  </MetaMetricsContext.Provider>
+);
+
+describe('useOptIn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (rewardsOptIn as jest.Mock).mockImplementation(() => async () => 'sub-123');
+    (
+      rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+    ).mockImplementation(() => async () => [
+      { account: {} as InternalAccount, success: true },
+    ]);
+    (updateMetaMetricsTraits as jest.Mock).mockImplementation(
+      () => async () => {
+        // noop
+      },
+    );
+    getSelectedAccountGroup.mockReturnValue('entropy:test/0');
+    (getInternalAccountsFromGroupById as jest.Mock).mockImplementation(
+      (_state, groupId: string) => {
+        if (groupId === 'entropy:test/1') {
+          return mockSideEffectAccounts;
+        }
+        if (groupId === 'entropy:test/0') {
+          return mockActiveGroupAccounts;
+        }
+        return [];
+      },
+    );
+  });
+
+  describe('Initial State', () => {
+    it('returns default loading and error state and clearOptinError works', () => {
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      expect(result.current.optinLoading).toBe(false);
+      expect(result.current.optinError).toBeNull();
+
+      act(() => {
+        result.current.clearOptinError();
+      });
+
+      expect(result.current.optinError).toBeNull();
+      expect(typeof result.current.optin).toBe('function');
+    });
+  });
+
+  describe('Successful opt-in', () => {
+    it('tracks started/completed, dispatches candidate SID, updates traits, and toggles loading', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-abc',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInStarted);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
+
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith('sub-abc');
+      expect(updateMetaMetricsTraits).toHaveBeenCalledWith({
+        [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
+      });
+      expect(result.current.optinLoading).toBe(false);
+      expect(result.current.optinError).toBeNull();
+    });
+
+    it('includes referral metrics properties and traits when referralCode is provided', async () => {
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin('REF-CODE');
+      });
+
+      const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+      const started = calls.find(
+        (c: { event: MetaMetricsEventName }) =>
+          c.event === MetaMetricsEventName.RewardsOptInStarted,
+      );
+      expect(started?.properties?.referred).toBe(true);
+      expect(started?.properties?.referral_code_used).toBe('REF-CODE');
+
+      expect(updateMetaMetricsTraits).toHaveBeenCalledWith({
+        [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
+        [MetaMetricsUserTrait.RewardsReferred]: true,
+        [MetaMetricsUserTrait.RewardsReferralCodeUsed]: 'REF-CODE',
+      });
+    });
+
+    it('uses side effect accounts for opt-in when available and links active group accounts', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-side-effect',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Should opt-in with side effect accounts (entropy:test/1)
+      expect(rewardsOptIn).toHaveBeenCalledWith({
+        accounts: mockSideEffectAccounts,
+        referralCode: undefined,
+      });
+
+      // Should link active group accounts after opt-in
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        mockActiveGroupAccounts,
+      );
+    });
+
+    it('uses active group accounts for opt-in when no side effect accounts available', async () => {
+      // Mock to return empty array for side effect accounts
+      (getInternalAccountsFromGroupById as jest.Mock).mockImplementation(
+        (_state, groupId: string) => {
+          if (groupId === 'entropy:test/1') {
+            return [];
+          }
+          if (groupId === 'entropy:test/0') {
+            return mockActiveGroupAccounts;
+          }
+          return [];
+        },
+      );
+
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-active',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Should opt-in with active group accounts
+      expect(rewardsOptIn).toHaveBeenCalledWith({
+        accounts: mockActiveGroupAccounts,
+        referralCode: undefined,
+      });
+
+      // Should not link accounts when there are no accounts to link
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+
+    it('does not link accounts when accountsToLinkAfterOptIn is empty', async () => {
+      // Mock to return empty array for active group accounts
+      (getInternalAccountsFromGroupById as jest.Mock).mockImplementation(
+        (_state, groupId: string) => {
+          if (groupId === 'entropy:test/1') {
+            return mockSideEffectAccounts;
+          }
+          if (groupId === 'entropy:test/0') {
+            return [];
+          }
+          return [];
+        },
+      );
+
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-no-link',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Should not link accounts when there are no accounts to link
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+
+    it('swallows link errors without affecting final state', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-link-error',
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('link fail');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(result.current.optinError).toBeNull();
+      expect(result.current.optinLoading).toBe(false);
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith('sub-link-error');
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+
+    it('swallows traits update errors without affecting final state', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-traits-error',
+      );
+      (updateMetaMetricsTraits as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('traits fail');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(result.current.optinError).toBeNull();
+      expect(result.current.optinLoading).toBe(false);
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
+        'sub-traits-error',
+      );
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+  });
+
+  describe('Error path', () => {
+    it('tracks failure and sets optinError when rewardsOptIn throws', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(() => async () => {
+        throw new Error('fail');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInFailed);
+      expect(result.current.optinLoading).toBe(false);
+      expect(result.current.optinError).toBe('mock error');
+      expect(setCandidateSubscriptionId).not.toHaveBeenCalled();
+      expect(updateMetaMetricsTraits).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch candidate SID when subscriptionId is null', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(() => async () => null);
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(setCandidateSubscriptionId).not.toHaveBeenCalled();
+      expect(updateMetaMetricsTraits).not.toHaveBeenCalled();
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).not.toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+  });
+});

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -1,0 +1,196 @@
+import { useCallback, useState, useContext, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import {
+  getMultichainAccountsByWalletId,
+  getWalletIdAndNameByAccountAddress,
+  getSelectedAccountGroup,
+  getInternalAccountsFromGroupById,
+} from '../../selectors/multichain-accounts/account-tree';
+import { setCandidateSubscriptionId } from '../../ducks/rewards';
+import { getSelectedAccount } from '../../selectors';
+import { MetaMetricsContext } from '../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+  MetaMetricsUserTrait,
+} from '../../../shared/constants/metametrics';
+import {
+  rewardsOptIn,
+  rewardsLinkAccountsToSubscriptionCandidate,
+  updateMetaMetricsTraits,
+} from '../../store/actions';
+import { handleRewardsErrorMessage } from '../../components/app/rewards/utils/handleRewardsErrorMessage';
+import { useI18nContext } from '../useI18nContext';
+import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
+
+export type UseOptinResult = {
+  /**
+   * Function to initiate the optin process
+   */
+  optin: (referralCode?: string) => Promise<void>;
+
+  /**
+   * Loading state for optin operation
+   */
+  optinLoading: boolean;
+  /**
+   * Error message from optin process
+   */
+  optinError: string | null;
+  /**
+   * Function to clear the optin error
+   */
+  clearOptinError: () => void;
+};
+
+export const useOptIn = (): UseOptinResult => {
+  const [optinError, setOptinError] = useState<string | null>(null);
+  const dispatch = useDispatch();
+  const [optinLoading, setOptinLoading] = useState<boolean>(false);
+  const trackEvent = useContext(MetaMetricsContext);
+  const t = useI18nContext();
+  const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
+  const selectedAccount = useSelector(getSelectedAccount);
+  const { id: walletId } = useSelector((state) =>
+    getWalletIdAndNameByAccountAddress(state, selectedAccount.address),
+  ) || { walletId: undefined };
+
+  const accountGroupsByWallet = useSelector((state: MultichainAccountsState) =>
+    walletId
+      ? getMultichainAccountsByWalletId(state, walletId as AccountWalletId)
+      : {},
+  );
+
+  // Link the first account group in the wallet if it's not the selected account group.
+  const sideEffectAccountGroupIdToLink = useMemo(
+    () =>
+      accountGroupsByWallet ? Object.keys(accountGroupsByWallet)[0] : undefined,
+    [accountGroupsByWallet],
+  );
+
+  // Get accounts for side effect account group
+  const sideEffectAccounts = useSelector((state) =>
+    sideEffectAccountGroupIdToLink
+      ? getInternalAccountsFromGroupById(
+          state,
+          sideEffectAccountGroupIdToLink as AccountGroupId,
+        )
+      : [],
+  );
+
+  // Get accounts for active (selected) account group
+  const activeGroupAccounts = useSelector((state) =>
+    selectedAccountGroupId
+      ? getInternalAccountsFromGroupById(
+          state,
+          selectedAccountGroupId as AccountGroupId,
+        )
+      : [],
+  );
+
+  const handleOptIn = useCallback(
+    async (referralCode?: string) => {
+      const referred = Boolean(referralCode);
+      const metricsProps = {
+        referred,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        referral_code_used: referralCode,
+      };
+      trackEvent({
+        category: MetaMetricsEventCategory.Rewards,
+        event: MetaMetricsEventName.RewardsOptInStarted,
+        properties: metricsProps,
+      });
+
+      let subscriptionId: string | null = null;
+
+      try {
+        setOptinLoading(true);
+        setOptinError(null);
+
+        // First, opt in with side effect accounts
+        const accountsToOptIn =
+          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
+            ? sideEffectAccounts
+            : activeGroupAccounts;
+
+        const accountsToLinkAfterOptIn =
+          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
+            ? activeGroupAccounts
+            : sideEffectAccounts;
+
+        subscriptionId = (await dispatch(
+          rewardsOptIn({ accounts: accountsToOptIn, referralCode }),
+        )) as unknown as string | null;
+
+        if (subscriptionId) {
+          if (accountsToLinkAfterOptIn.length > 0) {
+            try {
+              await dispatch(
+                rewardsLinkAccountsToSubscriptionCandidate(
+                  accountsToLinkAfterOptIn,
+                ),
+              );
+            } catch {
+              // Failed to link active group accounts.
+            }
+          }
+
+          trackEvent({
+            category: MetaMetricsEventCategory.Rewards,
+            event: MetaMetricsEventName.RewardsOptInCompleted,
+            properties: metricsProps,
+          });
+
+          // Update user traits
+          try {
+            await dispatch(
+              updateMetaMetricsTraits({
+                [MetaMetricsUserTrait.HasRewardsOptedIn]: 'on',
+                ...(referralCode && {
+                  [MetaMetricsUserTrait.RewardsReferred]: true,
+                  [MetaMetricsUserTrait.RewardsReferralCodeUsed]: referralCode,
+                }),
+              }),
+            );
+          } catch {
+            // Silently fail - traits update should not block opt-in
+          }
+        }
+      } catch (error) {
+        trackEvent({
+          category: MetaMetricsEventCategory.Rewards,
+          event: MetaMetricsEventName.RewardsOptInFailed,
+          properties: metricsProps,
+        });
+
+        const errorMessage = handleRewardsErrorMessage(error, t);
+        setOptinError(errorMessage);
+      }
+
+      if (subscriptionId) {
+        dispatch(setCandidateSubscriptionId(subscriptionId));
+      }
+
+      setOptinLoading(false);
+    },
+    [
+      trackEvent,
+      sideEffectAccountGroupIdToLink,
+      sideEffectAccounts,
+      activeGroupAccounts,
+      dispatch,
+      t,
+    ],
+  );
+
+  const clearOptinError = useCallback(() => setOptinError(null), []);
+
+  return {
+    optin: handleOptIn,
+    optinLoading,
+    optinError,
+    clearOptinError,
+  };
+};

--- a/ui/hooks/rewards/useValidateReferralCode.test.tsx
+++ b/ui/hooks/rewards/useValidateReferralCode.test.tsx
@@ -1,0 +1,178 @@
+import { act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers';
+import { useValidateReferralCode } from './useValidateReferralCode';
+
+jest.useFakeTimers();
+
+jest.mock('../../store/actions', () => ({
+  validateRewardsReferralCode: jest.fn(() => async () => true),
+}));
+
+const { validateRewardsReferralCode } = jest.requireMock(
+  '../../store/actions',
+) as { validateRewardsReferralCode: jest.Mock };
+
+describe('useValidateReferralCode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.setSystemTime(0);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns initial state for empty initialValue', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode(),
+      {},
+    );
+
+    expect(result.current.referralCode).toBe('');
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isUnknownError).toBe(false);
+    expect(validateRewardsReferralCode).not.toHaveBeenCalled();
+  });
+
+  it('does not validate while code length is less than 6', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode(),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abc');
+    });
+
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(validateRewardsReferralCode).not.toHaveBeenCalled();
+  });
+
+  it('validates successfully when code length is >= 6 and sets isValid=true', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abc123');
+    });
+
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValid).toBe(true);
+    // Uppercases and trims input before dispatching
+    const calls = validateRewardsReferralCode.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('ABC123');
+  });
+
+  it('sets isValid=false when validation returns false', async () => {
+    validateRewardsReferralCode.mockReturnValueOnce(async () => false);
+
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abcdef');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValid).toBe(false);
+  });
+
+  it('sets isUnknownError=true when validation throws', async () => {
+    validateRewardsReferralCode.mockImplementationOnce(() => async () => {
+      throw new Error('boom');
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abcdef');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.isUnknownError).toBe(true);
+  });
+
+  it('validateCode returns messages and toggles unknown error on thrown error', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode(),
+      {},
+    );
+
+    // Success
+    let msg = await result.current.validateCode('abcdef');
+    expect(msg).toBe('');
+
+    // Invalid
+    validateRewardsReferralCode.mockReturnValueOnce(async () => false);
+    msg = await result.current.validateCode('abcdef');
+    expect(msg).toBe('Invalid code');
+
+    // Unknown error
+    validateRewardsReferralCode.mockImplementationOnce(() => async () => {
+      throw new Error('boom');
+    });
+    msg = await result.current.validateCode('abcdef');
+    expect(msg).toBe('Unknown error');
+    expect(result.current.isUnknownError).toBe(true);
+  });
+
+  it('initialValue triggers validation and respects debounce', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('abc123', 500),
+      {},
+    );
+
+    // After mount, initialValue is set and validation starts
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+    expect(result.current.isValid).toBe(true);
+    const calls = validateRewardsReferralCode.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('ABC123');
+  });
+});

--- a/ui/hooks/rewards/useValidateReferralCode.ts
+++ b/ui/hooks/rewards/useValidateReferralCode.ts
@@ -1,0 +1,127 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { debounce } from 'lodash';
+import { useDispatch } from 'react-redux';
+import { validateRewardsReferralCode } from '../../store/actions';
+
+export type UseValidateReferralCodeResult = {
+  /**
+   * Current referral code value
+   */
+  referralCode: string;
+  /**
+   * Function to update the referral code and trigger validation
+   */
+  setReferralCode: (code: string) => void;
+  /**
+   * Function to validate a referral code without setting it
+   */
+  validateCode: (code: string) => Promise<string>;
+  /**
+   * Whether validation is currently in progress (during debounce period)
+   */
+  isValidating: boolean;
+  /**
+   * Whether the current referral code is valid
+   */
+  isValid: boolean;
+
+  /**
+   * Whether an unknown error occurred while validating the referral code
+   */
+  isUnknownError: boolean;
+};
+
+/**
+ * Custom hook for validating referral codes with debounced validation.
+ * Validates 6-character base32 encoded strings following RFC 4648 standard.
+ *
+ * @param initialValue - Initial referral code value (default: '')
+ * @param debounceMs - Debounce delay in milliseconds (default: 300)
+ * @returns UseValidateReferralCodeResult object with validation state and methods
+ */
+export const useValidateReferralCode = (
+  initialValue: string = '',
+  debounceMs: number = 1000,
+): UseValidateReferralCodeResult => {
+  const [referralCode, setReferralCodeState] = useState(initialValue);
+  const [error, setError] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [unknownError, setUnknownError] = useState(false);
+  const hasInitialized = useRef(false);
+  const dispatch = useDispatch();
+
+  const validateCode = useCallback(
+    async (code: string): Promise<string> => {
+      try {
+        const valid = await dispatch(validateRewardsReferralCode(code));
+
+        if (!valid) {
+          return 'Invalid code';
+        }
+        return '';
+      } catch (err) {
+        setUnknownError(true);
+        return 'Unknown error';
+      }
+    },
+    [dispatch],
+  );
+
+  // Debounced validation
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedValidation = useCallback(
+    debounce(async (code: string) => {
+      setUnknownError(false);
+      const validationError = await validateCode(code);
+      setError(validationError);
+      setIsValidating(false);
+    }, debounceMs),
+    [debounceMs, validateCode],
+  );
+
+  // Function to update referral code and trigger validation
+  const setReferralCode = useCallback(
+    (code: string) => {
+      const refinedCode = code.trim().toUpperCase();
+      setReferralCodeState(refinedCode);
+      // If not at minLength, do NOT validate; keep referral code state but clear error/validating state
+      if (refinedCode.length < 6) {
+        debouncedValidation.cancel();
+        setIsValidating(false);
+        setError('minLength 6 characters');
+        return;
+      }
+      if (refinedCode) {
+        setIsValidating(true);
+      }
+      debouncedValidation(refinedCode);
+    },
+    [debouncedValidation],
+  );
+
+  useEffect(() => {
+    if (!hasInitialized.current) {
+      setReferralCode(initialValue);
+      hasInitialized.current = true;
+    } else if (initialValue !== referralCode) {
+      // Only update if initialValue actually changed from current referralCode
+      setReferralCode(initialValue);
+    }
+    // only run on mount or when initialValue changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialValue]);
+
+  // Cleanup debounced function on unmount
+  useEffect(() => () => debouncedValidation.cancel(), [debouncedValidation]);
+
+  const isValid = Boolean(referralCode) && !error && !isValidating;
+
+  return {
+    referralCode,
+    setReferralCode,
+    validateCode,
+    isValidating,
+    isValid,
+    isUnknownError: unknownError,
+  };
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-268
Part 5 of https://github.com/MetaMask/metamask-extension/pull/36827 introduces new rewards hooks
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37917?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces four rewards-related React hooks with Redux/metrics integration and comprehensive tests.
> 
> - **Hooks (rewards)**:
>   - `ui/hooks/rewards/useGeoRewardsMetadata`:
>     - Fetches `RewardsGeoMetadata` on mount (conditional via `enabled`), manages loading/error/reset, dedupes concurrent fetches.
>   - `ui/hooks/rewards/useLinkAccountGroup`:
>     - Links eligible accounts in an `AccountGroupId` to a subscription candidate; checks support/status, emits MetaMetrics started/completed/failed events, returns per-address results with loading/error state.
>   - `ui/hooks/rewards/useOptIn`:
>     - Orchestrates opt-in (with optional referral), selects accounts (side-effect vs active group), links additional accounts post opt-in, tracks metrics, updates user traits, sets candidate subscription ID, handles errors.
>   - `ui/hooks/rewards/useValidateReferralCode`:
>     - Debounced referral code validation (`validateRewardsReferralCode`), exposes `setReferralCode`/`validateCode`, and `isValid`/`isValidating`/unknown-error state.
> - **Tests**:
>   - Adds thorough unit tests for all hooks covering success, loading, error, dedupe, metrics, and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8c2ba8611d84fb00c311f8f37238ca98dd8d8b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->