### PR TITLE
feat: rewards onboarding components

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5576,6 +5576,12 @@
   "reward": {
     "message": "Reward"
   },
+  "rewardsAuthFailDescription": {
+    "message": "An unknown error occurred while authenticating this account with the rewards program. Please try again later."
+  },
+  "rewardsAuthFailTitle": {
+    "message": "Unknown Error."
+  },
   "rewardsErrorMessagesAccountAlreadyRegistered": {
     "message": "This account is already registered with another Rewards profile. Please switch account to continue."
   },
@@ -5590,6 +5596,102 @@
   },
   "rewardsErrorMessagesSomethingWentWrong": {
     "message": "Something went wrong. Please try again shortly."
+  },
+  "rewardsOnboardingIntroDescription": {
+    "message": "Earn points for your activity. \nAdvance through levels to unlock rewards."
+  },
+  "rewardsOnboardingIntroGeoCheckFailedDescription": {
+    "message": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again."
+  },
+  "rewardsOnboardingIntroGeoCheckFailedTitle": {
+    "message": "Cannot determine opt-in eligibility"
+  },
+  "rewardsOnboardingIntroGeoCheckRetry": {
+    "message": "Retry"
+  },
+  "rewardsOnboardingIntroHardwareWalletDescription": {
+    "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
+  },
+  "rewardsOnboardingIntroHardwareWalletTitle": {
+    "message": "Account not supported"
+  },
+  "rewardsOnboardingIntroRewardsAuthFailRetry": {
+    "message": "Retry"
+  },
+  "rewardsOnboardingIntroStepConfirm": {
+    "message": "Claim 250 points"
+  },
+  "rewardsOnboardingIntroStepSkip": {
+    "message": "Not now"
+  },
+  "rewardsOnboardingIntroTitle": {
+    "message": "Rewards are here"
+  },
+  "rewardsOnboardingIntroUnsupportedRegionDescription": {
+    "message": "Rewards are not supported in your region yet. We are working on expanding access, so check back later."
+  },
+  "rewardsOnboardingIntroUnsupportedRegionTitle": {
+    "message": "Region not supported"
+  },
+  "rewardsOnboardingStep1Description": {
+    "message": "Every swap and perps trade you make in MetaMask gets you closer to rewards. Add your accounts and watch your points add up."
+  },
+  "rewardsOnboardingStep1Title": {
+    "message": "Earn points on every trade"
+  },
+  "rewardsOnboardingStep2Description": {
+    "message": "Hit points milestones to get perks like 50% off perps fees, exclusive tokens, and a free MetaMask Metal Card."
+  },
+  "rewardsOnboardingStep2Title": {
+    "message": "Level up for bigger perks"
+  },
+  "rewardsOnboardingStep3Description": {
+    "message": "You can earn points in the extension, but you’ll need the mobile app to trade perps, track your progress, and redeem rewards."
+  },
+  "rewardsOnboardingStep3Title": {
+    "message": "Unlock rewards on mobile"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer1": {
+    "message": "By selecting 'Claim Points', you agree to the MetaMask Rewards "
+  },
+  "rewardsOnboardingStep4LegalDisclaimer2": {
+    "message": "Supplemental Terms of Use and Privacy Notice"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer3": {
+    "message": ". We'll track onchain activity to reward you automatically –"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer4": {
+    "message": "learn more"
+  },
+  "rewardsOnboardingStep4OptInError": {
+    "message": "Opt-in failed"
+  },
+  "rewardsOnboardingStep4ReferralCodeError": {
+    "message": "Invalid referral code"
+  },
+  "rewardsOnboardingStep4ReferralCodeInput": {
+    "message": "Use a referral code to earn 250 points"
+  },
+  "rewardsOnboardingStep4ReferralCodePlaceholder": {
+    "message": "Referral code (optional)"
+  },
+  "rewardsOnboardingStep4ReferralCodeUnknownError": {
+    "message": "Referral code couldn’t be validated."
+  },
+  "rewardsOnboardingStep4ReferralCodeUnknownErrorDescription": {
+    "message": "Check your connection and try again."
+  },
+  "rewardsOnboardingStep4Title": {
+    "message": "You'll earn 250 points when you sign up!"
+  },
+  "rewardsOnboardingStep4TitleWithReferralCode": {
+    "message": "You'll earn 500 points when you sign up with a code!"
+  },
+  "rewardsOnboardingStepConfirm": {
+    "message": "Next"
+  },
+  "rewardsOnboardingStepOptIn": {
+    "message": "Claim points"
   },
   "rewardsPointsBalance": {
     "message": "$1 points",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5576,6 +5576,12 @@
   "reward": {
     "message": "Reward"
   },
+  "rewardsAuthFailDescription": {
+    "message": "An unknown error occurred while authenticating this account with the rewards program. Please try again later."
+  },
+  "rewardsAuthFailTitle": {
+    "message": "Unknown Error."
+  },
   "rewardsErrorMessagesAccountAlreadyRegistered": {
     "message": "This account is already registered with another Rewards profile. Please switch account to continue."
   },
@@ -5590,6 +5596,102 @@
   },
   "rewardsErrorMessagesSomethingWentWrong": {
     "message": "Something went wrong. Please try again shortly."
+  },
+  "rewardsOnboardingIntroDescription": {
+    "message": "Earn points for your activity. \nAdvance through levels to unlock rewards."
+  },
+  "rewardsOnboardingIntroGeoCheckFailedDescription": {
+    "message": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again."
+  },
+  "rewardsOnboardingIntroGeoCheckFailedTitle": {
+    "message": "Cannot determine opt-in eligibility"
+  },
+  "rewardsOnboardingIntroGeoCheckRetry": {
+    "message": "Retry"
+  },
+  "rewardsOnboardingIntroHardwareWalletDescription": {
+    "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
+  },
+  "rewardsOnboardingIntroHardwareWalletTitle": {
+    "message": "Account not supported"
+  },
+  "rewardsOnboardingIntroRewardsAuthFailRetry": {
+    "message": "Retry"
+  },
+  "rewardsOnboardingIntroStepConfirm": {
+    "message": "Claim 250 points"
+  },
+  "rewardsOnboardingIntroStepSkip": {
+    "message": "Not now"
+  },
+  "rewardsOnboardingIntroTitle": {
+    "message": "Rewards are here"
+  },
+  "rewardsOnboardingIntroUnsupportedRegionDescription": {
+    "message": "Rewards are not supported in your region yet. We are working on expanding access, so check back later."
+  },
+  "rewardsOnboardingIntroUnsupportedRegionTitle": {
+    "message": "Region not supported"
+  },
+  "rewardsOnboardingStep1Description": {
+    "message": "Every swap and perps trade you make in MetaMask gets you closer to rewards. Add your accounts and watch your points add up."
+  },
+  "rewardsOnboardingStep1Title": {
+    "message": "Earn points on every trade"
+  },
+  "rewardsOnboardingStep2Description": {
+    "message": "Hit points milestones to get perks like 50% off perps fees, exclusive tokens, and a free MetaMask Metal Card."
+  },
+  "rewardsOnboardingStep2Title": {
+    "message": "Level up for bigger perks"
+  },
+  "rewardsOnboardingStep3Description": {
+    "message": "You can earn points in the extension, but you’ll need the mobile app to trade perps, track your progress, and redeem rewards."
+  },
+  "rewardsOnboardingStep3Title": {
+    "message": "Unlock rewards on mobile"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer1": {
+    "message": "By selecting 'Claim Points', you agree to the MetaMask Rewards "
+  },
+  "rewardsOnboardingStep4LegalDisclaimer2": {
+    "message": "Supplemental Terms of Use and Privacy Notice"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer3": {
+    "message": ". We'll track onchain activity to reward you automatically –"
+  },
+  "rewardsOnboardingStep4LegalDisclaimer4": {
+    "message": "learn more"
+  },
+  "rewardsOnboardingStep4OptInError": {
+    "message": "Opt-in failed"
+  },
+  "rewardsOnboardingStep4ReferralCodeError": {
+    "message": "Invalid referral code"
+  },
+  "rewardsOnboardingStep4ReferralCodeInput": {
+    "message": "Use a referral code to earn 250 points"
+  },
+  "rewardsOnboardingStep4ReferralCodePlaceholder": {
+    "message": "Referral code (optional)"
+  },
+  "rewardsOnboardingStep4ReferralCodeUnknownError": {
+    "message": "Referral code couldn’t be validated."
+  },
+  "rewardsOnboardingStep4ReferralCodeUnknownErrorDescription": {
+    "message": "Check your connection and try again."
+  },
+  "rewardsOnboardingStep4Title": {
+    "message": "You'll earn 250 points when you sign up!"
+  },
+  "rewardsOnboardingStep4TitleWithReferralCode": {
+    "message": "You'll earn 500 points when you sign up with a code!"
+  },
+  "rewardsOnboardingStepConfirm": {
+    "message": "Next"
+  },
+  "rewardsOnboardingStepOptIn": {
+    "message": "Claim points"
   },
   "rewardsPointsBalance": {
     "message": "$1 points",

--- a/ui/components/app/rewards/RewardsErrorBanner.test.tsx
+++ b/ui/components/app/rewards/RewardsErrorBanner.test.tsx
@@ -1,0 +1,116 @@
+import React, { Ref } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ButtonProps } from '@metamask/design-system-react';
+import RewardsErrorBanner from './RewardsErrorBanner';
+
+// Partially mock the design-system Button to expose `isLoading` for assertions,
+// while keeping other components unchanged.
+jest.mock('@metamask/design-system-react', () => {
+  const actual = jest.requireActual('@metamask/design-system-react');
+  const ReactLib = jest.requireActual('react');
+
+  const MockButton = ReactLib.forwardRef(
+    (
+      { children, isLoading, onClick, ...rest }: ButtonProps,
+      ref: Ref<HTMLButtonElement>,
+    ) => (
+      <button
+        {...rest}
+        // Provide a stable attribute to assert loading state
+        data-loading={isLoading ? 'true' : 'false'}
+        ref={ref}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    ),
+  );
+
+  return {
+    ...actual,
+    Button: MockButton,
+  };
+});
+
+describe('RewardsErrorBanner', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title and description', () => {
+    render(
+      <RewardsErrorBanner
+        title="Error Title"
+        description="Something went wrong"
+      />,
+    );
+
+    expect(screen.getByTestId('rewards-error-banner')).toBeInTheDocument();
+    expect(screen.getByText('Error Title')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('does not render action buttons when no handlers provided', () => {
+    render(<RewardsErrorBanner title="T" description="D" />);
+    // No buttons should be present if both onDismiss and onConfirm are undefined
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders Dismiss button and calls onDismiss when clicked', () => {
+    const onDismiss = jest.fn();
+    render(
+      <RewardsErrorBanner title="T" description="D" onDismiss={onDismiss} />,
+    );
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    expect(dismissButton).toBeInTheDocument();
+
+    fireEvent.click(dismissButton);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Confirm button with default label and calls onConfirm', () => {
+    const onConfirm = jest.fn();
+    render(
+      <RewardsErrorBanner title="T" description="D" onConfirm={onConfirm} />,
+    );
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmButton).toBeInTheDocument();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Confirm button with custom label when provided', () => {
+    const onConfirm = jest.fn();
+    render(
+      <RewardsErrorBanner
+        title="T"
+        description="D"
+        onConfirm={onConfirm}
+        confirmButtonLabel="Proceed"
+      />,
+    );
+
+    const confirmButton = screen.getByRole('button', { name: 'Proceed' });
+    expect(confirmButton).toBeInTheDocument();
+  });
+
+  it('sets loading state on Confirm button when onConfirmLoading is true', () => {
+    const onConfirm = jest.fn();
+    render(
+      <RewardsErrorBanner
+        title="T"
+        description="D"
+        onConfirm={onConfirm}
+        onConfirmLoading
+      />,
+    );
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmButton).toBeInTheDocument();
+    // Assert the mocked Button exposes loading state via data-loading
+    expect(confirmButton).toHaveAttribute('data-loading', 'true');
+  });
+});

