### PR TITLE
fix: do not display Snap account dialogs for multichain wallet Snaps cp-13.11.0

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -20,7 +20,10 @@ import { IconName } from '../../../../ui/components/component-library/icon';
 import MetaMetricsController from '../../controllers/metametrics-controller';
 import { getUniqueAccountName } from '../../../../shared/lib/accounts';
 import { isSnapPreinstalled } from '../../../../shared/lib/snaps/snaps';
-import { getSnapName } from '../../../../shared/lib/accounts/snaps';
+import {
+  getSnapName,
+  isMultichainWalletSnap,
+} from '../../../../shared/lib/accounts/snaps';
 import {
   FEATURE_VERSION_2,
   isMultichainAccountsFeatureEnabled,
@@ -470,17 +473,22 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
   ) {
     assertIsValidSnapId(snapId);
 
+    // Preinstalled Snaps can skip some confirmation dialogs and multichain wallet Snaps will
+    // skip them automatically too!
+    const isPreinstalled = isSnapPreinstalled(snapId);
+    const isMultichainWallet = isPreinstalled && isMultichainWalletSnap(snapId);
+
     // If Snap is preinstalled and does not request confirmation, skip the confirmation dialog.
     const skipConfirmationDialog =
-      isSnapPreinstalled(snapId) && !displayConfirmation;
+      isMultichainWallet || (isPreinstalled && !displayConfirmation);
 
     // Only pre-installed Snaps can skip the account name suggestion dialog.
     const skipAccountNameSuggestionDialog =
-      isSnapPreinstalled(snapId) && !displayAccountNameSuggestion;
+      isMultichainWallet || (isPreinstalled && !displayAccountNameSuggestion);
 
     // Only pre-installed Snaps can skip the account from being selected.
     const skipSetSelectedAccountStep =
-      isSnapPreinstalled(snapId) && !setSelectedAccount;
+      isMultichainWallet || (isPreinstalled && !setSelectedAccount);
 
     const skipApprovalFlow =
       skipConfirmationDialog && skipAccountNameSuggestionDialog;
@@ -492,7 +500,10 @@ class SnapKeyringImpl implements SnapKeyringCallbacks {
       skipConfirmationDialog,
       skipAccountNameSuggestionDialog,
       skipApprovalFlow,
-      accountNameSuggestion,
+      // We do not set the account name suggestion if it's a multichain wallet Snap since the
+      // current naming could have race conditions with other account creations, and since
+      // naming is now handled by multichain account groups, we can skip this entirely.
+      accountNameSuggestion: isMultichainWallet ? '' : accountNameSuggestion,
       handleUserInput,
     });
 


### PR DESCRIPTION
## **Description**

We have a problem with the way the `SnapKeyring` handles internal options. This keyring can be destroy/re-created sometimes and this cause its internal transient context to be cleared/reset.

This can interfere with the Snap account creation flows (Bitcoin/Solana/Tron) when a previous instance of the `SnapKeyring` initiate the account creation but another one is created and finalize the flow. In that case, the new instance won't have the correct mapping for the internal options and will use the default options, thus, triggering some dialogs.

We are currently reworking the Snap keyring entirely, thus, it's not worth to fix it at that level, but to prevent those dialogs from popping-up, we now disable them for everything that's related to BIP-44 accounts.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38061?quickstart=1)

## **Changelog**

CHANGELOG entry: Prevent any dialogs for multichain wallet Snaps (Solana, Bitcoin, Tron)

## **Related issues**

Fixes:
- https://github.com/MetaMask/metamask-extension/issues/38046

## **Manual testing steps**

> [!NOTE]
> I did follow the same instructions than on the bug ticket and used `.zip` build

1. `yarn build --build-type main dist`
2. Install the extension by dropping the `.zip` (from the `builds` folder)
3. Disable "Backup & Sync" during onboarding
4. Onboard
5. Wait for all accounts to be discovered
  - You should not have any dialogs

> [!TIP]
> You can follow the same procedure to test this bug and you might (not 100% of the time) get 
 a dialog that pops-up to enter the account name (in step 5)

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/b35e059f-6cb5-43fd-b079-3412d6834201

### **After**

https://github.com/user-attachments/assets/5b568199-dab8-4a2f-8453-8fbae0b29bb2


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips confirmation, name suggestion, and selection dialogs for preinstalled multichain wallet Snaps, bypassing approval flow and suppressing name suggestions (disabled under IN_TEST).
> 
> - **Snap Keyring (`app/scripts/lib/snap-keyring/snap-keyring.ts`)**
>   - **Multichain wallet Snap handling**:
>     - Add `isMultichainWalletSnap` and compute `skipAll` for preinstalled multichain Snaps (BIP-44), with `IN_TEST` override.
>     - Skip confirmation and name suggestion dialogs, and auto-skip account selection when `skipAll`.
>     - Bypass approval flow when both dialogs are skipped.
>     - Avoid race-prone naming by passing empty `accountNameSuggestion` when `skipAll`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90064562f457bb781ceb7b07358d21bcfc5cdc9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->