### PR TITLE
fix: notification screen route

### DIFF
--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { NOTIFICATIONS_ROUTE } from '../../helpers/constants/routes';
 import {
@@ -58,7 +58,6 @@ function useNotificationAccounts() {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function NotificationsSettings() {
   const navigate = useNavigate();
-  const location = useLocation();
   const t = useI18nContext();
 
   // Selectors
@@ -86,9 +85,6 @@ export default function NotificationsSettings() {
     await accountSettingsProps.update(accountAddresses);
   };
 
-  // Previous page
-  const previousPage = location.state?.fromPage;
-
   return (
     <NotificationsPage>
       <Header
@@ -97,11 +93,15 @@ export default function NotificationsSettings() {
             ariaLabel="Back"
             iconName={IconName.ArrowLeft}
             size={ButtonIconSize.Md}
-            onClick={() =>
-              previousPage
-                ? navigate(previousPage)
-                : navigate(NOTIFICATIONS_ROUTE)
-            }
+            onClick={() => {
+              // Use browser history for natural back navigation
+              // Fallback to notifications route if no history exists
+              if (window.history.length > 1) {
+                navigate(-1);
+              } else {
+                navigate(NOTIFICATIONS_ROUTE);
+              }
+            }}
           />
         }
         endAccessory={null}

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -494,9 +494,7 @@ class SettingsPage extends PureComponent {
             this.setState({ showShieldEntryModal: true });
             return;
           }
-          navigate(key, {
-            state: { fromPage: currentPath },
-          });
+          navigate(key);
         }}
       />
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the Notification screen back button

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37921?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: notification screen back handling

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-709

## **Manual testing steps**

Scenario A
1. Settings > Notifications
2. Click back
3. Should go back to Settings

Scenario B
1. Home screen > Notifications
2. Click back
3. Should go back to Home

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use browser history for Notifications back navigation with route fallback and remove state-based back tracking from Settings tab navigation.
> 
> - **Routing/Navigation**
>   - `ui/pages/notifications-settings/notifications-settings.tsx`
>     - Replace `useLocation`/state-based back logic with history-based `navigate(-1)` and fallback to `NOTIFICATIONS_ROUTE`.
>     - Remove unused `useLocation` import.
>   - `ui/pages/settings/settings.component.js`
>     - Simplify tab `onSelect` to `navigate(key)`; stop passing `{ state: { fromPage: currentPath } }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de722badd78c386116acf343f1051b6829dc0710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->