### PR TITLE
chore: Remove obselete advisory ignore entries

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,21 +15,6 @@ nodeLinker: node-modules
 npmAuditIgnoreAdvisories:
   ### Advisories:
 
-  # Issue: yargs-parser Vulnerable to Prototype Pollution
-  # URL - https://github.com/advisories/GHSA-p9pc-299p-vxgp
-  # The affected version (<5.0.0) is only included via @ensdomains/ens via
-  # 'solc' which is not used in the imports we use from this package.
-  - 1088783
-
-  # Issue: protobufjs Prototype Pollution vulnerability
-  # URL - https://github.com/advisories/GHSA-h755-8qp9-cq85
-  # Not easily patched. Minimally effects the extension due to usage of
-  # LavaMoat lockdown. Additional id added that resolves to the same advisory
-  # but has a different entry due to it being a new dependency of
-  # @trezor/connect-web. Upgrading
-  - 1092429
-  - 1095136
-
   # Issue: Regular Expression Denial of Service (ReDOS)
   # URL: https://github.com/advisories/GHSA-257v-vj4p-3w2h
   # color-string is listed as a dependency of 'color' which is brought in by
@@ -37,48 +22,14 @@ npmAuditIgnoreAdvisories:
   # remove the color dependency. We should upgrade
   - 1089718
 
-  # Issue: semver vulnerable to Regular Expression Denial of Service
-  # URL: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
-  # semver is used in the solidity compiler portion of @truffle/codec that does
-  # not appear to be used.
-  - 1092461
-
-  # Issue: Malware in @solana/web3.js
-  # URL: https://github.com/advisories/GHSA-2mhj-xmf4-pr8m
-  # we patched this to ensure the vulnerable versions are not included, but the advisory
-  # was mistakenly originally created to flag all versions as vulnerable
-  - 1101059
-
-  # Issue: axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL
-  # URL: https://github.com/advisories/GHSA-jr5f-v2jv-69x6
-  # We are ignoring this on March 11, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
-  - 1102472
-
   # Issue: Issue: Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
-  # We are ignoring this on March 12, 2025 and April 24, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
-  - 1103026
+  # We are ignoring this on April 24, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
   - 1104001
-
-  # Issue: ses's global contour bindings leak into Compartment lexical scope
-  # URL: https://github.com/advisories/GHSA-h9w6-f932-gq62
-  # We are ignoring this on April 24, 2025 as it does not affect the codebase.
-  - 1103932
-
-  # Issue: React Router allows pre-render data spoofing on React-Router framework mode
-  # URL: https://github.com/MetaMask/metamask-extension/security/dependabot/228
-  # will be fixed in https://github.com/MetaMask/MetaMask-planning/issues/3261
-  - 1104031
-  - 1104032
 
   # Issue: `glob` vulnerability, already fixed in the version we're using (v10.5.0) but the
   # advisory range hasn't been updated yet.
   # URL: https://github.com/advisories/GHSA-5j98-mcp5-4vw2
   - 1109809
-
-  # Temp fix for https://github.com/MetaMask/metamask-extension/pull/16920 for the sake of 11.7.1 hotfix
-  # This will be removed in this ticket https://github.com/MetaMask/metamask-extension/issues/22299
-  - 'ts-custom-error (deprecation)'
-  - 'text-encoding (deprecation)'
 
   ### Package Deprecations:
 
@@ -86,82 +37,20 @@ npmAuditIgnoreAdvisories:
   # three years.
   - 'popper.js (deprecation)'
 
-  # React-router is out of date and brings in the following deprecated package
-  - 'mini-create-react-context (deprecation)'
-
-  # The affected version, which is less than 7.0.0, is brought in by
-  # ethereumjs-wallet version 0.6.5 used in the extension but only in a single
-  # file app/scripts/account-import-strategies/index.js, which may be easy to
-  # upgrade.
-  - 'uuid (deprecation)'
-
-  # @npmcli/move-file is brought in via CopyWebpackPlugin used in the storybook
-  # main.js file, which can be upgraded to remove this dependency in favor of
-  # @npmcli/fs
-  - '@npmcli/move-file (deprecation)'
-
-  # Upgrading babel will result in the following deprecated packages being
-  # updated:
-  - 'core-js (deprecation)'
-
   # Material UI dependencies are planned for removal
   - '@material-ui/core (deprecation)'
   - '@material-ui/styles (deprecation)'
