### PR TITLE
refactor: simplify confirmation routing

### DIFF
--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -50,7 +50,7 @@ export function useConfirmationNavigation() {
 
   const navigateToId = useCallback(
     (confirmationId?: string) => {
-      const url = getNavigateToConfirmation(
+      const url = getConfirmationRoute(
         confirmationId,
         confirmations,
         Boolean(approvalFlows?.length),
@@ -58,7 +58,7 @@ export function useConfirmationNavigation() {
       );
 
       if (url) {
-        navigate(url);
+        navigate(url, { replace: true });
       }
     },
     [approvalFlows?.length, confirmations, navigate, queryString],
@@ -95,7 +95,7 @@ export function useConfirmationNavigation() {
   };
 }
 
-export function getNavigateToConfirmation(
+export function getConfirmationRoute(
   confirmationId: string | undefined,
   confirmations: ApprovalRequest<Record<string, Json>>[],
   hasApprovalFlows: boolean,

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -66,7 +66,7 @@ import {
 } from '../../../shared/lib/ui-utils';
 import { AccountOverview } from '../../components/multichain';
 import { setEditedNetwork } from '../../store/actions';
-import { navigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
+import { getNavigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
 import PasswordOutdatedModal from '../../components/app/password-outdated-modal';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
 import RewardsOnboardingModal from '../../components/app/rewards/onboarding/OnboardingModal';
@@ -248,14 +248,16 @@ export default class Home extends PureComponent {
     } else if (canRedirect && haveBridgeQuotes) {
       history.push(CROSS_CHAIN_SWAP_ROUTE + PREPARE_SWAP_ROUTE);
     } else if (pendingApprovals.length || hasApprovalFlows) {
-      navigateToConfirmation(
+      const url = getNavigateToConfirmation(
         pendingApprovals?.[0]?.id,
         pendingApprovals,
         hasApprovalFlows,
-        history,
         '', // queryString
-        location.pathname, // currentPathname for skip-navigation optimization
       );
+
+      if (url) {
+        history.push(url);
+      }
     }
   }
 

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -66,7 +66,7 @@ import {
 } from '../../../shared/lib/ui-utils';
 import { AccountOverview } from '../../components/multichain';
 import { setEditedNetwork } from '../../store/actions';
-import { getNavigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
+import { getConfirmationRoute } from '../confirmations/hooks/useConfirmationNavigation';
 import PasswordOutdatedModal from '../../components/app/password-outdated-modal';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
 import RewardsOnboardingModal from '../../components/app/rewards/onboarding/OnboardingModal';
@@ -248,7 +248,7 @@ export default class Home extends PureComponent {
     } else if (canRedirect && haveBridgeQuotes) {
       history.push(CROSS_CHAIN_SWAP_ROUTE + PREPARE_SWAP_ROUTE);
     } else if (pendingApprovals.length || hasApprovalFlows) {
-      const url = getNavigateToConfirmation(
+      const url = getConfirmationRoute(
         pendingApprovals?.[0]?.id,
         pendingApprovals,
         hasApprovalFlows,
@@ -256,7 +256,7 @@ export default class Home extends PureComponent {
       );
 
       if (url) {
-        history.push(url);
+        history.replace(url);
       }
     }
   }

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -116,7 +116,7 @@ import {
 } from '../../ducks/metamask/metamask';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
-import { navigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
+import { getNavigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
@@ -674,14 +674,16 @@ export default function Routes() {
       isUnlocked &&
       (pendingApprovals.length > 0 || approvalFlows?.length > 0)
     ) {
-      navigateToConfirmation(
+      const url = getNavigateToConfirmation(
         pendingApprovals[0]?.id,
         pendingApprovals,
         Boolean(approvalFlows?.length),
-        history,
         '', // queryString
-        location.pathname, // currentPathname for skip-navigation optimization
       );
+
+      if (url) {
+        history.push(url);
+      }
     }
   }, [isUnlocked, pendingApprovals, approvalFlows, history, location.pathname]);
 

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -116,7 +116,7 @@ import {
 } from '../../ducks/metamask/metamask';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../shared/constants/preferences';
-import { getNavigateToConfirmation } from '../confirmations/hooks/useConfirmationNavigation';
+import { getConfirmationRoute } from '../confirmations/hooks/useConfirmationNavigation';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
@@ -674,7 +674,7 @@ export default function Routes() {
       isUnlocked &&
       (pendingApprovals.length > 0 || approvalFlows?.length > 0)
     ) {
-      const url = getNavigateToConfirmation(
+      const url = getConfirmationRoute(
         pendingApprovals[0]?.id,
         pendingApprovals,
         Boolean(approvalFlows?.length),

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -682,7 +682,7 @@ export default function Routes() {
       );
 
       if (url) {
-        history.push(url);
+        history.replace(url);
       }
     }
   }, [isUnlocked, pendingApprovals, approvalFlows, history, location.pathname]);


### PR DESCRIPTION
## **Description**

Simplifies the confirmation routing navigation. Removes the mixed use of react router v5 and v6 (v5-compat) from within the confirmation hook.

## **Changelog**

CHANGELOG entry: refactor: simplify confirmation routing

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces side-effecting confirmation navigation with a pure route builder and updates callers to navigate via returned URLs, removing mixed v5/v5-compat handling.
> 
> - **Confirmations routing**
>   - Convert `navigateToConfirmation` into pure `getConfirmationRoute` that returns a URL (or empty string) based on approval type.
>   - Update `useConfirmationNavigation` to call `getConfirmationRoute` and navigate via `navigate(url, { replace: true })`.
>   - Update `home.component.js` and `routes.component.tsx` to use `getConfirmationRoute` and `history.replace(url)` for redirects.
>   - Remove mixed v5/v5-compat navigation handling and pathname skip logic from the hook; eliminate passing of navigate/history to the helper.
>   - Preserve query string handling for `ApprovalType.Transaction`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18987bb822458734d0b8962fb1ab2b73a9985440. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->