### PR TITLE
Update react-tippy.d.ts

### DIFF
--- a/types/react-tippy.d.ts
+++ b/types/react-tippy.d.ts
@@ -1,8 +1,10 @@
-// Copied from <https://github.com/tvkhoa/react-tippy/blob/c6e6169e3f2cabe05f1bfbd7e0dea1ddef4debe8/index.d.ts>
-// which for some reason is not included in the distributed version
+// Copied and cleaned type definitions for the 'react-tippy' module.
 declare module 'react-tippy' {
   import * as React from 'react';
 
+  // --- Core Utility Types ---
+
+  /** Defines the supported placement positions for the tooltip. */
   export type Position =
     | 'top'
     | 'top-start'
@@ -16,30 +18,39 @@ declare module 'react-tippy' {
     | 'right'
     | 'right-start'
     | 'right-end';
+
+  /** Defines the events that trigger the tooltip visibility. */
   export type Trigger = 'mouseenter' | 'focus' | 'click' | 'manual';
+
+  /** Defines the supported entrance/exit animations. */
   export type Animation = 'shift' | 'perspective' | 'fade' | 'scale' | 'none';
+
+  /** Defines the supported size variants for arrow and tooltip. */
   export type Size = 'small' | 'regular' | 'big';
+
+  /** Defines the supported visual themes for the tooltip. */
   export type Theme = 'dark' | 'light' | 'transparent';
 
+  // --- Main Props Definition ---
+
+  /**
+   * Represents the props accepted by the Tooltip component.
+   * Note: popperOptions type is simplified to object if external Popper types are unavailable.
+   */
   export type TooltipProps = {
+    // Content and State
     title?: string;
     disabled?: boolean;
     open?: boolean;
     useContext?: boolean;
     onRequestClose?: () => void;
+
+    // Positioning and Triggers
     position?: Position;
     trigger?: Trigger;
     tabIndex?: number;
     interactive?: boolean;
     interactiveBorder?: number;
-    delay?: number;
-    hideDelay?: number;
-    animation?: Animation;
-    arrow?: boolean;
-    arrowSize?: Size;
-    animateFill?: boolean;
-    duration?: number;
-    hideDuration?: number;
     distance?: number;
     offset?: number;
     hideOnClick?: boolean | 'persistent';
@@ -48,32 +59,58 @@ declare module 'react-tippy' {
     inertia?: boolean;
     transitionFlip?: boolean;
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    popperOptions?: any;
+    // Timing and Animation
+    delay?: number;
+    hideDelay?: number;
+    animation?: Animation;
+    duration?: number;
+    hideDuration?: number;
+    animateFill?: boolean;
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    html?: React.ReactElement<any>;
-    unmountHTMLWhenHide?: boolean;
+    // Appearance and Styling
+    arrow?: boolean;
+    arrowSize?: Size;
+    theme?: Theme;
     size?: Size;
+    className?: string;
+    style?: React.CSSProperties;
+
+    // Advanced / Custom Content
+    // HTML content to display inside the tooltip (instead of 'title').
+    // Using ReactNode is generally safer and more flexible than ReactElement<any>.
+    html?: React.ReactNode; 
+    unmountHTMLWhenHide?: boolean;
+
+    // Popper Configuration (Use unknown for better type safety than 'any')
+    // Requires importing specific Popper.js/Popper.js Core types for full safety.
+    popperOptions?: Record<string, unknown>; 
+
+    // Sticky Behavior
     sticky?: boolean;
-    stickyDuration?: boolean;
+    stickyDuration?: boolean; // Typically takes a number (duration in ms), 'boolean' might be a shorthand.
+
+    // Lifecycle Callbacks
     beforeShown?: () => void;
     shown?: () => void;
     beforeHidden?: () => void;
     hidden?: () => void;
-    theme?: Theme;
-    className?: string;
-    style?: React.CSSProperties;
   };
 
+  /**
+   * The main Tooltip component.
+   */
   export class Tooltip extends React.Component<TooltipProps> {}
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+  /**
+   * A Higher-Order Component (HOC) that wraps a component to add tooltip functionality.
+   * It returns a new component type with injected props (P) and TooltipProps.
+   * @template P - The props of the wrapped component.
+   * @param component - The component to be wrapped.
+   * @param options - The TooltipProps configuration.
+   * @returns A new React ComponentType.
+   */
   export function withTooltip<P>(
     component: React.ComponentType<P>,
     options: TooltipProps,
-  ): JSX.Element;
+  ): React.ComponentType<P>;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cleans and strengthens TypeScript defs for `react-tippy`, refining `TooltipProps` and changing `withTooltip` to return `React.ComponentType<P>`.
> 
> - **Types**:
>   - **`TooltipProps`**: Reorganized and documented; strengthened types (e.g., `html: React.ReactNode` instead of `ReactElement<any>`, `popperOptions: Record<string, unknown>` instead of `any`).
>   - **Styling/Behavior**: Explicit `theme`, `className`, `style`, timing/animation, and sticky props clarified; added docs for core utility types (`Position`, `Trigger`, `Animation`, `Size`, `Theme`).
> - **API**:
>   - **`withTooltip`**: Return type changed from `JSX.Element` to `React.ComponentType<P>`.
> - **Cleanup**:
>   - Removed legacy comments/TODOs; added concise JSDoc annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ea9534656383c3f2139f691512ce81600a395d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->