### PR TITLE
fix: multiple opted in srps showing wrong balance cp-13.11.0

### DIFF
--- a/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
@@ -48,7 +48,6 @@ import {
   RewardsControllerGetCandidateSubscriptionIdAction,
   RewardsControllerGetHasAccountOptedInAction,
   RewardsControllerGetActualSubscriptionIdAction,
-  RewardsControllerGetFirstSubscriptionIdAction,
   RewardsControllerGetSeasonMetadataAction,
   RewardsControllerGetSeasonStatusAction,
 } from '../../controllers/rewards/rewards-controller.types';
@@ -83,7 +82,6 @@ export type RewardsControllerActions =
   | RewardsControllerGetCandidateSubscriptionIdAction
   | RewardsControllerGetHasAccountOptedInAction
   | RewardsControllerGetActualSubscriptionIdAction
-  | RewardsControllerGetFirstSubscriptionIdAction
   | RewardsControllerGetSeasonMetadataAction
   | RewardsControllerGetSeasonStatusAction;
 

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -877,11 +877,13 @@ export class RewardsController extends BaseController<
         }
 
         if (subscription) {
-          const candidateAt =
-            Object.keys(state.rewardsSubscriptions ?? {}).length > 0
-              ? new Date()
-              : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
-          subscription.candidateAt = candidateAt.toISOString();
+          if (!state.rewardsSubscriptions[subscription.id]?.candidateAt) {
+            const candidateAt =
+              Object.keys(state.rewardsSubscriptions ?? {}).length > 0
+                ? new Date()
+                : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
+            subscription.candidateAt = candidateAt.toISOString();
+          }
           state.rewardsSubscriptions[subscription.id] = subscription;
         }
       });
@@ -1531,11 +1533,16 @@ export class RewardsController extends BaseController<
       }
 
       state.rewardsAccounts[caipAccount] = accountState;
-      const candidateAt =
-        Object.keys(state.rewardsSubscriptions ?? {}).length > 0
-          ? new Date()
-          : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
-      optinResponse.subscription.candidateAt = candidateAt.toISOString();
+      if (
+        optinResponse?.subscription?.id &&
+        !state.rewardsSubscriptions[optinResponse.subscription.id]?.candidateAt
+      ) {
+        const candidateAt =
+          Object.keys(state.rewardsSubscriptions ?? {}).length > 0
+            ? new Date()
+            : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
+        optinResponse.subscription.candidateAt = candidateAt.toISOString();
+      }
       state.rewardsSubscriptions[optinResponse.subscription.id] =
         optinResponse.subscription;
     });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -135,6 +135,12 @@ type CacheOptions<T> = {
   swrCallback?: (old: T, fresh: T) => void; // Callback triggered after SWR refresh, to invalidate cache
 };
 
+// when rewards went live on mobile, take this date for subscriptions we detect first on device.
+// candidate subscriptions are sorted by candidateAt, so subscriptions marked with this date will be the first ones to be detected on device. (for i.e. linking new accounts)
+const INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT = new Date(
+  '2025-10-27T00:00:00.000Z',
+);
+
 /**
  * Get a value, from cache if exist
  */
@@ -398,10 +404,6 @@ export class RewardsController extends BaseController<
       'RewardsController:getActualSubscriptionId',
       this.getActualSubscriptionId.bind(this),
     );
