### PR TITLE
fix: cp-13.10.1 fetching token exchange rates for native tokens

### DIFF
--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -16,6 +16,8 @@ import { isObject, isStrictHexString } from '@metamask/utils';
 import { Web3Provider } from '@ethersproject/providers';
 import { Contract } from '@ethersproject/contracts';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { isNativeAddress } from '@metamask/bridge-controller';
+
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { logErrorWithMessage } from '../../../shared/modules/error';
 import {
@@ -802,10 +804,14 @@ export const fetchTokenExchangeRates = async (
   chainId,
 ) => {
   try {
+    const addresses = tokenAddresses.filter(
+      (tokenAddress) => !isNativeAddress(tokenAddress),
+    );
+
     return await fetchTokenContractExchangeRates({
       tokenPricesService: new CodefiTokenPricesServiceV2(),
       nativeCurrency,
-      tokenAddresses,
+      tokenAddresses: addresses,
       chainId,
     });
   } catch (err) {

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
@@ -33,10 +33,7 @@ export function useDappSwapUSDValues({
   const { value: fiatRates, pending: fiatRatesPending } = useAsyncResult<
     Record<Hex, number | undefined>
   >(() => {
-    const addresses = tokenAddresses.filter(
-      (tokenAddress) => !isNativeAddress(tokenAddress),
-    );
-    return fetchTokenExchangeRates('usd', addresses as Hex[], chainId);
+    return fetchTokenExchangeRates('usd', tokenAddresses as Hex[], chainId);
   }, [chainId, tokenAddresses?.length]);
 
   const { value: tokenDetails, pending: tokenDetailsPending } = useAsyncResult<


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fix: dapp-swap comparison fiat rate fetching for native tokens

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6327

## **Manual testing steps**

1. Trigger swap including native tokens
2. Check that fait conversion in metrics is correct

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves native-address filtering into `fetchTokenExchangeRates` and updates dapp swap hook to pass full token address list.
> 
> - **Utilities**:
>   - `ui/helpers/utils/util.js`: `fetchTokenExchangeRates` now filters out native token addresses using `isNativeAddress` before calling `fetchTokenContractExchangeRates`.
> - **Confirmations (Dapp Swap)**:
>   - `useDappSwapUSDValues.ts`: stops pre-filtering native addresses and calls `fetchTokenExchangeRates` with the full `tokenAddresses` array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f35ab00fd35ff68e5174fee2c4cbf12a4e5ac58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->