### PR TITLE
fix(38192): fix ui regression of removed LegacyLayout wrapper for CONFIRMATION_V_NEXT_ROUTE cp-13.11.0

### DIFF
--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -828,7 +828,7 @@ export default function Routes() {
               paramsAsProps: false,
             })}
           </RouteWithLayout>
-          <Route
+          <RouteWithLayout
             path={`${CONFIRM_TRANSACTION_ROUTE}/:id?`}
             layout={LegacyLayout}
           >
@@ -838,7 +838,7 @@ export default function Routes() {
               includeParams: true,
               paramsAsProps: false,
             })}
-          </Route>
+          </RouteWithLayout>
           <RouteWithLayout path={SWAPS_ROUTE} layout={LegacyLayout}>
             {createV5CompatRoute(Swaps, {
               wrapper: AuthenticatedV5Compat,
@@ -870,20 +870,26 @@ export default function Routes() {
               includeLocation: true,
             })}
           </RouteWithLayout>
-          <Route path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE} layout={LegacyLayout}>
+          <RouteWithLayout
+            path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE}
+            layout={LegacyLayout}
+          >
             {createV5CompatRoute(ConfirmAddSuggestedTokenPage, {
               wrapper: AuthenticatedV5Compat,
               includeNavigate: true,
               includeLocation: true,
             })}
-          </Route>
-          <Route path={CONFIRM_ADD_SUGGESTED_NFT_ROUTE} layout={LegacyLayout}>
+          </RouteWithLayout>
+          <RouteWithLayout
+            path={CONFIRM_ADD_SUGGESTED_NFT_ROUTE}
+            layout={LegacyLayout}
+          >
             {createV5CompatRoute(ConfirmAddSuggestedNftPage, {
               wrapper: AuthenticatedV5Compat,
               includeNavigate: true,
               includeLocation: true,
             })}
-          </Route>
+          </RouteWithLayout>
           <RouteWithLayout
             path={`${CONFIRMATION_V_NEXT_ROUTE}/:id?`}
             layout={LegacyLayout}

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -828,7 +828,10 @@ export default function Routes() {
               paramsAsProps: false,
             })}
           </RouteWithLayout>
-          <Route path={`${CONFIRM_TRANSACTION_ROUTE}/:id?`}>
+          <Route
+            path={`${CONFIRM_TRANSACTION_ROUTE}/:id?`}
+            layout={LegacyLayout}
+          >
             {createV5CompatRoute<{ id?: string }>(ConfirmTransaction, {
               wrapper: AuthenticatedV5Compat,
               includeLocation: true,
@@ -867,33 +870,30 @@ export default function Routes() {
               includeLocation: true,
             })}
           </RouteWithLayout>
-          <Route path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE}>
+          <Route path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE} layout={LegacyLayout}>
             {createV5CompatRoute(ConfirmAddSuggestedTokenPage, {
               wrapper: AuthenticatedV5Compat,
               includeNavigate: true,
               includeLocation: true,
             })}
           </Route>
-          <Route path={CONFIRM_ADD_SUGGESTED_NFT_ROUTE}>
+          <Route path={CONFIRM_ADD_SUGGESTED_NFT_ROUTE} layout={LegacyLayout}>
             {createV5CompatRoute(ConfirmAddSuggestedNftPage, {
               wrapper: AuthenticatedV5Compat,
               includeNavigate: true,
               includeLocation: true,
             })}
           </Route>
-          <Route path={`${CONFIRMATION_V_NEXT_ROUTE}/:id?`}>
-            {(props: RouteComponentProps<{ id?: string }>) => {
-              const renderFn = createV5CompatRoute<{ id?: string }>(
-                ConfirmationPage,
-                {
-                  wrapper: AuthenticatedV5Compat,
-                  includeParams: true,
-                  paramsAsProps: false,
-                },
-              );
-              return renderFn(props);
-            }}
-          </Route>
+          <RouteWithLayout
+            path={`${CONFIRMATION_V_NEXT_ROUTE}/:id?`}
+            layout={LegacyLayout}
+          >
+            {createV5CompatRoute<{ id?: string }>(ConfirmationPage, {
+              wrapper: AuthenticatedV5Compat,
+              includeParams: true,
+              paramsAsProps: false,
+            })}
+          </RouteWithLayout>
           <RouteWithLayout
             authenticated
             path={NEW_ACCOUNT_ROUTE}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a UI layout regression introduced in #37964 where the `layout` property was accidentally removed from several routes, causing confirmation screens to display incorrectly.

The fix is straightforward, restore the `layout` property to the affected route wrapper components to ensure proper UI rendering.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38239?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix ui regression of removed LegacyLayout wrapper for CONFIRMATION_V_NEXT_ROUTE

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38192

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1201" height="949" alt="Screenshot 2025-11-25 at 11 12 03" src="https://github.com/user-attachments/assets/3c94da82-69d2-416b-a72e-b5d09e887a27" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores `LegacyLayout` wrappers for confirm transaction, add suggested token/NFT, and vNext confirmation routes to fix layout regression.
> 
> - **Routes** (`ui/pages/routes/routes.component.tsx`):
>   - Wrap confirmation flows with `LegacyLayout`:
>     - `CONFIRM_TRANSACTION_ROUTE` (`/confirm-transaction/:id?`)
>     - `CONFIRMATION_V_NEXT_ROUTE` (`/confirmation-v-next/:id?`) via `RouteWithLayout`
>     - `CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE`
>     - `CONFIRM_ADD_SUGGESTED_NFT_ROUTE`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d02ea95e58936aa480c1640e575d3165f7f477d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->