### PR TITLE
fix: multichain site tooltip

### DIFF
--- a/ui/components/multichain-accounts/multichain-site-cell/tool-tip/multichain-site-cell-tooltip.tsx
+++ b/ui/components/multichain-accounts/multichain-site-cell/tool-tip/multichain-site-cell-tooltip.tsx
@@ -49,6 +49,7 @@ type TooltipContentProps = {
   moreAccountsText?: string;
   moreNetworksText?: string;
   avatarAccountVariant?: AvatarAccountVariant;
+  seedAddresses?: Record<string, string>;
 };
 
 const TooltipContent = React.memo<TooltipContentProps>(
@@ -58,6 +59,7 @@ const TooltipContent = React.memo<TooltipContentProps>(
     moreAccountsText,
     moreNetworksText,
     avatarAccountVariant,
+    seedAddresses,
   }) => {
     const displayAccountGroups = accountGroups?.slice(0, TOOLTIP_LIMIT) ?? [];
     const displayNetworks = networks?.slice(0, TOOLTIP_LIMIT) ?? [];
@@ -85,7 +87,7 @@ const TooltipContent = React.memo<TooltipContentProps>(
             >
               <AvatarAccount
                 size={AvatarAccountSize.Xs}
-                address={acc.id}
+                address={seedAddresses?.[acc.id] ?? ''}
                 variant={avatarAccountVariant}
               />
               <Text
@@ -235,6 +237,7 @@ export const MultichainSiteCellTooltip =
             moreAccountsText={moreAccountsText}
             moreNetworksText={moreNetworksText}
             avatarAccountVariant={avatarAccountVariant}
+            seedAddresses={seedAddresses}
           />
         }
         arrow

--- a/ui/components/multichain-accounts/multichain-site-cell/tool-tip/multichain-site-cell-tooltip.tsx
+++ b/ui/components/multichain-accounts/multichain-site-cell/tool-tip/multichain-site-cell-tooltip.tsx
@@ -33,6 +33,7 @@ import {
   MultichainAvatarGroupType,
 } from '../avatar-group/multichain-avatar-group';
 import { getIconSeedAddressesByAccountGroups } from '../../../../selectors/multichain-accounts/account-tree';
+import { getAvatarType } from '../../../app/preferred-avatar/preferred-avatar';
 
 export type MultichainSiteCellTooltipProps = {
   accountGroups?: AccountGroupWithInternalAccounts[];
@@ -47,10 +48,17 @@ type TooltipContentProps = {
   networks?: EvmAndMultichainNetworkConfigurationsWithCaipChainId[];
   moreAccountsText?: string;
   moreNetworksText?: string;
+  avatarAccountVariant?: AvatarAccountVariant;
 };
 
 const TooltipContent = React.memo<TooltipContentProps>(
-  ({ accountGroups, networks, moreAccountsText, moreNetworksText }) => {
+  ({
+    accountGroups,
+    networks,
+    moreAccountsText,
+    moreNetworksText,
+    avatarAccountVariant,
+  }) => {
     const displayAccountGroups = accountGroups?.slice(0, TOOLTIP_LIMIT) ?? [];
     const displayNetworks = networks?.slice(0, TOOLTIP_LIMIT) ?? [];
     const hasMoreAccounts =
@@ -78,7 +86,7 @@ const TooltipContent = React.memo<TooltipContentProps>(
               <AvatarAccount
                 size={AvatarAccountSize.Xs}
                 address={acc.id}
-                variant={AvatarAccountVariant.Jazzicon}
+                variant={avatarAccountVariant}
               />
               <Text
                 color={TextColor.overlayInverse}
@@ -166,6 +174,7 @@ TooltipContent.displayName = 'TooltipContent';
 export const MultichainSiteCellTooltip =
   React.memo<MultichainSiteCellTooltipProps>(({ accountGroups, networks }) => {
     const t = useI18nContext();
+    const avatarAccountVariant = useSelector(getAvatarType);
 
     const seedAddresses = useSelector((state: MultichainAccountsState) =>
       getIconSeedAddressesByAccountGroups(state, accountGroups ?? []),
@@ -225,6 +234,7 @@ export const MultichainSiteCellTooltip =
             networks={networks}
             moreAccountsText={moreAccountsText}
             moreNetworksText={moreNetworksText}
+            avatarAccountVariant={avatarAccountVariant}
           />
         }
         arrow


### PR DESCRIPTION
## **Description**

1. Restores the user's preferred avatar in the site cell tooltip that was hardcoded to Jazzicon in [this PR](https://github.com/MetaMask/metamask-extension/pull/37510)

2. Uses the correct seed address

## **Changelog**

CHANGELOG entry: fix: multichain site toolip

## **Related issues**

Fixes:

## **Manual testing steps**

1. Connect to dApp
2. Menu > All permissions
4. Click on connected site

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="259" height="278" alt="image" src="https://github.com/user-attachments/assets/485ecde0-c926-474d-a324-c097afda794a" />


### **After**

<img width="169" height="200" alt="image" src="https://github.com/user-attachments/assets/42513df8-b346-4f48-9c43-0c6c05113e28" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores preferred avatar variant and uses the correct seed address for account avatars in the multichain site tooltip.
> 
> - **UI (Multichain site tooltip)**
>   - Selects preferred avatar variant via `getAvatarType` and passes it to `TooltipContent`.
>   - Uses `seedAddresses[acc.id]` for `AvatarAccount` `address` and replaces hardcoded `Jazzicon` with the selected `variant`.
>   - Plumbs `seedAddresses` and `avatarAccountVariant` through tooltip props; updates avatar rendering for account list accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa8309ff53378d6e96037854d3233f5521ac1e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->