### PR TITLE
fix: use `maxConcurrency=1` for Snap account providers cp-13.11.0

### DIFF
--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -83,6 +83,7 @@ describe('MultichainAccountServiceInit', () => {
     expect(accountTreeControllerClassMock).toHaveBeenCalledWith({
       messenger: requestMock.controllerMessenger,
       providers: expect.any(Array),
+      providerConfigs: expect.any(Object),
     });
   });
 });

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -1,12 +1,12 @@
 import {
   MultichainAccountService,
   AccountProviderWrapper,
+  SOL_ACCOUNT_PROVIDER_NAME,
   ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   BtcAccountProvider,
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxAccountProvider,
-  SOL_ACCOUNT_PROVIDER_NAME,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/multichain-account-service';
 import { ControllerInitFunction } from '../types';

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -6,6 +6,7 @@ import {
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxAccountProvider,
+  SOL_ACCOUNT_PROVIDER_NAME,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/multichain-account-service';
 import { ControllerInitFunction } from '../types';
@@ -36,17 +37,33 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
   MultichainAccountServiceMessenger,
   MultichainAccountServiceInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
+  const snapAccountProviderConfig = {
+    // READ THIS CAREFULLY:
+    // We using 1 to prevent any concurrent `keyring_createAccount` requests, that make sure
+    // we prevent any desync between Snap's accounts and Metamask's accounts.
+    maxConcurrency: 1,
+    // Re-use the default config for the rest:
+    discovery: {
+      timeoutMs: 2000,
+      maxAttempts: 3,
+      backOffMs: 1000,
+    },
+    createAccounts: {
+      timeoutMs: 3000,
+    },
+  };
+
   ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const btcProvider = new AccountProviderWrapper(
     controllerMessenger,
-    new BtcAccountProvider(controllerMessenger),
+    new BtcAccountProvider(controllerMessenger, snapAccountProviderConfig),
   );
   ///: END:ONLY_INCLUDE_IF
 
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const trxProvider = new AccountProviderWrapper(
     controllerMessenger,
-    new TrxAccountProvider(controllerMessenger),
+    new TrxAccountProvider(controllerMessenger, snapAccountProviderConfig),
   );
   ///: END:ONLY_INCLUDE_IF
 
@@ -60,6 +77,9 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
       trxProvider,
       ///: END:ONLY_INCLUDE_IF
     ],
+    providerConfigs: {
+      [SOL_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
+    },
   });
 
   const preferencesState = initMessenger.call('PreferencesController:getState');

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -39,7 +39,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
 > = ({ controllerMessenger, initMessenger }) => {
   const snapAccountProviderConfig = {
     // READ THIS CAREFULLY:
-    // We using 1 to prevent any concurrent `keyring_createAccount` requests, that make sure
+    // We are using 1 to prevent any concurrent `keyring_createAccount` requests. This ensures
     // we prevent any desync between Snap's accounts and Metamask's accounts.
     maxConcurrency: 1,
     // Re-use the default config for the rest:


### PR DESCRIPTION
## **Description**

It seems that having concurrent calls to `keyring_createAccount` cause some synchronization issues between Snap's accounts and MetaMask accounts. We're not sure of the real root cause yet for this, but preventing concurrent calls seems to mitigate (or even completely prevent) this kind of issues.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38116?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Mitigates (partially):
- https://github.com/MetaMask/metamask-extension/issues/37228

Should fix:
- https://github.com/MetaMask/metamask-extension/issues/38103
- https://github.com/MetaMask/metamask-extension/issues/38104

## **Manual testing steps**

Nothing special to tests for this.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared Snap account provider config (maxConcurrency=1) and applies it to BTC, TRX, and SOL providers, updating tests accordingly.
> 
> - **Multichain Account Service Init (`multichain-account-service-init.ts`)**:
>   - Add `snapAccountProviderConfig` with `maxConcurrency: 1` and timeouts.
>   - Pass config to `BtcAccountProvider` and `TrxAccountProvider` via `AccountProviderWrapper`.
>   - Add `providerConfigs` mapping for `SOL_ACCOUNT_PROVIDER_NAME` to use the same config.
> - **Tests (`multichain-account-service-init.test.ts`)**:
>   - Expect `providerConfigs` in `MultichainAccountService` constructor args.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a48ffee8df0113c79162c28b4c46f5ae98031ac6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->