--- a/ui/components/app/rewards/RewardsErrorBanner.tsx
+++ b/ui/components/app/rewards/RewardsErrorBanner.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  Button,
+  Icon,
+  TextVariant,
+  BoxFlexDirection,
+  BoxAlignItems,
+  ButtonVariant,
+  ButtonSize,
+  IconName,
+  IconSize,
+  FontWeight,
+} from '@metamask/design-system-react';
+
+export type RewardsErrorBannerProps = {
+  title: string;
+  description: string;
+  onDismiss?: () => void;
+  onConfirm?: () => void;
+  confirmButtonLabel?: string;
+  onConfirmLoading?: boolean;
+};
+
+const RewardsErrorBanner: React.FC<RewardsErrorBannerProps> = ({
+  title,
+  description,
+  onDismiss,
+  onConfirm,
+  confirmButtonLabel,
+  onConfirmLoading,
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Start}
+    className="bg-error-muted rounded-2xl p-4 gap-4 w-full"
+    data-testid="rewards-error-banner"
+  >
+    {/* Column 1: Error Icon */}
+    <Box className="w-8 h-8">
+      <Icon
+        name={IconName.Error}
+        size={IconSize.Xl}
+        className="text-error-default"
+      />
+    </Box>
+
+    {/* Column 2: Content */}
+    <Box className="flex flex-col gap-2">
+      <Box className="flex flex-col gap-2">
+        {/* Title */}
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
+          {title}
+        </Text>
+
+        {/* Description */}
+        <Text variant={TextVariant.BodyMd}>{description}</Text>
+      </Box>
+
+      {/* Button Section */}
+      {(onDismiss || onConfirm) && (
+        <Box flexDirection={BoxFlexDirection.Row} className="gap-2">
+          {onDismiss && (
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Md}
+              onClick={onDismiss}
+              className="flex-1"
+            >
+              Dismiss
+            </Button>
+          )}
+          {onConfirm && (
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Md}
+              onClick={onConfirm}
+              isLoading={onConfirmLoading}
+              className="flex-1"
+            >
+              {confirmButtonLabel || 'Confirm'}
+            </Button>
+          )}
+        </Box>
+      )}
+    </Box>
+  </Box>
+);
+
+export default RewardsErrorBanner;

--- a/ui/components/app/rewards/RewardsErrorToast.test.tsx
+++ b/ui/components/app/rewards/RewardsErrorToast.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { setErrorToast } from '../../../ducks/rewards';
+import RewardsErrorToast from './RewardsErrorToast';
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+  return {
+    ...actual,
+    useSelector: jest.fn(),
+    useDispatch: jest.fn(),
+  };
+});
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+
+describe('RewardsErrorToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    mockUseSelector.mockReturnValue({
+      isOpen: false,
+      title: '',
+      description: '',
+      actionText: '',
+      onActionClick: undefined,
+    });
+
+    render(<RewardsErrorToast />);
+    expect(screen.queryByTestId('rewards-error-toast')).toBeNull();
+  });
+
+  it('renders ToastContainer and content when open', () => {
+    const onActionClick = jest.fn();
+    const mockDispatch = jest.fn();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+
+    const title = 'Something went wrong';
+    const description = 'Please try again later';
+    const actionText = 'Retry';
+
+    mockUseSelector.mockReturnValue({
+      isOpen: true,
+      title,
+      description,
+      actionText,
+      onActionClick,
+    });
+
+    render(<RewardsErrorToast />);
+
+    expect(screen.getByTestId('rewards-error-toast')).toBeInTheDocument();
+    expect(screen.getByText(title)).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+    expect(screen.getByText(actionText)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(actionText));
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches setErrorToast to close when close button is clicked', () => {
+    const onActionClick = jest.fn();
+    const mockDispatch = jest.fn();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+
+    const title = 'Critical error';
+    const description = 'Operation failed';
+    const actionText = 'Details';
+
+    mockUseSelector.mockReturnValue({
+      isOpen: true,
+      title,
+      description,
+      actionText,
+      onActionClick,
+    });
+
+    render(<RewardsErrorToast />);
+
+    const closeButton = document.querySelector(
+      '.mm-banner-base__close-button',
+    ) as HTMLElement | null;
+    expect(closeButton).toBeTruthy();
+    if (closeButton) {
+      fireEvent.click(closeButton);
+    }
+
+    const expectedAction = setErrorToast({
+      isOpen: false,
+      title,
+      description,
+      actionText,
+      onActionClick,
+    });
+    expect(mockDispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('does not render action button when actionText is not provided', () => {
+    mockUseSelector.mockReturnValue({
+      isOpen: true,
+      title: 'Error',
+      description: 'No action available',
+      actionText: undefined,
+      onActionClick: undefined,
+    });
+
+    render(<RewardsErrorToast />);
+    expect(screen.getByTestId('rewards-error-toast')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry/iu })).toBeNull();
+  });
+});

