### PR TITLE
fix: social login authentication state before rehydrate cp-13.11.0

### DIFF
--- a/ui/pages/onboarding-flow/account-exist/account-exist.test.tsx
+++ b/ui/pages/onboarding-flow/account-exist/account-exist.test.tsx
@@ -46,10 +46,6 @@ describe('Account Exist Seedless Onboarding View', () => {
   });
 
   it('should navigate to the unlock page when the button is clicked', async () => {
-    const setFirstTimeFlowTypeSpy = jest
-      .spyOn(Actions, 'setFirstTimeFlowType')
-      .mockReturnValue(jest.fn().mockResolvedValueOnce(null));
-
     const { getByText } = renderWithProvider(<AccountExist />, customMockStore);
     const loginButton = getByText('Log in');
     fireEvent.click(loginButton);
@@ -58,18 +54,15 @@ describe('Account Exist Seedless Onboarding View', () => {
       expect(mockUseNavigate).toHaveBeenCalledWith(ONBOARDING_UNLOCK_ROUTE, {
         replace: true,
       });
-      expect(setFirstTimeFlowTypeSpy).toHaveBeenCalledWith(
-        FirstTimeFlowType.socialImport,
-      );
     });
   });
 
-  it('should navigate to the welcome page when the firstTimeFlowType is not socialCreate', () => {
+  it('should navigate to the welcome page when the firstTimeFlowType is not socialImport', () => {
     const store = configureMockStore([thunk])({
       ...mockState,
       metamask: {
         ...mockState.metamask,
-        firstTimeFlowType: FirstTimeFlowType.socialImport,
+        firstTimeFlowType: FirstTimeFlowType.socialCreate,
       },
     });
 

--- a/ui/pages/onboarding-flow/account-exist/account-exist.tsx
+++ b/ui/pages/onboarding-flow/account-exist/account-exist.tsx
@@ -29,7 +29,6 @@ import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import {
   forceUpdateMetamaskState,
   resetOnboarding,
-  setFirstTimeFlowType,
 } from '../../../store/actions';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -80,15 +79,11 @@ export default function AccountExist() {
       tags: { source: 'account_status_redirect' },
       parentContext: onboardingParentContext?.current,
     });
-    await dispatch(setFirstTimeFlowType(FirstTimeFlowType.socialImport));
     navigate(ONBOARDING_UNLOCK_ROUTE, { replace: true });
   };
 
   useEffect(() => {
-    if (firstTimeFlowType !== FirstTimeFlowType.socialCreate) {
-      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
-    }
-    if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
+    if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
       // Track page view event for account already exists page
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
@@ -99,9 +94,11 @@ export default function AccountExist() {
         op: TraceOperation.OnboardingUserJourney,
         parentContext: onboardingParentContext?.current,
       });
+    } else {
+      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
     }
     return () => {
-      if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
+      if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
         bufferedEndTrace?.({
           name: TraceName.OnboardingNewSocialAccountExists,
         });

--- a/ui/pages/onboarding-flow/account-not-found/account-not-found.test.tsx
+++ b/ui/pages/onboarding-flow/account-not-found/account-not-found.test.tsx
@@ -53,10 +53,6 @@ describe('Account Not Found Seedless Onboarding View', () => {
   });
 
   it('should navigate to the create-password route when the button is clicked', async () => {
-    const setFirstTimeFlowTypeSpy = jest
-      .spyOn(Actions, 'setFirstTimeFlowType')
-      .mockReturnValue(jest.fn().mockResolvedValueOnce(null));
-
     const { getByText } = renderWithProvider(
       <AccountNotFound />,
       customMockStore,
@@ -66,9 +62,6 @@ describe('Account Not Found Seedless Onboarding View', () => {
     fireEvent.click(loginButton);
 
     await waitFor(() => {
-      expect(setFirstTimeFlowTypeSpy).toHaveBeenCalledWith(
-        FirstTimeFlowType.socialCreate,
-      );
       expect(mockUseNavigate).toHaveBeenCalledWith(
         ONBOARDING_CREATE_PASSWORD_ROUTE,
         {
@@ -78,12 +71,12 @@ describe('Account Not Found Seedless Onboarding View', () => {
     });
   });
 
-  it('should navigate to the welcome page when the firstTimeFlowType is not socialImport', () => {
+  it('should navigate to the welcome page when the firstTimeFlowType is not socialCreate', () => {
     const store = configureMockStore([thunk])({
       ...mockState,
       metamask: {
         ...mockState.metamask,
-        firstTimeFlowType: FirstTimeFlowType.socialCreate,
+        firstTimeFlowType: FirstTimeFlowType.socialImport,
       },
     });
 

--- a/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
+++ b/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
@@ -29,7 +29,6 @@ import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import {
   forceUpdateMetamaskState,
   resetOnboarding,
-  setFirstTimeFlowType,
 } from '../../../store/actions';
 import {
   MetaMetricsEventAccountType,
@@ -74,16 +73,11 @@ export default function AccountNotFound() {
       tags: { source: 'account_status_redirect' },
       parentContext: onboardingParentContext?.current,
     });
-    dispatch(setFirstTimeFlowType(FirstTimeFlowType.socialCreate));
     navigate(ONBOARDING_CREATE_PASSWORD_ROUTE, { replace: true });
   };
 
   useEffect(() => {
-    if (firstTimeFlowType !== FirstTimeFlowType.socialImport) {
-      // if the onboarding flow is not social import, redirect to the welcome page
-      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
-    }
-    if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
+    if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
         event: MetaMetricsEventName.AccountNotFoundPageViewed,
@@ -93,9 +87,11 @@ export default function AccountNotFound() {
         op: TraceOperation.OnboardingUserJourney,
         parentContext: onboardingParentContext?.current,
       });
+    } else {
+      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
     }
     return () => {
-      if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
+      if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
         bufferedEndTrace?.({
           name: TraceName.OnboardingExistingSocialAccountNotFound,
         });

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -916,7 +916,6 @@ export function getIsSeedlessOnboardingUserAuthenticated(): ThunkAction<
         'getIsSeedlessOnboardingUserAuthenticated',
         [],
       );
-      console.log('isAuthenticated', isAuthenticated);
       return isAuthenticated;
     } catch (error) {
       log.warn('getIsSeedlessOnboardingUserAuthenticated error', error);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -916,6 +916,7 @@ export function getIsSeedlessOnboardingUserAuthenticated(): ThunkAction<
         'getIsSeedlessOnboardingUserAuthenticated',
         [],
       );
+      console.log('isAuthenticated', isAuthenticated);
       return isAuthenticated;
     } catch (error) {
       log.warn('getIsSeedlessOnboardingUserAuthenticated error', error);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixed social login authentication-state validation in rehydration flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38170?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed social login authentication validation in rehydrate.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38172

## **Manual testing steps**

1. Click on create new wallet and login with existing social login account
2. After completing social login, close the browser at the unlock page
3. Open the browser and wallet again. 
4. You should be redirect back to the welcome page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors social login onboarding to async-validate auth before redirects, adjusts first-time flow checks, and simplifies Account Exist/Not Found to navigate without mutating flow state; updates tests accordingly.
> 
> - **Onboarding Welcome (`ui/pages/onboarding-flow/welcome/welcome.js`)**
>   - Replace `getIsSocialLoginUserAuthenticated` with `getIsSocialLoginFlow` and async auth check via `getIsSeedlessOnboardingUserAuthenticated` before redirecting.
>   - Guard redirects with `isMounted` flag; handle social create vs import navigation accordingly.
>   - Defer setting `firstTimeFlowType` for social flows until after OAuth result (set to `socialCreate` for new users, `socialImport` for existing).
> - **Account pages**
>   - `account-exist.tsx` and `account-not-found.tsx`:
>     - Remove `setFirstTimeFlowType` dispatches; rely on navigation only.
>     - In `useEffect`, invert/clarify conditions to show page only for the matching `FirstTimeFlowType` (`socialImport` for exist, `socialCreate` for not-found); otherwise redirect to `ONBOARDING_WELCOME_ROUTE`.
>     - Add "use different login method" handler to reset onboarding state and navigate to welcome.
> - **Tests**
>   - Update tests to remove expectations around `setFirstTimeFlowType` and reflect new routing conditions and reset behavior in both account pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b3b5104507c9433738377c2712348bb62152ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->