### PR TITLE
fix: shield handle evm account only from account group (multichain) cp-13.11.0

### DIFF
--- a/shared/constants/subscriptions.ts
+++ b/shared/constants/subscriptions.ts
@@ -46,6 +46,8 @@ export enum ShieldUserAccountCategoryEnum {
 export enum ShieldUserAccountTypeEnum {
   EOA = 'EOA',
   ERC4337 = 'SmartAccount',
+  // in case user current selected account could be non evm like bitcoin, solana
+  OTHER = 'Other',
 }
 
 export enum ShieldCtaActionClickedEnum {

--- a/shared/modules/shield/metrics.ts
+++ b/shared/modules/shield/metrics.ts
@@ -47,24 +47,23 @@ export function getLatestSubscriptionStatus(
 }
 
 export function getUserAccountType(
-  account: InternalAccount,
+  account: InternalAccount | null,
 ): ShieldUserAccountTypeEnum {
-  if (account.type === 'eip155:eoa') {
+  if (account?.type === 'eip155:eoa') {
     return ShieldUserAccountTypeEnum.EOA;
-  } else if (account.type === 'eip155:erc4337') {
+  } else if (account?.type === 'eip155:erc4337') {
     return ShieldUserAccountTypeEnum.ERC4337;
   }
-  // Shield is currently only supported for EVM accounts, so this should never happen
-  throw new Error('Unsupported account type');
+  return ShieldUserAccountTypeEnum.OTHER;
 }
 
 export function getUserAccountCategory(
-  account: InternalAccount,
+  account: InternalAccount | null,
   keyringsMetadata: KeyringObject[],
 ): ShieldUserAccountCategoryEnum {
-  const entropySource = account.options?.entropySource;
+  const entropySource = account?.options?.entropySource;
   const isHdKeyringAccount =
-    account.metadata.keyring.type === KeyringType.hdKeyTree;
+    account?.metadata?.keyring?.type === KeyringType.hdKeyTree;
 
   if (entropySource && isHdKeyringAccount) {
     const keyringIndex = keyringsMetadata.findIndex(
@@ -105,7 +104,7 @@ export function getUserBalanceCategory(balanceInUSD: number): BalanceCategory {
 }
 
 export function getUserAccountTypeAndCategory(
-  account: InternalAccount,
+  account: InternalAccount | null,
   keyringsMetadata: KeyringObject[],
 ) {
   const userAccountType = getUserAccountType(account);
@@ -129,7 +128,7 @@ export function getUserAccountTypeAndCategory(
  * @returns The common tracking props.
  */
 export function getShieldCommonTrackingProps(
-  account: InternalAccount,
+  account: InternalAccount | null,
   keyringsMetadata: KeyringObject[],
   balanceInUSD: number,
 ) {

--- a/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
+++ b/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
@@ -5,12 +5,13 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { getMetaMaskHdKeyrings, getSelectedAccount } from '../../../selectors';
+import { getMetaMaskHdKeyrings } from '../../../selectors';
 import { useAccountTotalFiatBalance } from '../../useAccountTotalFiatBalance';
 import { getShieldCommonTrackingProps } from '../../../../shared/modules/shield';
 import { MetaMaskReduxDispatch } from '../../../store/store';
 import { setShieldSubscriptionMetricsProps } from '../../../store/actions';
 import { EntryModalSourceEnum } from '../../../../shared/constants/subscriptions';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../selectors/multichain-accounts/account-tree';
 import {
   CaptureShieldClaimSubmissionEventParams,
   CaptureShieldCryptoConfirmationEventParams,
@@ -36,7 +37,11 @@ import {
 export const useSubscriptionMetrics = () => {
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const trackEvent = useContext(MetaMetricsContext);
-  const selectedAccount = useSelector(getSelectedAccount);
+  const evmInternalAccount = useSelector((state) =>
+    // Account address will be the same for all EVM accounts
+    getInternalAccountBySelectedAccountGroupAndCaip(state, 'eip155:1'),
+  );
+  const selectedAccount = evmInternalAccount;
   const hdKeyingsMetadata = useSelector(getMetaMaskHdKeyrings);
   const { totalFiatBalance } = useAccountTotalFiatBalance(
     selectedAccount,

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -51,7 +51,6 @@ import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors
 import {
   getMetaMetricsId,
   getModalTypeForShieldEntryModal,
-  getSelectedInternalAccount,
   getUnapprovedConfirmations,
   selectNetworkConfigurationByChainId,
 } from '../../selectors';
@@ -400,9 +399,12 @@ export const useSubscriptionEligibility = (product: ProductType) => {
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const isSignedIn = useSelector(selectIsSignedIn);
   const isUnlocked = useSelector(getIsUnlocked);
-  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const evmInternalAccount = useSelector((state) =>
+    // Account address will be the same for all EVM accounts
+    getInternalAccountBySelectedAccountGroupAndCaip(state, 'eip155:1'),
+  );
   const { totalFiatBalance } = useAccountTotalFiatBalance(
-    selectedAccount,
+    evmInternalAccount,
     false,
     true, // use USD conversion rate instead of the current currency
   );

--- a/ui/hooks/subscription/useSubscriptionPricing.ts
+++ b/ui/hooks/subscription/useSubscriptionPricing.ts
@@ -16,7 +16,6 @@ import {
   getSubscriptionCryptoApprovalAmount,
   getSubscriptionPricing as getSubscriptionPricingAction,
 } from '../../store/actions';
-import { getSelectedAccount } from '../../selectors';
 import { getTokenBalancesEvm } from '../../selectors/assets';
 import { useTokenBalances as pollAndUpdateEvmBalances } from '../useTokenBalances';
 import {
@@ -26,6 +25,12 @@ import {
 } from '../../components/multichain/asset-picker-amount/asset-picker-modal/types';
 import { AssetType } from '../../../shared/constants/transaction';
 import { useAsyncResult } from '../useAsync';
+import {
+  getAccountGroupsByAddress,
+  getInternalAccountByGroupAndCaip,
+  getSelectedAccountGroup,
+} from '../../selectors/multichain-accounts/account-tree';
+import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
 
 export type TokenWithApprovalAmount = (
   | AssetWithDisplayData<ERC20Asset>
@@ -66,9 +71,19 @@ export const useAvailableTokenBalances = (params: {
     [paymentChains],
   );
 
-  const selectedAccount = useSelector(getSelectedAccount);
+  // Use accountAddress's account group if it exists, otherwise use the selected account group
+  const selectedAccountGroup = useSelector(getSelectedAccountGroup);
+  const [requestedAccountGroup] = useSelector((state) =>
+    getAccountGroupsByAddress(state as MultichainAccountsState, ['']),
+  );
+  const accountGroupIdToUse = requestedAccountGroup?.id ?? selectedAccountGroup;
+
+  // Get internal account to use for each supported scope
+  const evmAccount = useSelector((state) =>
+    getInternalAccountByGroupAndCaip(state, accountGroupIdToUse, 'eip155:1'),
+  );
   const evmBalances = useSelector((state) =>
-    getTokenBalancesEvm(state, selectedAccount.address),
+    getTokenBalancesEvm(state, evmAccount?.address),
   );
 
   // Poll and update evm balances for payment chains


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates the Shield subscription feature to properly handle multichain account scenarios where the currently selected account may be a non-EVM account (e.g., Bitcoin, Solana). Previously, Shield subscription features would fail or throw errors when a non-EVM account was selected, as Shield is only supported for EVM accounts.

1. **Multichain account support**: Added `OTHER` account type to `ShieldUserAccountTypeEnum` to handle cases where the selected account is non-EVM (Bitcoin, Solana, etc.)

2. **EVM account selection**: Updated Shield subscription hooks and metrics to explicitly select EVM accounts (using `eip155:1` CAIP-2 identifier) instead of relying on the currently selected account, which may be non-EVM

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38155?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Shield subscription feature to properly handle multichain scenarios where non-EVM accounts (Bitcoin, Solana) are selected

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38131

## **Manual testing steps**

1. Set up a wallet with both EVM and non-EVM accounts (e.g., Bitcoin or Solana account)
2. Select a non-EVM account as the active account
3. Navigate to Shield subscription features (e.g., Shield plan page, subscription settings)
4. Verify that Shield subscription features work correctly and use the EVM account for balance calculations and metrics
5. Verify that metrics tracking properly categorizes the account as `OTHER` when a non-EVM account is selected
6. Test Shield subscription eligibility checks with non-EVM account selected
7. Test Shield subscription pricing and payment token selection with non-EVM account selected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a3579a5dc646cdf16db7a30d2fde2eededc996d3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->