### PR TITLE
fix: Remove `tabs` permission to avoid new warnings cp-13.10.1

### DIFF
--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -84,7 +84,6 @@
     "notifications",
     "scripting",
     "storage",
-    "tabs",
     "unlimitedStorage",
     "webRequest",
     "offscreen",

--- a/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
+++ b/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
@@ -82,8 +82,8 @@ export function transformManifest(
     }
   }
 
-  if (args.test && args.manifest_version === 2) {
-    // test builds need "tabs" permission for switchToWindowWithTitle in MV2
+  if (args.test) {
+    // test builds need "tabs" permission for switchToWindowWithTitle
     transforms.push(addTabsPermission);
   }
 


### PR DESCRIPTION
## **Description**

The recent addition of the `tabs` permission will result in new permission warnings upon update, which is extremely disruptive and is something we'd never do except as a last resort.

The permission wasn't actually needed, and has been removed. This removal uncovered a bug in our Webpack build (the `tabs` permission was erroneously only added for MV2 test builds, but we need it for MV3 test builds as well), which has been fixed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38075?quickstart=1)

## **Changelog**

CHANGELOG entry: Remove unnecessary extension permission

## **Related issues**

N/A

## **Manual testing steps**

Test that the sidepanel still works in general. Particularly with dapp confirmations, and the "Connected status" indicator, and current selected dapp.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `tabs` from the MV3 manifest and updates the build transform to add `tabs` only for test builds (all manifest versions).
> 
> - **Manifest (MV3)**:
>   - Remove `tabs` from `permissions` in `app/manifest/v3/_base.json`.
> - **Build/Manifest transform**:
>   - Update `transformManifest` in `development/webpack/utils/plugins/ManifestPlugin/helpers.ts` to add `tabs` when `args.test` is true, regardless of `manifest_version`.
>   - Retains error if `tabs` already exists and continues adding dev/test manifest key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862591ee41518a6c5e61167f4012b90991d82c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->