### PR TITLE
feat: handles rewards deeplink with referral code

### DIFF
--- a/shared/lib/deep-links/routes/rewards.ts
+++ b/shared/lib/deep-links/routes/rewards.ts
@@ -1,14 +1,13 @@
-import { BaseUrl } from '../../../constants/urls';
 import { Route } from './route';
 
 export default new Route({
   pathname: '/rewards',
   getTitle: (_: URLSearchParams) => 'deepLink_theRewardsPage',
   handler: function handler(params: URLSearchParams) {
-    const rewardsUrl = new URL('/rewards', BaseUrl.MetaMask);
-    params.forEach((value, key) => rewardsUrl.searchParams.append(key, value));
+    const query = new URLSearchParams(params);
     return {
-      redirectTo: rewardsUrl,
+      path: '/rewards',
+      query,
     };
   },
 });

--- a/test/e2e/page-objects/pages/rewards/rewards-page.ts
+++ b/test/e2e/page-objects/pages/rewards/rewards-page.ts
@@ -1,0 +1,15 @@
+import { Driver } from '../../../webdriver/driver';
+
+export default class RewardsPage {
+  protected readonly driver: Driver;
+
+  private readonly onboardingModal = '[data-testid="rewards-onboarding-modal"]';
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  async checkPageIsLoaded(): Promise<void> {
+    await this.driver.waitForSelector(this.onboardingModal);
+  }
+}

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -7,6 +7,7 @@ import DeepLink from '../../page-objects/pages/deep-link-page';
 import LoginPage from '../../page-objects/pages/login-page';
 import SwapPage from '../../page-objects/pages/swap/swap-page';
 import HomePage from '../../page-objects/pages/home/homepage';
+import RewardsPage from '../../page-objects/pages/rewards/rewards-page';
 import { emptyHtmlPage } from '../../mock-e2e';
 import FixtureBuilder from '../../fixture-builder';
 import { BaseUrl } from '../../../../shared/constants/urls';
@@ -85,7 +86,7 @@ describe('Deep Link', function () {
       'signed without sig_params',
       'unsigned',
     ] as const,
-    ['/home', '/swap', '/INVALID'] as const,
+    ['/home', '/swap', '/INVALID', '/rewards'] as const,
     ['continue'] as const,
   ).map(([locked, signed, route, action]) => {
     return { locked, signed, route, action };
@@ -181,6 +182,9 @@ and we'll take you to the right place.`
               break;
             case '/swap':
               Page = SwapPage;
+              break;
+            case '/rewards':
+              Page = RewardsPage;
               break;
             default: {
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
@@ -286,59 +290,6 @@ and we'll take you to the right place.`
 
         await driver.waitForUrl({
           url: `${BaseUrl.MetaMask}/prediction-markets`,
-        });
-      },
-    );
-  });
-
-  it('handles /rewards route redirect', async function () {
-    await withFixtures(
-      await getConfig(this.test?.fullTitle()),
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
-        const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
-
-        const rawUrl = `https://link.metamask.io/rewards`;
-        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl);
-
-        // test signed flow
-        await driver.openNewURL(signedUrl);
-
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/rewards` });
-
-        await driver.navigate();
-        await homePage.checkPageIsLoaded();
-
-        // test unsigned flow
-        await driver.openNewURL(rawUrl);
-
-        await driver.waitForUrl({ url: `${BaseUrl.MetaMask}/rewards` });
-      },
-    );
-  });
-
-  it('handles /rewards referral route redirect', async function () {
-    await withFixtures(
-      await getConfig(this.test?.fullTitle()),
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
-        const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
-
-        const rawUrl = `https://link.metamask.io/rewards?referral=MIAMI5`;
-
-        // test unsigned flow
-        await driver.openNewURL(rawUrl);
-
-        await driver.waitForUrl({
-          url: `${BaseUrl.MetaMask}/rewards?referral=MIAMI5`,
         });
       },
     );

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1031,6 +1031,7 @@
     "onboardingModalOpen": "boolean",
     "onboardingActiveStep": "string",
     "onboardingModalRendered": "boolean",
