### PR TITLE
fix: double account creation timeout for Snap-based accounts

### DIFF
--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -49,7 +49,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
       backOffMs: 1000,
     },
     createAccounts: {
-      timeoutMs: 3000,
+      timeoutMs: 6000,
     },
   };
 


### PR DESCRIPTION
## **Description**

Doubling timeout value when creating Snap-based BIP-44 accounts.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38191?quickstart=1)

## **Changelog**

CHANGELOG entry: Updating timeout for BIP-44 account creations (from 3s to 6s)

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase Snap-based BIP-44 account creation timeout from 3s to 6s in `multichain-account-service-init.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fddb9ad7d0001d1f2c467477d1d3ac0a64a91321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->