### PR TITLE
fix: cp-13.10.4 parse signed deep links with empty `sig_params` correctly

### DIFF
--- a/shared/lib/deep-links/canonicalize.test.ts
+++ b/shared/lib/deep-links/canonicalize.test.ts
@@ -82,4 +82,36 @@ describe('canonicalize', () => {
     expect(original.searchParams.get(SIG_PARAM)).toBe('abc');
     expect(original.searchParams.get(SIG_PARAMS_PARAM)).toBe('a,b');
   });
+
+  it('removes all params when `sig_params` is present but empty (no params signed)', () => {
+    const url = new URL(
+      `https://example.com/path?a=2&b=1&${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}`,
+    );
+    // No a or b params should be included, only sig_params= should remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('removes all params when `sig_params=` is present but empty (no params signed)', () => {
+    const url = new URL(
+      `https://example.com/path?a=2&b=1&${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}=`,
+    );
+    // No a or b params should be included,  only sig_params= should remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('treats URLs with `sig_params` (when no other params are included) as valid sig_params', () => {
+    const url = new URL(
+      `https://example.com/path?${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}`,
+    );
+    // No params were included, but sig_params should still remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('treats URLs with `sig_params=` (when no other params are included) as valid sig_params', () => {
+    const url = new URL(
+      `https://example.com/path?${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}=`,
+    );
+    // No params were included, but sig_params should still remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
 });