+    "onboardingReferralCode": "string",
     "geoLocation": "null",
     "optinAllowedForGeo": "null",
     "optinAllowedForGeoLoading": "boolean",

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -33,7 +33,7 @@ import OnboardingStep3 from './OnboardingStep3';
 import OnboardingStep4 from './OnboardingStep4';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export default function OnboardingModal() {
+export default function OnboardingModal({ onClose }: { onClose?: () => void }) {
   const isOpen = useSelector(selectOnboardingModalOpen);
   const onboardingStep = useSelector(selectOnboardingActiveStep);
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
@@ -44,7 +44,8 @@ export default function OnboardingModal() {
   const handleClose = useCallback(() => {
     dispatch(setOnboardingModalOpen(false));
     dispatch(setOnboardingActiveStep(OnboardingStep.INTRO));
-  }, [dispatch]);
+    onClose?.();
+  }, [dispatch, onClose]);
 
   const renderContent = useCallback(() => {
     if (

--- a/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
@@ -12,9 +12,11 @@ import {
   IconName,
   IconSize,
   Text,
+  TextButton,
+  TextButtonSize,
   TextVariant,
 } from '@metamask/design-system-react';
-import { Link } from '@material-ui/core';
+import { useSelector } from 'react-redux';
 import {
   ModalBody,
   TextField,
@@ -25,6 +27,7 @@ import { useValidateReferralCode } from '../../../../hooks/rewards/useValidateRe
 import LoadingIndicator from '../../../ui/loading-indicator';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import { useOptIn } from '../../../../hooks/rewards/useOptIn';
+import { selectOnboardingReferralCode } from '../../../../ducks/rewards/selectors';
 import {
   REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
   REWARDS_ONBOARD_TERMS_URL,
@@ -35,6 +38,7 @@ const OnboardingStep4: React.FC = () => {
   const t = useI18nContext();
 
   const { optinLoading, optinError, optin } = useOptIn();
+  const onboardingReferralCode = useSelector(selectOnboardingReferralCode);
 
   const {
     referralCode,
@@ -42,8 +46,11 @@ const OnboardingStep4: React.FC = () => {
     isValidating: isValidatingReferralCode,
     isValid: referralCodeIsValid,
     isUnknownError: isUnknownErrorReferralCode,
-  } = useValidateReferralCode();
-
+  } = useValidateReferralCode(
+    onboardingReferralCode
+      ? onboardingReferralCode.trim().toUpperCase()
+      : undefined,
+  );
   const handleNext = useCallback(async () => {
     await optin(referralCode);
   }, [optin, referralCode]);
@@ -52,8 +59,8 @@ const OnboardingStep4: React.FC = () => {
     if (isValidatingReferralCode) {
       return (
         <LoadingIndicator
-          alt={undefined}
-          title={undefined}
+          alt="Verifying referral code..."
+          title="Verifying referral code..."
           isLoading={true}
           style={{ width: 32, height: 32, left: 5 }}
         />
@@ -206,13 +213,21 @@ const OnboardingStep4: React.FC = () => {
             className="text-alternative text-center"
           >
             {t('rewardsOnboardingStep4LegalDisclaimer1')}{' '}
-            <Link className="text-primary-default" onClick={openTermsOfUse}>
+            <TextButton
+              size={TextButtonSize.BodySm}
+              className="text-primary-default"
+              onClick={openTermsOfUse}
+            >
               {t('rewardsOnboardingStep4LegalDisclaimer2')}
-            </Link>
+            </TextButton>
             {t('rewardsOnboardingStep4LegalDisclaimer3')}{' '}
-            <Link className="text-primary-default" onClick={openLearnMore}>
+            <TextButton
+              size={TextButtonSize.BodySm}
+              className="text-primary-default min-w-10"
+              onClick={openLearnMore}
+            >
               {t('rewardsOnboardingStep4LegalDisclaimer4')}
-            </Link>
+            </TextButton>
             .{' '}
           </Text>
         </Box>

--- a/ui/ducks/rewards/index.test.ts
+++ b/ui/ducks/rewards/index.test.ts
@@ -7,6 +7,7 @@ import rewardsReducer, {
   resetRewardsState,
   setOnboardingModalOpen,
   setOnboardingActiveStep,
+  setOnboardingReferralCode,
   setRewardsGeoMetadata,
   setRewardsGeoMetadataLoading,
   setRewardsGeoMetadataError,
@@ -78,6 +79,23 @@ describe('Ducks - Rewards', () => {
       expect(actions[0].type).toBe('rewards/setOnboardingActiveStep');
       const newState = rewardsReducer(initialState, actions[0]);
       expect(newState.onboardingActiveStep).toBe(OnboardingStep.STEP1);
+    });
+
+    it('setOnboardingReferralCode updates onboardingReferralCode', () => {
+      store.dispatch(setOnboardingReferralCode('ABC123'));
+      const actions = store.getActions();
+      expect(actions[0].type).toBe('rewards/setOnboardingReferralCode');
+      const newState = rewardsReducer(initialState, actions[0]);
+      expect(newState.onboardingReferralCode).toBe('ABC123');
+    });
+
+    it('setOnboardingReferralCode clears onboardingReferralCode when payload is null', () => {
+      const existing = { ...initialState, onboardingReferralCode: 'ABC123' };
+      store.dispatch(setOnboardingReferralCode(null));
+      const actions = store.getActions();
+      expect(actions[0].type).toBe('rewards/setOnboardingReferralCode');
+      const newState = rewardsReducer(existing, actions[0]);
+      expect(newState.onboardingReferralCode).toBeNull();
     });
 
     it('setRewardsGeoMetadata sets location and opt-in flags when payload provided', () => {

--- a/ui/ducks/rewards/index.ts
+++ b/ui/ducks/rewards/index.ts
@@ -11,6 +11,7 @@ export type RewardsState = {
   onboardingModalOpen: boolean;
   onboardingActiveStep: OnboardingStep;
   onboardingModalRendered: boolean;
+  onboardingReferralCode: string | null;
 
   // Geolocation state
   geoLocation: string | null;
@@ -39,6 +40,7 @@ export const initialState: RewardsState = {
   onboardingModalOpen: false,
   onboardingActiveStep: OnboardingStep.INTRO,
   onboardingModalRendered: true,
+  onboardingReferralCode: '',
 
   geoLocation: null,
   optinAllowedForGeo: null,
@@ -89,6 +91,13 @@ const rewardsSlice = createSlice({
 
     setOnboardingModalRendered: (state, action: PayloadAction<boolean>) => {
       state.onboardingModalRendered = action.payload;
+    },
+
+    setOnboardingReferralCode: (
+      state,
+      action: PayloadAction<string | null>,
+    ) => {
+      state.onboardingReferralCode = action.payload;
     },
 
     setRewardsGeoMetadata: (
@@ -179,6 +188,7 @@ export const {
   setOnboardingModalOpen,
   setOnboardingActiveStep,
   setOnboardingModalRendered,
+  setOnboardingReferralCode,
   setCandidateSubscriptionId,
   setSeasonStatusLoading,
   setSeasonStatus,

--- a/ui/ducks/rewards/selectors.test.ts
+++ b/ui/ducks/rewards/selectors.test.ts
@@ -1,6 +1,7 @@
 import {
   selectOnboardingModalOpen,
   selectOnboardingActiveStep,
+  selectOnboardingReferralCode,
   selectOptinAllowedForGeo,
   selectOptinAllowedForGeoLoading,
   selectOptinAllowedForGeoError,
@@ -53,6 +54,13 @@ describe('rewards selectors', () => {
         rewards: { onboardingActiveStep: OnboardingStep.STEP1 },
       });
       expect(selectOnboardingActiveStep(state)).toBe(OnboardingStep.STEP1);
+    });
+
+    it('selectOnboardingReferralCode returns referral code', () => {
+      const state = buildState({
+        rewards: { onboardingReferralCode: ' ABC123 ' },
+      });
+      expect(selectOnboardingReferralCode(state)).toBe(' ABC123 ');
     });
 
     it('selectOptinAllowedForGeo returns geo eligibility', () => {

--- a/ui/ducks/rewards/selectors.ts
+++ b/ui/ducks/rewards/selectors.ts
@@ -16,6 +16,9 @@ export const selectOnboardingActiveStep = (state: MetaMaskReduxState) =>
 export const selectOnboardingModalRendered = (state: MetaMaskReduxState) =>
   state.rewards.onboardingModalRendered;
 
+export const selectOnboardingReferralCode = (state: MetaMaskReduxState) =>
+  state.rewards.onboardingReferralCode;
+
 export const selectOptinAllowedForGeo = (state: MetaMaskReduxState) =>
   state.rewards.optinAllowedForGeo;
 
@@ -43,6 +46,29 @@ export const selectRewardsEnabled = createSelector(
   getUseExternalServices,
   (remoteFeatureFlags, useExternalServices): boolean => {
     const rewardsFeatureFlag = remoteFeatureFlags?.rewardsEnabled as
+      | VersionGatedFeatureFlag
+      | boolean
+      | undefined;
+
+    const resolveFlag = (flag: unknown): boolean => {
+      if (typeof flag === 'boolean') {
+        return flag;
+      }
+      return Boolean(
+        validatedVersionGatedFeatureFlag(flag as VersionGatedFeatureFlag),
+      );
+    };
+
+    const featureFlagEnabled = resolveFlag(rewardsFeatureFlag);
+    return featureFlagEnabled && Boolean(useExternalServices);
+  },
+);
+
+export const selectRewardsOnboardingEnabled = createSelector(
+  getRemoteFeatureFlags,
+  getUseExternalServices,
+  (remoteFeatureFlags, useExternalServices): boolean => {
+    const rewardsFeatureFlag = remoteFeatureFlags?.rewardsOnboardingEnabled as
       | VersionGatedFeatureFlag
       | boolean
       | undefined;

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -151,12 +151,14 @@ export const WALLET_DETAILS_ROUTE = '/wallet-details/:id';
 export const DEFI_ROUTE = '/defi';
 
 export const SHIELD_PLAN_ROUTE = '/shield-plan';
+export const REWARDS_ROUTE = '/rewards';
 
 export const ROUTES = [
   { path: DEFAULT_ROUTE, label: 'Home', trackInAnalytics: true },
   { path: '', label: 'Home', trackInAnalytics: true }, // "" is an alias for the Home route
   { path: UNLOCK_ROUTE, label: 'Unlock Page', trackInAnalytics: true },
   { path: LOCK_ROUTE, label: 'Lock Page', trackInAnalytics: true },
+  { path: REWARDS_ROUTE, label: 'Rewards Page', trackInAnalytics: true },
   {
     path: ACCOUNT_LIST_PAGE_ROUTE,
     label: 'Account List Page',

--- a/ui/pages/rewards/index.tsx
+++ b/ui/pages/rewards/index.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { Box } from '@metamask/design-system-react';
+import LoadingIndicator from '../../components/ui/loading-indicator';
+import {
+  selectCandidateSubscriptionId,
+  selectRewardsEnabled,
+  selectRewardsOnboardingEnabled,
+} from '../../ducks/rewards/selectors';
+import { useCandidateSubscriptionId } from '../../hooks/rewards/useCandidateSubscriptionId';
+import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import {
+  setOnboardingModalOpen,
+  setOnboardingReferralCode,
+} from '../../ducks/rewards';
+import RewardsOnboardingModal from '../../components/app/rewards/onboarding/OnboardingModal';
+
+const RewardsPage: React.FC = () => {
+  const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
+  const rewardsEnabled = useSelector(selectRewardsEnabled);
+  const rewardsOnboardingEnabled = useSelector(selectRewardsOnboardingEnabled);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const redirectOnClose = useCallback(() => {
+    navigate(DEFAULT_ROUTE);
+  }, [navigate]);
+
+  useCandidateSubscriptionId();
+
+  // Capture referral code from URL on mount and store in Redux for onboarding
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const referral = params.get('referral');
+    if (referral && referral.length > 0) {
+      dispatch(setOnboardingReferralCode(referral));
+    } else {
+      dispatch(setOnboardingReferralCode(null));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // Redirect to homepage if candidateSubscriptionId is found or error
+    if (
+      !rewardsEnabled ||
+      !rewardsOnboardingEnabled ||
+      (candidateSubscriptionId &&
+        candidateSubscriptionId !== 'pending' &&
+        candidateSubscriptionId !== 'retry')
+    ) {
+      navigate(DEFAULT_ROUTE, { replace: true });
+    } else if (!candidateSubscriptionId) {
+      // else open the rewards onboarding modal
+      dispatch(setOnboardingModalOpen(true));
+    }
+  }, [candidateSubscriptionId, navigate, dispatch]);
+
+  return (
+    <Box className="flex justify-center items-center flex-1">
+      <LoadingIndicator
+        alt="Loading"
+        title="Loading"
+        isLoading={true}
+        style={{ width: 32, height: 32, left: 5 }}
+      />
+      <RewardsOnboardingModal onClose={redirectOnClose} />
+    </Box>
+  );
+};
+
+export default RewardsPage;

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -75,6 +75,7 @@ import {
   GATOR_PERMISSIONS,
   TOKEN_TRANSFER_ROUTE,
   REVIEW_GATOR_PERMISSIONS_ROUTE,
+  REWARDS_ROUTE,
 } from '../../helpers/constants/routes';
 import { getProviderConfig } from '../../../shared/modules/selectors/networks';
 import {
@@ -115,6 +116,7 @@ import {
   getIsUnlocked,
 } from '../../ducks/metamask/metamask';
 import { useI18nContext } from '../../hooks/useI18nContext';
+import RewardsPage from '../rewards';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
 import { navigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
 import {
@@ -1131,6 +1133,12 @@ export default function Routes() {
             path={SHIELD_PLAN_ROUTE}
             component={ShieldPlan}
             layout={LegacyLayout}
+          />
+          <RouteWithLayout
+            authenticated
+            path={REWARDS_ROUTE}
+            component={RewardsPage}
+            layout={RootLayout}
           />
           <RouteWithLayout
             authenticated


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-548
Handles rewards deeplink such as:
- https://link.metamask.io/rewards
- https://link.metamask.io/rewards?referral=DAB123

If user has a rewards profile --> redirect to homepage 
If use has not opted in yet --> open the rewards onboarding modal

To test locally:
chrome-extension://hebhblbkkdabgoldnojllkipeoacjioc/home.html#link?u=/rewards
chrome-extension://hebhblbkkdabgoldnojllkipeoacjioc/home.html#link?u=/rewards?referral=DAB123

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38072?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b27a37ac-e9c7-4e2c-8481-6f57b63edfed


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes /rewards deep links to a new in-app Rewards page that opens onboarding, seeds referral code from query params, and updates state/selectors with comprehensive tests.
> 
> - **Routing/UI**
>   - Add `REWARDS_ROUTE` (`/rewards`) and register it in `routes.component.tsx` with `RewardsPage`.
>   - Update deep-link handler for `'/rewards'` to return `{ path: '/rewards', query }` instead of external redirect.
> - **Rewards Page** (`ui/pages/rewards/index.tsx`)
>   - Opens onboarding modal; on close navigates to `DEFAULT_ROUTE`.
>   - Parses `referral` from URL and stores via `setOnboardingReferralCode`.
>   - Redirects to home when rewards or onboarding disabled, or when `candidateSubscriptionId` is resolved; otherwise opens modal.
> - **Onboarding**
>   - `OnboardingModal` accepts optional `onClose` callback and invokes it on close.
>   - `OnboardingStep4` seeds validation with trimmed/uppercased `onboardingReferralCode`, adds explicit alt/title for loader, and replaces MUI `Link` with `TextButton`.
> - **State/Selectors**
>   - Add `onboardingReferralCode` to rewards state, actions (`setOnboardingReferralCode`), and selectors (`selectOnboardingReferralCode`).
>   - Add `selectRewardsOnboardingEnabled` feature-flag selector.
>   - Update state logs schema (`state-logs.json`).
> - **Tests**
>   - E2E: include `/rewards` in deep-link scenarios and add `RewardsPage` page object asserting onboarding modal.
>   - Unit: tests for new reducer action and selectors; `OnboardingStep4` tests for referral seeding, validation, and legal links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a409144d676f6782e83100018cd52f4653fad56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->