### PR TITLE
feat: Add deep link for settings page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2016,6 +2016,9 @@
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"
   },
+  "deepLink_theSettingsPage": {
+    "message": "the settings page"
+  },
   "deepLink_theSwapsPage": {
     "message": "the swaps page"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2016,6 +2016,9 @@
   "deepLink_theRewardsPage": {
     "message": "the MetaMask Rewards page"
   },
+  "deepLink_theSettingsPage": {
+    "message": "the settings page"
+  },
   "deepLink_theSwapsPage": {
     "message": "the swaps page"
   },

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -6,6 +6,7 @@ import nonevm from './nonevm';
 import perps from './perps';
 import predict from './predict';
 import rewards from './rewards';
+import settings from './settings';
 
 import type { Route } from './route';
 import shield from './shield';
@@ -47,3 +48,4 @@ addRoute(perps);
 addRoute(predict);
 addRoute(rewards);
 addRoute(shield);
+addRoute(settings);

--- a/shared/lib/deep-links/routes/settings.ts
+++ b/shared/lib/deep-links/routes/settings.ts
@@ -1,0 +1,19 @@
+import { SETTINGS_ROUTE, Route } from './route';
+
+export default new Route({
+  pathname: '/settings',
+  getTitle: (_: URLSearchParams) => 'deepLink_theSettingsPage',
+  handler: function handler(params: URLSearchParams) {
+    const settingsTab = params.get('tab');
+
+    switch (settingsTab) {
+      case 'security':
+        return {
+          path: `${SETTINGS_ROUTE}/security`,
+          query: new URLSearchParams(),
+        };
+      default:
+        return { path: SETTINGS_ROUTE, query: new URLSearchParams() };
+    }
+  },
+});

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -8,6 +8,7 @@ import LoginPage from '../../page-objects/pages/login-page';
 import SwapPage from '../../page-objects/pages/swap/swap-page';
 import HomePage from '../../page-objects/pages/home/homepage';
 import RewardsPage from '../../page-objects/pages/rewards/rewards-page';
+import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { emptyHtmlPage } from '../../mock-e2e';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import { BaseUrl } from '../../../../shared/constants/urls';
@@ -87,7 +88,7 @@ describe('Deep Link', function () {
       'signed without sig_params',
       'unsigned',
     ] as const,
-    ['/home', '/swap', '/INVALID', REWARDS_ROUTE] as const,
+    ['/home', '/swap', '/INVALID', REWARDS_ROUTE, '/settings'] as const,
     ['continue'] as const,
   ).map(([locked, signed, route, action]) => {
     return { locked, signed, route, action };
@@ -180,6 +181,9 @@ and we'll take you to the right place.`
             case '/home':
             case '/INVALID':
               Page = HomePage;
+              break;
+            case '/settings':
+              Page = SettingsPage;
               break;
             case '/swap':
               Page = SwapPage;


### PR DESCRIPTION
## **Description**
This PR adds deep link for `settings` page and possibility to use `?tab=security` to open the `security` tab on settings page automatically.

Note: Once we add the link, we can also sign it to avoid warning message on interstitial page.

## Depends on: https://github.com/MetaMask/metamask-extension/pull/38685

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38003?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added deep link for settings page

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Try opening http://link.metamask.io/settings
2. Make sure that it's linking to the settings page
3. 1. Try opening http://link.metamask.io/settings?tab=security
4. Make sure that it's linking to the settings security page

## **Screenshots/Recordings**
### **Before**
Nothing to show in this section. Settings deep link didn't exist before this PR.

### **After**

https://github.com/user-attachments/assets/ecdfaec6-0c2f-4f06-884e-1330b2a5acf2

https://github.com/user-attachments/assets/dded541c-0f63-431f-8969-4e761999345b

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `/settings` deep link (supports `?tab=security`) with i18n title and e2e coverage.
> 
> - **Deep Links**:
>   - **New Route**: Add `/settings` route in `shared/lib/deep-links/routes/settings.ts` with title `deepLink_theSettingsPage` and handler supporting `?tab=security` → `${SETTINGS_ROUTE}/security`.
>   - **Registration**: Import and register `settings` in `shared/lib/deep-links/routes/index.ts`.
> - **i18n**:
>   - Add `deepLink_theSettingsPage` to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Update `test/e2e/tests/deep-link/deep-link.spec.ts` to include `/settings` in scenarios and handle via `SettingsPage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd4197330b79e6f117de2c13c20e5f147c22bf6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->