--- a/shared/lib/deep-links/canonicalize.ts
+++ b/shared/lib/deep-links/canonicalize.ts
@@ -13,7 +13,7 @@ export function canonicalize(url: URL): string {
 
   const sigParams = url.searchParams.get(SIG_PARAMS_PARAM);
 
-  if (sigParams) {
+  if (typeof sigParams === 'string') {
     const allowedParams = sigParams.split(',');
     const signedParams = new URLSearchParams();
 

--- a/shared/lib/deep-links/canonicalize.ts
+++ b/shared/lib/deep-links/canonicalize.ts
@@ -14,13 +14,17 @@ export function canonicalize(url: URL): string {
   const sigParams = url.searchParams.get(SIG_PARAMS_PARAM);
 
   if (typeof sigParams === 'string') {
-    const allowedParams = sigParams.split(',');
     const signedParams = new URLSearchParams();
+    // sigParams might be "" (empty), in which case we
+    // don't need to split and search
+    if (sigParams) {
+      const allowedParams = sigParams.split(',');
 
-    for (const allowedParam of allowedParams) {
-      const values = url.searchParams.getAll(allowedParam);
-      for (const value of values) {
-        signedParams.append(allowedParam, value);
+      for (const allowedParam of allowedParams) {
+        const values = url.searchParams.getAll(allowedParam);
+        for (const value of values) {
+          signedParams.append(allowedParam, value);
+        }
       }
     }
 

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -35,7 +35,7 @@ export function addRoute(route: Route) {
 
 if (process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS || process.env.IN_TEST) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
-  addRoute(require('./test-route'));
+  addRoute(require('./test-route').default);
 }
 
 addRoute(buy);

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -33,6 +33,11 @@ export function addRoute(route: Route) {
   routes.set(route.pathname, route);
 }
 
+if (process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS || process.env.IN_TEST) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+  addRoute(require('./test-route'));
+}
+
 addRoute(buy);
 addRoute(home);
 addRoute(notifications);

--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -11,6 +11,7 @@ export {
   NOTIFICATIONS_ROUTE,
   SHIELD_PLAN_ROUTE,
   SETTINGS_ROUTE,
+  DEVELOPER_OPTIONS_ROUTE,
 } from '../../../../ui/helpers/constants/routes';
 
 /**

--- a/shared/lib/deep-links/routes/test-route.ts
+++ b/shared/lib/deep-links/routes/test-route.ts
@@ -6,7 +6,7 @@ export default new Route({
   handler: function handler(params: URLSearchParams) {
     return {
       // we use the developer options route for testing purposes
-      // because it doesn't require any special permissions to access
+      // because it doesn't rewrite query params
       path: DEVELOPER_OPTIONS_ROUTE,
       query: params,
     };

--- a/shared/lib/deep-links/routes/test-route.ts
+++ b/shared/lib/deep-links/routes/test-route.ts
@@ -1,0 +1,14 @@
+import { DEVELOPER_OPTIONS_ROUTE, Route } from './route';
+
+export default new Route({
+  pathname: '/test',
+  getTitle: (_: URLSearchParams) => 'deepLink_thePerpsPage',
+  handler: function handler(params: URLSearchParams) {
+    return {
+      // we use the developer options route for testing purposes
+      // because it doesn't require any special permissions to access
+      path: DEVELOPER_OPTIONS_ROUTE,
+      query: params,
+    };
+  },
+});

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -610,57 +610,6 @@ and we'll take you to the right place.`
     );
   });
 
-  it('signed with empty sig_params, but url has extra params added, does not expose extra params', async function () {
-    await withFixtures(
-      await getConfig(this.test?.fullTitle()),
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
-        const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
-
-        const rawUrl = 'https://link.metamask.io/home?sig_params=';
-        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl, false)}&foo=0&foo=1&bar=2&baz=3`;
-
-        await driver.openNewURL(signedUrl);
-        const deepLink = new DeepLink(driver);
-        await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
-        await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
-
-        assert.deepStrictEqual(hashParams.size, 0);
-      },
-    );
-  });
-
-  it('signed with sig_params, url has no extra params added, works', async function () {
-    await withFixtures(
-      await getConfig(this.test?.fullTitle()),
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
-        const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
-
-        const rawUrl = 'https://link.metamask.io/home?sig_params='; // empty!
-        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
-
-        await driver.openNewURL(signedUrl);
-        const deepLink = new DeepLink(driver);
-        await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
-        await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
-
-        assert.deepStrictEqual(hashParams.size, 0);
-      },
-    );
-  });
 
   it('signed without sig_params exposes all params (foo, bar, baz)', async function () {
     await withFixtures(

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -592,20 +592,68 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl =
-          'https://link.metamask.io/home?foo=0&foo=1&bar=2&baz=3&sig_params=foo,bar';
-        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
+        const rawUrl = 'https://link.metamask.io/test?foo=0&foo=1&bar=2';
+        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl)}&baz=3`;
 
         await driver.openNewURL(signedUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['0', '1']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['2']);
         assert.equal(hashParams.has('baz'), false);
+      },
+    );
+  });
+
+  it('signed with empty sig_params, but url has extra params added, does not expose extra params', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/test';
+        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl)}&foo=0&foo=1&bar=2&baz=3`;
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        await deepLink.clickContinueButton();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+
+        assert.deepStrictEqual(hashParams.size, 0);
+      },
+    );
+  });
+
+  it('signed with sig_params, url has no extra params added, works', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/test';
+        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl);
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        await deepLink.clickContinueButton();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+
+        assert.deepStrictEqual(hashParams.size, 0);
       },
     );
   });
@@ -621,15 +669,14 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl = 'https://link.metamask.io/home?foo=1&bar=2&baz=3';
+        const rawUrl = 'https://link.metamask.io/test?foo=1&bar=2&baz=3';
         const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
 
         await driver.openNewURL(signedUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['1']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['2']);
@@ -649,14 +696,13 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl = 'https://link.metamask.io/home?foo=1&foo=2&bar=3';
+        const rawUrl = 'https://link.metamask.io/test?foo=1&foo=2&bar=3';
 
         await driver.openNewURL(rawUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['1', '2']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['3']);

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -610,6 +610,58 @@ and we'll take you to the right place.`
     );
   });
 
+  it('signed with empty sig_params, but url has extra params added, does not expose extra params', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/home?sig_params=';
+        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl, false)}&foo=0&foo=1&bar=2&baz=3`;
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+        await deepLink.clickContinueButton();
+        await homePage.checkPageIsLoaded();
+
+        assert.deepStrictEqual(hashParams.size, 0);
+      },
+    );
+  });
+
+  it('signed with sig_params, url has no extra params added, works', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/home?sig_params='; // empty!
+        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+        await deepLink.clickContinueButton();
+        await homePage.checkPageIsLoaded();
+
+        assert.deepStrictEqual(hashParams.size, 0);
+      },
+    );
+  });
+
   it('signed without sig_params exposes all params (foo, bar, baz)', async function () {
     await withFixtures(
       await getConfig(this.test?.fullTitle()),

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -610,7 +610,6 @@ and we'll take you to the right place.`
     );
   });
 
-
   it('signed without sig_params exposes all params (foo, bar, baz)', async function () {
     await withFixtures(
       await getConfig(this.test?.fullTitle()),

--- a/test/e2e/tests/deep-link/helpers.ts
+++ b/test/e2e/tests/deep-link/helpers.ts
@@ -96,9 +96,5 @@ export function cartesianProduct<T extends unknown[][]>(...sets: T) {
 export function getHashParams(url: URL) {
   const hash = url.hash.slice(1); // remove leading '#'
   const hashQuery = hash.split('?')[1] ?? '';
-  const hashParams = new URLSearchParams(hashQuery);
-  const encodedUrl = hashParams.get('u') ?? '';
-  const decodedUrl = decodeURIComponent(encodedUrl);
-  const decodedQuery = decodedUrl.split('?')[1] ?? '';
-  return new URLSearchParams(decodedQuery);
+  return new URLSearchParams(hashQuery);
 }

--- a/test/e2e/tests/deep-link/helpers.ts
+++ b/test/e2e/tests/deep-link/helpers.ts
@@ -38,10 +38,8 @@ export async function signDeepLink(
   if (withSigParams) {
     const sigParams = [...new Set(signedUrl.searchParams.keys())];
 
-    if (sigParams.length) {
-      signedUrl.searchParams.append(SIG_PARAMS_PARAM, sigParams.join(','));
-      signedUrl.searchParams.sort();
-    }
+    signedUrl.searchParams.append(SIG_PARAMS_PARAM, sigParams.join(','));
+    signedUrl.searchParams.sort();
   }
 
   const signed = await crypto.subtle.sign(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In previous versions, this link would not verify: https://link.metamask.io/home?sig_params=&sig=OHXtQkiw6eH0yxVZb3wFabCEahlcimocFuh8I90u2nEF2Ats3ETf_fQ2qO4zEx8PYr5CXzU0PQFEOgXuGpmHvQ&utm_medium=github

Now it does.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38142?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: signed deep links with empty `sig_params` with extra params as valid
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**

-->
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes deep link canonicalization/parsing for empty `sig_params`, introduces a test-only `/test` route, and updates e2e/unit tests accordingly.
> 
> - **Deep Links**:
>   - **Canonicalization**: `canonicalize` now treats present-but-empty `sig_params` as valid, retaining only `sig_params` and removing all other params; preserves original URL; sorts consistently.
>   - **Parsing**: Ensures `sig_params` is stripped from handler params and filters params strictly to those listed in `sig_params`.
>   - **Helpers**: `signDeepLink` always appends `sig_params` (can be empty) before signing; `getHashParams` simplified to read query directly from hash.
> - **Routes**:
>   - Adds test-only route `shared/lib/deep-links/routes/test-route.ts` and conditionally registers it in `routes/index.ts` when `ENABLE_SETTINGS_PAGE_DEV_OPTIONS` or `IN_TEST` is set; re-exports `DEVELOPER_OPTIONS_ROUTE`.
> - **Tests**:
>   - Unit: New cases for empty `sig_params` in `canonicalize.test.ts` and handler param filtering in `parse.test.ts`.
>   - E2E: Switch deep-link tests to `/test` route and add scenarios covering empty `sig_params`, strict filtering, and unsigned flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d704d518eefeb4a999b818ecd03e904b32ed05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->