-    this.messenger.registerActionHandler(
-      'RewardsController:getFirstSubscriptionId',
-      this.getFirstSubscriptionId.bind(this),
-    );
   }
 
   /**
@@ -453,19 +455,6 @@ export class RewardsController extends BaseController<
   getActualSubscriptionId(account: CaipAccountId): string | null {
     const accountState = this.#getAccountState(account);
     return accountState?.subscriptionId || null;
-  }
-
-  /**
-   * Get the first subscription ID from the subscriptions map
-   *
-   * @returns The first subscription ID or null if no subscriptions exist
-   */
-  getFirstSubscriptionId(): string | null {
-    if (!this.state.rewardsSubscriptions) {
-      return null;
-    }
-    const subscriptionIds = Object.keys(this.state.rewardsSubscriptions);
-    return subscriptionIds.length > 0 ? subscriptionIds[0] : null;
   }
 
   /**
@@ -888,6 +877,11 @@ export class RewardsController extends BaseController<
         }
 
         if (subscription) {
+          const candidateAt =
+            Object.keys(state.rewardsSubscriptions ?? {}).length > 0
+              ? new Date()
+              : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
+          subscription.candidateAt = candidateAt.toISOString();
           state.rewardsSubscriptions[subscription.id] = subscription;
         }
       });
@@ -1537,6 +1531,11 @@ export class RewardsController extends BaseController<
       }
 
       state.rewardsAccounts[caipAccount] = accountState;
+      const candidateAt =
+        Object.keys(state.rewardsSubscriptions ?? {}).length > 0
+          ? new Date()
+          : INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT;
+      optinResponse.subscription.candidateAt = candidateAt.toISOString();
       state.rewardsSubscriptions[optinResponse.subscription.id] =
         optinResponse.subscription;
     });
@@ -1635,7 +1634,26 @@ export class RewardsController extends BaseController<
 
     // Fallback to the first subscription ID from the subscriptions map
     const subscriptionIds = Object.keys(this.state.rewardsSubscriptions);
-    if (subscriptionIds.length > 0) {
+    if (subscriptionIds.length === 1) {
+      return subscriptionIds[0];
+    } else if (subscriptionIds.length > 1) {
+      const sortedSubscriptions = Object.values(
+        this.state.rewardsSubscriptions,
+      ).sort((subscriptionA, subscriptionB) => {
+        try {
+          const priorityA =
+            subscriptionA?.candidateAt || subscriptionA?.createdAt;
+          const priorityB =
+            subscriptionB?.candidateAt || subscriptionB?.createdAt;
+
+          return new Date(priorityA).getTime() - new Date(priorityB).getTime();
+        } catch {
+          return 0;
+        }
+      });
+      if (sortedSubscriptions.length > 0) {
+        return sortedSubscriptions[0].id;
+      }
       return subscriptionIds[0];
     }
 

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -24,6 +24,8 @@ export type SubscriptionDto = {
     address: string;
     chainId: number;
   }[];
+  createdAt: string;
+  candidateAt?: string;
 };
 
 export type MobileLoginDto = {
@@ -641,14 +643,6 @@ export type RewardsControllerGetHasAccountOptedInAction = {
 export type RewardsControllerGetActualSubscriptionIdAction = {
   type: 'RewardsController:getActualSubscriptionId';
   handler: (account: CaipAccountId) => string | null;
-};
-
-/**
- * Action for getting the first subscription ID
- */
-export type RewardsControllerGetFirstSubscriptionIdAction = {
-  type: 'RewardsController:getFirstSubscriptionId';
-  handler: () => string | null;
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -509,6 +509,7 @@ describe('RewardsDataService', () => {
         id: 'test-subscription-id',
         referralCode: 'test-referral-code',
         accounts: [],
+        createdAt: new Date().toISOString(),
       },
     };
 
@@ -667,6 +668,7 @@ describe('RewardsDataService', () => {
       id: mockSubscriptionId,
       referralCode: 'test-referral-code',
       accounts: [],
+      createdAt: new Date().toISOString(),
     };
 
     const mockOptinResponse: LoginResponseDto = {

--- a/ui/components/app/rewards/onboarding/OnboardingStep4.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep4.test.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { Ref } from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { ButtonProps } from '@metamask/design-system-react';
 
 import OnboardingStep4 from './OnboardingStep4';
 import {
@@ -11,6 +12,50 @@ import {
 jest.mock('../../../../hooks/useI18nContext', () => ({
   useI18nContext: jest.fn(() => (key: string) => key),
 }));
+
+// Partially mock the design-system Button to expose props for assertions
+jest.mock('@metamask/design-system-react', () => {
+  const actual = jest.requireActual('@metamask/design-system-react');
+  const ReactLib = jest.requireActual('react');
+
+  const MockButton = ReactLib.forwardRef(
+    (
+      {
+        children,
+        isLoading,
+        isDisabled,
+        variant,
+        size,
+        className,
+        onClick,
+        ...rest
+      }: ButtonProps,
+      ref: Ref<HTMLButtonElement>,
+    ) => (
+      <button
+        {...rest}
+        data-testid="opt-in-button"
+        data-variant={variant}
+        data-size={size}
+        data-loading={isLoading ? 'true' : 'false'}
+        data-disabled={isDisabled ? 'true' : 'false'}
+        disabled={isDisabled}
+        ref={ref}
+        onClick={onClick}
+        className={className}
+      >
+        {children}
+      </button>
+    ),
+  );
+
+  return {
+    ...actual,
+    Button: MockButton,
+    ButtonVariant: actual.ButtonVariant,
+    ButtonSize: actual.ButtonSize,
+  };
+});
 
 jest.mock('../../../../hooks/rewards/useOptIn', () => ({
   useOptIn: jest.fn(),

--- a/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingStep4.tsx
@@ -173,6 +173,7 @@ const OnboardingStep4: React.FC = () => {
         className="w-full my-2"
         disabled={isDisabled}
         isDisabled={isDisabled}
+        isLoading={optinLoading}
       >
         {t('rewardsOnboardingStepOptIn')}
       </Button>
@@ -243,10 +244,12 @@ const OnboardingStep4: React.FC = () => {
 
       {/* Error Section */}
       {optinError && (
-        <RewardsErrorBanner
-          title={t('rewardsOnboardingStep4OptInError')}
-          description={optinError}
-        />
+        <Box className="pt-4">
+          <RewardsErrorBanner
+            title={t('rewardsOnboardingStep4OptInError')}
+            description={optinError}
+          />
+        </Box>
       )}
 
       {/* Title Section */}

--- a/ui/hooks/rewards/useCandidateSubscriptionId.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.ts
@@ -8,6 +8,7 @@ import {
   selectRewardsEnabled,
 } from '../../ducks/rewards/selectors';
 import { setCandidateSubscriptionId } from '../../ducks/rewards';
+import { useAppSelector } from '../../store/store';
 
 type UseCandidateSubscriptionIdReturn = {
   fetchCandidateSubscriptionId: () => Promise<void>;
@@ -23,6 +24,9 @@ export const useCandidateSubscriptionId =
     const isUnlocked = useSelector(getIsUnlocked);
     const isRewardsEnabled = useSelector(selectRewardsEnabled);
     const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
+    const rewardsActiveAccountSubscriptionId = useAppSelector(
+      (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
+    );
 
     const isLoading = useRef(false);
 
@@ -30,6 +34,13 @@ export const useCandidateSubscriptionId =
       try {
         if (!isRewardsEnabled) {
           dispatch(setCandidateSubscriptionId(null));
+          return;
+        }
+        if (rewardsActiveAccountSubscriptionId) {
+          isLoading.current = false;
+          dispatch(
+            setCandidateSubscriptionId(rewardsActiveAccountSubscriptionId),
+          );
           return;
         }
         if (isLoading.current) {
@@ -50,7 +61,7 @@ export const useCandidateSubscriptionId =
       } finally {
         isLoading.current = false;
       }
-    }, [isRewardsEnabled, dispatch]);
+    }, [isRewardsEnabled, dispatch, rewardsActiveAccountSubscriptionId]);
 
     useEffect(() => {
       if (candidateSubscriptionId === 'retry') {

--- a/ui/hooks/rewards/useSeasonStatus.test.ts
+++ b/ui/hooks/rewards/useSeasonStatus.test.ts
@@ -179,6 +179,70 @@ describe('useSeasonStatus', () => {
         expect(rewardsState.seasonStatusError).toBeNull();
       });
     });
+
+    const INVALID_SUB_IDS = ['pending', 'retry', 'error'] as const;
+    type InvalidSubId = (typeof INVALID_SUB_IDS)[number];
+
+    INVALID_SUB_IDS.forEach((subId: InvalidSubId) => {
+      it(`clears state and does not call actions when subscriptionId is ${subId} via useEffect`, async () => {
+        const { store } = renderHookWithProvider(
+          () =>
+            useSeasonStatus({
+              subscriptionId: subId,
+              onAuthorizationError: mockOnAuthorizationError,
+            }),
+          {
+            metamask: {
+              isUnlocked: true,
+              useExternalServices: true,
+              remoteFeatureFlags: { rewardsEnabled: true },
+              rewardsActiveAccount: {
+                account: 'eip155:1:0x123',
+                subscriptionId: subId,
+              },
+              rewardsSubscriptions: {},
+            },
+          },
+        );
+
+        await waitFor(() => {
+          expect(getRewardsSeasonMetadata).not.toHaveBeenCalled();
+          expect(getRewardsSeasonStatus).not.toHaveBeenCalled();
+          const rewardsState = getRewardsSlice(store);
+          expect(rewardsState.seasonStatus).toBeNull();
+          expect(rewardsState.seasonStatusLoading).toBe(false);
+          expect(rewardsState.seasonStatusError).toBeNull();
+        });
+      });
+    });
+
+    it('clears state and does not call actions when subscriptionId is null via useEffect', async () => {
+      const { store } = renderHookWithProvider(
+        () =>
+          useSeasonStatus({
+            subscriptionId: null,
+            onAuthorizationError: mockOnAuthorizationError,
+          }),
+        {
+          metamask: {
+            isUnlocked: true,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(getRewardsSeasonMetadata).not.toHaveBeenCalled();
+        expect(getRewardsSeasonStatus).not.toHaveBeenCalled();
+        const rewardsState = getRewardsSlice(store);
+        expect(rewardsState.seasonStatus).toBeNull();
+        expect(rewardsState.seasonStatusLoading).toBe(false);
+        expect(rewardsState.seasonStatusError).toBeNull();
+      });
+    });
   });
 
   describe('fetchSeasonStatus function', () => {

--- a/ui/hooks/rewards/useSeasonStatus.ts
+++ b/ui/hooks/rewards/useSeasonStatus.ts
@@ -42,7 +42,7 @@ export const useSeasonStatus = ({
   const isUnlocked = useSelector(getIsUnlocked);
   const isRewardsEnabled = useSelector(selectRewardsEnabled);
 
-  const isLoading = useRef(false);
+  const isLoadingFor = useRef<CandidateSubscriptionId | null>(null);
 
   const fetchSeasonStatus = useCallback(async (): Promise<void> => {
     // Don't fetch if no subscriptionId or season metadata
@@ -59,11 +59,14 @@ export const useSeasonStatus = ({
       return;
     }
 
-    if (isLoading.current) {
+    if (
+      Boolean(isLoadingFor.current) &&
+      isLoadingFor.current === subscriptionId
+    ) {
       return;
     }
 
-    isLoading.current = true;
+    isLoadingFor.current = subscriptionId;
 
     dispatch(setSeasonStatusLoading(true));
 
@@ -97,7 +100,7 @@ export const useSeasonStatus = ({
         dispatch(setSeasonStatus(null));
       }
     } finally {
-      isLoading.current = false;
+      isLoadingFor.current = null;
       dispatch(setSeasonStatusLoading(false));
     }
   }, [subscriptionId, onAuthorizationError, isRewardsEnabled, dispatch]);


### PR DESCRIPTION
## **Description**

If a user has accounts in their srp's tied to more than 1 reward subscription, then right now the app might show the incorrect balance (i.e. showing balance of subscription A instead of subscription B) when changing accounts.

The rule is (just like in mobile):

- The first reward subscription we detect on the device (extension) and its balance should be shown for all accounts that are either added to the first subscription OR not added yet to any subscription.
- The balance of the second subscription is only shown when an account is selected belonging to that subscription.

Keep in mind that multiple reward subscriptions spread around 1 or multiple SRP's are an edge case.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38129

## **Manual testing steps**

1. Have an SRP where account 1 is tied to a subscription A with points X
2. Have an account in same SRP or different SRP tied to subscription B with points Y
3. Switch between accounts, reward points balance will sometimes wrongly show points of subscription B.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track and prioritize subscription selection by candidateAt/createdAt, prefer active account’s subscription, and improve UI/hooks loading and error handling.
> 
> - **RewardsController**:
>   - Add `INITIAL_DEVICE_SUBSCRIPTION_CANDIDATE_AT` and set `subscription.candidateAt` when missing (first on device vs subsequent now/current time).
>   - Update `getCandidateSubscriptionId` to prefer `rewardsActiveAccount.subscriptionId`, then earliest by `candidateAt` (fallback `createdAt`), else discover via opt-in status with silent auth.
>   - Remove `RewardsController:getFirstSubscriptionId` action/handler.
>   - Store login/opt-in responses and ensure `subscription.createdAt`/`candidateAt` are present.
> - **Types**:
>   - Extend `SubscriptionDto` with `createdAt` and optional `candidateAt`.
> - **Hooks**:
>   - `useCandidateSubscriptionId`: return active account’s `subscriptionId` without fetching; maintain loading guard; tests updated.
>   - `useSeasonStatus`: ignore invalid `subscriptionId` states, prevent concurrent fetches per id, clear state on auth/season errors; tests added.
> - **UI (OnboardingStep4)**:
>   - Add `isLoading` to opt-in Button; wrap opt-in error banner in padded container; enhance tests with mocked Button props.
> - **Tests**:
>   - Widespread updates to align with `candidateAt`/`createdAt` handling, sorting logic, and removed action; data-service tests include `createdAt` in responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b288fc4520ead0a3d204d068d013f5526aa96496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->