### PR TITLE
feat: Implement rewards text into dapp swap comparison banner

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2583,6 +2583,9 @@
   "estimatedFeeTooltip": {
     "message": "Amount paid to process the transaction on network."
   },
+  "estimatedPointsRow": {
+    "message": "Est. points"
+  },
   "ethGasPriceFetchWarning": {
     "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1887,6 +1887,9 @@
   "dappSwapQuoteDifference": {
     "message": "Save $1"
   },
+  "dappSwapRewardText": {
+    "message": "Earn $1 points"
+  },
   "darkTheme": {
     "message": "Dark"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2583,6 +2583,9 @@
   "estimatedFeeTooltip": {
     "message": "Amount paid to process the transaction on network."
   },
+  "estimatedPointsRow": {
+    "message": "Est. points"
+  },
   "ethGasPriceFetchWarning": {
     "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1887,6 +1887,9 @@
   "dappSwapQuoteDifference": {
     "message": "Save $1"
   },
+  "dappSwapRewardText": {
+    "message": "Earn $1 points"
+  },
   "darkTheme": {
     "message": "Dark"
   },

--- a/ui/hooks/bridge/useRewards.test.ts
+++ b/ui/hooks/bridge/useRewards.test.ts
@@ -794,7 +794,7 @@ describe('useRewards', () => {
       expect(result.current.hasError).toBe(true);
       expect(result.current.estimatedPoints).toBeNull();
       expect(mockLogError).toHaveBeenCalledWith(
-        '[useRewards] Error estimating points:',
+        '[useRewardsWithQuote] Error estimating points:',
         error,
       );
     });

--- a/ui/hooks/bridge/useRewards.ts
+++ b/ui/hooks/bridge/useRewards.ts
@@ -105,27 +105,35 @@ type UseRewardsParams = {
   > | null;
 };
 
-export const useRewards = ({
-  activeQuote,
-}: UseRewardsParams): UseRewardsResult => {
+type UseRewardsWithQuoteParams = {
+  quote: NonNullable<
+    NonNullable<ReturnType<typeof selectBridgeQuotes>['activeQuote']>['quote']
+  > | null;
+  fromAddress: string | null | undefined;
+  chainId: string | null | undefined;
+};
+
+/**
+ * A hook that accepts quote, fromAddress, and chainId as arguments
+ * and estimates rewards for the given quote.
+ *
+ * @param options0 - The hook parameters
+ * @param options0.quote - The bridge quote to estimate rewards for
+ * @param options0.fromAddress - The address sending the transaction
+ * @param options0.chainId - The chain ID for the transaction
+ * @returns An object containing rewards estimation state
+ */
+export const useRewardsWithQuote = ({
+  quote,
+  fromAddress,
+  chainId,
+}: UseRewardsWithQuoteParams): UseRewardsResult => {
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [estimatedPoints, setEstimatedPoints] = useState<number | null>(null);
   const [shouldShowRewardsRow, setShouldShowRewardsRow] = useState(false);
   const [hasError, setHasError] = useState(false);
-  const prevRequestId = usePrevious(activeQuote?.requestId);
-  const fromToken = useSelector(getFromToken);
-  const toToken = useSelector(getToToken);
-  const quoteRequest = useSelector(getQuoteRequest);
-  const currentChainId = useMultichainSelector(getMultichainCurrentChainId);
-  const caipChainId = currentChainId
-    ? formatChainIdToCaip(currentChainId.toString())
-    : null;
-  const selectedAccount = useSelector((state) =>
-    caipChainId
-      ? getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId)
-      : null,
-  );
+  const prevRequestId = usePrevious(quote?.requestId);
   const rewardsEnabled = useSelector(selectRewardsEnabled);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -204,7 +212,7 @@ export const useRewards = ({
 
           setEstimatedPoints(result.pointsEstimate);
         } catch (error) {
-          log.error('[useRewards] Error estimating points:', error);
+          log.error('[useRewardsWithQuote] Error estimating points:', error);
           setEstimatedPoints(null);
           setHasError(true);
         } finally {
@@ -225,15 +233,7 @@ export const useRewards = ({
         | null,
     ) => {
       // Skip if no active quote or missing required data
-      if (
-        !estimationQuoteArg ||
-        !fromToken ||
-        !toToken ||
-        !selectedAccount?.address ||
-        !quoteRequest?.srcTokenAmount ||
-        !currentChainId ||
-        !rewardsEnabled
-      ) {
+      if (!estimationQuoteArg || !fromAddress || !chainId || !rewardsEnabled) {
         setEstimatedPoints(null);
         setShouldShowRewardsRow(false);
         setIsLoading(false);
@@ -245,10 +245,7 @@ export const useRewards = ({
 
       try {
         // Format account to CAIP-10
-        caipAccount = formatAccountToCaipAccountId(
-          selectedAccount.address,
-          currentChainId.toString(),
-        );
+        caipAccount = formatAccountToCaipAccountId(fromAddress, chainId);
 
         if (!caipAccount) {
           return;
@@ -281,28 +278,19 @@ export const useRewards = ({
         setHasError(false);
       }
     },
-    [
-      fromToken,
-      toToken,
-      selectedAccount,
-      quoteRequest,
-      currentChainId,
-      rewardsEnabled,
-      debouncedEstimatePoints,
-      dispatch,
-    ],
+    [fromAddress, chainId, rewardsEnabled, debouncedEstimatePoints, dispatch],
   );
 
   // Estimate points when dependencies change
   useEffect(() => {
-    if (prevRequestId !== activeQuote?.requestId) {
-      estimatePoints(activeQuote);
+    if (prevRequestId !== quote?.requestId) {
+      estimatePoints(quote);
     }
   }, [
     estimatePoints,
     // Only re-estimate when quote changes (not during loading)
-    activeQuote?.requestId,
-    activeQuote,
+    quote?.requestId,
+    quote,
     prevRequestId,
   ]);
 
@@ -312,4 +300,45 @@ export const useRewards = ({
     estimatedPoints,
     hasError,
   };
+};
+
+/**
+ * A hook that reads data from Redux selectors and passes it to useRewardsWithQuote.
+ * Includes Bridge-specific validation checks for fromToken, toToken, and quoteRequest
+ * and passes the data to useRewardsWithQuote.
+ *
+ * @param options - The hook parameters
+ * @param options.activeQuote - The active bridge quote
+ * @returns An object containing rewards estimation state
+ */
+export const useRewards = ({
+  activeQuote,
+}: UseRewardsParams): UseRewardsResult => {
+  const fromToken = useSelector(getFromToken);
+  const toToken = useSelector(getToToken);
+  const quoteRequest = useSelector(getQuoteRequest);
+  const currentChainId = useMultichainSelector(getMultichainCurrentChainId);
+  const caipChainId = currentChainId
+    ? formatChainIdToCaip(currentChainId.toString())
+    : null;
+  const selectedAccount = useSelector((state) =>
+    caipChainId
+      ? getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId)
+      : null,
+  );
+
+  // Bridge-specific validation: ensure all required Bridge UI data is present
+  const hasRequiredBridgeData =
+    fromToken &&
+    toToken &&
+    quoteRequest?.srcTokenAmount &&
+    selectedAccount?.address;
+
+  // Use the child hook with data from selectors
+  // Pass null for quote if Bridge validation fails to prevent estimation
+  return useRewardsWithQuote({
+    quote: hasRequiredBridgeData ? activeQuote : null,
+    fromAddress: selectedAccount?.address,
+    chainId: currentChainId?.toString(),
+  });
 };

--- a/ui/hooks/bridge/useRewards.ts
+++ b/ui/hooks/bridge/useRewards.ts
@@ -117,10 +117,10 @@ type UseRewardsWithQuoteParams = {
  * A hook that accepts quote, fromAddress, and chainId as arguments
  * and estimates rewards for the given quote.
  *
- * @param options0 - The hook parameters
- * @param options0.quote - The bridge quote to estimate rewards for
- * @param options0.fromAddress - The address sending the transaction
- * @param options0.chainId - The chain ID for the transaction
+ * @param options - The hook parameters
+ * @param options.quote - The bridge quote to estimate rewards for
+ * @param options.fromAddress - The address sending the transaction
+ * @param options.chainId - The chain ID for the transaction
  * @returns An object containing rewards estimation state
  */
 export const useRewardsWithQuote = ({
@@ -334,7 +334,6 @@ export const useRewards = ({
     quoteRequest?.srcTokenAmount &&
     selectedAccount?.address;
 
-  // Use the child hook with data from selectors
   // Pass null for quote if Bridge validation fails to prevent estimation
   return useRewardsWithQuote({
     quote: hasRequiredBridgeData ? activeQuote : null,

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -11,6 +11,7 @@ import { getRemoteFeatureFlags } from '../../../../../selectors/remote-feature-f
 import { Confirmation } from '../../../types/confirm';
 import { useDappSwapComparisonInfo } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo';
 import * as ConfirmContext from '../../../context/confirm';
+import { useDappSwapComparisonRewardText } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText';
 import { DappSwapComparisonBanner } from './dapp-swap-comparison-banner';
 
 jest.mock(
@@ -42,6 +43,13 @@ jest.mock(
       captureDappSwapComparisonDisplayProperties:
         mockCaptureDappSwapComparisonDisplayProperties,
     })),
+  }),
+);
+
+jest.mock(
+  '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText',
+  () => ({
+    useDappSwapComparisonRewardText: jest.fn(),
   }),
 );
 
@@ -101,6 +109,9 @@ function render(args: Record<string, string> = {}) {
 describe('<DappSwapComparisonBanner />', () => {
   const mockGetRemoteFeatureFlags = jest.mocked(getRemoteFeatureFlags);
   const mockUseDappSwapComparisonInfo = jest.mocked(useDappSwapComparisonInfo);
+  const mockUseDappSwapComparisonRewardText = jest.mocked(
+    useDappSwapComparisonRewardText,
+  );
 
   beforeEach(() => {
     mockCaptureDappSwapComparisonDisplayProperties.mockClear();
@@ -108,6 +119,7 @@ describe('<DappSwapComparisonBanner />', () => {
       dappSwapMetrics: { enabled: true },
       dappSwapUi: { enabled: true, threshold: 0.01 },
     });
+    mockUseDappSwapComparisonRewardText.mockReturnValue(null);
   });
 
   it('renders component without errors', () => {
@@ -199,5 +211,14 @@ describe('<DappSwapComparisonBanner />', () => {
     ).toHaveBeenNthCalledWith(1, {
       swap_mm_cta_displayed: 'true',
     });
+  });
+
+  it('renders rewards text when it is provided', () => {
+    mockUseDappSwapComparisonRewardText.mockReturnValue({
+      text: 'Earn 100 points',
+      estimatedPoints: 100,
+    });
+    const { getByText } = render();
+    expect(getByText('Earn 100 points')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -219,6 +219,6 @@ describe('<DappSwapComparisonBanner />', () => {
       estimatedPoints: 100,
     });
     const { getByText } = render();
-    expect(getByText('Earn 100 points')).toBeInTheDocument();
+    expect(getByText(/Earn 100 points/u)).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -216,7 +216,7 @@ const DappSwapComparisonInner = () => {
             {t('dappSwapQuoteDifference', [
               `$${(gasDifference + tokenAmountDifference).toFixed(2)}`,
             ])}
-            {rewardsText ? <span>{rewardsText}</span> : null}
+            {rewardsText && <span>{rewardsText}</span>}
           </Text>
           <Text color={TextColor.TextAlternative} variant={TextVariant.BodyXs}>
             {t('dappSwapBenefits')}

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -24,6 +24,7 @@ import { useConfirmContext } from '../../../context/confirm';
 import { useDappSwapComparisonInfo } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo';
 import { useDappSwapComparisonMetrics } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonMetrics';
 import { useSwapCheck } from '../../../hooks/transactions/dapp-swap-comparison/useSwapCheck';
+import { useDappSwapComparisonRewardText } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText';
 import { QuoteSwapSimulationDetails } from '../../transactions/quote-swap-simulation-details/quote-swap-simulation-details';
 import { ConfirmInfoSection } from '../../../../../components/app/confirm/info/row/section';
 import { NetworkRow } from '../info/shared/network-row/network-row';
@@ -96,6 +97,7 @@ const DappSwapComparisonInner = () => {
     dappSwapUi: DappSwapUiFlag;
   };
   const { setQuoteSelectedForMMSwap } = useConfirmContext();
+  const rewardsText = useDappSwapComparisonRewardText();
   const [selectedSwapType, setSelectedSwapType] = useState<SwapType>(
     SwapType.Current,
   );
@@ -214,6 +216,7 @@ const DappSwapComparisonInner = () => {
             {t('dappSwapQuoteDifference', [
               `$${(gasDifference + tokenAmountDifference).toFixed(2)}`,
             ])}
+            {rewardsText ? <span>{rewardsText}</span> : null}
           </Text>
           <Text color={TextColor.TextAlternative} variant={TextVariant.BodyXs}>
             {t('dappSwapBenefits')}

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -97,7 +97,7 @@ const DappSwapComparisonInner = () => {
     dappSwapUi: DappSwapUiFlag;
   };
   const { setQuoteSelectedForMMSwap } = useConfirmContext();
-  const rewardsText = useDappSwapComparisonRewardText();
+  const rewards = useDappSwapComparisonRewardText();
   const [selectedSwapType, setSelectedSwapType] = useState<SwapType>(
     SwapType.Current,
   );
@@ -216,7 +216,7 @@ const DappSwapComparisonInner = () => {
             {t('dappSwapQuoteDifference', [
               `$${(gasDifference + tokenAmountDifference).toFixed(2)}`,
             ])}
-            {rewardsText && <span>{rewardsText}</span>}
+            {rewards && <span> • {rewards.text}</span>}
           </Text>
           <Text color={TextColor.TextAlternative} variant={TextVariant.BodyXs}>
             {t('dappSwapBenefits')}

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -216,7 +216,7 @@ const DappSwapComparisonInner = () => {
             {t('dappSwapQuoteDifference', [
               `$${(gasDifference + tokenAmountDifference).toFixed(2)}`,
             ])}
-            {rewards && <span> • {rewards.text}</span>}
+            {rewards && <span>{` • ${rewards.text}`}</span>}
           </Text>
           <Text color={TextColor.TextAlternative} variant={TextVariant.BodyXs}>
             {t('dappSwapBenefits')}

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
@@ -8,6 +8,7 @@ import { GasFeesSection } from '../shared/gas-fees-section/gas-fees-section';
 import { TransactionDetails } from '../shared/transaction-details/transaction-details';
 import { TransactionAccountDetails } from '../batch/transaction-account-details';
 import { BatchSimulationDetails } from '../batch/batch-simulation-details/batch-simulation-details';
+import { EstimatedPointsSection } from '../../../estimated-points';
 
 const BaseTransactionInfo = () => {
   const { currentConfirmation: transactionMeta, isQuotedSwapDisplayedInInfo } =
@@ -29,6 +30,7 @@ const BaseTransactionInfo = () => {
       )}
       <GasFeesSection />
       <AdvancedDetails />
+      <EstimatedPointsSection />
     </>
   );
 };

--- a/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
+++ b/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useDappSwapComparisonRewardText } from '../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText';
+import { useConfirmContext } from '../../context/confirm';
 import { EstimatedPointsSection } from './estimated-points';
 
 jest.mock('../../../../hooks/useI18nContext', () => ({
@@ -13,8 +16,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../hooks/transactions/dapp-swap-comparison/useSwapCheck', () => ({
-  useSwapCheck: jest.fn(),
+jest.mock('../../context/confirm', () => ({
+  useConfirmContext: jest.fn(),
 }));
 
 jest.mock('../../../../components/app/confirm/info/row', () => ({
@@ -37,49 +40,53 @@ jest.mock('../../../../components/app/rewards/RewardsBadge', () => ({
   ),
 }));
 
-const { useI18nContext } = require('../../../../hooks/useI18nContext');
-const {
+const mockUseI18nContext = jest.mocked(useI18nContext);
+const mockUseDappSwapComparisonRewardText = jest.mocked(
   useDappSwapComparisonRewardText,
-} = require('../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText');
-const {
-  useSwapCheck,
-} = require('../../hooks/transactions/dapp-swap-comparison/useSwapCheck');
+);
+const mockUseConfirmContext = jest.mocked(useConfirmContext);
 
 describe('EstimatedPointsSection', () => {
   const mockT = jest.fn((key) => key);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useI18nContext.mockReturnValue(mockT);
+    mockUseI18nContext.mockReturnValue(mockT);
   });
 
   it('returns null when rewards is null', () => {
-    useDappSwapComparisonRewardText.mockReturnValue(null);
-    useSwapCheck.mockReturnValue({ isQuotedSwap: true });
+    mockUseDappSwapComparisonRewardText.mockReturnValue(null);
+    mockUseConfirmContext.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+    } as unknown as ReturnType<typeof useConfirmContext>);
 
     const { container } = render(<EstimatedPointsSection />);
 
     expect(container.firstChild).toBeNull();
   });
 
-  it('returns null when isQuotedSwap is false', () => {
-    useDappSwapComparisonRewardText.mockReturnValue({
+  it('returns null when isQuotedSwapDisplayedInInfo is false', () => {
+    mockUseDappSwapComparisonRewardText.mockReturnValue({
       text: 'Earn up to 100 points',
       estimatedPoints: 100,
     });
-    useSwapCheck.mockReturnValue({ isQuotedSwap: false });
+    mockUseConfirmContext.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: false,
+    } as unknown as ReturnType<typeof useConfirmContext>);
 
     const { container } = render(<EstimatedPointsSection />);
 
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders the section when rewards exist and isQuotedSwap is true', () => {
-    useDappSwapComparisonRewardText.mockReturnValue({
+  it('renders the section when rewards exist and isQuotedSwapDisplayedInInfo is true', () => {
+    mockUseDappSwapComparisonRewardText.mockReturnValue({
       text: 'Earn up to 100 points',
       estimatedPoints: 100,
     });
-    useSwapCheck.mockReturnValue({ isQuotedSwap: true });
+    mockUseConfirmContext.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+    } as unknown as ReturnType<typeof useConfirmContext>);
 
     render(<EstimatedPointsSection />);
 

--- a/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
+++ b/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
@@ -21,7 +21,13 @@ jest.mock('../../context/confirm', () => ({
 }));
 
 jest.mock('../../../../components/app/confirm/info/row', () => ({
-  ConfirmInfoRow: ({ children, label }: any) => (
+  ConfirmInfoRow: ({
+    children,
+    label,
+  }: {
+    children: React.ReactNode;
+    label: string;
+  }) => (
     <div data-testid="confirm-info-row" data-label={label}>
       {children}
     </div>
@@ -29,13 +35,13 @@ jest.mock('../../../../components/app/confirm/info/row', () => ({
 }));
 
 jest.mock('../../../../components/app/confirm/info/row/section', () => ({
-  ConfirmInfoSection: ({ children }: any) => (
+  ConfirmInfoSection: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="confirm-info-section">{children}</div>
   ),
 }));
 
 jest.mock('../../../../components/app/rewards/RewardsBadge', () => ({
-  RewardsBadge: ({ formattedPoints }: any) => (
+  RewardsBadge: ({ formattedPoints }: { formattedPoints: string }) => (
     <div data-testid="rewards-badge">{formattedPoints}</div>
   ),
 }));

--- a/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
+++ b/ui/pages/confirmations/components/estimated-points/estimated-points.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { EstimatedPointsSection } from './estimated-points';
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: jest.fn(),
+}));
+
+jest.mock(
+  '../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText',
+  () => ({
+    useDappSwapComparisonRewardText: jest.fn(),
+  }),
+);
+
+jest.mock('../../hooks/transactions/dapp-swap-comparison/useSwapCheck', () => ({
+  useSwapCheck: jest.fn(),
+}));
+
+jest.mock('../../../../components/app/confirm/info/row', () => ({
+  ConfirmInfoRow: ({ children, label }: any) => (
+    <div data-testid="confirm-info-row" data-label={label}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('../../../../components/app/confirm/info/row/section', () => ({
+  ConfirmInfoSection: ({ children }: any) => (
+    <div data-testid="confirm-info-section">{children}</div>
+  ),
+}));
+
+jest.mock('../../../../components/app/rewards/RewardsBadge', () => ({
+  RewardsBadge: ({ formattedPoints }: any) => (
+    <div data-testid="rewards-badge">{formattedPoints}</div>
+  ),
+}));
+
+const { useI18nContext } = require('../../../../hooks/useI18nContext');
+const {
+  useDappSwapComparisonRewardText,
+} = require('../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText');
+const {
+  useSwapCheck,
+} = require('../../hooks/transactions/dapp-swap-comparison/useSwapCheck');
+
+describe('EstimatedPointsSection', () => {
+  const mockT = jest.fn((key) => key);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useI18nContext.mockReturnValue(mockT);
+  });
+
+  it('returns null when rewards is null', () => {
+    useDappSwapComparisonRewardText.mockReturnValue(null);
+    useSwapCheck.mockReturnValue({ isQuotedSwap: true });
+
+    const { container } = render(<EstimatedPointsSection />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when isQuotedSwap is false', () => {
+    useDappSwapComparisonRewardText.mockReturnValue({
+      text: 'Earn up to 100 points',
+      estimatedPoints: 100,
+    });
+    useSwapCheck.mockReturnValue({ isQuotedSwap: false });
+
+    const { container } = render(<EstimatedPointsSection />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the section when rewards exist and isQuotedSwap is true', () => {
+    useDappSwapComparisonRewardText.mockReturnValue({
+      text: 'Earn up to 100 points',
+      estimatedPoints: 100,
+    });
+    useSwapCheck.mockReturnValue({ isQuotedSwap: true });
+
+    render(<EstimatedPointsSection />);
+
+    expect(screen.getByTestId('confirm-info-row')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-info-row')).toHaveAttribute(
+      'data-label',
+      'estimatedPointsRow',
+    );
+    expect(screen.getByTestId('rewards-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('rewards-badge')).toHaveTextContent('100');
+  });
+});

--- a/ui/pages/confirmations/components/estimated-points/estimated-points.tsx
+++ b/ui/pages/confirmations/components/estimated-points/estimated-points.tsx
@@ -5,14 +5,14 @@ import { ConfirmInfoRow } from '../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../components/app/confirm/info/row/section';
 import { RewardsBadge } from '../../../../components/app/rewards/RewardsBadge';
 import { useDappSwapComparisonRewardText } from '../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText';
-import { useSwapCheck } from '../../hooks/transactions/dapp-swap-comparison/useSwapCheck';
+import { useConfirmContext } from '../../context/confirm';
 
 export const EstimatedPointsSection = () => {
   const t = useI18nContext();
   const rewards = useDappSwapComparisonRewardText();
-  const { isQuotedSwap } = useSwapCheck();
+  const { isQuotedSwapDisplayedInInfo } = useConfirmContext();
 
-  if (!rewards || !isQuotedSwap) {
+  if (!rewards || !isQuotedSwapDisplayedInInfo) {
     return null;
   }
 

--- a/ui/pages/confirmations/components/estimated-points/estimated-points.tsx
+++ b/ui/pages/confirmations/components/estimated-points/estimated-points.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { ConfirmInfoRow } from '../../../../components/app/confirm/info/row';
+import { ConfirmInfoSection } from '../../../../components/app/confirm/info/row/section';
+import { RewardsBadge } from '../../../../components/app/rewards/RewardsBadge';
+import { useDappSwapComparisonRewardText } from '../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText';
+import { useSwapCheck } from '../../hooks/transactions/dapp-swap-comparison/useSwapCheck';
+
+export const EstimatedPointsSection = () => {
+  const t = useI18nContext();
+  const rewards = useDappSwapComparisonRewardText();
+  const { isQuotedSwap } = useSwapCheck();
+
+  if (!rewards || !isQuotedSwap) {
+    return null;
+  }
+
+  return (
+    <ConfirmInfoSection data-testid="estimated-points-section">
+      <ConfirmInfoRow label={t('estimatedPointsRow')}>
+        <RewardsBadge formattedPoints={rewards.estimatedPoints.toString()} />
+      </ConfirmInfoRow>
+    </ConfirmInfoSection>
+  );
+};

--- a/ui/pages/confirmations/components/estimated-points/index.ts
+++ b/ui/pages/confirmations/components/estimated-points/index.ts
@@ -1,0 +1,1 @@
+export * from './estimated-points';

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
@@ -88,7 +88,10 @@ describe('useDappSwapComparisonRewardText', () => {
 
     const result = await runHook();
 
-    expect(result).toBe(' • Earn 1500 points');
+    expect(result).toEqual({
+      text: 'Earn 1500 points',
+      estimatedPoints: 1500,
+    });
   });
 
   it('returns null when no estimatedPoints', async () => {

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
@@ -1,6 +1,5 @@
 import { act } from '@testing-library/react';
 import { useRewardsWithQuote } from '../../../../../hooks/bridge/useRewards';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
 
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
 import { mockSwapConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.test.ts
@@ -1,0 +1,124 @@
+import { act } from '@testing-library/react';
+import { useRewardsWithQuote } from '../../../../../hooks/bridge/useRewards';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { mockSwapConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { Confirmation } from '../../../types/confirm';
+import { useDappSwapComparisonInfo } from './useDappSwapComparisonInfo';
+import { useDappSwapComparisonRewardText } from './useDappSwapComparisonRewardText';
+
+jest.mock('../../../../../hooks/bridge/useRewards');
+jest.mock('./useDappSwapComparisonInfo');
+
+async function runHook() {
+  const response = renderHookWithConfirmContextProvider(
+    useDappSwapComparisonRewardText,
+    getMockConfirmStateForTransaction(mockSwapConfirmation as Confirmation),
+  );
+
+  await act(async () => {
+    // Ignore
+  });
+
+  return response.result.current;
+}
+
+describe('useDappSwapComparisonRewardText', () => {
+  const mockUseDappSwapComparisonInfo = useDappSwapComparisonInfo as jest.Mock;
+  const mockUseRewardsWithQuote = useRewardsWithQuote as jest.Mock;
+
+  const mockSelectedQuote = {
+    quote: { id: 'quote-1' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDappSwapComparisonInfo.mockReturnValue({
+      selectedQuote: mockSelectedQuote,
+    });
+  });
+
+  it('returns null when shouldShowRewardsRow is false', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: false,
+      isLoading: false,
+      estimatedPoints: 1500,
+      hasError: false,
+    });
+
+    const result = await runHook();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when hasError is true', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: true,
+      isLoading: false,
+      estimatedPoints: 1500,
+      hasError: true,
+    });
+
+    const result = await runHook();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when isLoading is true', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: true,
+      isLoading: true,
+      estimatedPoints: 1500,
+      hasError: false,
+    });
+
+    const result = await runHook();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns formatted reward text when estimatedPoints is provided', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: true,
+      isLoading: false,
+      estimatedPoints: 1500,
+      hasError: false,
+    });
+
+    const result = await runHook();
+
+    expect(result).toBe(' • Earn 1500 points');
+  });
+
+  it('returns null when no estimatedPoints', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: true,
+      isLoading: false,
+      estimatedPoints: null,
+      hasError: false,
+    });
+
+    const result = await runHook();
+
+    expect(result).toBeNull();
+  });
+
+  it('calls useRewardsWithQuote with correct parameters', async () => {
+    mockUseRewardsWithQuote.mockReturnValue({
+      shouldShowRewardsRow: true,
+      isLoading: false,
+      estimatedPoints: 2000,
+      hasError: false,
+    });
+
+    await runHook();
+
+    expect(mockUseRewardsWithQuote).toHaveBeenCalledWith({
+      quote: mockSelectedQuote.quote,
+      fromAddress: '0x5206d14bfa10bd18989038fe628a79a135f2ee2f',
+      chainId: '0x2105',
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
@@ -1,0 +1,29 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { useRewardsWithQuote } from '../../../../../hooks/bridge/useRewards';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../../context/confirm';
+import { useDappSwapComparisonInfo } from './useDappSwapComparisonInfo';
+
+export const useDappSwapComparisonRewardText = (): string | null => {
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+  const { selectedQuote } = useDappSwapComparisonInfo();
+  const t = useI18nContext();
+
+  const { shouldShowRewardsRow, isLoading, estimatedPoints, hasError } =
+    useRewardsWithQuote({
+      quote: selectedQuote?.quote ?? null,
+      fromAddress: transactionMeta?.txParams?.from ?? '',
+      chainId: transactionMeta?.chainId ?? '',
+    });
+
+  if (!shouldShowRewardsRow || hasError || isLoading) {
+    return null;
+  }
+
+  if (estimatedPoints) {
+    return ` • ${t('dappSwapRewardText', [estimatedPoints.toString()])}`;
+  }
+
+  return null;
+};

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
@@ -4,10 +4,13 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import { useDappSwapComparisonInfo } from './useDappSwapComparisonInfo';
 
-export const useDappSwapComparisonRewardText = (): string | null => {
+export const useDappSwapComparisonRewardText = (): {
+  text: string;
+  estimatedPoints: number;
+} | null => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
-  const { selectedQuote } = useDappSwapComparisonInfo();
+  const { selectedQuote } = useDappSwapComparisonInfo(undefined);
   const t = useI18nContext();
 
   const { shouldShowRewardsRow, isLoading, estimatedPoints, hasError } =
@@ -22,7 +25,10 @@ export const useDappSwapComparisonRewardText = (): string | null => {
   }
 
   if (estimatedPoints) {
-    return ` • ${t('dappSwapRewardText', [estimatedPoints.toString()])}`;
+    return {
+      text: t('dappSwapRewardText', [estimatedPoints.toString()]),
+      estimatedPoints,
+    };
   }
 
   return null;

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonRewardText.ts
@@ -10,7 +10,7 @@ export const useDappSwapComparisonRewardText = (): {
 } | null => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
-  const { selectedQuote } = useDappSwapComparisonInfo(undefined);
+  const { selectedQuote } = useDappSwapComparisonInfo();
   const t = useI18nContext();
 
   const { shouldShowRewardsRow, isLoading, estimatedPoints, hasError } =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to implement rewards banner into dapp swap comparison banner.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37933?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6282

## **Manual testing steps**

TBD

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds rewards points estimation and display to the dapp swap comparison banner and confirmations info, refactoring hooks and adding i18n strings and tests.
> 
> - **UI (Confirmations)**
>   - Show rewards text in `dapp-swap-comparison-banner` when available.
>   - Add `EstimatedPointsSection` (with `RewardsBadge`) to base transaction info.
> - **Hooks/Logic**
>   - Introduce `useRewardsWithQuote(quote, fromAddress, chainId)`; refactor `useRewards` to wrap it with Bridge-specific validation.
>   - New `useDappSwapComparisonRewardText` to format rewards banner text.
>   - Minor log tag change to `[useRewardsWithQuote]`.
> - **i18n**
>   - Add `dappSwapRewardText` and `estimatedPointsRow` to `app/_locales/en*/messages.json`.
> - **Tests**
>   - Add tests for `EstimatedPointsSection` and `useDappSwapComparisonRewardText`.
>   - Update `useRewards` and banner tests for new behavior/strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f69cb06effb3fed0132e06fcfa39b8739cb227c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->