### PR TITLE
ci: Improve bundle size warning

### DIFF
--- a/development/metamaskbot-build-announce.ts
+++ b/development/metamaskbot-build-announce.ts
@@ -7,6 +7,11 @@ const benchmarkPlatforms = ['chrome', 'firefox'];
 const buildTypes = ['browserify', 'webpack'];
 const pageTypes = ['standardHome', 'powerUserHome'];
 
+/**
+ * The threshold for whether to highlight a change in bundle size, in bytes.
+ */
+const BUNDLE_SIZE_THRESOLD = 1_000;
+
 type BenchmarkResults = Record<
   (typeof benchmarkPlatforms)[number],
   Record<
@@ -397,17 +402,25 @@ async function start(): Promise<void> {
       .map((row) => `<li>${row}</li>`)
       .join('\n')}</ul>`;
 
-    const sizeDiff = diffs.background + diffs.common;
+    const sizeDiffBackground = diffs.background + diffs.common;
+    const sizeDiffUi = diffs.ui + diffs.common;
 
-    const sizeDiffWarning =
-      sizeDiff > 0
-        ? `🚨 Warning! Bundle size has increased!`
-        : `🚀 Bundle size reduced!`;
+    let sizeDiffWarning;
+    if (
+      sizeDiffBackground > BUNDLE_SIZE_THRESOLD ||
+      sizeDiffUi > BUNDLE_SIZE_THRESOLD
+    ) {
+      sizeDiffWarning = `🚨 Warning! Bundle size has increased!`;
+    } else if (
+      sizeDiffBackground < -BUNDLE_SIZE_THRESOLD ||
+      sizeDiffUi < -BUNDLE_SIZE_THRESOLD
+    ) {
+      sizeDiffWarning = `🚀 Bundle size reduced!`;
+    }
 
-    const sizeDiffExposedContent =
-      sizeDiff === 0
-        ? `Bundle size diffs`
-        : `Bundle size diffs [${sizeDiffWarning}]`;
+    const sizeDiffExposedContent = sizeDiffWarning
+      ? `Bundle size diffs [${sizeDiffWarning}]`
+      : `Bundle size diffs`;
 
     const sizeDiffBody = `<details><summary>${sizeDiffExposedContent}</summary>${sizeDiffHiddenContent}</details>\n\n`;
 


### PR DESCRIPTION
## **Description**

The warning shown on `metamaskbot` comments abount bundle size can be misleading. It only considers the background bundle size (despite the UI being far more impactful for performance), and it's too sensitive to miniscule changes in bundle size that don't have any real impact.

The warning has been adjusted to consider significant changes in bundle size for UI or background, and to suppress any warning when the bundle size change is under one KB.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37958?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes bundle size alerts less noisy and more representative of impact.
> 
> - Adds `BUNDLE_SIZE_THRESOLD = 1_000` bytes
> - Computes separate size diffs for `background` and `ui` (each including `common`)
> - Shows warning only if either diff exceeds threshold; shows reduction message only if below negative threshold; otherwise omits warning
> - Summary label now includes warning tag only when applicable
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3baf30e31e3645498ce89ac70e34f3a053ba6a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->