### PR TITLE
feat: show onboarding tour when signing up for rewards

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -668,6 +668,7 @@
     },
     "@material-ui/core": {
       "globals": {
+        "Image": true,
         "_formatMuiErrorMessage": true,
         "addEventListener": true,
         "clearInterval": true,
@@ -677,8 +678,13 @@
         "document": true,
         "getComputedStyle": true,
         "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
         "performance.now": true,
         "removeEventListener": true,
+        "requestAnimationFrame": true,
         "setInterval": true,
         "setTimeout": true
       },
@@ -688,6 +694,7 @@
         "@material-ui/core>@material-ui/system": true,
         "@material-ui/core>@material-ui/utils": true,
         "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>popper.js": true,
         "prop-types": true,
         "react": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -668,6 +668,7 @@
     },
     "@material-ui/core": {
       "globals": {
+        "Image": true,
         "_formatMuiErrorMessage": true,
         "addEventListener": true,
         "clearInterval": true,
@@ -677,8 +678,13 @@
         "document": true,
         "getComputedStyle": true,
         "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
         "performance.now": true,
         "removeEventListener": true,
+        "requestAnimationFrame": true,
         "setInterval": true,
         "setTimeout": true
       },
@@ -688,6 +694,7 @@
         "@material-ui/core>@material-ui/system": true,
         "@material-ui/core>@material-ui/utils": true,
         "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>popper.js": true,
         "prop-types": true,
         "react": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -668,6 +668,7 @@
     },
     "@material-ui/core": {
       "globals": {
+        "Image": true,
         "_formatMuiErrorMessage": true,
         "addEventListener": true,
         "clearInterval": true,
@@ -677,8 +678,13 @@
         "document": true,
         "getComputedStyle": true,
         "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
         "performance.now": true,
         "removeEventListener": true,
+        "requestAnimationFrame": true,
         "setInterval": true,
         "setTimeout": true
       },
@@ -688,6 +694,7 @@
         "@material-ui/core>@material-ui/system": true,
         "@material-ui/core>@material-ui/utils": true,
         "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>popper.js": true,
         "prop-types": true,
         "react": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -668,6 +668,7 @@
     },
     "@material-ui/core": {
       "globals": {
+        "Image": true,
         "_formatMuiErrorMessage": true,
         "addEventListener": true,
         "clearInterval": true,
@@ -677,8 +678,13 @@
         "document": true,
         "getComputedStyle": true,
         "getSelection": true,
+        "innerHeight": true,
+        "innerWidth": true,
+        "matchMedia": true,
+        "navigator": true,
         "performance.now": true,
         "removeEventListener": true,
+        "requestAnimationFrame": true,
         "setInterval": true,
         "setTimeout": true
       },
@@ -688,6 +694,7 @@
         "@material-ui/core>@material-ui/system": true,
         "@material-ui/core>@material-ui/utils": true,
         "@material-ui/core>clsx": true,
+        "react-redux>hoist-non-react-statics": true,
         "@material-ui/core>popper.js": true,
         "prop-types": true,
         "react": true,

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -5,7 +5,9 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   selectCandidateSubscriptionId,
   selectOnboardingModalRendered,
+  selectRewardsBadgeHidden,
   selectRewardsEnabled,
+  selectRewardsOnboardingEnabled,
   selectSeasonStatus,
   selectSeasonStatusError,
 } from '../../../ducks/rewards/selectors';
