### PR TITLE
fix: cp-13.11.0 filter out tron staked tokens

### DIFF
--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1,4 +1,4 @@
-import { EthScope, SolScope } from '@metamask/keyring-api';
+import { EthScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { cloneDeep } from 'lodash';
@@ -956,6 +956,7 @@ describe('Balance change selectors', () => {
 
 describe('getAssetsBySelectedAccountGroup', () => {
   beforeEach(() => {
+    getAssetsBySelectedAccountGroup.clearCache();
     getAssetsBySelectedAccountGroup.memoizedResultFunc.clearCache();
   });
 
@@ -987,7 +988,346 @@ describe('getAssetsBySelectedAccountGroup', () => {
     const result = getAssetsBySelectedAccountGroup(mockState);
 
     expect(selectorMock).toHaveBeenCalledWith(mockState.metamask);
-    expect(result).toBe(selectorMockResult);
+    expect(result).toStrictEqual(selectorMockResult);
+  });
+
+  it('filters out tron staked bandwidth and energy', () => {
+    const selectorMock = jest
+      .mocked(selectAssetsBySelectedAccountGroup)
+      .mockReturnValue({
+        'tron:728126428': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            fiat: {
+              balance: 0,
+              currency: 'usd',
+              conversionRate: 0.28516,
+            },
+            chainId: 'tron:728126428',
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+        ],
+        'tron:3448148188': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+        ],
+        'tron:2494104990': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+        ],
+      });
+
+    const result = getAssetsBySelectedAccountGroup(mockState);
+
+    expect(selectorMock).toHaveBeenCalled();
+    expect(result[TrxScope.Mainnet]).toHaveLength(1);
+    expect(result[TrxScope.Nile]).toHaveLength(1);
+    expect(result[TrxScope.Shasta]).toHaveLength(1);
   });
 });
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -8,7 +8,7 @@ import {
   calculateBalanceChangeForAccountGroup,
   selectAssetsBySelectedAccountGroup,
 } from '@metamask/assets-controllers';
-import { CaipAssetId } from '@metamask/keyring-api';
+import { CaipAssetId, TrxScope } from '@metamask/keyring-api';
 import {
   CaipAssetType,
   CaipChainId,
@@ -29,6 +29,7 @@ import type {
   CurrencyRateState,
   BalanceChangePeriod,
   BalanceChangeResult,
+  Asset,
 } from '@metamask/assets-controllers';
 import { TEST_CHAINS } from '../../shared/constants/network';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
@@ -41,6 +42,10 @@ import {
 } from '../ducks/metamask/metamask';
 import { findAssetByAddress } from '../pages/asset/util';
 import { isEvmChainId } from '../../shared/lib/asset-utils';
+import {
+  TRON_RESOURCE_SYMBOLS_SET,
+  TronResourceSymbol,
+} from '../../shared/constants/multichain/assets';
 import { getSelectedInternalAccount } from './accounts';
 import { getMultichainBalances } from './multichain';
 import { EMPTY_OBJECT } from './shared';
@@ -1040,8 +1045,34 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
       ...multichainState,
     };
   },
-  (assetListState: AssetListState) =>
-    selectAssetsBySelectedAccountGroup(assetListState),
+  (assetListState: AssetListState) => {
+    const assetsByAccountGroup =
+      selectAssetsBySelectedAccountGroup(assetListState);
+
+    // Filter Tron tokens
+    const newAssetsByAccountGroup = { ...assetsByAccountGroup };
+    Object.values(TrxScope).forEach((tronChainId) => {
+      if (!newAssetsByAccountGroup[tronChainId]) {
+        return;
+      }
+
+      newAssetsByAccountGroup[tronChainId] = newAssetsByAccountGroup[
+        tronChainId
+      ].filter((asset: Asset) => {
+        if (
+          asset.chainId.startsWith('tron:') &&
+          TRON_RESOURCE_SYMBOLS_SET.has(
+            asset.symbol?.toLowerCase() as TronResourceSymbol,
+          )
+        ) {
+          return false;
+        }
+        return true;
+      });
+    });
+
+    return newAssetsByAccountGroup;
+  },
 );
 
 export const getAsset = createSelector(


### PR DESCRIPTION
## **Description**

This selector does not filter out TRON staked tokens (energy and bandwidth). To match mobile, we have added some filtering on the selector level (as this selector is used in many places).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37993?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: filter out tron energy and bandwidth from send flow

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37991 https://consensyssoftware.atlassian.net/browse/ASSETS-1814

## **Manual testing steps**

1. Go to send flow
2. Filter on TRON chain
3. EXPECTED: You should only see the native TRON token

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/9f1b503aa63840be8fdf838fac5384c8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters TRON bandwidth/energy (including staked variants) from `getAssetsBySelectedAccountGroup` results and adds tests to validate the behavior.
> 
> - **Selectors**:
>   - Update `ui/selectors/assets.ts` `getAssetsBySelectedAccountGroup` to remove TRON resource/staked assets using `TrxScope` and `TRON_RESOURCE_SYMBOLS_SET`.
>   - Import `TrxScope`, `Asset`, and TRON constants; return filtered assets per TRON chain.
> - **Tests**:
>   - Add test ensuring TRON staked bandwidth/energy assets are filtered, leaving only native TRX per `TrxScope`.
>   - Clear selector caches in `beforeEach`; tighten assertion to `toStrictEqual`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c39d8b9220a5c8985810ff5f590b06c9d845ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->