-  - '@material-ui/system (deprecation)'
-
-  # @ensdomains/ens should be explored for upgrade. The following packages are
-  # deprecated and would be resolved by upgrading to newer versions of
-  # ensdomains packages:
-  - '@ensdomains/ens (deprecation)'
-  - '@ensdomains/resolver (deprecation)'
-  - 'testrpc (deprecation)'
 
   # Dependencies brought in by @truffle/decoder that are deprecated:
   - 'cids (deprecation)' # via @ensdomains/content-hash
   - 'multibase (deprecation)' # via cids
   - 'multicodec (deprecation)' # via cids
 
-  # MetaMask owned repositories brought in by other MetaMask dependencies that
-  # can be resolved by updating the versions throughout the dependency tree
-  - 'eth-sig-util (deprecation)' # via @metamask/eth-ledger-bridge-keyring
-  - '@metamask/controller-utils (deprecation)' # via @metamask/phishing-controller
-  - 'safe-event-emitter (deprecation)' # via eth-block-tracker and others
-
-  # @metamask-institutional relies upon crypto which is deprecated
-  - 'crypto (deprecation)'
-
-  # @metamask/providers uses webextension-polyfill-ts which has been moved to
-  # @types/webextension-polyfill
-  - 'webextension-polyfill-ts (deprecation)'
-
-  # Imported in @trezor/blockchain-link@npm:2.1.8, but not actually depended on
-  # by MetaMask
-  - 'ripple-lib (deprecation)'
-
-  # Brought in by ethereumjs-utils, which is used in the extension and in many
-  # other dependencies. At the time of this exclusion, the extension has three
-  # old versions of ethereumjs-utils which should be upgraded to
-  # @ethereumjs/utils throughout our owned repositories. However even doing
-  # that may be insufficient due to dependencies we do not own still relying
-  # upon old versions of ethereumjs-utils.
-  - 'ethereum-cryptography (deprecation)'
-
   # Currently in use for the network list drag and drop functionality.
   # Maintenance has stopped and the project will be archived in 2025.
   - 'react-beautiful-dnd (deprecation)'
   # New package name format for new versions: @ethereumjs/wallet.
   - 'ethereumjs-wallet (deprecation)'
-
-  # The new trezor version breaks the webpack build due to issues with ESM and CommonJS
-  # Leading to this error on start: `Uncaught ReferenceError: exports is not defined`
-  # We temporarily ignore the audit failure until we can safely upgrade to the new version without breaking the webpack build
-  # Check Trezor 9.5.X Changelog for more info: https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md
-  - '@trezor/connect-web (deprecation)'
-
-  # We temporarily ignore the deprecation notice to unblock ci
-  # Issue: @solana/web3.js version 2.0 is now @solana/kit! Remove @solana/web3.js@2 from your dependencies and replace it with @solana/kit.
-  # As needed, upgrade all of your @solana-program/* dependencies to the latest versions that use Kit.
-  - '@solana/web3.js (deprecation)'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs


### PR DESCRIPTION
## **Description**

Remove obsolete entries from the list of security advisories and deprecations that we are ignoring.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37941?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes numerous outdated advisory/deprecation ignores in `.yarnrc.yml`, retaining a minimal set and updating the Babel advisory note.
> 
> - **Config (`.yarnrc.yml`)**:
>   - **npmAuditIgnoreAdvisories**:
>     - Remove many obsolete ignore entries (e.g., yargs-parser, protobufjs, semver, axios, ses, React Router, Solana/Web3, Trezor).
>     - Retain only `1089718`, `1104001`, `1109809` with concise rationale comments.
>     - Update comment/date for Babel advisory `1104001`.
>   - **Package Deprecations**:
>     - Remove numerous deprecated-package ignores.
>     - Retain a small set: `'popper.js (deprecation)'`, `'@material-ui/core (deprecation)'`, `'@material-ui/styles (deprecation)'`, `'cids (deprecation)'`, `'multibase (deprecation)'`, `'multicodec (deprecation)'`, `'react-beautiful-dnd (deprecation)'`, `'ethereumjs-wallet (deprecation)'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc00524f4c909398edaedda2bee882cabe9b332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->