--- a/ui/components/app/rewards/RewardsErrorToast.tsx
+++ b/ui/components/app/rewards/RewardsErrorToast.tsx
@@ -1,0 +1,46 @@
+import { useDispatch, useSelector } from 'react-redux';
+import React, { useCallback } from 'react';
+import { Box } from '@metamask/design-system-react';
+import { Icon, IconName } from '../../component-library';
+import { IconColor } from '../../../helpers/constants/design-system';
+import { selectErrorToast } from '../../../ducks/rewards/selectors';
+import { setErrorToast } from '../../../ducks/rewards';
+import { Toast } from '../../multichain/toast/toast';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default function RewardsErrorToast() {
+  const { isOpen, title, description, actionText, onActionClick } =
+    useSelector(selectErrorToast);
+  const dispatch = useDispatch();
+
+  const handleClose = useCallback(() => {
+    dispatch(
+      setErrorToast({
+        isOpen: false,
+        title,
+        description,
+        actionText,
+        onActionClick,
+      }),
+    );
+  }, [actionText, description, dispatch, onActionClick, title]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Box data-testid="rewards-error-toast">
+      <Toast
+        startAdornment={
+          <Icon name={IconName.Danger} color={IconColor.errorDefault} />
+        }
+        text={title}
+        description={description}
+        actionText={actionText}
+        onActionClick={onActionClick}
+        onClose={handleClose}
+      />
+    </Box>
+  );
+}

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
@@ -1,0 +1,524 @@
+import React, { Ref } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ButtonProps } from '@metamask/design-system-react';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import OnboardingIntroStep from './OnboardingIntroStep';
+
+// Mock i18n to return the key for readability in assertions
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+// Partially mock the design-system Button to expose `isLoading` and `isDisabled` for assertions
+jest.mock('@metamask/design-system-react', () => {
+  const actual = jest.requireActual('@metamask/design-system-react');
+  const ReactLib = jest.requireActual('react');
+
+  const MockButton = ReactLib.forwardRef(
+    (
+      { children, isLoading, isDisabled, onClick, ...rest }: ButtonProps,
+      ref: Ref<HTMLButtonElement>,
+    ) => (
+      <button
+        {...rest}
+        // Provide stable attributes to assert loading and disabled states
+        data-loading={isLoading ? 'true' : 'false'}
+        disabled={isDisabled}
+        ref={ref}
+        onClick={onClick}
+        className={`${rest.className || ''} ${isLoading ? 'mm-button-base--loading' : ''} ${isDisabled ? 'mm-button-base--disabled' : ''}`}
+      >
+        {children}
+      </button>
+    ),
+  );
+
+  return {
+    ...actual,
+    Button: MockButton,
+  };
+});
+
+// Mock react-redux hooks
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+// Mock rewards actions to capture payloads dispatched
+jest.mock('../../../../ducks/rewards', () => ({
+  setErrorToast: jest.fn((payload) => ({ type: 'SET_ERROR_TOAST', payload })),
+  setOnboardingActiveStep: jest.fn((step) => ({
+    type: 'SET_ONBOARDING_STEP',
+    step,
+  })),
+  setOnboardingModalOpen: jest.fn((open) => ({ type: 'SET_MODAL_OPEN', open })),
+}));
+
+// Mock selectors to avoid brittle sequencing of useSelector calls
+jest.mock('../../../../ducks/rewards/selectors', () => ({
+  selectOptinAllowedForGeo: jest.fn(),
+  selectOptinAllowedForGeoLoading: jest.fn(),
+  selectOptinAllowedForGeoError: jest.fn(),
+  selectCandidateSubscriptionId: jest.fn(),
+}));
+
+// Mock hardware wallet selector
+jest.mock('../../../../../shared/modules/selectors', () => ({
+  isHardwareWallet: jest.fn(),
+}));
+
+// Mock shared storage helper to avoid side effects from useEffect
+jest.mock('../../../../../shared/lib/storage-helpers', () => ({
+  setStorageItem: jest.fn(() => Promise.resolve()),
+}));
+
+// Mock useAppSelector to control rewardsActiveAccount subscription id
+jest.mock('../../../../store/store', () => ({
+  useAppSelector: jest.fn(),
+}));
+
+// Mock geo rewards metadata hook to supply a retry handler
+jest.mock('../../../../hooks/rewards/useGeoRewardsMetadata', () => ({
+  useGeoRewardsMetadata: jest.fn(),
+}));
+
+// Mock candidate subscription ID hook to supply a retry handler
+jest.mock('../../../../hooks/rewards/useCandidateSubscriptionId', () => ({
+  useCandidateSubscriptionId: jest.fn(),
+}));
+
+describe('OnboardingIntroStep', () => {
+  const { useSelector, useDispatch } = jest.requireMock('react-redux');
+  const { setErrorToast, setOnboardingActiveStep, setOnboardingModalOpen } =
+    jest.requireMock('../../../../ducks/rewards');
+  const {
+    selectOptinAllowedForGeo,
+    selectOptinAllowedForGeoLoading,
+    selectOptinAllowedForGeoError,
+    selectCandidateSubscriptionId,
+  } = jest.requireMock('../../../../ducks/rewards/selectors');
+  const { isHardwareWallet } = jest.requireMock(
+    '../../../../../shared/modules/selectors',
+  );
+  const { useAppSelector } = jest.requireMock('../../../../store/store');
+  const { useGeoRewardsMetadata } = jest.requireMock(
+    '../../../../hooks/rewards/useGeoRewardsMetadata',
+  );
+  const { useCandidateSubscriptionId } = jest.requireMock(
+    '../../../../hooks/rewards/useCandidateSubscriptionId',
+  );
+
+  const dispatchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useDispatch as jest.Mock).mockReturnValue(dispatchMock);
+    // Ensure useSelector calls the provided selector function without using any
+    (useSelector as jest.Mock).mockImplementation(
+      (selector: (state: unknown) => unknown) => selector({} as unknown),
+    );
+    // Default: no active subscription id
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+    // Default geo metadata hook with a retry function
+    (useGeoRewardsMetadata as jest.Mock).mockReturnValue({
+      fetchGeoRewardsMetadata: jest.fn(),
+    });
+    // Default candidate subscription ID hook with a retry function
+    (useCandidateSubscriptionId as jest.Mock).mockReturnValue({
+      fetchCandidateSubscriptionId: jest.fn(),
+    });
+
+    // Default selector returns
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+  });
+
+  it('renders title, description, image, and action buttons', () => {
+    // Defaults from beforeEach are sufficient for rendering
+
+    render(<OnboardingIntroStep />);
+
+    expect(
+      screen.getByTestId('onboarding-intro-container'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-intro-title'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('rewardsOnboardingIntroTitle')).toBeInTheDocument();
+    expect(
+      screen.getByText('rewardsOnboardingIntroDescription'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-intro-image'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('intro-image')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-intro-actions'),
+    ).toBeInTheDocument();
+    // Buttons available with translated labels
+    expect(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepSkip' }),
+    ).toBeInTheDocument();
+  });
+
+  it('on confirm: shows error toast for candidate subscription ID fetch failure and includes retry handler', () => {
+    const fetchCandidateSubscriptionId = jest.fn();
+    (useCandidateSubscriptionId as jest.Mock).mockReturnValue({
+      fetchCandidateSubscriptionId,
+    });
+
+    // Trigger the first error branch: candidate subscription ID fetch failed
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('error');
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    );
+
+    expect(setErrorToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        title: 'rewardsAuthFailTitle',
+        description: 'rewardsAuthFailDescription',
+        actionText: 'rewardsOnboardingIntroRewardsAuthFailRetry',
+        onActionClick: fetchCandidateSubscriptionId,
+      }),
+    );
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
+    );
+  });
+
+  it('on confirm: shows error toast for geo check failure and includes retry handler', () => {
+    const fetchGeoRewardsMetadata = jest.fn();
+    (useGeoRewardsMetadata as jest.Mock).mockReturnValue({
+      fetchGeoRewardsMetadata,
+    });
+
+    // Trigger the geo check failed branch (only when no active subscription id)
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(true);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    );
+
+    expect(setErrorToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        title: 'rewardsOnboardingIntroGeoCheckFailedTitle',
+        description: 'rewardsOnboardingIntroGeoCheckFailedDescription',
+        actionText: 'rewardsOnboardingIntroGeoCheckRetry',
+        onActionClick: fetchGeoRewardsMetadata,
+      }),
+    );
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
+    );
+  });
+
+  it('on confirm: shows error toast for unsupported region', () => {
+    // Trigger the unsupported region branch: opt-in is not allowed
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    );
+
+    expect(setErrorToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        title: 'rewardsOnboardingIntroUnsupportedRegionTitle',
+        description: 'rewardsOnboardingIntroUnsupportedRegionDescription',
+      }),
+    );
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
+    );
+  });
+
+  it('on confirm: shows error toast for hardware wallet usage', () => {
+    // Trigger the hardware wallet branch
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(true);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    );
+
+    expect(setErrorToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        title: 'rewardsOnboardingIntroHardwareWalletTitle',
+        description: 'rewardsOnboardingIntroHardwareWalletDescription',
+      }),
+    );
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
+    );
+  });
+
+  it('on confirm: proceeds to STEP1 when allowed and not hardware wallet', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
+    );
+
+    expect(setOnboardingActiveStep).toHaveBeenCalledWith(OnboardingStep.STEP1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SET_ONBOARDING_STEP',
+        step: OnboardingStep.STEP1,
+      }),
+    );
+  });
+
+  it('on skip: closes the onboarding modal', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+
+    render(<OnboardingIntroStep />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepSkip' }),
+    );
+
+    expect(setOnboardingModalOpen).toHaveBeenCalledWith(false);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_MODAL_OPEN', open: false }),
+    );
+  });
+
+  it('disables confirm button when rewardsActiveAccountSubscriptionId is set', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue('subscription-123');
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('disables confirm button when candidateSubscriptionId is pending', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('pending');
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('disables confirm button when candidateSubscriptionId is retry', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('retry');
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('disables confirm button when optinAllowedForGeoLoading is true', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('shows loading state when optinAllowedForGeoLoading is true', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toHaveClass('mm-button-base--loading');
+  });
+
+  it('shows loading state when candidateSubscriptionId is pending', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('pending');
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toHaveClass('mm-button-base--loading');
+  });
+
+  it('shows loading state when candidateSubscriptionId is retry', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('retry');
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toHaveClass('mm-button-base--loading');
+  });
+
+  it('does not proceed when rewardsActiveAccountSubscriptionId is set and button is clicked', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue('subscription-123');
+
+    render(<OnboardingIntroStep />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'rewardsOnboardingIntroStepConfirm',
+    });
+    expect(confirmButton).toBeDisabled();
+    // Even if we try to click (which shouldn't work when disabled), verify no action
+    fireEvent.click(confirmButton);
+    expect(setOnboardingActiveStep).not.toHaveBeenCalled();
+  });
+
+  it('calls useGeoRewardsMetadata with enabled true when no active subscription and no candidate subscription', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    expect(useGeoRewardsMetadata).toHaveBeenCalledWith({
+      enabled: true,
+    });
+  });
+
+  it('calls useGeoRewardsMetadata with enabled true when no active subscription and candidate subscription is error', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue('error');
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    expect(useGeoRewardsMetadata).toHaveBeenCalledWith({
+      enabled: true,
+    });
+  });
+
+  it('calls useGeoRewardsMetadata with enabled false when active subscription exists', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue('subscription-123');
+
+    render(<OnboardingIntroStep />);
+
+    expect(useGeoRewardsMetadata).toHaveBeenCalledWith({
+      enabled: false,
+    });
+  });
+
+  it('calls useGeoRewardsMetadata with enabled false when candidate subscription exists and is not error', () => {
+    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
+    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
+    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
+    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(
+      'valid-subscription-id',
+    );
+    (isHardwareWallet as jest.Mock).mockReturnValue(false);
+    (useAppSelector as jest.Mock).mockReturnValue(undefined);
+
+    render(<OnboardingIntroStep />);
+
+    expect(useGeoRewardsMetadata).toHaveBeenCalledWith({
+      enabled: false,
+    });
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -1,0 +1,275 @@
+import React, { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontFamily,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import {
+  setErrorToast,
+  setOnboardingActiveStep,
+  setOnboardingModalOpen,
+} from '../../../../ducks/rewards';
+import { ModalBody } from '../../../component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { setStorageItem } from '../../../../../shared/lib/storage-helpers';
+import { REWARDS_GTM_MODAL_SHOWN } from '../utils/constants';
+import {
+  selectCandidateSubscriptionId,
+  selectOptinAllowedForGeo,
+  selectOptinAllowedForGeoError,
+  selectOptinAllowedForGeoLoading,
+} from '../../../../ducks/rewards/selectors';
+import { useGeoRewardsMetadata } from '../../../../hooks/rewards/useGeoRewardsMetadata';
+import { useCandidateSubscriptionId } from '../../../../hooks/rewards/useCandidateSubscriptionId';
+import { useAppSelector } from '../../../../store/store';
+import { isHardwareWallet } from '../../../../../shared/modules/selectors';
+
+/**
+ * OnboardingIntroStep Component
+ *
+ * Main introduction screen for the rewards onboarding flow.
+ * Handles geo validation, account type checking, and navigation to next steps.
+ */
+const OnboardingIntroStep: React.FC = () => {
+  const dispatch = useDispatch();
+  const t = useI18nContext();
+
+  const setHasSeenRewardsIntroModal = useCallback(async () => {
+    await setStorageItem(REWARDS_GTM_MODAL_SHOWN, 'true');
+  }, []);
+
+  useEffect(() => {
+    setHasSeenRewardsIntroModal();
+  }, [setHasSeenRewardsIntroModal]);
+
+  const optinAllowedForGeo = useSelector(selectOptinAllowedForGeo);
+  const optinAllowedForGeoLoading = useSelector(
+    selectOptinAllowedForGeoLoading,
+  );
+  const optinAllowedForGeoError = useSelector(selectOptinAllowedForGeoError);
+  const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
+  const candidateSubscriptionIdError = candidateSubscriptionId === 'error';
+  const rewardsActiveAccountSubscriptionId = useAppSelector(
+    (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
+  );
+
+  const hardwareWalletUsed = useSelector(isHardwareWallet);
+
+  // If we don't know of a subscription id, we need to fetch the geo metadata
+  const { fetchGeoRewardsMetadata } = useGeoRewardsMetadata({
+    enabled:
+      !rewardsActiveAccountSubscriptionId &&
+      (!candidateSubscriptionId || candidateSubscriptionIdError),
+  });
+
+  const { fetchCandidateSubscriptionId } = useCandidateSubscriptionId();
+
+  /**
+   * Handles the confirm/continue button press
+   */
+  const handleNext = useCallback(async () => {
+    // Show error modal if candidate subscription ID fetch failed
+    if (candidateSubscriptionIdError) {
+      dispatch(
+        setErrorToast({
+          isOpen: true,
+          title: t('rewardsAuthFailTitle'),
+          description: t('rewardsAuthFailDescription'),
+          onActionClick: fetchCandidateSubscriptionId,
+          actionText: t('rewardsOnboardingIntroRewardsAuthFailRetry'),
+        }),
+      );
+      return;
+    }
+
+    // Show error modal if geo check failed
+    if (
+      optinAllowedForGeoError &&
+      !optinAllowedForGeo &&
+      !optinAllowedForGeoLoading &&
+      !rewardsActiveAccountSubscriptionId
+    ) {
+      dispatch(
+        setErrorToast({
+          isOpen: true,
+          title: t('rewardsOnboardingIntroGeoCheckFailedTitle'),
+          description: t('rewardsOnboardingIntroGeoCheckFailedDescription'),
+          onActionClick: fetchGeoRewardsMetadata,
+          actionText: t('rewardsOnboardingIntroGeoCheckRetry'),
+        }),
+      );
+      return;
+    }
+
+    // Show error modal if unsupported region
+    if (optinAllowedForGeo === false) {
+      dispatch(
+        setErrorToast({
+          isOpen: true,
+          title: t('rewardsOnboardingIntroUnsupportedRegionTitle'),
+          description: t('rewardsOnboardingIntroUnsupportedRegionDescription'),
+        }),
+      );
+      return;
+    }
+
+    // Show error modal if hardware wallet
+    if (hardwareWalletUsed) {
+      dispatch(
+        setErrorToast({
+          isOpen: true,
+          title: t('rewardsOnboardingIntroHardwareWalletTitle'),
+          description: t('rewardsOnboardingIntroHardwareWalletDescription'),
+        }),
+      );
+      return;
+    }
+
+    // Proceed to next onboarding step
+    dispatch(setOnboardingActiveStep(OnboardingStep.STEP1));
+  }, [
+    candidateSubscriptionIdError,
+    dispatch,
+    fetchCandidateSubscriptionId,
+    fetchGeoRewardsMetadata,
+    hardwareWalletUsed,
+    optinAllowedForGeo,
+    optinAllowedForGeoError,
+    optinAllowedForGeoLoading,
+    rewardsActiveAccountSubscriptionId,
+    t,
+  ]);
+
+  /**
+   * Handles the close button press
+   */
+  const handleClose = useCallback(() => {
+    dispatch(setOnboardingModalOpen(false));
+  }, [dispatch]);
+
+  /**
+   * Renders the main title section
+   */
+  const renderTitle = () => (
+    <Box
+      className="gap-2"
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      data-testid="rewards-onboarding-intro-title"
+    >
+      <Box className="justify-center items-center">
+        <Text
+          fontFamily={FontFamily.Hero}
+          variant={TextVariant.DisplayLg}
+          className={'text-center text-white font-medium'}
+          style={{
+            lineHeight: '1',
+          }}
+        >
+          {t('rewardsOnboardingIntroTitle')}
+        </Text>
+      </Box>
+      <Text
+        variant={TextVariant.BodyMd}
+        className={'text-center text-white font-medium'}
+      >
+        {t('rewardsOnboardingIntroDescription')}
+      </Text>
+    </Box>
+  );
+
+  /**
+   * Renders the intro image section
+   */
+  const renderImage = () => (
+    <Box
+      className="flex justify-center items-center my-4 absolute"
+      style={{ top: 180 }}
+      data-testid="rewards-onboarding-intro-image"
+    >
+      <img
+        src="https://images.ctfassets.net/9sy2a0egs6zh/5vsF0CDPAgGRK4VpjxyKT9/e744a921a9666172aa4f92852356ca7a/rewards-onboarding-intro.png"
+        alt="Rewards onboarding intro"
+        className="w-full max-w-lg h-auto object-contain"
+        data-testid="intro-image"
+      />
+    </Box>
+  );
+
+  /**
+   * Renders the action buttons section
+   */
+  const renderActions = () => (
+    <Box
+      className="flex flex-col justify-end flex-1"
+      data-testid="rewards-onboarding-intro-actions"
+    >
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        isLoading={
+          optinAllowedForGeoLoading ||
+          candidateSubscriptionId === 'pending' ||
+          candidateSubscriptionId === 'retry'
+        }
+        isDisabled={
+          optinAllowedForGeoLoading ||
+          Boolean(rewardsActiveAccountSubscriptionId) ||
+          candidateSubscriptionId === 'pending' ||
+          candidateSubscriptionId === 'retry'
+        }
+        onClick={handleNext}
+        className="w-full my-2 bg-white"
+      >
+        <Text variant={TextVariant.BodyMd} className="text-black font-medium">
+          {t('rewardsOnboardingIntroStepConfirm')}
+        </Text>
+      </Button>
+      <Button
+        size={ButtonSize.Lg}
+        onClick={handleClose}
+        className="w-full bg-gray-500 border-gray-500 hover:bg-primary-default-hover"
+      >
+        <Text variant={TextVariant.BodyMd} className="text-white font-medium">
+          {t('rewardsOnboardingIntroStepSkip')}
+        </Text>
+      </Button>
+    </Box>
+  );
+
+  return (
+    <Box
+      className="w-full h-full overflow-y-auto"
+      data-testid="onboarding-intro-container"
+    >
+      <Box
+        className="w-full h-full bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage:
+            'url(https://images.ctfassets.net/9sy2a0egs6zh/3IxIZWE6JZHzDNhlpiLeJq/7e765a752a7ae0b90dd327ddca496175/rewards-onboarding-intro-bg.png)',
+        }}
+      >
+        <ModalBody className="w-full h-full pt-8 pb-4 flex flex-col">
+          {/* Title Section */}
+          {renderTitle()}
+
+          {/* Image Section */}
+          {renderImage()}
+
+          {/* Actions Section */}
+          {renderActions()}
+        </ModalBody>
+      </Box>
+    </Box>
+  );
+};
+
+export default OnboardingIntroStep;

--- a/ui/components/app/rewards/onboarding/OnboardingModal.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.test.tsx
@@ -1,0 +1,347 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  selectOnboardingModalOpen,
+  selectOnboardingActiveStep,
+  selectCandidateSubscriptionId,
+} from '../../../../ducks/rewards/selectors';
+import {
+  setOnboardingActiveStep,
+  setOnboardingModalOpen,
+} from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import { ThemeType } from '../../../../../shared/constants/preferences';
+import type { MetaMaskReduxState } from '../../../../store/store';
+import OnboardingModal from './OnboardingModal';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useTheme', () => ({
+  useTheme: jest.fn(() => 'light'),
+}));
+
+// Stub child components to simple test markers
+jest.mock('./OnboardingIntroStep', () => () => (
+  <div data-testid="intro-step">Intro Step</div>
+));
+jest.mock('./OnboardingStep1', () => () => (
+  <div data-testid="step1">Step 1</div>
+));
+jest.mock('./OnboardingStep2', () => () => (
+  <div data-testid="step2">Step 2</div>
+));
+jest.mock('./OnboardingStep3', () => () => (
+  <div data-testid="step3">Step 3</div>
+));
+jest.mock('./OnboardingStep4', () => () => (
+  <div data-testid="step4">Step 4</div>
+));
+
+jest.mock('../RewardsErrorToast', () => () => (
+  <div data-testid="rewards-error-toast">Toast</div>
+));
+
+const mockedUseSelector = useSelector as jest.Mock;
+const mockedUseDispatch = useDispatch as jest.Mock;
+
+function setupSelectors({
+  isOpen = true,
+  step = OnboardingStep.INTRO,
+  candidateSubscriptionId = null as string | null,
+} = {}) {
+  mockedUseSelector.mockImplementation(
+    (selector: (state: MetaMaskReduxState) => unknown): unknown => {
+      if (selector === selectOnboardingModalOpen) {
+        return isOpen;
+      }
+      if (selector === selectOnboardingActiveStep) {
+        return step;
+      }
+      if (selector === selectCandidateSubscriptionId) {
+        return candidateSubscriptionId;
+      }
+      // Default fallback if any other selector is used
+      return undefined;
+    },
+  );
+}
+
+describe('OnboardingModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal open and shows intro content', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.INTRO,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('rewards-onboarding-modal')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-modal-header'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('intro-step')).toBeInTheDocument();
+    expect(screen.getByTestId('rewards-error-toast')).toBeInTheDocument();
+  });
+
+  it('renders the correct step component when onboardingStep is STEP2', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP2,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('step2')).toBeInTheDocument();
+  });
+
+  it('dispatches close and resets step when candidateSubscriptionId is present', async () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: 'abc123',
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledWith(setOnboardingModalOpen(false));
+      expect(dispatchMock).toHaveBeenCalledWith(
+        setOnboardingActiveStep(OnboardingStep.INTRO),
+      );
+    });
+  });
+
+  it('sets header theme attribute based on useTheme: light', () => {
+    setupSelectors({ isOpen: true, step: OnboardingStep.INTRO });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    expect(header).toHaveAttribute('data-theme', ThemeType.light);
+  });
+
+  it('sets header theme attribute based on useTheme: dark', () => {
+    const { useTheme } = jest.requireMock('../../../../hooks/useTheme');
+    useTheme.mockReturnValue('dark');
+
+    setupSelectors({ isOpen: true, step: OnboardingStep.STEP3 });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    expect(header).toHaveAttribute('data-theme', ThemeType.dark);
+  });
+
+  it('renders the correct step component when onboardingStep is STEP1', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('step1')).toBeInTheDocument();
+  });
+
+  it('renders the correct step component when onboardingStep is STEP3', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP3,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('step3')).toBeInTheDocument();
+  });
+
+  it('renders the correct step component when onboardingStep is STEP4', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP4,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('step4')).toBeInTheDocument();
+  });
+
+  it('renders intro step as default when onboardingStep is invalid', () => {
+    setupSelectors({
+      isOpen: true,
+      step: 'invalid-step' as OnboardingStep,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.getByTestId('intro-step')).toBeInTheDocument();
+  });
+
+  it('hides close button when onboardingStep is INTRO', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.INTRO,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    // The close button is rendered but hidden via style.display
+    const closeButton = header.querySelector('[aria-label]');
+    if (closeButton) {
+      expect(closeButton).toHaveStyle({ display: 'none' });
+    }
+  });
+
+  it('shows close button when onboardingStep is not INTRO', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    // The close button should be visible
+    const closeButton = header.querySelector('[aria-label]');
+    if (closeButton) {
+      expect(closeButton).toHaveStyle({ display: 'block' });
+    }
+  });
+
+  it('does not close modal when candidateSubscriptionId is "error"', async () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: 'error',
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    await waitFor(() => {
+      expect(dispatchMock).not.toHaveBeenCalledWith(
+        setOnboardingModalOpen(false),
+      );
+    });
+    expect(screen.getByTestId('step1')).toBeInTheDocument();
+  });
+
+  it('does not close modal when candidateSubscriptionId is "pending"', async () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: 'pending',
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    await waitFor(() => {
+      expect(dispatchMock).not.toHaveBeenCalledWith(
+        setOnboardingModalOpen(false),
+      );
+    });
+    expect(screen.getByTestId('step1')).toBeInTheDocument();
+  });
+
+  it('does not close modal when candidateSubscriptionId is "retry"', async () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: 'retry',
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    await waitFor(() => {
+      expect(dispatchMock).not.toHaveBeenCalledWith(
+        setOnboardingModalOpen(false),
+      );
+    });
+    expect(screen.getByTestId('step1')).toBeInTheDocument();
+  });
+
+  it('returns null content when candidateSubscriptionId is valid', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP1,
+      candidateSubscriptionId: 'valid-subscription-id',
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    expect(screen.queryByTestId('step1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('intro-step')).not.toBeInTheDocument();
+  });
+
+  it('dispatches close and resets step when close button is clicked', () => {
+    setupSelectors({
+      isOpen: true,
+      step: OnboardingStep.STEP2,
+      candidateSubscriptionId: null,
+    });
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingModal />);
+
+    // Find and click the close button in the header
+    const header = screen.getByTestId('rewards-onboarding-modal-header');
+    const closeButton = header.querySelector('[aria-label]');
+    expect(closeButton).toBeInTheDocument();
+
+    if (closeButton) {
+      fireEvent.click(closeButton);
+      expect(dispatchMock).toHaveBeenCalledWith(setOnboardingModalOpen(false));
+      expect(dispatchMock).toHaveBeenCalledWith(
+        setOnboardingActiveStep(OnboardingStep.INTRO),
+      );
+    }
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  ModalContentSize,
+} from '../../../component-library';
+import { ThemeType } from '../../../../../shared/constants/preferences';
+import {
+  AlignItems,
+  JustifyContent,
+} from '../../../../helpers/constants/design-system';
+import {
+  selectOnboardingModalOpen,
+  selectOnboardingActiveStep,
+  selectCandidateSubscriptionId,
+} from '../../../../ducks/rewards/selectors';
+import {
+  setOnboardingActiveStep,
+  setOnboardingModalOpen,
+  setOnboardingModalRendered,
+} from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import { useTheme } from '../../../../hooks/useTheme';
+import RewardsErrorToast from '../RewardsErrorToast';
+import OnboardingIntroStep from './OnboardingIntroStep';
+import OnboardingStep1 from './OnboardingStep1';
+import OnboardingStep2 from './OnboardingStep2';
+import OnboardingStep3 from './OnboardingStep3';
+import OnboardingStep4 from './OnboardingStep4';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default function OnboardingModal() {
+  const isOpen = useSelector(selectOnboardingModalOpen);
+  const onboardingStep = useSelector(selectOnboardingActiveStep);
+  const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
+  const dispatch = useDispatch();
+
+  const theme = useTheme();
+
+  const handleClose = useCallback(() => {
+    dispatch(setOnboardingModalOpen(false));
+    dispatch(setOnboardingActiveStep(OnboardingStep.INTRO));
+  }, [dispatch]);
+
+  const renderContent = useCallback(() => {
+    if (
+      candidateSubscriptionId &&
+      candidateSubscriptionId !== 'error' &&
+      candidateSubscriptionId !== 'pending' &&
+      candidateSubscriptionId !== 'retry'
+    ) {
+      // TODO: render mobile QR code
+      return null;
+    }
+
+    switch (onboardingStep) {
+      case OnboardingStep.INTRO:
+        return <OnboardingIntroStep />;
+      case OnboardingStep.STEP1:
+        return <OnboardingStep1 />;
+      case OnboardingStep.STEP2:
+        return <OnboardingStep2 />;
+      case OnboardingStep.STEP3:
+        return <OnboardingStep3 />;
+      case OnboardingStep.STEP4:
+        return <OnboardingStep4 />;
+      default:
+        return <OnboardingIntroStep />;
+    }
+  }, [candidateSubscriptionId, onboardingStep]);
+
+  useEffect(() => {
+    dispatch(setOnboardingModalRendered(true));
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (
+      candidateSubscriptionId &&
+      candidateSubscriptionId !== 'error' &&
+      candidateSubscriptionId !== 'pending' &&
+      candidateSubscriptionId !== 'retry'
+    ) {
+      handleClose();
+    }
+  }, [candidateSubscriptionId, handleClose]);
+
+  return (
+    <Modal
+      data-testid="rewards-onboarding-modal"
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
+      <ModalOverlay />
+      <ModalContent
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.center}
+        size={ModalContentSize.Md}
+        modalDialogProps={{
+          paddingTop: 0,
+          paddingBottom: 0,
+          style: {
+            height: '800px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+        }}
+      >
+        <ModalHeader
+          data-theme={theme === 'light' ? ThemeType.light : ThemeType.dark}
+          data-testid="rewards-onboarding-modal-header"
+          closeButtonProps={{
+            className: 'absolute z-10',
+            style: {
+              top: '24px',
+              right: '12px',
+              display:
+                onboardingStep === OnboardingStep.INTRO ? 'none' : 'block',
+            },
+          }}
+          paddingBottom={0}
+          onClose={handleClose}
+        />
+
+        {renderContent()}
+        <RewardsErrorToast />
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/components/app/rewards/onboarding/OnboardingStep1.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep1.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useDispatch } from 'react-redux';
+
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import OnboardingStep1 from './OnboardingStep1';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+// Mock ProgressIndicator to verify props passed
+jest.mock(
+  './ProgressIndicator',
+  () => (props: { totalSteps: number; currentStep: number }) => (
+    <div
+      data-testid="rewards-onboarding-step1-progress"
+      data-current-step={props.currentStep}
+      data-total-steps={props.totalSteps}
+    >
+      Progress
+    </div>
+  ),
+);
+
+const mockedUseDispatch = useDispatch as jest.Mock;
+
+describe('OnboardingStep1', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders layout sections and translation keys', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep1 />);
+
+    expect(
+      screen.getByTestId('rewards-onboarding-step1-container'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step1-image'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step1-info'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step1-actions'),
+    ).toBeInTheDocument();
+
+    // Title and description use translation keys via t()
+    expect(screen.getByText('rewardsOnboardingStep1Title')).toBeInTheDocument();
+    expect(
+      screen.getByText('rewardsOnboardingStep1Description'),
+    ).toBeInTheDocument();
+
+    // Confirm button text
+    expect(
+      screen.getByText('rewardsOnboardingStepConfirm'),
+    ).toBeInTheDocument();
+  });
+
+  it('passes correct progress props to ProgressIndicator', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep1 />);
+
+    const progress = screen.getByTestId('rewards-onboarding-step1-progress');
+    expect(progress).toHaveAttribute('data-current-step', '1');
+    expect(progress).toHaveAttribute('data-total-steps', '4');
+  });
+
+  it('advances to STEP2 when confirm is clicked', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep1 />);
+
+    const confirmButton = screen.getByText('rewardsOnboardingStepConfirm');
+    fireEvent.click(confirmButton);
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      setOnboardingActiveStep(OnboardingStep.STEP2),
+    );
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingStep1.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep1.tsx
@@ -1,0 +1,110 @@
+import { useDispatch } from 'react-redux';
+import React, { useCallback } from 'react';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import { ModalBody } from '../../../component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import ProgressIndicator from './ProgressIndicator';
+
+const OnboardingStep1: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const t = useI18nContext();
+
+  const handleNext = useCallback(() => {
+    dispatch(setOnboardingActiveStep(OnboardingStep.STEP2));
+  }, [dispatch]);
+
+  const renderStepImage = () => (
+    <>
+      <svg
+        className="w-full absolute"
+        viewBox="0 0 393 454"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+        style={{ left: 0 }}
+      >
+        <path
+          d="M 302.98438 0 L 213.17773 113.25586 L 162.85742 113.25586 L 162.85742 224.83594 L 162.84766 224.83594 L 162.84766 113.09766 L 62.902344 113.09766 L -37.042969 226.49805 L -37.042969 339.89844 L 62.902344 339.89844 L 162.8125 226.53711 L 162.8125 339.9707 L 212.77539 339.9707 L 212.77539 340.4043 L 302.69336 453.79883 L 392.61523 453.79883 L 392.61523 340.4043 L 361.58008 301.26758 L 361.58008 224.83594 L 304.5332 224.83594 L 392.90625 113.39453 L 392.90625 0 L 302.98438 0 z "
+          fill="var(--color-background-muted)"
+        />
+      </svg>
+
+      <img
+        src="https://images.ctfassets.net/9sy2a0egs6zh/5ieKFEvd1qM3crY76W751i/ab846811e550d4a84c12a063f468f30c/rewards-onboarding-step1.png"
+        className="w-full z-10 object-contain"
+        data-testid="rewards-onboarding-step1-image"
+      />
+    </>
+  );
+
+  const renderStepInfo = () => (
+    <Box
+      className="flex flex-col min-h-30 gap-2 flex-1 justify-end"
+      data-testid="rewards-onboarding-step1-info"
+    >
+      <Text variant={TextVariant.HeadingLg} className="text-center">
+        {t('rewardsOnboardingStep1Title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-center text-alternative"
+      >
+        {t('rewardsOnboardingStep1Description')}
+      </Text>
+    </Box>
+  );
+
+  /**
+   * Renders the action buttons section
+   */
+  const renderActions = () => (
+    <Box
+      className="flex flex-col my-2"
+      data-testid="rewards-onboarding-step1-actions"
+    >
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onClick={handleNext}
+        className="w-full my-2"
+      >
+        {t('rewardsOnboardingStepConfirm')}
+      </Button>
+    </Box>
+  );
+
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid="rewards-onboarding-step1-container"
+    >
+      {/* Progress Indicator */}
+      <ProgressIndicator
+        totalSteps={4}
+        currentStep={1}
+        data-testid="rewards-onboarding-step1-progress"
+      />
+
+      {/* Image Section */}
+      {renderStepImage()}
+
+      {/* Title Section */}
+      {renderStepInfo()}
+
+      {/* Actions Section */}
+      {renderActions()}
+    </ModalBody>
+  );
+};
+
+export default OnboardingStep1;

--- a/ui/components/app/rewards/onboarding/OnboardingStep2.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep2.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useDispatch } from 'react-redux';
+
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import OnboardingStep2 from './OnboardingStep2';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+// Mock ProgressIndicator to verify props passed
+jest.mock(
+  './ProgressIndicator',
+  () => (props: { totalSteps: number; currentStep: number }) => (
+    <div
+      data-testid="rewards-onboarding-step2-progress"
+      data-current-step={props.currentStep}
+      data-total-steps={props.totalSteps}
+    >
+      Progress
+    </div>
+  ),
+);
+
+const mockedUseDispatch = useDispatch as jest.Mock;
+
+describe('OnboardingStep2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders layout sections and translation keys', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep2 />);
+
+    expect(
+      screen.getByTestId('rewards-onboarding-step2-container'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step2-image'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step2-info'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step2-actions'),
+    ).toBeInTheDocument();
+
+    // Title and description use translation keys via t()
+    expect(screen.getByText('rewardsOnboardingStep2Title')).toBeInTheDocument();
+    expect(
+      screen.getByText('rewardsOnboardingStep2Description'),
+    ).toBeInTheDocument();
+
+    // Confirm button text
+    expect(
+      screen.getByText('rewardsOnboardingStepConfirm'),
+    ).toBeInTheDocument();
+  });
+
+  it('passes correct progress props to ProgressIndicator', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep2 />);
+
+    const progress = screen.getByTestId('rewards-onboarding-step2-progress');
+    expect(progress).toHaveAttribute('data-current-step', '2');
+    expect(progress).toHaveAttribute('data-total-steps', '4');
+  });
+
+  it('advances to STEP3 when confirm is clicked', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep2 />);
+
+    const confirmButton = screen.getByText('rewardsOnboardingStepConfirm');
+    fireEvent.click(confirmButton);
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      setOnboardingActiveStep(OnboardingStep.STEP3),
+    );
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingStep2.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep2.tsx
@@ -1,0 +1,110 @@
+import { useDispatch } from 'react-redux';
+import React, { useCallback } from 'react';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import { ModalBody } from '../../../component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import ProgressIndicator from './ProgressIndicator';
+
+const OnboardingStep2: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const t = useI18nContext();
+
+  const handleNext = useCallback(() => {
+    dispatch(setOnboardingActiveStep(OnboardingStep.STEP3));
+  }, [dispatch]);
+
+  const renderStepImage = () => (
+    <>
+      <svg
+        className="w-full absolute"
+        viewBox="0 0 393 454"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+        style={{ left: 0 }}
+      >
+        <path
+          d="M 257.61523 0 L 121.50195 136.11328 L 121.50195 272.51562 L 30.742188 272.51562 L 30.742188 363.25781 L 166.87109 363.25781 L 166.87109 454 L 302.98438 454 L 393.72852 363.25781 L 393.71289 363.25781 L 393.71289 272.51562 L 393.73047 272.51562 L 302.79492 227.04688 L 393.73047 136.11328 L 393.73047 0 L 257.61523 0 z M 30.742188 363.25781 L -60 363.25781 L -60 454 L 30.742188 454 L 30.742188 363.25781 z M -59.998047 45.660156 L -14.626953 136.40234 L 121.48633 136.40234 L 76.115234 45.660156 L -59.998047 45.660156 z M 121.48633 181.76953 L 30.744141 272.51367 L 121.48633 272.51367 L 121.48633 181.76953 z M 212.24414 272.36914 L 212.24414 272.51562 L 165.20898 272.51562 L 212.24414 272.36914 z "
+          fill="var(--color-background-muted)"
+        />
+      </svg>
+
+      <img
+        src="https://images.ctfassets.net/9sy2a0egs6zh/2wG5gvQmC4d95TShVVpsEX/9bd7f199f47833fdc68e403a059713df/rewards-onboarding-step2.png"
+        className="w-full z-10 object-contain"
+        data-testid="rewards-onboarding-step2-image"
+      />
+    </>
+  );
+
+  const renderStepInfo = () => (
+    <Box
+      className="flex flex-col min-h-30 gap-2 flex-1 justify-end"
+      data-testid="rewards-onboarding-step2-info"
+    >
+      <Text variant={TextVariant.HeadingLg} className="text-center">
+        {t('rewardsOnboardingStep2Title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-center text-alternative"
+      >
+        {t('rewardsOnboardingStep2Description')}
+      </Text>
+    </Box>
+  );
+
+  /**
+   * Renders the action buttons section
+   */
+  const renderActions = () => (
+    <Box
+      className="flex flex-col justify-end my-2"
+      data-testid="rewards-onboarding-step2-actions"
+    >
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onClick={handleNext}
+        className="w-full my-2"
+      >
+        {t('rewardsOnboardingStepConfirm')}
+      </Button>
+    </Box>
+  );
+
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid="rewards-onboarding-step2-container"
+    >
+      {/* Progress Indicator */}
+      <ProgressIndicator
+        totalSteps={4}
+        currentStep={2}
+        data-testid="rewards-onboarding-step2-progress"
+      />
+
+      {/* Image Section */}
+      {renderStepImage()}
+
+      {/* Title Section */}
+      {renderStepInfo()}
+
+      {/* Actions Section */}
+      {renderActions()}
+    </ModalBody>
+  );
+};
+
+export default OnboardingStep2;

