### PR TITLE
fix: get from address from non evm network

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
@@ -8,7 +8,10 @@ import {
 import { screen, fireEvent } from '@testing-library/react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
-import { MOCK_ACCOUNT_SOLANA_MAINNET } from '../../../../test/data/mock-accounts';
+import {
+  MOCK_ACCOUNT_SOLANA_MAINNET,
+  MOCK_ACCOUNT_BIP122_P2WPKH,
+} from '../../../../test/data/mock-accounts';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MULTICHAIN_PROVIDER_CONFIGS,
@@ -18,6 +21,7 @@ import {
 } from '../../../../shared/constants/multichain/networks';
 import mockState from '../../../../test/data/mock-state.json';
 import configureStore from '../../../store/store';
+import { shortenAddress as utilShortenAddress } from '../../../helpers/utils/util';
 import { MultichainTransactionDetailsModal } from './multichain-transaction-details-modal';
 import {
   getAddressUrl,
@@ -343,5 +347,57 @@ describe('MultichainTransactionDetailsModal', () => {
     expect(feeElement).not.toBeNull();
     expect(feeElement?.textContent).toContain('0.000005');
     expect(feeElement?.textContent).toContain('SOL');
+  });
+
+  it('displays the correct from address for Bitcoin send transaction', () => {
+    const btcTransaction = {
+      ...mockTransaction,
+      account: MOCK_ACCOUNT_BIP122_P2WPKH.id,
+    };
+
+    const modifiedMockState = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        internalAccounts: {
+          ...mockState.metamask.internalAccounts,
+          accounts: {
+            ...mockState.metamask.internalAccounts.accounts,
+            [MOCK_ACCOUNT_BIP122_P2WPKH.id]: MOCK_ACCOUNT_BIP122_P2WPKH,
+          },
+        },
+      },
+    };
+
+    const store = configureStore(modifiedMockState.metamask);
+    const props = {
+      transaction: btcTransaction,
+      onClose: jest.fn(),
+      userAddress: MOCK_ACCOUNT_BIP122_P2WPKH.address,
+      networkConfig: MULTICHAIN_PROVIDER_CONFIGS[MultichainNetworks.BITCOIN],
+    };
+
+    renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <MultichainTransactionDetailsModal {...props} />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+
+    const fromLabel = screen.getByText('from');
+    expect(fromLabel).toBeInTheDocument();
+
+    const shortenedFromAddress = utilShortenAddress(
+      MOCK_ACCOUNT_BIP122_P2WPKH.address,
+    );
+    const fromAddressElement = screen.getByText(shortenedFromAddress);
+    expect(fromAddressElement).toBeInTheDocument();
+
+    const expectedHref = getAddressUrl(
+      MOCK_ACCOUNT_BIP122_P2WPKH.address,
+      MULTICHAIN_PROVIDER_CONFIGS[MultichainNetworks.BITCOIN].chainId,
+    );
+    const fromLink = fromAddressElement.closest('a');
+    expect(fromLink).toHaveAttribute('href', expectedHref);
   });
 });

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -5,6 +5,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/keyring-api';
+import { useSelector } from 'react-redux';
 import {
   Display,
   FlexDirection,
@@ -48,6 +49,10 @@ import {
 } from '../../../hooks/useMultichainTransactionDisplay';
 import { MultichainProviderConfig } from '../../../../shared/constants/multichain/networks';
 import {
+  getInternalAccountsObject,
+  isNonEvmAccount,
+} from '../../../selectors/accounts';
+import {
   formatTimestamp,
   getTransactionUrl,
   getAddressUrl,
@@ -84,6 +89,12 @@ export function MultichainTransactionDetailsModal({
     timestamp,
     id,
   } = useMultichainTransactionDisplay(transaction, networkConfig);
+
+  const internalAccountsById = useSelector(getInternalAccountsObject);
+  const txInternalAccount = internalAccountsById?.[transaction.account];
+  const nonEvmSenderAddress = isNonEvmAccount(txInternalAccount)
+    ? txInternalAccount?.address
+    : undefined;
 
   const getStatusColor = (txStatus: string) => {
     switch (txStatus?.toLowerCase()) {
@@ -286,9 +297,12 @@ export function MultichainTransactionDetailsModal({
             gap={4}
           >
             {/* From */}
-            {type === TransactionType.Send
-              ? accountComponent(t('from'), userAddress)
-              : accountComponent(t('from'), from?.address)}
+            {accountComponent(
+              t('from'),
+              type === TransactionType.Send
+                ? nonEvmSenderAddress || userAddress
+                : from?.address,
+            )}
 
             {/* Amounts per token */}
             <>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is to fix the from address from the sent transaction modal when it's not an EVM network.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37937?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: get from address from non evm network

## **Related issues**

Fixes: From address for non EVM account is correctly displayed instead of EVM account address.

## **Manual testing steps**

1. Send a transaction from a non EVM account
2. Go to the Activity tab and select the transaction
3. Check the from field that it's the correct address

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="359" height="477" alt="before" src="https://github.com/user-attachments/assets/8fe9ce8c-00d1-4c1d-a9c1-ad7bb1d0a5ca" />


### **After**

<!-- [screenshots/recordings] -->

<img width="359" height="477" alt="send" src="https://github.com/user-attachments/assets/cfee347a-415d-41a6-9878-2ab67cb9fd2b" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use non‑EVM internal account address for the "from" field in send transactions and add BTC test coverage to verify it.
> 
> - **UI**:
>   - `multichain-transaction-details-modal.tsx`: Resolve sender via Redux selectors; for `send` transactions, use the internal account address when it’s a non‑EVM account, falling back to `userAddress` otherwise.
> - **Tests**:
>   - `multichain-transaction-details-modal.test.tsx`: Add Bitcoin account fixture and test asserting the correct shortened "from" address and explorer link for BTC send; minor test utilities imported to support assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c8b52f9ba6214cf2395ec0b22f400682a73e4b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->