### PR TITLE
fix: rewards ui hover button color

### DIFF
--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
@@ -117,8 +117,12 @@ describe('OnboardingIntroStep', () => {
     (useDispatch as jest.Mock).mockReturnValue(dispatchMock);
     // Ensure useSelector calls the provided selector function without using any
     (useSelector as jest.Mock).mockImplementation(
-      (selector: (state: unknown) => unknown) => selector({} as unknown),
+      (selector: (state: unknown) => unknown) =>
+        // Provide a minimal state shape with metamask.theme to satisfy getTheme
+        selector({ metamask: { theme: 'light' } } as unknown),
     );
+    // Ensure document has a data-theme attribute for useTheme resolution
+    document.documentElement.setAttribute('data-theme', 'light');
     // Default: no active subscription id
     (useAppSelector as jest.Mock).mockReturnValue(undefined);
     // Default geo metadata hook with a retry function

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react';
+import { useTheme } from '../../../../hooks/useTheme';
 import { OnboardingStep } from '../../../../ducks/rewards/types';
 import {
   setErrorToast,
@@ -41,6 +42,7 @@ import { isHardwareWallet } from '../../../../../shared/modules/selectors';
 const OnboardingIntroStep: React.FC = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
+  const theme = useTheme();
 
   const setHasSeenRewardsIntroModal = useCallback(async () => {
     await setStorageItem(REWARDS_GTM_MODAL_SHOWN, 'true');
@@ -227,7 +229,7 @@ const OnboardingIntroStep: React.FC = () => {
           candidateSubscriptionId === 'retry'
         }
         onClick={handleNext}
-        className="w-full my-2 bg-white hover:bg-default-hover"
+        className={`w-full my-2 bg-white ${theme === 'light' ? 'hover:bg-default-hover' : 'hover:bg-icon-default-hover'}`}
       >
         <Text variant={TextVariant.BodyMd} className="text-black font-medium">
           {t('rewardsOnboardingIntroStepConfirm')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes onboarding intro modal confirm button hover color 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38059?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the onboarding confirm button hover color respect light/dark theme and update tests to provide theme context.
> 
> - **Rewards Onboarding UI**:
>   - Use `useTheme` in `OnboardingIntroStep` to make the confirm button hover color theme-aware (`hover:bg-default-hover` for light, `hover:bg-icon-default-hover` for dark).
> - **Tests**:
>   - Update `OnboardingIntroStep.test.tsx` to provide `metamask.theme` via `useSelector` and set `document.documentElement` `data-theme` for theme resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6eb887705f31943be99d48676dc1c60b4778af3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->