### PR TITLE
chore: Define explicit empty persistence key for controllers without state

### DIFF
--- a/app/scripts/controller-init/assets/assets-contract-controller-init.ts
+++ b/app/scripts/controller-init/assets/assets-contract-controller-init.ts
@@ -27,5 +27,6 @@ export const AssetsContractControllerInit: ControllerInitFunction<
   return {
     controller,
     memStateKey: null,
+    persistedStateKey: null,
   };
 };

--- a/app/scripts/controller-init/assets/nft-detection-controller-init.ts
+++ b/app/scripts/controller-init/assets/nft-detection-controller-init.ts
@@ -29,5 +29,6 @@ export const NftDetectionControllerInit: ControllerInitFunction<
 
   return {
     controller,
+    persistedStateKey: null,
   };
 };

--- a/app/scripts/controller-init/defi-positions/defi-positions-controller-init.ts
+++ b/app/scripts/controller-init/defi-positions/defi-positions-controller-init.ts
@@ -39,5 +39,6 @@ export const DeFiPositionsControllerInit: ControllerInitFunction<
 
   return {
     controller,
+    persistedStateKey: null,
   };
 };

--- a/app/scripts/controller-init/institutional-snap/institutional-snap-controller-init.ts
+++ b/app/scripts/controller-init/institutional-snap/institutional-snap-controller-init.ts
@@ -12,5 +12,6 @@ export const InstitutionalSnapControllerInit: ControllerInitFunction<
 
   return {
     controller,
+    persistedStateKey: null,
   };
 };

--- a/app/scripts/controller-init/rewards-data-service-init.ts
+++ b/app/scripts/controller-init/rewards-data-service-init.ts
@@ -23,5 +23,6 @@ export const RewardsDataServiceInit: ControllerInitFunction<
 
   return {
     controller,
+    persistedStateKey: null,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

As part of a different PR, I noticed multiple controllers/services that didn't specify `persistedStateKey: null` when not using persisted state. This PR fixes that.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38168?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Define `persistedStateKey: null` for several stateless controller/service init modules.
> 
> - **Controller/service init**:
>   - Set `persistedStateKey: null` in `assets/assets-contract-controller-init.ts` (alongside existing `memStateKey: null`).
>   - Set `persistedStateKey: null` in `assets/nft-detection-controller-init.ts`.
>   - Set `persistedStateKey: null` in `defi-positions/defi-positions-controller-init.ts`.
>   - Set `persistedStateKey: null` in `institutional-snap/institutional-snap-controller-init.ts`.
>   - Set `persistedStateKey: null` in `rewards-data-service-init.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b4386e6aed63f6fbdb4dc48dd116d1cb7eadb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->