### PR TITLE
fix: add resync mechanism to sync Snap accounts states with client accounts cp-13.11.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5207,12 +5207,20 @@ export default class MetamaskController extends EventEmitter {
     }
 
     await this.accountsController.updateAccounts();
+
     ///: BEGIN:ONLY_INCLUDE_IF(multichain)
     // Init multichain accounts after creating internal accounts.
     await this.multichainAccountService.init();
+    // READ THIS CAREFULLY:
+    // There is is/was a bug with Snap accounts that can be desynchronized (Solana). To
+    // automatically "fix" this corrupted state, we run this method which will re-sync
+    // MetaMask accounts and Snap accounts upon login.
+    await this.multichainAccountService.resyncAccounts();
     ///: END:ONLY_INCLUDE_IF
+
     // Force account-tree refresh after all accounts have been updated.
     this.accountTreeController.init();
+
     // TODO: Move this logic to the SnapKeyring directly.
     // Forward selected accounts to the Snap keyring, so each Snaps can fetch those accounts.
     await this.forwardSelectedAccountGroupToSnapKeyring(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5224,7 +5224,7 @@ export default class MetamaskController extends EventEmitter {
     if (this.isMultichainAccountsFeatureState2Enabled()) {
       const resyncAndAlignAccounts = async () => {
         // READ THIS CAREFULLY:
-        // There is is/was a bug with Snap accounts that can be desynchronized (Solana). To
+        // There is/was a bug with Snap accounts that can be desynchronized (Solana). To
         // automatically "fix" this corrupted state, we run this method which will re-sync
         // MetaMask accounts and Snap accounts upon login.
         // BUG: https://github.com/MetaMask/metamask-extension/issues/37228

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -728,6 +728,24 @@ describe('MetaMaskController', () => {
       });
     });
 
+    describe('#submitPasswordOrEncryptionKey', () => {
+      const password = 'a-fake-password';
+
+      it('should call multichainAccountService.resyncAccounts when submitPasswordOrEncryptionKey is called', async () => {
+        const mockResyncAccounts = jest.fn();
+
+        metamaskController.multichainAccountService = {
+          init: jest.fn(),
+          resyncAccounts: mockResyncAccounts,
+        };
+
+        await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
+        await metamaskController.submitPasswordOrEncryptionKey({ password });
+
+        expect(mockResyncAccounts).toHaveBeenCalled();
+      });
+    });
+
     describe('setLocked', () => {
       it('should lock KeyringController', async () => {
         await metamaskController.createNewVaultAndKeychain('password');

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -122,6 +122,20 @@ function* ulidGenerator(ulids = mockULIDs) {
 }
 
 /**
+ * Utility function that waits for all pending promises to be resolved.
+ * This is necessary when testing asynchronous execution flows that are
+ * initiated by synchronous calls.
+ *
+ * @returns A promise that resolves when all pending promises are completed.
+ */
+async function waitForAllPromises() {
+  // Wait for next tick to flush all pending promises. It's requires since
+  // we are testing some asynchronous execution flows that are started by
+  // synchronous calls.
+  await new Promise(process.nextTick);
+}
+
+/**
  * Generate mock patches for a complete state replacement.
  *
  * @returns A list of mock patches.
@@ -731,18 +745,28 @@ describe('MetaMaskController', () => {
     describe('#submitPasswordOrEncryptionKey', () => {
       const password = 'a-fake-password';
 
-      it('should call multichainAccountService.resyncAccounts when submitPasswordOrEncryptionKey is called', async () => {
+      it('should call resyncAccounts and alignWallets asynchronously when submitPasswordOrEncryptionKey is called', async () => {
+        const mockAlignWallets = jest.fn();
         const mockResyncAccounts = jest.fn();
+
+        // We only trigger this behavior when the feature flag is enabled.
+        jest
+          .spyOn(metamaskController, 'isMultichainAccountsFeatureState2Enabled')
+          .mockReturnValue(true);
 
         metamaskController.multichainAccountService = {
           init: jest.fn(),
           resyncAccounts: mockResyncAccounts,
+          alignWallets: mockAlignWallets,
         };
 
         await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
         await metamaskController.submitPasswordOrEncryptionKey({ password });
 
+        await waitForAllPromises();
+
         expect(mockResyncAccounts).toHaveBeenCalled();
+        expect(mockAlignWallets).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## **Description**

This will automatically fix corrupted states if users have desync'd accounts.

This should mitigate some errors that were spotted with the rewards system where some Solana address could not be registered.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37987?quickstart=1)

## **Changelog**

CHANGELOG entry: Automatically re-sync accounts between Snaps and MetaMask

## **Related issues**

Fix for users that already encountered this bug (their "not found" accounts will automatically be re-created now, acting as a migration):
- https://github.com/MetaMask/metamask-extension/issues/37228

## **Manual testing steps**

> Difficult to manually test this since it implies to "hack" the non-EVM Snaps to trigger state-inconsistencies

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On unlock, asynchronously resync Snap and MetaMask accounts, then align wallets; adds tests to verify both are invoked.
> 
> - **Controller**:
>   - In `app/scripts/metamask-controller.js` `submitPasswordOrEncryptionKey`, after init and account-tree refresh, if multichain state2 is enabled, run `multichainAccountService.resyncAccounts()` then `alignWallets()` asynchronously via a helper.
> - **Tests**:
>   - Add `waitForAllPromises` utility.
>   - New test in `app/scripts/metamask-controller.test.js` asserts `resyncAccounts` and `alignWallets` are called asynchronously after `submitPasswordOrEncryptionKey`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfec6a906a2906661373df9a4931d408bc762d59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->