### PR TITLE
fix: center-aligned the image for protect wallet modal

### DIFF
--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -68,15 +68,13 @@ export default function RecoveryPhraseReminder({ onConfirm }) {
             display={Display.Flex}
             alignItems={AlignItems.center}
             justifyContent={JustifyContent.center}
+            marginBottom={2}
           >
             <img
               src="images/forgot-password-lock.png"
-              width={154}
-              height={154}
+              width={100}
+              height={100}
               alt={t('recoveryPhraseReminderTitle')}
-              style={{
-                alignSelf: 'center',
-              }}
             />
           </Box>
           <Text>{t('recoveryPhraseReminderSubText')}</Text>

--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -11,6 +11,7 @@ import {
   Display,
   FlexDirection,
   BlockSize,
+  JustifyContent,
 } from '../../../helpers/constants/design-system';
 import { ONBOARDING_REVEAL_SRP_ROUTE } from '../../../helpers/constants/routes';
 import {
@@ -62,7 +63,12 @@ export default function RecoveryPhraseReminder({ onConfirm }) {
           </Box>
         </ModalHeader>
         <ModalBody>
-          <Box width={BlockSize.Full} textAlign={TextAlign.Center}>
+          <Box
+            width={BlockSize.Full}
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            justifyContent={JustifyContent.center}
+          >
             <img
               src="images/forgot-password-lock.png"
               width={154}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37968?quickstart=1)

In this PR, the Image is centre-aligned for the Protect Wallet Modal.

Issue Thread:  https://consensys.slack.com/archives/C08AG8ARL3V/p1763408515138959

Jira Link: https://consensyssoftware.atlassian.net/browse/SL-331

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: center-aligned the image for protect wallet modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="742" height="1504" alt="Screenshot 2025-11-17 at 11 39 22 AM" src="https://github.com/user-attachments/assets/6d61d044-72f6-43da-b565-066f3b45c25b" />


### **After**

<!-- [screenshots/recordings] -->

<img width="927" height="987" alt="Screenshot 2025-11-19 at 1 11 29 PM" src="https://github.com/user-attachments/assets/43c40fab-e027-403e-b761-915082e2b025" />
<img width="388" height="998" alt="Screenshot 2025-11-19 at 1 11 40 PM" src="https://github.com/user-attachments/assets/239b1311-6d06-428e-9a6a-2c5a8b0648ad" />
<img width="484" height="660" alt="Screenshot 2025-11-19 at 1 12 52 PM" src="https://github.com/user-attachments/assets/effd5e6c-e444-43c1-937e-3afdfb57685a" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centers and resizes the lock image in the recovery phrase reminder modal using flex layout.
> 
> - **UI**:
>   - **Recovery phrase reminder modal** (`ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js`):
>     - Center-aligns lock image by wrapping in `Box` with `display=Flex`, `alignItems=center`, `justifyContent=center` and adds `marginBottom={2}`.
>     - Reduces image size from `154x154` to `100x100` and removes inline `alignSelf`.
>     - Imports and uses `JustifyContent` from design-system constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5b83660ebf7d4b930c9e32b04d86efcbbd3b205. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->