### PR TITLE
fix: alignment of loading indicators on the deep link page cp-13.11.0

### DIFF
--- a/ui/pages/deep-link/deep-link.tsx
+++ b/ui/pages/deep-link/deep-link.tsx
@@ -351,6 +351,7 @@ export const DeepLink = ({ location }: DeepLinkProps) => {
                 as="div"
                 data-testid="deep-link-description"
                 paddingBottom={12}
+                height={BlockSize.Full}
               >
                 <Text
                   key="description"

--- a/ui/pages/deep-link/deep-link.tsx
+++ b/ui/pages/deep-link/deep-link.tsx
@@ -19,7 +19,6 @@ import {
   Display,
   FlexDirection,
   FontWeight,
-  JustifyContent,
   TextAlign,
   TextColor,
   TextVariant,
@@ -27,11 +26,7 @@ import {
 import { Text } from '../../components/component-library/text/text';
 import { Box } from '../../components/component-library/box/box';
 import { Container } from '../../components/component-library/container/container';
-import {
-  ButtonLink,
-  ContainerMaxWidth,
-  Label,
-} from '../../components/component-library';
+import { ButtonLink, Label } from '../../components/component-library';
 import { Checkbox } from '../../components/component-library/checkbox/checkbox';
 import { setSkipDeepLinkInterstitial } from '../../store/actions';
 import { getPreferences } from '../../selectors/selectors';
@@ -292,9 +287,8 @@ export const DeepLink = ({ location }: DeepLinkProps) => {
     <Container
       display={Display.Flex}
       alignItems={AlignItems.center}
-      justifyContent={JustifyContent.center}
       flexDirection={FlexDirection.Column}
-      maxWidth={ContainerMaxWidth.Md}
+      style={{ marginTop: '111px' }}
     >
       <Box
         display={Display.Flex}
@@ -304,14 +298,18 @@ export const DeepLink = ({ location }: DeepLinkProps) => {
         backgroundColor={BackgroundColor.backgroundDefault}
         borderColor={BorderColor.borderMuted}
         borderRadius={BorderRadius.MD}
-        width={BlockSize.Full}
+        style={{ width: '446px', minHeight: '592px' }}
         paddingLeft={6}
         paddingRight={6}
         paddingTop={12}
         paddingBottom={8}
         borderWidth={1}
       >
-        <Box>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          alignItems={AlignItems.center}
+        >
           {pageNotFoundError ? (
             <img
               className="error-404-image"


### PR DESCRIPTION
## **Description**
This PR fixes alignment of the loading indicator and MetaMask logo on the deep link page.

There are two different alignment types fixed:
1. Alignment of the position of the MetaMask fox logo within the main loading page and deep link page.
2. Alignment of the loading indicator spinning icon below MetaMask fox logo on the deep link page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38152?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
3. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix loading indicators alignment on the deep link page

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Try using different variations of deep link that would trigger different pages and messages.
2. Make sure that interstitial page is displayed correctly.
3. Make sure that loading indicators are properly aligned.

## **Screenshots/Recordings**
### **Before**
https://github.com/user-attachments/assets/65de3bf2-df45-4d00-9a46-57b86e8f54b4

### **After**
https://github.com/user-attachments/assets/3ba2e2b9-a17e-42dc-8de9-73183d69f18c

#### Testing of other pages

<img width="1209" height="912" alt="Screenshot 2025-11-24 at 19 17 47" src="https://github.com/user-attachments/assets/29d7e318-b086-433c-b378-4bb8392aa03b" />
<img width="1209" height="912" alt="Screenshot 2025-11-24 at 19 18 06" src="https://github.com/user-attachments/assets/72989368-46c9-424c-860b-5a332ed381f5" />
<img width="1209" height="912" alt="Screenshot 2025-11-24 at 19 18 23" src="https://github.com/user-attachments/assets/def6f2b8-c0f3-450a-815e-136ac0c3d737" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts deep link page layout to center the logo and loading spinner with fixed container sizing and spacing.
> 
> - **UI (deep link page `ui/pages/deep-link/deep-link.tsx`)**:
>   - Centers header visuals by introducing an inner flex `Box` and removing outer justify centering; adds top margin to page container.
>   - Sets fixed container dimensions (`width: 446px`, `minHeight: 592px`) for consistent layout.
>   - Ensures logo and spinner alignment; explicitly sizes logo to `160px` square.
>   - Improves content spacing and flow: description wrapper gets `height={BlockSize.Full}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2d520264ff5b0f82489f1d74d5da9c63de7f4ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->