### PR TITLE
feat: add analytics tracking for account pin, hide, and list viewed events

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -8353,6 +8353,13 @@ export default class MetamaskController extends EventEmitter {
     }
   };
 
+  /**
+   * Updates the pinned accounts list
+   *
+   * @deprecated This method is deprecated and will be removed in the future.
+   * use AccountTreeController.setAccountGroupPinned instead
+   * @param {AccountAddress[]} pinnedAccountList - The list of accounts to update in the state.
+   */
   updateAccountsList = (pinnedAccountList) => {
     try {
       this.accountOrderController.updateAccountsList(pinnedAccountList);
@@ -8384,6 +8391,13 @@ export default class MetamaskController extends EventEmitter {
     await this.lookupSelectedNetworks();
   };
 
+  /**
+   * Updates the hidden accounts list
+   *
+   * @deprecated This method is deprecated and will be removed in the future.
+   * use AccountTreeController.setAccountGroupHidden instead
+   * @param {AccountAddress[]} hiddenAccountList - The list of accounts to update in the state.
+   */
   updateHiddenAccountsList = (hiddenAccountList) => {
     try {
       this.accountOrderController.updateHiddenAccountsList(hiddenAccountList);

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -874,6 +874,8 @@ export enum MetaMetricsEventName {
   BlockExplorerLinkClicked = 'Block Explorer Clicked',
   AccountRemoved = 'Account Removed',
   AccountRemoveFailed = 'Account Remove Failed',
+  AccountPinned = 'Account Pinned',
+  AccountHidden = 'Account Hidden',
   TestNetworksDisplayed = 'Test Networks Displayed',
   AddNetworkButtonClick = 'Add Network Button Clicked',
   CustomNetworkAdded = 'Custom Network Added',

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -710,6 +710,8 @@ export enum MetaMetricsEventName {
   AccountsSyncAdded = 'Accounts Sync Added',
   AccountsSyncNameUpdated = 'Accounts Sync Name Updated',
   AccountsSyncErroneousSituation = 'Accounts Sync Erroneous Situation',
+  AccountPinned = 'Account Pinned',
+  AccountHidden = 'Account Hidden',
   ProfileActivityUpdated = 'Profile Activity Updated',
   ActivityDetailsOpened = 'Activity Details Opened',
   ActivityDetailsClosed = 'Activity Details Closed',

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -876,8 +876,6 @@ export enum MetaMetricsEventName {
   BlockExplorerLinkClicked = 'Block Explorer Clicked',
   AccountRemoved = 'Account Removed',
   AccountRemoveFailed = 'Account Remove Failed',
-  AccountPinned = 'Account Pinned',
-  AccountHidden = 'Account Hidden',
   TestNetworksDisplayed = 'Test Networks Displayed',
   AddNetworkButtonClick = 'Add Network Button Clicked',
   CustomNetworkAdded = 'Custom Network Added',

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -28,6 +28,8 @@ const mockState = {
         },
       },
     },
+    pinnedAccountList: [],
+    hiddenAccountList: [],
   },
 };
 

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -16,17 +16,30 @@ const menuIconSelector = '.multichain-account-cell-popover-menu-button-icon';
 const menuItemSelector = '.multichain-account-cell-menu-item';
 const errorColorSelector = '.mm-box--color-error-default';
 
-const mockState = {
+const DEFAULT_ACCOUNT_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+const DEFAULT_WALLET_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ';
+
+type MockStateOptions = {
+  pinned?: boolean;
+  hidden?: boolean;
+  accountName?: string;
+};
+
+const createMockState = ({
+  pinned = false,
+  hidden = false,
+  accountName = 'Test Account',
+}: MockStateOptions = {}) => ({
   metamask: {
     accountTree: {
       wallets: {
-        'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
+        [DEFAULT_WALLET_ID]: {
           groups: {
-            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
+            [DEFAULT_ACCOUNT_GROUP_ID]: {
               metadata: {
-                name: 'Test Account',
-                pinned: false,
-                hidden: false,
+                name: accountName,
+                pinned,
+                hidden,
               },
             },
           },
@@ -36,7 +49,9 @@ const mockState = {
     pinnedAccountList: [],
     hiddenAccountList: [],
   },
-};
+});
+
+const mockState = createMockState();
 
 jest.mock('../../../store/actions', () => {
   const actualActions = jest.requireActual('../../../store/actions');
@@ -293,50 +308,15 @@ describe('MultichainAccountMenu', () => {
 
   it('unpins account before hiding when clicking hide on a pinned account', async () => {
     const mockOnToggle = jest.fn();
-    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
 
-    // Create state with pinned account
-    const stateWithPinnedAccount = {
-      ...mockState,
-      metamask: {
-        ...mockState.metamask,
-        accountTree: {
-          ...mockState.metamask.accountTree,
-          wallets: {
-            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
-              ...mockState.metamask.accountTree.wallets[
-                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-              ],
-              groups: {
-                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
-                  ...mockState.metamask.accountTree.wallets[
-                    'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                  ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
-                  metadata: {
-                    ...mockState.metamask.accountTree.wallets[
-                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
-                      .metadata,
-                    pinned: true,
-                    hidden: false,
-                  },
-                },
-              },
-            },
-          },
-        },
+    renderComponent(
+      {
+        accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
+        isRemovable: false,
+        isOpen: true,
+        onToggle: mockOnToggle,
       },
-    };
-
-    const store = configureStore(stateWithPinnedAccount);
-    renderWithProvider(
-      <MultichainAccountMenu
-        accountGroupId={accountGroupId}
-        isRemovable={false}
-        isOpen={true}
-        onToggle={mockOnToggle}
-      />,
-      store,
+      createMockState({ pinned: true }),
     );
 
     // Hide option should be the fifth menu item
@@ -351,61 +331,26 @@ describe('MultichainAccountMenu', () => {
 
     // Should unpin first, then hide
     expect(mockSetAccountGroupPinned).toHaveBeenCalledWith(
-      accountGroupId,
+      DEFAULT_ACCOUNT_GROUP_ID,
       false,
     );
     expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
-      accountGroupId,
+      DEFAULT_ACCOUNT_GROUP_ID,
       true,
     );
   });
 
   it('unhides account before pinning when clicking pin on a hidden account', async () => {
     const mockOnToggle = jest.fn();
-    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
 
-    // Create state with hidden account
-    const stateWithHiddenAccount = {
-      ...mockState,
-      metamask: {
-        ...mockState.metamask,
-        accountTree: {
-          ...mockState.metamask.accountTree,
-          wallets: {
-            'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
-              ...mockState.metamask.accountTree.wallets[
-                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-              ],
-              groups: {
-                'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
-                  ...mockState.metamask.accountTree.wallets[
-                    'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                  ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
-                  metadata: {
-                    ...mockState.metamask.accountTree.wallets[
-                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
-                      .metadata,
-                    pinned: false,
-                    hidden: true,
-                  },
-                },
-              },
-            },
-          },
-        },
+    renderComponent(
+      {
+        accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
+        isRemovable: false,
+        isOpen: true,
+        onToggle: mockOnToggle,
       },
-    };
-
-    const store = configureStore(stateWithHiddenAccount);
-    renderWithProvider(
-      <MultichainAccountMenu
-        accountGroupId={accountGroupId}
-        isRemovable={false}
-        isOpen={true}
-        onToggle={mockOnToggle}
-      />,
-      store,
+      createMockState({ hidden: true }),
     );
 
     // Pin option should be the fourth menu item
@@ -420,11 +365,11 @@ describe('MultichainAccountMenu', () => {
 
     // Should unhide first, then pin
     expect(mockSetAccountGroupHidden).toHaveBeenCalledWith(
-      accountGroupId,
+      DEFAULT_ACCOUNT_GROUP_ID,
       false,
     );
     expect(mockSetAccountGroupPinned).toHaveBeenCalledWith(
-      accountGroupId,
+      DEFAULT_ACCOUNT_GROUP_ID,
       true,
     );
   });
@@ -432,10 +377,9 @@ describe('MultichainAccountMenu', () => {
   describe('Pin/Unpin account tracking', () => {
     it('tracks AccountPinned event when pinning an account', async () => {
       const mockOnToggle = jest.fn();
-      const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
 
       renderComponent({
-        accountGroupId,
+        accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
         isRemovable: false,
         isOpen: true,
         onToggle: mockOnToggle,
@@ -463,48 +407,15 @@ describe('MultichainAccountMenu', () => {
 
     it('tracks AccountPinned event when unpinning an account', async () => {
       const mockOnToggle = jest.fn();
-      const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
-
-      const stateWithPinnedAccount = {
-        ...mockState,
-        metamask: {
-          ...mockState.metamask,
-          accountTree: {
-            ...mockState.metamask.accountTree,
-            wallets: {
-              'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
-                ...mockState.metamask.accountTree.wallets[
-                  'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                ],
-                groups: {
-                  'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
-                    ...mockState.metamask.accountTree.wallets[
-                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
-                    metadata: {
-                      ...mockState.metamask.accountTree.wallets[
-                        'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                      ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
-                        .metadata,
-                      pinned: true,
-                      hidden: false,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
 
       renderComponent(
         {
-          accountGroupId,
+          accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
           isRemovable: false,
           isOpen: true,
           onToggle: mockOnToggle,
         },
-        stateWithPinnedAccount,
+        createMockState({ pinned: true }),
       );
 
       const menuItems = document.querySelectorAll(menuItemSelector);
@@ -531,10 +442,9 @@ describe('MultichainAccountMenu', () => {
   describe('Hide/Unhide account tracking', () => {
     it('tracks AccountHidden event when hiding an account', async () => {
       const mockOnToggle = jest.fn();
-      const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
 
       renderComponent({
-        accountGroupId,
+        accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
         isRemovable: false,
         isOpen: true,
         onToggle: mockOnToggle,
@@ -554,6 +464,7 @@ describe('MultichainAccountMenu', () => {
         category: MetaMetricsEventCategory.Accounts,
         properties: {
           hidden: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           hidden_count_after: 1,
         },
       });
@@ -561,48 +472,15 @@ describe('MultichainAccountMenu', () => {
 
     it('tracks AccountHidden event when unhiding an account', async () => {
       const mockOnToggle = jest.fn();
-      const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
-
-      const stateWithHiddenAccount = {
-        ...mockState,
-        metamask: {
-          ...mockState.metamask,
-          accountTree: {
-            ...mockState.metamask.accountTree,
-            wallets: {
-              'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
-                ...mockState.metamask.accountTree.wallets[
-                  'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                ],
-                groups: {
-                  'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default': {
-                    ...mockState.metamask.accountTree.wallets[
-                      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default'],
-                    metadata: {
-                      ...mockState.metamask.accountTree.wallets[
-                        'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
-                      ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default']
-                        .metadata,
-                      pinned: false,
-                      hidden: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
 
       renderComponent(
         {
-          accountGroupId,
+          accountGroupId: DEFAULT_ACCOUNT_GROUP_ID,
           isRemovable: false,
           isOpen: true,
           onToggle: mockOnToggle,
         },
-        stateWithHiddenAccount,
+        createMockState({ hidden: true }),
       );
 
       const menuItems = document.querySelectorAll(menuItemSelector);


### PR DESCRIPTION
## **Description**

Add analytics tracking for the Pin & Hide Accounts feature to understand user engagement with account organization features.

This PR implements three new Segment events:
- **Account Pinned**: Tracks when users pin/unpin accounts with counts
- **Account Hidden**: Tracks when users hide/unhide accounts with counts  
- **Account List Viewed**: Tracks account list views with pinned, hidden, and total account counts

These events enable analysis of:
- Pin vs hide feature adoption
- Usage trends over time
- Average pinned/hidden accounts per user
- Total account distribution

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37545?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

[MUL-125](https://consensyssoftware.atlassian.net/browse/MUL-125)

Requires: https://github.com/Consensys/segment-schema/pull/353

## **Manual testing steps**

1. Open MetaMask extension and unlock wallet
2. Navigate to account list (click account menu)
3. Open the three-dot menu for any account
4. Click "Pin to top" - verify `Account Pinned` event fires with `pinned: true` and `pinned_count_after`
5. Click "Unpin" - verify `Account Pinned` event fires with `pinned: false` and updated count
6. Click "Hide account" - verify `Account Hidden` event fires with `hidden: true` and `hidden_count_after`
7. Open hidden accounts list and unhide - verify `Account Hidden` event fires with `hidden: false`
8. Close and reopen account list - verify `Account List Viewed` event fires with `pinned_count`, `hidden_count`, and `total_accounts`

## **Screenshots/Recordings**

### **Before**

No analytics tracking for pin/hide account features

### **After**

Analytics

[MUL-125]: https://consensyssoftware.atlassian.net/browse/MUL-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds analytics for account organization actions and minor refactors.
> 
> - In `multichain-account-menu.tsx`, fires `MetaMetricsEventName.AccountPinned` and `AccountHidden` via `MetaMetricsContext` on pin/hide with `pinned_count_after`/`hidden_count_after`, computing counts from `accountTree`
> - Preserves behavior to unhide before pin and unpin before hide; closes popover after actions
> - Extends `shared/constants/metametrics.ts` with `AccountPinned` and `AccountHidden`
> - Updates tests to cover tracking and refactors mocks (`createMockState`, context provider)
> - Adds deprecation JSDoc to `updateAccountsList` and `updateHiddenAccountsList` in `metamask-controller.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62071f6302900bfc6aa0e483ec514edbc5c7805e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->