### PR TITLE
fix: enabled metrics toggle after shield subs cp-13.11.0

### DIFF
--- a/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
+++ b/ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx
@@ -24,7 +24,6 @@ import {
   getParticipateInMetaMetrics,
   getUseExternalServices,
 } from '../../../../selectors';
-import { getIsActiveShieldSubscription } from '../../../../selectors/subscription';
 
 const MetametricsToggle = ({
   dataCollectionForMarketing,
@@ -49,10 +48,6 @@ const MetametricsToggle = ({
   const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
   const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
   const useExternalServices = useSelector(getUseExternalServices);
-  const isActiveShieldSubscription = useSelector(getIsActiveShieldSubscription);
-  // we will enable the metametrics option if the user has a shield subscription and user can't toggle the metametrics option with active shield subscription
-  const disableMetametricsToggle =
-    isActiveShieldSubscription || !useExternalServices;
 
   const handleUseParticipateInMetaMetrics = async (isParticipated: boolean) => {
     if (isParticipated) {
@@ -121,7 +116,7 @@ const MetametricsToggle = ({
         >
           <ToggleButton
             value={participateInMetaMetrics}
-            disabled={disableMetametricsToggle}
+            disabled={!useExternalServices}
             onToggle={(value) => handleUseParticipateInMetaMetrics(!value)}
             offLabel={t('off')}
             onLabel={t('on')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enable metrics toggle in settings after shield subscription. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38176?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: enabled metametrics toggle for active shield subscribers

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38178

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the MetaMetrics toggle regardless of Shield subscription, disabling it only when external services are off.
> 
> - **Settings UI (`ui/pages/settings/security-tab/metametrics-toggle/metametrics-toggle.tsx`)**:
>   - Enable MetaMetrics toggle independent of Shield subscription by removing `getIsActiveShieldSubscription` usage and the `disableMetametricsToggle` logic.
>   - `ToggleButton` `disabled` now depends only on `!useExternalServices`.
>   - Minor cleanup: removed unused selector import and related variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5120bab4b1432d358fecce568bfb707f3431d501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->