### PR TITLE
fix: flaky test `Settings Does not fetch ENS data for ENS Domain when ENS and IPFS switched off `

### DIFF
--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -80,7 +80,7 @@ describe('Settings', function () {
         title: this.test?.fullTitle(),
         testSpecificMock: ensDomainPassthrough,
       },
-      async ({ driver, mockedEndpoint }) => {
+      async ({ driver }) => {
         await loginWithBalanceValidation(driver);
 
         // navigate to security & privacy settings screen

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -102,6 +102,8 @@ describe('Settings', function () {
           // since all we care about is getting to the correct URL
         }
 
+        // Ensure that the redirect to ENS Domains does not happen
+        // Instead, the domain will be kept which is a 404
         await driver.wait(async () => {
           const currentUrl = await driver.getCurrentUrl();
           return currentUrl === ENS_NAME_URL;

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -62,11 +62,16 @@ describe('Settings', function () {
     async function ensDomainPassthrough(
       mockServer: MockttpServer,
     ): Promise<MockedEndpoint[]> {
-      const passthroughEndpoint = await mockServer
+      // We want the browser to handle the request error
+      const ensNamePassThrough = await mockServer
         .forGet(ENS_NAME_URL)
         .thenPassThrough();
+      // This should never be hit, but in case it is, then we'll catch it
+      const ensDomainsPassThrough = await mockServer
+        .forGet(/https:\/\/app\.ens\.domains\/name\/.*/u)
+        .thenPassThrough();
 
-      return [passthroughEndpoint];
+      return [ensNamePassThrough, ensDomainsPassThrough];
     }
 
     await withFixtures(

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -95,17 +95,12 @@ describe('Settings', function () {
         await privacySettings.toggleIpfsGateway();
         await privacySettings.toggleEnsDomainResolution();
 
-        await driver.openNewPage(ENS_NAME_URL);
-
-        // Wait for a potential request to happen
-        await driver.delay(5000);
-
-        // Ensure that the redirect to ENS Domains does not happen
-        // Instead, the domain will be kept which is a 404
-        await driver.wait(async () => {
-          const isPending = await mockedEndpoint.isPending();
-          return isPending === true;
-        });
+        try {
+          await driver.openNewPage(ENS_NAME_URL);
+        } catch (e) {
+          // Ignore ERR_PROXY_CONNECTION_FAILED error
+          // since all we care about is getting to the correct URL
+        }
 
         await driver.wait(async () => {
           const currentUrl = await driver.getCurrentUrl();

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -59,22 +59,26 @@ describe('Settings', function () {
   });
 
   it('Does not fetch ENS data for ENS Domain when ENS and IPFS switched off', async function () {
-    async function mockEnsDestination(
+    async function ensDomainPassthrough(
       mockServer: MockttpServer,
-    ): Promise<MockedEndpoint> {
-      return await mockServer.forGet(ENS_DESTINATION_URL).thenCallback(() => {
-        // We don't care about response, just to check if the request is made or not
-        return {
-          statusCode: 200,
-        };
-      });
+    ): Promise<MockedEndpoint[]> {
+      // We want the browser to handle the request error
+      const ensNamePassThrough = await mockServer
+        .forGet(ENS_NAME_URL)
+        .thenPassThrough();
+      // This should never be hit, but in case it is, then we'll catch it
+      const ensDomainsPassThrough = await mockServer
+        .forGet(ENS_DESTINATION_URL)
+        .thenPassThrough();
+
+      return [ensNamePassThrough, ensDomainsPassThrough];
     }
 
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
-        testSpecificMock: mockEnsDestination,
+        testSpecificMock: ensDomainPassthrough,
       },
       async ({ driver, mockedEndpoint }) => {
         await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -86,7 +86,12 @@ describe('Settings', function () {
 
         // Now that we no longer need the MetaMask UI, and want the browser
         // to handle the request error, we need to stop the server
-        await server.stop();
+        await server.forAnyRequest().thenPassThrough({
+          beforeRequest: (req) => {
+            console.log('MM Request going to a live server =========', req.url);
+            return {};
+          },
+        });
 
         try {
           await driver.openNewPage(ENS_NAME_URL);

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -84,14 +84,13 @@ describe('Settings', function () {
         await privacySettings.toggleIpfsGateway();
         await privacySettings.toggleEnsDomainResolution();
 
-        // Now that we no longer need the MetaMask UI, and want the browser
-        // to handle the request error, we need to stop the server
-        await server.forAnyRequest().thenPassThrough({
-          beforeRequest: (req) => {
-            console.log('MM Request going to a live server =========', req.url);
-            return {};
-          },
-        });
+        // Let the request pass through to verify we trigger the error page
+        await server
+          .forAnyRequest()
+          .matching(
+            (request) => request.headers.host?.toLowerCase() === ENS_NAME,
+          )
+          .thenPassThrough();
 
         try {
           await driver.openNewPage(ENS_NAME_URL);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The spec is flaky as sometimes we get a failed request, because we stopped the mock server.


This changes the approach and keeps the mock server open. We only let pass through the ens req
This will avoid errors while other API requests happen on the background, as we keep the rest of the mocks as usual

<img width="401" height="126" alt="image" src="https://github.com/user-attachments/assets/24f60101-e9e6-4376-823f-454cc61a1ba7" />


https://github.com/search?q=org%3AMetaMask+%22failed+to+generate+nonce%22&type=code

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37983?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the ENS/IPFS settings e2e test by keeping the mock server running and pass-through ENS requests instead of stopping the server.
> 
> - **E2E Tests (`test/e2e/tests/settings/ipfs-ens-resolution.spec.ts`)**:
>   - Import `MockedEndpoint` and add `ensDomainPassthrough` helper to pass through `ENS_NAME_URL` and `ENS_DESTINATION_URL`.
>   - Replace ad-hoc server handling with `testSpecificMock: ensDomainPassthrough`; remove manual server stop.
>   - Goal: avoid request failures by keeping mocks active while allowing ENS requests to pass through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b076d8e8f71e60a6eab045c39e7f5615bb29ad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->