@@ -111,6 +113,8 @@ describe('RewardsPointsBalance', () => {
   const setSelectorValues = ({
     locale = 'en-US',
     rewardsEnabled = true,
+    rewardsOnboardingEnabled = true,
+    rewardsBadgeHidden = false,
     candidateSubscriptionId = 'test-subscription-id',
     seasonStatus = mockSeasonStatus,
     seasonStatusError = null,
@@ -120,6 +124,8 @@ describe('RewardsPointsBalance', () => {
   }: {
     locale?: string;
     rewardsEnabled?: boolean;
+    rewardsOnboardingEnabled?: boolean;
+    rewardsBadgeHidden?: boolean;
     candidateSubscriptionId?: string | null;
     seasonStatus?: typeof mockSeasonStatus | null;
     seasonStatusError?: string | null;
@@ -133,6 +139,12 @@ describe('RewardsPointsBalance', () => {
       }
       if (selector === selectRewardsEnabled) {
         return rewardsEnabled;
+      }
+      if (selector === selectRewardsOnboardingEnabled) {
+        return rewardsOnboardingEnabled;
+      }
+      if (selector === selectRewardsBadgeHidden) {
+        return rewardsBadgeHidden;
       }
       if (selector === selectCandidateSubscriptionId) {
         return candidateSubscriptionId;
@@ -193,7 +205,12 @@ describe('RewardsPointsBalance', () => {
   });
 
   it('should render sign-up badge when candidateSubscriptionId is null', () => {
-    setSelectorValues({ candidateSubscriptionId: null, seasonStatus: null });
+    setSelectorValues({
+      candidateSubscriptionId: null,
+      seasonStatus: null,
+      rewardsOnboardingEnabled: true,
+      rewardsBadgeHidden: false,
+    });
     render(<RewardsPointsBalance />);
     const container = screen.getByTestId('rewards-points-balance');
     expect(container).toBeInTheDocument();

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -13,6 +13,7 @@ import {
   selectOnboardingModalRendered,
   selectRewardsBadgeHidden,
   selectRewardsEnabled,
+  selectRewardsOnboardingEnabled,
   selectSeasonStatus,
   selectSeasonStatusError,
 } from '../../../ducks/rewards/selectors';
@@ -39,6 +40,7 @@ export const RewardsPointsBalance = () => {
   const dispatch = useDispatch();
 
   const rewardsEnabled = useSelector(selectRewardsEnabled);
+  const rewardsOnboardingEnabled = useSelector(selectRewardsOnboardingEnabled);
   const rewardsBadgeHidden = useSelector(selectRewardsBadgeHidden);
   const seasonStatus = useSelector(selectSeasonStatus);
   const seasonStatusError = useSelector(selectSeasonStatusError);
@@ -100,6 +102,7 @@ export const RewardsPointsBalance = () => {
     if (
       !isTestEnv &&
       rewardsEnabled &&
+      rewardsOnboardingEnabled &&
       candidateSubscriptionId === null && // determined that it's null
       !rewardsActiveAccountSubscriptionId && // determined that it's not the active account
       !onboardingModalRendered
@@ -113,6 +116,7 @@ export const RewardsPointsBalance = () => {
     candidateSubscriptionId,
     rewardsActiveAccountSubscriptionId,
     onboardingModalRendered,
+    rewardsOnboardingEnabled,
   ]);
 
   const setHasSeenOnboardingInStorage = useCallback(async () => {
@@ -143,7 +147,7 @@ export const RewardsPointsBalance = () => {
   }
 
   if (!candidateSubscriptionId) {
-    return rewardsBadgeHidden ? null : (
+    return rewardsBadgeHidden || !rewardsOnboardingEnabled ? null : (
       <RewardsBadge
         boxClassName="gap-1 px-1.5 bg-background-muted rounded"
         formattedPoints={t('rewardsSignUp')}

--- a/ui/ducks/rewards/selectors.ts
+++ b/ui/ducks/rewards/selectors.ts
@@ -61,6 +61,29 @@ export const selectRewardsEnabled = createSelector(
   },
 );
 
+export const selectRewardsOnboardingEnabled = createSelector(
+  getRemoteFeatureFlags,
+  getUseExternalServices,
+  (remoteFeatureFlags, useExternalServices): boolean => {
+    const rewardsFeatureFlag = remoteFeatureFlags?.rewardsOnboardingEnabled as
+      | VersionGatedFeatureFlag
+      | boolean
+      | undefined;
+
+    const resolveFlag = (flag: unknown): boolean => {
+      if (typeof flag === 'boolean') {
+        return flag;
+      }
+      return Boolean(
+        validatedVersionGatedFeatureFlag(flag as VersionGatedFeatureFlag),
+      );
+    };
+
+    const featureFlagEnabled = resolveFlag(rewardsFeatureFlag);
+    return featureFlagEnabled && Boolean(useExternalServices);
+  },
+);
+
 export const selectErrorToast = (state: MetaMaskReduxState) =>
   state.rewards.errorToast;
 

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -69,6 +69,7 @@ import { setEditedNetwork } from '../../store/actions';
 import { navigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
 import PasswordOutdatedModal from '../../components/app/password-outdated-modal';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
+import RewardsOnboardingModal from '../../components/app/rewards/onboarding/OnboardingModal';
 ///: BEGIN:ONLY_INCLUDE_IF(build-beta)
 import BetaHomeFooter from './beta/beta-home-footer.component';
 ///: END:ONLY_INCLUDE_IF
@@ -176,6 +177,7 @@ export default class Home extends PureComponent {
     pendingShieldCohort: PropTypes.string,
     setPendingShieldCohort: PropTypes.func,
     isSignedIn: PropTypes.bool,
+    rewardsEnabled: PropTypes.bool,
   };
 
   state = {
@@ -868,6 +870,7 @@ export default class Home extends PureComponent {
       isPrimarySeedPhraseBackedUp,
       showShieldEntryModal,
       isSocialLoginFlow,
+      rewardsEnabled,
     } = this.props;
 
     if (forgottenPassword) {
@@ -934,6 +937,11 @@ export default class Home extends PureComponent {
             <TermsOfUsePopup onAccept={this.onAcceptTermsOfUse} />
           ) : null}
           {showShieldEntryModal && <ShieldEntryModal />}
+          {rewardsEnabled &&
+            !showTermsOfUse &&
+            !showWhatsNew &&
+            !showMultiRpcEditModal &&
+            !displayUpdateModal && <RewardsOnboardingModal />}
           {isPopup && !connectedStatusPopoverHasBeenShown
             ? this.renderPopover()
             : null}

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -178,6 +178,7 @@ export default class Home extends PureComponent {
     setPendingShieldCohort: PropTypes.func,
     isSignedIn: PropTypes.bool,
     rewardsEnabled: PropTypes.bool,
+    rewardsOnboardingEnabled: PropTypes.bool,
   };
 
   state = {
@@ -871,6 +872,7 @@ export default class Home extends PureComponent {
       showShieldEntryModal,
       isSocialLoginFlow,
       rewardsEnabled,
+      rewardsOnboardingEnabled,
     } = this.props;
 
     if (forgottenPassword) {
@@ -909,6 +911,23 @@ export default class Home extends PureComponent {
       showTermsOfUsePopup &&
       !isSocialLoginFlow;
 
+    const showRecoveryPhrase =
+      !showWhatsNew &&
+      showRecoveryPhraseReminder &&
+      !isPrimarySeedPhraseBackedUp;
+
+    const showRewardsModal =
+      rewardsEnabled &&
+      rewardsOnboardingEnabled &&
+      canSeeModals &&
+      !showTermsOfUse &&
+      !showWhatsNew &&
+      !showMultiRpcEditModal &&
+      !displayUpdateModal &&
+      !isSeedlessPasswordOutdated &&
+      !showShieldEntryModal &&
+      !showRecoveryPhrase;
+
     return (
       <ScrollContainer className="main-container main-container--has-shadow">
         <Route path={CONNECTED_ROUTE} component={ConnectedSites} exact />
@@ -926,9 +945,7 @@ export default class Home extends PureComponent {
           {showMultiRpcEditModal && <MultiRpcEditModal />}
           {displayUpdateModal && <UpdateModal />}
           {showWhatsNew ? <WhatsNewModal onClose={hideWhatsNewPopup} /> : null}
-          {!showWhatsNew &&
-          showRecoveryPhraseReminder &&
-          !isPrimarySeedPhraseBackedUp ? (
+          {showRecoveryPhrase ? (
             <RecoveryPhraseReminder
               onConfirm={this.onRecoveryPhraseReminderClose}
             />
@@ -937,11 +954,7 @@ export default class Home extends PureComponent {
             <TermsOfUsePopup onAccept={this.onAcceptTermsOfUse} />
           ) : null}
           {showShieldEntryModal && <ShieldEntryModal />}
-          {rewardsEnabled &&
-            !showTermsOfUse &&
-            !showWhatsNew &&
-            !showMultiRpcEditModal &&
-            !displayUpdateModal && <RewardsOnboardingModal />}
+          {showRewardsModal && <RewardsOnboardingModal />}
           {isPopup && !connectedStatusPopoverHasBeenShown
             ? this.renderPopover()
             : null}

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -66,6 +66,7 @@ import {
 } from '../../ducks/metamask/metamask';
 import { getSwapsFeatureIsLive } from '../../ducks/swaps/swaps';
 import { fetchBuyableChains } from '../../ducks/ramps';
+import { selectRewardsEnabled } from '../../ducks/rewards/selectors';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
@@ -195,6 +196,7 @@ const mapStateToProps = (state) => {
     isSocialLoginFlow: getIsSocialLoginFlow(state),
     pendingShieldCohort: getPendingShieldCohort(state),
     isSignedIn: state.metamask.isSignedIn,
+    rewardsEnabled: selectRewardsEnabled(state),
   };
 };
 

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -66,7 +66,10 @@ import {
 } from '../../ducks/metamask/metamask';
 import { getSwapsFeatureIsLive } from '../../ducks/swaps/swaps';
 import { fetchBuyableChains } from '../../ducks/ramps';
-import { selectRewardsEnabled } from '../../ducks/rewards/selectors';
+import {
+  selectRewardsEnabled,
+  selectRewardsOnboardingEnabled,
+} from '../../ducks/rewards/selectors';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
@@ -197,6 +200,7 @@ const mapStateToProps = (state) => {
     pendingShieldCohort: getPendingShieldCohort(state),
     isSignedIn: state.metamask.isSignedIn,
     rewardsEnabled: selectRewardsEnabled(state),
+    rewardsOnboardingEnabled: selectRewardsOnboardingEnabled(state),
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-268
Part 7 of https://github.com/MetaMask/metamask-extension/pull/36827 install onboarding modal on homepage
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37920?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show onboarding tour when signing up for rewards

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce rewards onboarding feature flag, show onboarding modal on Home, gate sign-up badge/modal in RewardsPointsBalance, update tests, and expand LavaMoat policies.
> 
> - **Rewards UI/Logic**:
>   - Add selector `selectRewardsOnboardingEnabled` to gate onboarding via remote feature flag.
>   - Update `RewardsPointsBalance` to:
>     - Respect `selectRewardsOnboardingEnabled` for opening the onboarding modal and for sign-up badge visibility.
>     - Persist onboarding-seen state; minor effect cleanups.
>   - Home page (`home.component/container`):
>     - Inject `rewardsEnabled` and `rewardsOnboardingEnabled` and conditionally render `RewardsOnboardingModal` alongside existing modal gating.
> - **Tests**:
>   - Expand `RewardsPointsBalance.test.tsx` to cover onboarding-flag and badge-hidden scenarios.
> - **LavaMoat policies**:
>   - Broaden allowed globals/packages for `@material-ui/core` (e.g., `Image`, `innerHeight/Width`, `matchMedia`, `navigator`, `requestAnimationFrame`, `react-redux>hoist-non-react-statics`) across `beta`, `experimental`, `flask`, and `main` policy files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf0b9a93bae8b752d4e317ded3fc257e53b0c1c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->