### PR TITLE
fix: cp-13.10.1 prevent account list from fetching list of all accounts balances

### DIFF
--- a/app/scripts/controller-init/token-balances-controller-init.test.ts
+++ b/app/scripts/controller-init/token-balances-controller-init.test.ts
@@ -72,6 +72,7 @@ describe('TokenBalancesControllerInit', () => {
       queryMultipleAccounts: true,
       allowExternalServices: expect.any(Function),
       accountsApiChainIds: expect.any(Function),
+      platform: 'extension',
     });
   });
 });

--- a/app/scripts/controller-init/token-balances-controller-init.ts
+++ b/app/scripts/controller-init/token-balances-controller-init.ts
@@ -33,6 +33,7 @@ export const TokenBalancesControllerInit: ControllerInitFunction<
         ? (featureFlagForAccountApiBalances as `0x${string}`[])
         : [];
     },
+    platform: 'extension',
   });
 
   return {

--- a/ui/hooks/useAssetsUpdateAllAccountBalances.test.ts
+++ b/ui/hooks/useAssetsUpdateAllAccountBalances.test.ts
@@ -130,7 +130,7 @@ describe('useAssetsUpdateAllAccountBalances', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockUpdateBalancesFoAccounts).toHaveBeenCalledWith(
       initialChainIds,
-      true,
+      false,
     );
 
     // Update chain IDs and rerender
@@ -140,7 +140,7 @@ describe('useAssetsUpdateAllAccountBalances', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(2);
     expect(mockUpdateBalancesFoAccounts).toHaveBeenCalledWith(
       updatedChainIds,
-      true,
+      false,
     );
   });
 

--- a/ui/hooks/useAssetsUpdateAllAccountBalances.ts
+++ b/ui/hooks/useAssetsUpdateAllAccountBalances.ts
@@ -37,7 +37,7 @@ export const useAssetsUpdateAllAccountBalances = (): {
         // Update balance state for ALL accounts across all enabled EVM chains
         // TokenBalancesController is configured with queryMultipleAccounts: true
         // so this will update balances for all accounts, not just the selected one
-        await dispatch(updateBalancesFoAccounts(enabledChainIds, true));
+        await dispatch(updateBalancesFoAccounts(enabledChainIds, false));
       }
     } catch (error) {
       console.warn('Error updating balances state for all accounts', error);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

prevent token list from fetching balances for all accounts

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38065?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent token list from fetching balances for all accounts

## **Related issues**

Fixes: #38105

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches balance updates to use the non-all-accounts path and passes `platform: 'extension'` when initializing `TokenBalancesController`.
> 
> - **Assets/Hooks**
>   - `useAssetsUpdateAllAccountBalances`: calls `updateBalancesFoAccounts(enabledChainIds, false)` instead of `true`.
>   - Tests updated to expect the new boolean flag where applicable.
> - **Controller Init**
>   - `TokenBalancesControllerInit`: passes `platform: 'extension'` to `TokenBalancesController`.
>   - Corresponding test updated to assert the `platform` argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ecafdc07313d65b37c5242e8994f41902cc830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->