### PR TITLE
fix: shield claim submission error message

### DIFF
--- a/ui/pages/settings/transaction-shield-tab/claims-form/constants.ts
+++ b/ui/pages/settings/transaction-shield-tab/claims-form/constants.ts
@@ -14,7 +14,6 @@ export const ERROR_MESSAGE_MAP: Partial<
     SubmitClaimErrorCode,
     {
       messageKey: string;
-      params?: (string | number)[];
       field?: SubmitClaimField;
     }
   >

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -8007,6 +8007,9 @@ export async function submitShieldClaim(
 
     return ClaimSubmitToastType.Success;
   } catch (error) {
+    if (error instanceof SubmitClaimError) {
+      throw error;
+    }
     log.error('[submitShieldClaim] Failed to submit shield claim:', error);
     throw new SubmitClaimError(ClaimSubmitToastType.Errored);
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix Claim submission error message.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37924?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Shield claim error handling by using i18n keys with params, routing mapped errors to specific fields, and preserving SubmitClaimError propagation.
> 
> - **Shield Claims UI (`claims-form.tsx`)**:
>   - Error state now stores `messageKey` + optional `params`; `setErrorMessage` accepts params.
>   - On submit errors, map root `errorCode`s (e.g., `SUBMISSION_WINDOW_EXPIRED`) to field errors or toast, passing params like `validSubmissionWindowDays`.
>   - Field help/error texts use `t(key, params)` for email, reimbursement address, impacted tx hash, and description.
>   - Dependency arrays updated (include `validSubmissionWindowDays`).
> - **Constants (`constants.ts`)**:
>   - `ERROR_MESSAGE_MAP` type no longer includes `params`; maintains message keys and optional `field` routing.
> - **Store (`ui/store/actions.ts`)**:
>   - `submitShieldClaim` rethrows existing `SubmitClaimError` and logs only unexpected errors before wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d5cb6e269f35a483284fc22730db54225c22a1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->