### PR TITLE
fix: cp-13.11.0 Update dapp swap comparison banner UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3685,7 +3685,7 @@
     "message": "Wallet notifications are currently not active."
   },
   "metamaskSwap": {
-    "message": "Metamask Swap"
+    "message": "MetaMask Swap"
   },
   "metamaskSwapsOfflineDescription": {
     "message": "MetaMask Swaps is undergoing maintenance. Please check back later."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3685,7 +3685,7 @@
     "message": "Wallet notifications are currently not active."
   },
   "metamaskSwap": {
-    "message": "Metamask Swap"
+    "message": "MetaMask Swap"
   },
   "metamaskSwapsOfflineDescription": {
     "message": "MetaMask Swaps is undergoing maintenance. Please check back later."

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -197,18 +197,28 @@ describe('<DappSwapComparisonBanner />', () => {
       selectedQuoteValueDifference: 0.1,
       gasDifference: 0.01,
       tokenAmountDifference: 0.01,
+      destinationTokenSymbol: 'TEST',
     } as unknown as ReturnType<typeof useDappSwapComparisonInfo>);
-    const { getByText } = render();
-    const quoteSwapButton = getByText('Market rate');
-    fireEvent.click(quoteSwapButton);
-    expect(mockSetQuotedSwapDisplayedInInfo).toHaveBeenCalledTimes(1);
+    const { getByTestId } = render();
+    const metamaskSwapTab = getByTestId('metamask-swap-tab');
+    fireEvent.click(metamaskSwapTab);
+    const marketRateTab = getByTestId('market-rate-tab');
+    fireEvent.click(marketRateTab);
+    expect(mockSetQuotedSwapDisplayedInInfo).toHaveBeenCalledTimes(2);
+    expect(mockSetQuotedSwapDisplayedInInfo).toHaveBeenNthCalledWith(1, true);
+    expect(mockSetQuotedSwapDisplayedInInfo).toHaveBeenNthCalledWith(2, false);
     expect(
       mockCaptureDappSwapComparisonDisplayProperties,
-    ).toHaveBeenCalledTimes(1);
+    ).toHaveBeenCalledTimes(2);
     expect(
       mockCaptureDappSwapComparisonDisplayProperties,
     ).toHaveBeenNthCalledWith(1, {
       swap_mm_cta_displayed: 'true',
+    });
+    expect(
+      mockCaptureDappSwapComparisonDisplayProperties,
+    ).toHaveBeenNthCalledWith(2, {
+      swap_mm_opened: 'true',
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -130,7 +130,7 @@ describe('<DappSwapComparisonBanner />', () => {
     } as unknown as ReturnType<typeof useDappSwapComparisonInfo>);
     const { getByText } = render();
     expect(getByText('Market rate')).toBeInTheDocument();
-    expect(getByText('Metamask Swap')).toBeInTheDocument();
+    expect(getByText('MetaMask Swap')).toBeInTheDocument();
     expect(getByText('Save and earn with MetaMask Swaps')).toBeInTheDocument();
     expect(getByText('Save $0.02')).toBeInTheDocument();
     expect(
@@ -166,7 +166,7 @@ describe('<DappSwapComparisonBanner />', () => {
       tokenAmountDifference: 0.01,
     } as unknown as ReturnType<typeof useDappSwapComparisonInfo>);
     const { getByText } = render();
-    const quoteSwapButton = getByText('Metamask Swap');
+    const quoteSwapButton = getByText('MetaMask Swap');
     fireEvent.click(quoteSwapButton);
     expect(mockSetQuotedSwapDisplayedInInfo).toHaveBeenCalledTimes(1);
     expect(

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 import { getRemoteFeatureFlags } from '../../../../../selectors/remote-feature-flags';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { ConfirmInfoSection } from '../../../../../components/app/confirm/info/row/section';
+import { Tab, Tabs } from '../../../../../components/ui/tabs';
 import { useDappSwapComparisonInfo } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo';
 import { useDappSwapComparisonMetrics } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapComparisonMetrics';
 import { useDappSwapCheck } from '../../../hooks/transactions/dapp-swap-comparison/useDappSwapCheck';
@@ -23,7 +24,6 @@ import { useDappSwapComparisonRewardText } from '../../../hooks/transactions/dap
 import { useDappSwapContext } from '../../../context/dapp-swap';
 import { QuoteSwapSimulationDetails } from '../../transactions/quote-swap-simulation-details/quote-swap-simulation-details';
 import { NetworkRow } from '../info/shared/network-row/network-row';
-import { Tab, Tabs } from '../../../../../components/ui/tabs';
 
 const DAPP_SWAP_THRESHOLD = 0.01;
 

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -37,6 +37,36 @@ const enum SwapType {
   Metamask = 'metamask',
 }
 
+// Swaps tabs are memoized to prevent animation jitter in MMSwap tab
+const SwapTabs = React.memo(
+  ({ onTabClick }: { onTabClick: (key: string) => void }) => {
+    const t = useI18nContext();
+
+    return (
+      <Tabs
+        defaultActiveTabKey="marketRate"
+        onTabClick={onTabClick}
+        tabListProps={{
+          className: 'dapp-swap__tabs',
+        }}
+      >
+        <Tab
+          tabKey="marketRate"
+          name={t('marketRate')}
+          className="flex-1"
+          data-testid="market-rate-tab"
+        />
+        <Tab
+          tabKey="mmswap"
+          name={t('metamaskSwap')}
+          className="flex-1 animate-mm-swap-text"
+          data-testid="metamask-swap-tab"
+        />
+      </Tabs>
+    );
+  },
+);
+
 const DappSwapComparisonInner = () => {
   const t = useI18nContext();
   const {
@@ -123,34 +153,15 @@ const DappSwapComparisonInner = () => {
     setSelectedQuote(selectedQuote);
   }, [selectedQuote, setSelectedQuote]);
 
-  if (!swapComparisonDisplayed) {
-    return null;
-  }
+  // if (!swapComparisonDisplayed) {
+  //   return null;
+  // }
 
   const dappTypeSelected = selectedSwapType === SwapType.Current;
 
   return (
     <Box>
-      <Tabs
-        defaultActiveTabKey="marketRate"
-        onTabClick={onTabClick}
-        tabListProps={{
-          className: 'dapp-swap__tabs',
-        }}
-      >
-        <Tab
-          tabKey="marketRate"
-          name={t('marketRate')}
-          className="flex-1"
-          data-testid="market-rate-tab"
-        />
-        <Tab
-          tabKey="mmswap"
-          name={t('metamaskSwap')}
-          className="flex-1"
-          data-testid="metamask-swap-tab"
-        />
-      </Tabs>
+      <SwapTabs onTabClick={onTabClick} />
       {showDappSwapComparisonBanner && dappTypeSelected && (
         <Box
           className="dapp-swap_callout"

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -153,9 +153,9 @@ const DappSwapComparisonInner = () => {
     setSelectedQuote(selectedQuote);
   }, [selectedQuote, setSelectedQuote]);
 
-  // if (!swapComparisonDisplayed) {
-  //   return null;
-  // }
+  if (!swapComparisonDisplayed) {
+    return null;
+  }
 
   const dappTypeSelected = selectedSwapType === SwapType.Current;
 

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -92,6 +92,17 @@ const DappSwapComparisonInner = () => {
     selectedQuote,
   ]);
 
+  const onTabClick = useCallback(
+    (tabKey: string) => {
+      if (tabKey === 'marketRate') {
+        updateSwapToCurrent();
+      } else if (tabKey === 'mmswap') {
+        updateSwapToSelectedQuote();
+      }
+    },
+    [updateSwapToCurrent, updateSwapToSelectedQuote],
+  );
+
   const swapComparisonDisplayed =
     dappSwapUi?.enabled &&
     (selectedQuoteValueDifference >=
@@ -122,13 +133,7 @@ const DappSwapComparisonInner = () => {
     <Box>
       <Tabs
         defaultActiveTabKey="marketRate"
-        onTabClick={(tabKey) => {
-          if (tabKey === 'marketRate') {
-            updateSwapToCurrent();
-          } else if (tabKey === 'mmswap') {
-            updateSwapToSelectedQuote();
-          }
-        }}
+        onTabClick={onTabClick}
         tabListProps={{
           className: 'dapp-swap__tabs',
         }}

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -3,15 +3,10 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   Box,
   BoxBackgroundColor,
-  BoxBorderColor,
-  Button,
   ButtonIcon,
   ButtonIconSize,
-  ButtonSize,
-  ButtonVariant,
   IconName,
   Text,
-  TextButton,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
@@ -28,6 +23,7 @@ import { useDappSwapComparisonRewardText } from '../../../hooks/transactions/dap
 import { useDappSwapContext } from '../../../context/dapp-swap';
 import { QuoteSwapSimulationDetails } from '../../transactions/quote-swap-simulation-details/quote-swap-simulation-details';
 import { NetworkRow } from '../info/shared/network-row/network-row';
+import { Tab, Tabs } from '../../../../../components/ui/tabs';
 
 const DAPP_SWAP_THRESHOLD = 0.01;
 
@@ -40,44 +36,6 @@ const enum SwapType {
   Current = 'current',
   Metamask = 'metamask',
 }
-
-const enum SwapButtonType {
-  Text = 'text',
-  ButtonType = 'button',
-}
-
-const SwapButton = ({
-  className = '',
-  type,
-  label,
-  onClick,
-}: {
-  className?: string;
-  type: SwapButtonType;
-  label: string;
-  onClick: () => void;
-}) => {
-  if (type === SwapButtonType.ButtonType) {
-    return (
-      <Button
-        className={`dapp-swap_rounded-button ${className}`}
-        size={ButtonSize.Md}
-        variant={ButtonVariant.Secondary}
-        onClick={onClick}
-      >
-        {label}
-      </Button>
-    );
-  }
-  return (
-    <TextButton
-      className={`dapp-swap_text-button ${className}`}
-      onClick={onClick}
-    >
-      {label}
-    </TextButton>
-  );
-};
 
 const DappSwapComparisonInner = () => {
   const t = useI18nContext();
@@ -162,41 +120,38 @@ const DappSwapComparisonInner = () => {
 
   return (
     <Box>
-      <Box
-        borderColor={BoxBorderColor.BorderMuted}
-        borderWidth={1}
-        className="dapp-swap_wrapper"
-        marginBottom={4}
-        marginTop={2}
-        padding={1}
+      <Tabs
+        defaultActiveTabKey="marketRate"
+        onTabClick={(tabKey) => {
+          if (tabKey === 'marketRate') {
+            updateSwapToCurrent();
+          } else if (tabKey === 'mmswap') {
+            updateSwapToSelectedQuote();
+          }
+        }}
+        tabListProps={{
+          className: 'dapp-swap__tabs',
+        }}
       >
-        <SwapButton
-          className="dapp-swap_dapp-swap-button"
-          type={
-            selectedSwapType === SwapType.Current
-              ? SwapButtonType.ButtonType
-              : SwapButtonType.Text
-          }
-          onClick={updateSwapToCurrent}
-          label={t('marketRate')}
+        <Tab
+          tabKey="marketRate"
+          name={t('marketRate')}
+          className="flex-1"
+          data-testid="market-rate-tab"
         />
-        <SwapButton
-          className="dapp-swap_mm-swap-button"
-          type={
-            selectedSwapType === SwapType.Metamask
-              ? SwapButtonType.ButtonType
-              : SwapButtonType.Text
-          }
-          onClick={updateSwapToSelectedQuote}
-          label={t('metamaskSwap')}
+        <Tab
+          tabKey="mmswap"
+          name={t('metamaskSwap')}
+          className="flex-1"
+          data-testid="metamask-swap-tab"
         />
-      </Box>
+      </Tabs>
       {showDappSwapComparisonBanner && dappTypeSelected && (
         <Box
           className="dapp-swap_callout"
-          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+          backgroundColor={BoxBackgroundColor.BackgroundSection}
           marginBottom={4}
-          padding={4}
+          padding={3}
           role="button"
           onClick={updateSwapToSelectedQuote}
         >

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
@@ -62,3 +62,32 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
     border-top: 1px solid var(--color-border-muted);
   }
 }
+
+.animate-mm-swap-text {
+  background: linear-gradient(
+    45deg,
+    currentColor 0%,
+    currentColor 35%,
+    var(--color-success-default) 50%,
+    currentColor 65%,
+    currentColor 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+
+  animation: wave-green 1.5s ease-in-out infinite;
+  will-change: background-position;
+
+}
+
+
+@keyframes wave-green {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
@@ -3,9 +3,6 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 */
 /* stylelint-disable color-no-hex */
 .dapp-swap {
-  &_wrapper {
-    border-radius: 8px;
-  }
 
   &_rounded-button {
     border-radius: 8px;
@@ -17,14 +14,10 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
     }
   }
 
-  &_mm-swap-button {
-    color: var(--color-success-default);
-    width: 50%;
-
-    &:hover {
-      color: var(--color-success-default) !important;
-      text-decoration: none !important;
-    }
+  &__tabs {
+    margin-bottom: 20px;
+    margin-top: 12px;
+    border-bottom: 1px solid var(--color-border-muted);
   }
 
   &_dapp-swap-button {
@@ -39,13 +32,14 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 
   &_close-button {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 6px;
+    right: 10px;
   }
 
   &_callout {
     border-radius: 8px;
     position: relative;
+    border: 1px solid var(--color-border-muted);
   }
 
   &_callout-text {
@@ -58,19 +52,13 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 
   &_callout-arrow {
     position: absolute;
-    top: -12px;
+    top: -8px;
     left: 75%;
-    transform: translateX(-50%);
-    width: 0;
-    height: 0;
-  }
-
-  &_callout-arrow::before {
-    content: "";
-    position: absolute;
-    width: 24px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
+    transform: translateX(-50%) rotate(45deg);
     background: var(--color-background-section);
-    clip-path: polygon(50% 0, 0 100%, 100% 100%);
+    border-left: 1px solid var(--color-border-muted);
+    border-top: 1px solid var(--color-border-muted);
   }
 }

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/index.scss
@@ -3,7 +3,6 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 */
 /* stylelint-disable color-no-hex */
 .dapp-swap {
-
   &_rounded-button {
     border-radius: 8px;
   }
@@ -64,29 +63,28 @@ Disabling Stylelint's hex color rule here because the TypeScript migration dashb
 }
 
 .animate-mm-swap-text {
-  background: linear-gradient(
-    45deg,
-    currentColor 0%,
-    currentColor 35%,
-    var(--color-success-default) 50%,
-    currentColor 65%,
-    currentColor 100%
-  );
+  background:
+    linear-gradient(
+      45deg,
+      currentColor 0%,
+      currentColor 35%,
+      var(--color-success-default) 50%,
+      currentColor 65%,
+      currentColor 100%
+    );
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-
   animation: wave-green 1.5s ease-in-out infinite;
   will-change: background-position;
-
 }
-
 
 @keyframes wave-green {
   0% {
     background-position: 100% 0;
   }
+
   100% {
     background-position: -100% 0;
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to adjust design changes in the dapp swap comparison banner.

Note: No changelog needed because this feature is not released yet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38006?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6312

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="514" height="814" alt="before dark" src="https://github.com/user-attachments/assets/647201a7-8dce-4072-b945-c1f0fe99f945" />

<img width="512" height="732" alt="before light" src="https://github.com/user-attachments/assets/00d779fb-44cc-473f-8b89-f33293f278c9" />


### **After**

<img width="512" height="732" alt="after dark" src="https://github.com/user-attachments/assets/e89d1cc3-a598-4909-b825-97a5ccba6c7d" />


<img width="512" height="732" alt="after light" src="https://github.com/user-attachments/assets/3cf520d7-d964-41f7-a3ac-3e26bcade9ed" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the dapp swap comparison banner to a tabbed UI with updated styling/animations, fixes “MetaMask Swap” casing in locales, and updates tests accordingly.
> 
> - **UI (Confirmations dapp swap comparison banner)**:
>   - Replace button toggle with memoized `Tabs` (`marketRate`, `metamaskSwap`) via `components/ui/tabs` and add `onTabClick` to switch swap views.
>   - Tweak banner visuals: use `BackgroundSection`, adjust padding, add border, reposition close button, and redesign callout arrow; add animated gradient text (`.animate-mm-swap-text`).
>   - Remove old button/text toggle code and wrapper.
> - **Styles**:
>   - Add `.dapp-swap__tabs` and animation keyframes; update callout/arrow and close button CSS.
> - **Locales**:
>   - Correct casing: `metamaskSwap` message to "MetaMask Swap" in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Update expectations from "Metamask Swap" to "MetaMask Swap"; interact via tab `data-testid`s; assert `setQuotedSwapDisplayedInInfo` and metrics are called appropriately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becd718e92292527ef954e4e0a70bbf7aafe07c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->