### PR TITLE
fix: reset payment method to card when no tokens are available

### DIFF
--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -225,12 +225,15 @@ const ShieldPlan = () => {
   // should only trigger if selectedTokenAddress change (shouldn't trigger again if selected token object updated but still same token)
   useEffect(() => {
     const lastUsedPaymentMethod = lastUsedPaymentDetails?.type;
-    // if the last used payment method is not crypto, don't set default method
     if (
       selectedTokenAddress &&
       lastUsedPaymentMethod !== PAYMENT_TYPES.byCard
     ) {
       setSelectedPaymentMethod(PAYMENT_TYPES.byCrypto);
+    } else {
+      // should reset to byCard when selectedTokenAddress becomes undefined (no tokens available)
+      // to prevent switching to a plan without available tokens leaves selectedPaymentMethod as byCrypto with no tokens
+      setSelectedPaymentMethod(PAYMENT_TYPES.byCard);
     }
   }, [selectedTokenAddress, setSelectedPaymentMethod, lastUsedPaymentDetails]);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Shield Plan Payment Method Reset Fix**: Fixes a bug in the Shield Plan page where switching to a plan without available tokens would leave the payment method set to `byCrypto` even though no tokens were available. The fix ensures that when `selectedTokenAddress` becomes undefined (no tokens available), the payment method is automatically reset to `byCard` to prevent users from being stuck in an invalid state.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37965?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug in Shield Plan where payment method would not reset to card payment when switching to a plan without available tokens

## **Related issues**

Fixes:

## **Manual testing steps**

1. Navigate to Shield Plan page
2. Select a plan that has available tokens (e.g., annual plan)
3. Select crypto payment method
4. Switch to a plan that doesn't have available tokens (e.g., monthly plan on a network without supported tokens)
5. Verify that the payment method automatically resets to "Card"
6. Verify that the UI correctly displays the card payment option

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure payment method switches to card when selected crypto token becomes undefined, preventing crypto selection with no tokens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d368e4f0ffa0353e52f3b6b39d2ebae65c46dfa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->