### PR TITLE
fix: alignment of loading indicators on the deep link page

### DIFF
--- a/ui/pages/deep-link/deep-link.tsx
+++ b/ui/pages/deep-link/deep-link.tsx
@@ -19,7 +19,6 @@ import {
   Display,
   FlexDirection,
   FontWeight,
-  JustifyContent,
   TextAlign,
   TextColor,
   TextVariant,
@@ -27,11 +26,7 @@ import {
 import { Text } from '../../components/component-library/text/text';
 import { Box } from '../../components/component-library/box/box';
 import { Container } from '../../components/component-library/container/container';
-import {
-  ButtonLink,
-  ContainerMaxWidth,
-  Label,
-} from '../../components/component-library';
+import { ButtonLink, Label } from '../../components/component-library';
 import { Checkbox } from '../../components/component-library/checkbox/checkbox';
 import { setSkipDeepLinkInterstitial } from '../../store/actions';
 import { getPreferences } from '../../selectors/selectors';
@@ -292,9 +287,8 @@ export const DeepLink = ({ location }: DeepLinkProps) => {
     <Container
       display={Display.Flex}
       alignItems={AlignItems.center}
-      justifyContent={JustifyContent.center}
       flexDirection={FlexDirection.Column}
-      maxWidth={ContainerMaxWidth.Md}
+      style={{ marginTop: '111px' }}
     >
       <Box
         display={Display.Flex}
@@ -304,14 +298,18 @@ export const DeepLink = ({ location }: DeepLinkProps) => {
         backgroundColor={BackgroundColor.backgroundDefault}
         borderColor={BorderColor.borderMuted}
         borderRadius={BorderRadius.MD}
-        width={BlockSize.Full}
+        style={{ width: '446px', minHeight: '592px' }}
         paddingLeft={6}
         paddingRight={6}
         paddingTop={12}
         paddingBottom={8}
         borderWidth={1}
       >
-        <Box>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          alignItems={AlignItems.center}
+        >
           {pageNotFoundError ? (
             <img
               className="error-404-image"


### PR DESCRIPTION
## **Description**
This PR fixes alignment of the loading indicator and MetaMask logo on the deep link page.

There are two different alignment types fixed:
1. Alignment of the position of the MetaMask fox logo within the main loading page and deep link page.
2. Alignment of the loading indicator spinning icon below MetaMask fox logo on the deep link page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38153?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix loading indicators alignment on the deep link page

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Try using different variations of deep link that would trigger different pages and messages.
2. Make sure that interstitial page is displayed correctly.
3. Make sure that loading indicators are properly aligned.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/3fa3a4ce-b2ef-4ae0-bc70-922c6ffe24d1

### **After**

https://github.com/user-attachments/assets/7fbc6caa-a902-4fad-bc2d-6734a51a1bdf


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centers the MetaMask logo and loading spinner on the deep link page with fixed container sizing and spacing adjustments.
> 
> - **UI (deep link page `ui/pages/deep-link/deep-link.tsx`)**:
>   - **Layout**:
>     - Add `marginTop` to `Container`; center content via nested `Box` with flex column alignment.
>     - Set fixed panel `style` (`width: 446px`, `minHeight: 592px`) instead of full-width.
>     - Specify logo size (`160x160`) and place spinner directly beneath within the centered wrapper.
>   - **Cleanup**:
>     - Remove unused `JustifyContent` and `ContainerMaxWidth` props/imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7d72040c890a016d634ef1b66ab568a4a85cfc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->