### PR TITLE
feat: force dark mode on banner if active

### DIFF
--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -12,7 +12,6 @@ import {
 } from '@metamask/subscription-controller';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { NameType } from '@metamask/name-controller';
-import { useSelector } from 'react-redux';
 import {
   BannerAlert,
   BannerAlertSeverity,
@@ -86,7 +85,7 @@ import {
   ShieldErrorStateViewEnum,
 } from '../../../../shared/constants/subscriptions';
 import { ThemeType } from '../../../../shared/constants/preferences';
-import { getTheme } from '../../../selectors';
+import { useTheme } from '../../../hooks/useTheme';
 import CancelMembershipModal from './cancel-membership-modal';
 import { isCardPaymentMethod, isCryptoPaymentMethod } from './types';
 import ShieldBannerAnimation from './shield-banner-animation';
@@ -107,7 +106,7 @@ const TransactionShield = () => {
   }, [search]);
 
   const { formatCurrency } = useFormatters();
-  const theme = useSelector(getTheme);
+  const theme = useTheme();
   const isLightTheme = theme === ThemeType.light;
 
   const {

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -669,6 +669,7 @@ const TransactionShield = () => {
       {membershipErrorBanner}
       <Box className="transaction-shield-page__container" marginBottom={4}>
         <Box
+          data-theme={isMembershipInactive ? theme : ThemeType.dark}
           className={classnames(
             'transaction-shield-page__row transaction-shield-page__membership',
             {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Force dark mode on banner when subscription is active since the background color is using dark color whether in light/dark mode. Fixes the tags visibility

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38204?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Enforces dark mode on the active membership banner

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
**Tag visibility issue on light mode**
<img width="576" height="145" alt="Screenshot 2025-11-25 at 12 41 20 AM" src="https://github.com/user-attachments/assets/4801f7b5-41da-433e-885e-6d98d2bc5055" />


<!-- [screenshots/recordings] -->

### **After**
**Subscription Active**
<img width="576" height="148" alt="Screenshot 2025-11-25 at 12 40 41 AM" src="https://github.com/user-attachments/assets/9f73e1dd-0bd5-4d51-b1cb-835a929fef6b" />
<img width="577" height="148" alt="Screenshot 2025-11-25 at 12 40 19 AM" src="https://github.com/user-attachments/assets/ab8e3ad8-5a93-43f2-a001-c0877ec8d872" />



**Subscription Inactive**
<img width="584" height="274" alt="Screenshot 2025-11-25 at 12 39 14 AM" src="https://github.com/user-attachments/assets/8fb39f4d-9e7d-47fc-8ea0-6310b646848a" />
<img width="581" height="268" alt="Screenshot 2025-11-25 at 12 38 57 AM" src="https://github.com/user-attachments/assets/805bb48d-ddcd-41fe-90d0-dedaf3e9d2f9" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces dark mode on the active membership banner and replaces the Redux theme selector with the `useTheme` hook.
> 
> - **Settings > Transaction Shield** (`ui/pages/settings/transaction-shield-tab/transaction-shield.tsx`):
>   - **Theming**:
>     - Replace `useSelector(getTheme)` with `useTheme`.
>     - Add `data-theme` on membership container to force `ThemeType.dark` when membership is active; use current `theme` when inactive.
>   - Improves tag visibility by ensuring consistent dark background styling when active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262551add312d630eb22b0cf72b8de44749c071b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->