--- a/ui/components/app/rewards/onboarding/OnboardingStep3.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep3.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useDispatch } from 'react-redux';
+
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import OnboardingStep3 from './OnboardingStep3';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+// Mock ProgressIndicator to verify props passed
+jest.mock(
+  './ProgressIndicator',
+  () => (props: { totalSteps: number; currentStep: number }) => (
+    <div
+      data-testid="rewards-onboarding-step3-progress"
+      data-current-step={props.currentStep}
+      data-total-steps={props.totalSteps}
+    >
+      Progress
+    </div>
+  ),
+);
+
+const mockedUseDispatch = useDispatch as jest.Mock;
+
+describe('OnboardingStep3', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders layout sections and translation keys', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep3 />);
+
+    expect(
+      screen.getByTestId('rewards-onboarding-step3-container'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step3-image'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step3-info'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step3-actions'),
+    ).toBeInTheDocument();
+
+    // Title and description use translation keys via t()
+    expect(screen.getByText('rewardsOnboardingStep3Title')).toBeInTheDocument();
+    expect(
+      screen.getByText('rewardsOnboardingStep3Description'),
+    ).toBeInTheDocument();
+
+    // Confirm button text
+    expect(
+      screen.getByText('rewardsOnboardingStepConfirm'),
+    ).toBeInTheDocument();
+  });
+
+  it('passes correct progress props to ProgressIndicator', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep3 />);
+
+    const progress = screen.getByTestId('rewards-onboarding-step3-progress');
+    expect(progress).toHaveAttribute('data-current-step', '3');
+    expect(progress).toHaveAttribute('data-total-steps', '4');
+  });
+
+  it('advances to STEP4 when confirm is clicked', () => {
+    const dispatchMock = jest.fn();
+    mockedUseDispatch.mockReturnValue(dispatchMock);
+
+    render(<OnboardingStep3 />);
+
+    const confirmButton = screen.getByText('rewardsOnboardingStepConfirm');
+    fireEvent.click(confirmButton);
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      setOnboardingActiveStep(OnboardingStep.STEP4),
+    );
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingStep3.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep3.tsx
@@ -1,0 +1,110 @@
+import { useDispatch } from 'react-redux';
+import React, { useCallback } from 'react';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { setOnboardingActiveStep } from '../../../../ducks/rewards';
+import { OnboardingStep } from '../../../../ducks/rewards/types';
+import { ModalBody } from '../../../component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import ProgressIndicator from './ProgressIndicator';
+
+const OnboardingStep3: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const t = useI18nContext();
+
+  const handleNext = useCallback(() => {
+    dispatch(setOnboardingActiveStep(OnboardingStep.STEP4));
+  }, [dispatch]);
+
+  const renderStepImage = () => (
+    <>
+      <svg
+        className="w-full absolute"
+        viewBox="0 0 393 454"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+        style={{ left: 0 }}
+      >
+        <path
+          d="M 294.88086 0 L 197.81836 90.767578 L 197.81836 181.53516 L 294.88086 181.53516 L 294.93555 181.48438 L 294.93555 181.54102 L 197.94922 181.54102 L 197.94922 272 L 99 272 L 0 362.99805 L 0 454 L 99 454 L 198 362.99805 L 198 362.81641 L 294.84375 272.27148 L 294.93555 272.27148 L 294.93555 362.11914 L 392 362.11914 L 392 181.35938 L 295.06836 181.35938 L 391.94336 90.767578 L 391.94336 0 L 294.88086 0 z "
+          fill="var(--color-background-muted)"
+        />
+      </svg>
+
+      <img
+        src="https://images.ctfassets.net/9sy2a0egs6zh/7ERFcIMMLMTL4EekVoOana/a03bef86b2cb4f87fc5ee84afd427d21/rewards-onboarding-step3.png"
+        className="w-full z-10 object-contain"
+        data-testid="rewards-onboarding-step3-image"
+      />
+    </>
+  );
+
+  const renderStepInfo = () => (
+    <Box
+      className="flex flex-col min-h-30 gap-2 flex-1 justify-end"
+      data-testid="rewards-onboarding-step3-info"
+    >
+      <Text variant={TextVariant.HeadingLg} className="text-center">
+        {t('rewardsOnboardingStep3Title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-center text-alternative"
+      >
+        {t('rewardsOnboardingStep3Description')}
+      </Text>
+    </Box>
+  );
+
+  /**
+   * Renders the action buttons section
+   */
+  const renderActions = () => (
+    <Box
+      className="flex flex-col justify-end my-2"
+      data-testid="rewards-onboarding-step3-actions"
+    >
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onClick={handleNext}
+        className="w-full my-2"
+      >
+        {t('rewardsOnboardingStepConfirm')}
+      </Button>
+    </Box>
+  );
+
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid="rewards-onboarding-step3-container"
+    >
+      {/* Progress Indicator */}
+      <ProgressIndicator
+        totalSteps={4}
+        currentStep={3}
+        data-testid="rewards-onboarding-step3-progress"
+      />
+
+      {/* Image Section */}
+      {renderStepImage()}
+
+      {/* Title Section */}
+      {renderStepInfo()}
+
+      {/* Actions Section */}
+      {renderActions()}
+    </ModalBody>
+  );
+};
+
+export default OnboardingStep3;

--- a/ui/components/app/rewards/onboarding/OnboardingStep4.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep4.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import OnboardingStep4 from './OnboardingStep4';
+import {
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+  REWARDS_ONBOARD_TERMS_URL,
+} from './constants';
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(() => (key: string) => key),
+}));
+
+jest.mock('../../../../hooks/rewards/useOptIn', () => ({
+  useOptIn: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/rewards/useValidateReferralCode', () => ({
+  useValidateReferralCode: jest.fn(),
+}));
+
+// Mock ProgressIndicator to verify props passed
+jest.mock(
+  './ProgressIndicator',
+  () => (props: { totalSteps: number; currentStep: number }) => (
+    <div
+      data-testid="rewards-onboarding-step4-progress"
+      data-current-step={props.currentStep}
+      data-total-steps={props.totalSteps}
+    >
+      Progress
+    </div>
+  ),
+);
+
+// Stub RewardsErrorBanner to deterministic testing
+jest.mock(
+  '../RewardsErrorBanner',
+  () =>
+    ({ title, description }: { title: string; description: string }) => (
+      <div data-testid="rewards-error-banner">
+        <span data-testid="banner-title">{title}</span>
+        <span data-testid="banner-description">{description}</span>
+      </div>
+    ),
+);
+
+const mockedUseOptIn = jest.requireMock('../../../../hooks/rewards/useOptIn')
+  .useOptIn as jest.Mock;
+const mockedUseValidateReferralCode = jest.requireMock(
+  '../../../../hooks/rewards/useValidateReferralCode',
+).useValidateReferralCode as jest.Mock;
+
+function setup({
+  referralCode = '',
+  isValid = false,
+  isValidating = false,
+  isUnknownError = false,
+  optinLoading = false,
+  optinError = '',
+} = {}) {
+  const setReferralCode = jest.fn();
+  const optin = jest.fn();
+
+  mockedUseValidateReferralCode.mockReturnValue({
+    referralCode,
+    setReferralCode,
+    isValidating,
+    isValid,
+    isUnknownError,
+  });
+
+  mockedUseOptIn.mockReturnValue({
+    optinLoading,
+    optinError,
+    optin,
+  });
+
+  return { setReferralCode, optin };
+}
+
+describe('OnboardingStep4', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Prevent actual window.open
+    jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  it('renders layout sections and translation keys', () => {
+    setup();
+    render(<OnboardingStep4 />);
+
+    expect(
+      screen.getByTestId('rewards-onboarding-step4-container'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step4-info'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step4-actions'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('rewards-onboarding-step4-legal-disclaimer'),
+    ).toBeInTheDocument();
+
+    // Image alt uses title translation key
+    expect(
+      screen.getByAltText('rewardsOnboardingStep4Title'),
+    ).toBeInTheDocument();
+    // Heading and referral input label
+    expect(screen.getByText('rewardsOnboardingStep4Title')).toBeInTheDocument();
+    expect(
+      screen.getByText('rewardsOnboardingStep4ReferralCodeInput'),
+    ).toBeInTheDocument();
+    // Placeholder and button text
+    expect(
+      screen.getByPlaceholderText(
+        'rewardsOnboardingStep4ReferralCodePlaceholder',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('rewardsOnboardingStepOptIn')).toBeInTheDocument();
+  });
+
+  it('passes correct progress props to ProgressIndicator', () => {
+    setup();
+    render(<OnboardingStep4 />);
+
+    const progress = screen.getByTestId('rewards-onboarding-step4-progress');
+    expect(progress).toHaveAttribute('data-current-step', '4');
+    expect(progress).toHaveAttribute('data-total-steps', '4');
+  });
+
+  it('updates referral code on input change', () => {
+    const { setReferralCode } = setup();
+    render(<OnboardingStep4 />);
+
+    const input = screen.getByPlaceholderText(
+      'rewardsOnboardingStep4ReferralCodePlaceholder',
+    );
+    fireEvent.change(input, { target: { value: 'ABCDEF' } });
+    expect(setReferralCode).toHaveBeenCalledWith('ABCDEF');
+  });
+
+  it('shows referral error message when invalid with length >= 6', () => {
+    setup({
+      referralCode: 'ABCDEF',
+      isValid: false,
+      isValidating: false,
+      isUnknownError: false,
+    });
+    render(<OnboardingStep4 />);
+
+    expect(
+      screen.getByText('rewardsOnboardingStep4ReferralCodeError'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables opt-in button when loading', () => {
+    setup({ optinLoading: true });
+    render(<OnboardingStep4 />);
+    const button = screen.getByRole('button', {
+      name: 'rewardsOnboardingStepOptIn',
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it('disables opt-in button when referral code is invalid and non-empty', () => {
+    setup({ referralCode: 'A', isValid: false });
+    render(<OnboardingStep4 />);
+    const button = within(
+      screen.getByTestId('rewards-onboarding-step4-actions'),
+    ).getByRole('button', { name: 'rewardsOnboardingStepOptIn' });
+    expect(button).toBeDisabled();
+  });
+
+  it('disables opt-in button when unknown referral error is present', () => {
+    setup({ isUnknownError: true });
+    render(<OnboardingStep4 />);
+    const button = screen.getByRole('button', {
+      name: 'rewardsOnboardingStepOptIn',
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it('enables opt-in button and calls optin with referral code when valid', () => {
+    const { optin } = setup({ referralCode: 'REFCODE', isValid: true });
+    render(<OnboardingStep4 />);
+
+    const button = within(
+      screen.getByTestId('rewards-onboarding-step4-actions'),
+    ).getByRole('button', { name: 'rewardsOnboardingStepOptIn' });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(optin).toHaveBeenCalledWith('REFCODE');
+  });
+
+  it('renders unknown referral error banner when isUnknownErrorReferralCode is true', () => {
+    setup({ isUnknownError: true });
+    render(<OnboardingStep4 />);
+
+    const banner = screen.getByTestId('rewards-error-banner');
+    expect(screen.getByTestId('banner-title')).toHaveTextContent(
+      'rewardsOnboardingStep4ReferralCodeUnknownError',
+    );
+    expect(screen.getByTestId('banner-description')).toHaveTextContent(
+      'rewardsOnboardingStep4ReferralCodeUnknownErrorDescription',
+    );
+    expect(banner).toBeInTheDocument();
+  });
+
+  it('renders opt-in error banner with description when optinError is present', () => {
+    setup({ optinError: 'server down' });
+    render(<OnboardingStep4 />);
+
+    expect(screen.getByTestId('rewards-error-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('banner-title')).toHaveTextContent(
+      'rewardsOnboardingStep4OptInError',
+    );
+    expect(screen.getByTestId('banner-description')).toHaveTextContent(
+      'server down',
+    );
+  });
+
+  it('opens legal links with the correct URLs', () => {
+    setup();
+    render(<OnboardingStep4 />);
+
+    const termsLink = screen.getByText(
+      'rewardsOnboardingStep4LegalDisclaimer2',
+    );
+    fireEvent.click(termsLink);
+    expect(window.open).toHaveBeenCalledWith(
+      REWARDS_ONBOARD_TERMS_URL,
+      '_blank',
+      'noopener,noreferrer',
+    );
+
+    const learnMoreLink = screen.getByText(
+      'rewardsOnboardingStep4LegalDisclaimer4',
+    );
+    fireEvent.click(learnMoreLink);
+    expect(window.open).toHaveBeenCalledWith(
+      REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+});

--- a/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
@@ -1,0 +1,254 @@
+import React, { useCallback } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { Link } from '@material-ui/core';
+import {
+  ModalBody,
+  TextField,
+  TextFieldSize,
+} from '../../../component-library';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useValidateReferralCode } from '../../../../hooks/rewards/useValidateReferralCode';
+import LoadingIndicator from '../../../ui/loading-indicator';
+import RewardsErrorBanner from '../RewardsErrorBanner';
+import { useOptIn } from '../../../../hooks/rewards/useOptIn';
+import {
+  REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+  REWARDS_ONBOARD_TERMS_URL,
+} from './constants';
+import ProgressIndicator from './ProgressIndicator';
+
+const OnboardingStep4: React.FC = () => {
+  const t = useI18nContext();
+
+  const { optinLoading, optinError, optin } = useOptIn();
+
+  const {
+    referralCode,
+    setReferralCode: handleReferralCodeChange,
+    isValidating: isValidatingReferralCode,
+    isValid: referralCodeIsValid,
+    isUnknownError: isUnknownErrorReferralCode,
+  } = useValidateReferralCode();
+
+  const handleNext = useCallback(async () => {
+    await optin(referralCode);
+  }, [optin, referralCode]);
+
+  const renderIcon = () => {
+    if (isValidatingReferralCode) {
+      return (
+        <LoadingIndicator
+          alt={undefined}
+          title={undefined}
+          isLoading={true}
+          style={{ width: 32, height: 32, left: 5 }}
+        />
+      );
+    }
+
+    if (referralCodeIsValid) {
+      return (
+        <Icon
+          name={IconName.Confirmation}
+          size={IconSize.Lg}
+          color={IconColor.SuccessDefault}
+        />
+      );
+    }
+
+    if (referralCode.length >= 6) {
+      return (
+        <Icon
+          name={IconName.Error}
+          size={IconSize.Lg}
+          color={IconColor.ErrorDefault}
+        />
+      );
+    }
+
+    return null;
+  };
+
+  const referralCodeIsError =
+    referralCode.length >= 6 &&
+    !referralCodeIsValid &&
+    !isValidatingReferralCode &&
+    !isUnknownErrorReferralCode;
+
+  const isDisabled =
+    optinLoading ||
+    (!referralCodeIsValid && Boolean(referralCode)) ||
+    isUnknownErrorReferralCode;
+
+  const renderStepInfo = () => (
+    <Box
+      className="flex flex-col min-h-30 gap-4 flex-1 justify-end"
+      data-testid="rewards-onboarding-step4-info"
+    >
+      <img
+        src="https://images.ctfassets.net/9sy2a0egs6zh/2W921m9iDZsozDlv1pNx4z/c04e3577afd665ae5434d8b7115c4bcc/rewards-onboarding-step4.png"
+        className="z-10 object-contain self-center my-4"
+        width={100}
+        height={100}
+        alt={t('rewardsOnboardingStep4Title')}
+      />
+      <Text variant={TextVariant.HeadingLg} className="text-center">
+        {referralCodeIsValid
+          ? t('rewardsOnboardingStep4TitleWithReferralCode')
+          : t('rewardsOnboardingStep4Title')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Bold}
+        className="text-center mt-8"
+      >
+        {t('rewardsOnboardingStep4ReferralCodeInput')}
+      </Text>
+      <Box className="relative" style={{ height: 64 }}>
+        <TextField
+          placeholder={t('rewardsOnboardingStep4ReferralCodePlaceholder')}
+          value={referralCode}
+          autoCapitalize="characters"
+          onChange={(e) => handleReferralCodeChange(e.target.value)}
+          disabled={optinLoading}
+          size={TextFieldSize.Lg}
+          className="w-full"
+          style={{
+            backgroundColor: optinLoading
+              ? 'bg-background-pressed'
+              : 'bg-background-default',
+            borderColor: referralCodeIsError
+              ? 'border-error-default'
+              : 'border-muted',
+          }}
+          endAccessory={renderIcon()}
+          error={referralCodeIsError}
+        />
+        {referralCodeIsError && (
+          <Text variant={TextVariant.BodySm} className="text-error-default">
+            {t('rewardsOnboardingStep4ReferralCodeError')}
+          </Text>
+        )}
+      </Box>
+
+      {isUnknownErrorReferralCode && (
+        <RewardsErrorBanner
+          title={t('rewardsOnboardingStep4ReferralCodeUnknownError')}
+          description={t(
+            'rewardsOnboardingStep4ReferralCodeUnknownErrorDescription',
+          )}
+        />
+      )}
+    </Box>
+  );
+
+  /**
+   * Renders the action buttons section
+   */
+  const renderActions = () => (
+    <Box
+      className="flex flex-col justify-end my-2"
+      data-testid="rewards-onboarding-step4-actions"
+    >
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onClick={handleNext}
+        className="w-full my-2"
+        disabled={isDisabled}
+        isDisabled={isDisabled}
+      >
+        {t('rewardsOnboardingStepOptIn')}
+      </Button>
+    </Box>
+  );
+
+  const renderLegalDisclaimer = () => {
+    const openTermsOfUse = () => {
+      window.open(REWARDS_ONBOARD_TERMS_URL, '_blank', 'noopener,noreferrer');
+    };
+
+    const openLearnMore = () => {
+      window.open(
+        REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
+        '_blank',
+        'noopener,noreferrer',
+      );
+    };
+
+    return (
+      <Box
+        className="w-full flex-row mt-2"
+        data-testid="rewards-onboarding-step4-legal-disclaimer"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          className="justify-center flex-wrap gap-2"
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            className="text-alternative text-center"
+          >
+            {t('rewardsOnboardingStep4LegalDisclaimer1')}{' '}
+            <Link className="text-primary-default" onClick={openTermsOfUse}>
+              {t('rewardsOnboardingStep4LegalDisclaimer2')}
+            </Link>
+            {t('rewardsOnboardingStep4LegalDisclaimer3')}{' '}
+            <Link className="text-primary-default" onClick={openLearnMore}>
+              {t('rewardsOnboardingStep4LegalDisclaimer4')}
+            </Link>
+            .{' '}
+          </Text>
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid="rewards-onboarding-step4-container"
+    >
+      {/* Progress Indicator */}
+      <ProgressIndicator
+        totalSteps={4}
+        currentStep={4}
+        data-testid="rewards-onboarding-step4-progress"
+      />
+
+      {/* Error Section */}
+      {optinError && (
+        <RewardsErrorBanner
+          title={t('rewardsOnboardingStep4OptInError')}
+          description={optinError}
+        />
+      )}
+
+      {/* Title Section */}
+      {renderStepInfo()}
+
+      {/* Actions Section */}
+      {renderActions()}
+
+      {/* Legal Disclaimer Section */}
+      {renderLegalDisclaimer()}
+    </ModalBody>
+  );
+};
+
+export default OnboardingStep4;

--- a/ui/components/app/rewards/onboarding/ProgressIndicator.test.tsx
+++ b/ui/components/app/rewards/onboarding/ProgressIndicator.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ProgressIndicator from './ProgressIndicator';
+
+jest.mock('../../../../hooks/useTheme', () => ({
+  useTheme: jest.fn(() => 'light'),
+}));
+
+const mockedUseTheme = jest.requireMock('../../../../hooks/useTheme')
+  .useTheme as jest.Mock;
+
+describe('ProgressIndicator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the correct number of indicators for total steps', () => {
+    mockedUseTheme.mockReturnValue('light');
+    render(<ProgressIndicator totalSteps={4} currentStep={1} />);
+
+    const container = screen.getByTestId('progress-indicator-container');
+    expect(container).toBeInTheDocument();
+    expect(container.childElementCount).toBe(4);
+  });
+
+  describe('when theme is light', () => {
+    it('marks the current step as active with wide width and black background', () => {
+      mockedUseTheme.mockReturnValue('light');
+      render(<ProgressIndicator totalSteps={4} currentStep={2} />);
+
+      const container = screen.getByTestId('progress-indicator-container');
+      const items = Array.from(container.children) as HTMLElement[];
+      expect(items).toHaveLength(4);
+
+      // Active is index 1 (currentStep - 1)
+      const active = items[1];
+      expect(active).toHaveClass('w-6');
+      expect(active).toHaveClass('bg-black');
+
+      // All others are inactive and small/muted
+      items.forEach((item, idx) => {
+        if (idx !== 1) {
+          expect(item).toHaveClass('w-3');
+          expect(item).toHaveClass('bg-muted');
+          expect(item).not.toHaveClass('w-6');
+          expect(item).not.toHaveClass('bg-black');
+        }
+      });
+    });
+  });
+
+  describe('when theme is dark', () => {
+    it('marks the current step as active with wide width and white background', () => {
+      mockedUseTheme.mockReturnValue('dark');
+      render(<ProgressIndicator totalSteps={3} currentStep={3} />);
+
+      const container = screen.getByTestId('progress-indicator-container');
+      const items = Array.from(container.children) as HTMLElement[];
+      expect(items).toHaveLength(3);
+
+      // Active is index 2 (currentStep - 1)
+      const active = items[2];
+      expect(active).toHaveClass('w-6');
+      expect(active).toHaveClass('bg-white');
+
+      // Other items are inactive
+      items.slice(0, 2).forEach((item) => {
+        expect(item).toHaveClass('w-3');
+        expect(item).toHaveClass('bg-muted');
+        expect(item).not.toHaveClass('w-6');
+        expect(item).not.toHaveClass('bg-white');
+      });
+    });
+  });
+});

--- a/ui/components/app/rewards/onboarding/ProgressIndicator.tsx
+++ b/ui/components/app/rewards/onboarding/ProgressIndicator.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxAlignItems,
+} from '@metamask/design-system-react';
+
+import { useTheme } from '../../../../hooks/useTheme';
+
+type ProgressIndicatorProps = {
+  totalSteps: number;
+  currentStep: number;
+};
+
+const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({
+  totalSteps,
+  currentStep,
+}) => {
+  const theme = useTheme();
+  const activeColor = theme === 'light' ? 'bg-black' : 'bg-white';
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Center}
+      alignItems={BoxAlignItems.Center}
+      className="gap-1"
+      data-testid="progress-indicator-container"
+    >
+      {Array.from({ length: totalSteps }, (_, index) => (
+        <Box
+          key={index}
+          className={`h-3 rounded-xl
+            ${index === currentStep - 1 ? `w-6 ${activeColor}` : 'w-3 h-3 bg-muted'}`}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default ProgressIndicator;

--- a/ui/components/app/rewards/onboarding/constants.ts
+++ b/ui/components/app/rewards/onboarding/constants.ts
@@ -1,0 +1,4 @@
+export const REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL =
+  'https://support.metamask.io/manage-crypto/metamask-rewards';
+
+export const REWARDS_ONBOARD_TERMS_URL = 'https://go.metamask.io/rewards-terms';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-268
Part 6 of https://github.com/MetaMask/metamask-extension/pull/36827 introduces new rewards onboarding components
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37919?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements the Rewards onboarding flow (modal with steps, error toast/banner, referral opt‑in) with full tests and new locale strings.
> 
> - **UI/Flow**:
>   - Add `Rewards` onboarding modal `ui/components/app/rewards/onboarding/OnboardingModal.tsx` with steps `OnboardingIntroStep`, `OnboardingStep1`, `OnboardingStep2`, `OnboardingStep3`, `OnboardingStep4` and `ProgressIndicator`.
>   - New error surfaces: `RewardsErrorBanner` and `RewardsErrorToast`.
> - **Logic**:
>   - Intro step handles geo eligibility, hardware wallet checks, and candidate subscription ID states (`pending/retry/error`) with retry actions; advances through steps; persists modal‑shown flag.
>   - Step 4 supports referral code validation UI and opt‑in action; legal links via constants in `onboarding/constants.ts`.
> - **i18n**:
>   - Add/enhance Rewards onboarding and error strings in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Comprehensive tests for modal, steps 1–4, error banner/toast, and progress indicator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 978bad2e88b4f14dac4d18b3b233396134633ccd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->