### PR TITLE
fix: cp-13.11.0 tron resources not displaying

### DIFF
--- a/ui/pages/asset/hooks/useTronResources.test.ts
+++ b/ui/pages/asset/hooks/useTronResources.test.ts
@@ -12,7 +12,7 @@ import { useTronResources } from './useTronResources';
 // Mock the selectors
 jest.mock('../../../selectors/assets', () => ({
   ...jest.requireActual('../../../selectors/assets'),
-  getAssetsBySelectedAccountGroup: jest.fn(),
+  getAssetsBySelectedAccountGroupWithTronResources: jest.fn(),
 }));
 
 jest.mock('../../../selectors/multichain', () => ({
@@ -66,7 +66,7 @@ describe('useTronResources', () => {
         `${chainId}/resource:max-bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -112,7 +112,7 @@ describe('useTronResources', () => {
       const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -148,7 +148,7 @@ describe('useTronResources', () => {
       const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -188,7 +188,7 @@ describe('useTronResources', () => {
         `${chainId}/resource:max-bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.MAX_ENERGY, maxEnergyAssetId),
@@ -231,7 +231,7 @@ describe('useTronResources', () => {
         `${chainId}/token:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -276,7 +276,7 @@ describe('useTronResources', () => {
 
     it('handles empty assets array', () => {
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [],
       });
@@ -306,7 +306,7 @@ describe('useTronResources', () => {
 
     it('handles chainId with no assets', () => {
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({});
 
       (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
@@ -340,7 +340,7 @@ describe('useTronResources', () => {
         `${chainId}/resource:max-bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -374,7 +374,7 @@ describe('useTronResources', () => {
   describe('when account is undefined', () => {
     it('returns default values', () => {
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({});
 
       (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue(
@@ -402,7 +402,7 @@ describe('useTronResources', () => {
   describe('when chainId is empty', () => {
     it('returns default values', () => {
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({});
 
       (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
@@ -433,7 +433,7 @@ describe('useTronResources', () => {
       const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
@@ -470,7 +470,7 @@ describe('useTronResources', () => {
       const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
 
       (
-        assetsSelectors.getAssetsBySelectedAccountGroup as unknown as jest.Mock
+        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
       ).mockReturnValue({
         [chainId]: [
           createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),

--- a/ui/pages/asset/hooks/useTronResources.ts
+++ b/ui/pages/asset/hooks/useTronResources.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { CaipAssetId } from '@metamask/keyring-api';
 import { isTronResource } from '../../../../shared/lib/asset-utils';
-import { getAssetsBySelectedAccountGroup } from '../../../selectors/assets';
+import { getAssetsBySelectedAccountGroupWithTronResources } from '../../../selectors/assets';
 import { getMultichainBalances } from '../../../selectors/multichain';
 import { TRON_RESOURCE } from '../../../../shared/constants/multichain/assets';
 
@@ -28,7 +28,9 @@ export const useTronResources = (
   energy: TronResource;
   bandwidth: TronResource;
 } => {
-  const accountGroupAssets = useSelector(getAssetsBySelectedAccountGroup);
+  const accountGroupAssets = useSelector(
+    getAssetsBySelectedAccountGroupWithTronResources,
+  );
   const multichainBalances = useSelector(getMultichainBalances);
 
   return useMemo(() => {

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1007,44 +1007,47 @@ export const selectBalanceByWallet = (walletId: string) =>
     };
   });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- There is no type for the root state
+const getStateForAssetSelector = ({ metamask }: any) => {
+  const initialState = {
+    accountTree: metamask.accountTree,
+    internalAccounts: metamask.internalAccounts,
+    allTokens: metamask.allTokens,
+    allIgnoredTokens: metamask.allIgnoredTokens,
+    tokenBalances: metamask.tokenBalances,
+    marketData: metamask.marketData,
+    currencyRates: metamask.currencyRates,
+    currentCurrency: metamask.currentCurrency,
+    networkConfigurationsByChainId: metamask.networkConfigurationsByChainId,
+    accountsByChainId: metamask.accountsByChainId,
+  };
+
+  let multichainState = {
+    accountsAssets: {},
+    assetsMetadata: {},
+    allIgnoredAssets: {},
+    balances: {},
+    conversionRates: {},
+  };
+
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  multichainState = {
+    accountsAssets: metamask.accountsAssets,
+    assetsMetadata: metamask.assetsMetadata,
+    allIgnoredAssets: metamask.allIgnoredAssets,
+    balances: metamask.balances,
+    conversionRates: metamask.conversionRates,
+  };
+  ///: END:ONLY_INCLUDE_IF
+
+  return {
+    ...initialState,
+    ...multichainState,
+  } as AssetListState;
+};
+
 export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
-  ({ metamask }) => {
-    const initialState = {
-      accountTree: metamask.accountTree,
-      internalAccounts: metamask.internalAccounts,
-      allTokens: metamask.allTokens,
-      allIgnoredTokens: metamask.allIgnoredTokens,
-      tokenBalances: metamask.tokenBalances,
-      marketData: metamask.marketData,
-      currencyRates: metamask.currencyRates,
-      currentCurrency: metamask.currentCurrency,
-      networkConfigurationsByChainId: metamask.networkConfigurationsByChainId,
-      accountsByChainId: metamask.accountsByChainId,
-    };
-
-    let multichainState = {
-      accountsAssets: {},
-      assetsMetadata: {},
-      allIgnoredAssets: {},
-      balances: {},
-      conversionRates: {},
-    };
-
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    multichainState = {
-      accountsAssets: metamask.accountsAssets,
-      assetsMetadata: metamask.assetsMetadata,
-      allIgnoredAssets: metamask.allIgnoredAssets,
-      balances: metamask.balances,
-      conversionRates: metamask.conversionRates,
-    };
-    ///: END:ONLY_INCLUDE_IF
-
-    return {
-      ...initialState,
-      ...multichainState,
-    };
-  },
+  getStateForAssetSelector,
   (assetListState: AssetListState) => {
     const assetsByAccountGroup =
       selectAssetsBySelectedAccountGroup(assetListState);
@@ -1074,6 +1077,13 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
     return newAssetsByAccountGroup;
   },
 );
+
+export const getAssetsBySelectedAccountGroupWithTronResources =
+  createDeepEqualSelector(
+    getStateForAssetSelector,
+    (assetListState: AssetListState) =>
+      selectAssetsBySelectedAccountGroup(assetListState),
+  );
 
 export const getAsset = createSelector(
   [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes issue with Tron resources not displaying in the details page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38101?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed issue with Tron resources not displaying in the details page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38100

## **Manual testing steps**

1. Click on the Tron native asset
2. Resources should be present

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1578" height="1880" alt="image" src="https://github.com/user-attachments/assets/e391e776-efe3-4c65-a5e5-bee9e84ab85c" />

### **After**

<!-- [screenshots/recordings] -->
<img width="1622" height="1886" alt="image" src="https://github.com/user-attachments/assets/b55fe099-4f4c-4a45-9635-fdb3c44d20ea" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new selector that includes Tron resource assets and updates the Tron resources hook/tests to consume it, ensuring resources appear on the asset details page.
> 
> - **Selectors**:
>   - Extract `getStateForAssetSelector` helper to compose state for asset selectors.
>   - Keep `getAssetsBySelectedAccountGroup` (filters out Tron resources) and add `getAssetsBySelectedAccountGroupWithTronResources` to return unfiltered assets.
> - **Hook**:
>   - Update `useTronResources` to use `getAssetsBySelectedAccountGroupWithTronResources`, enabling energy/bandwidth data to be found and displayed.
> - **Tests**:
>   - Update mocks and usages to reference the new selector throughout `useTronResources.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d772835bb6b6c7aa4d05b5657ff1d9e5dc6abbf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->