### PR TITLE
fix: Show correct balance values in fiat for gas tokens

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.test.ts
@@ -2,6 +2,7 @@ import { Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { GasFeeToken } from '@metamask/transaction-controller';
 
+import { CHAIN_IDS } from '../../../../../../../shared/constants/network';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../shared/constants/transaction';
 import { getMockConfirmStateForTransaction } from '../../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../../test/data/confirmations/contract-interaction';
@@ -21,10 +22,48 @@ const GAS_FEE_TOKEN_MOCK: GasFeeToken = {
   symbol: 'USDC',
 };
 
-function getState({ gasFeeTokens }: { gasFeeTokens?: GasFeeToken[] } = {}) {
+function getState({
+  gasFeeTokens,
+  chainId,
+  currencyRates,
+}: {
+  gasFeeTokens?: GasFeeToken[];
+  chainId?: Hex;
+  currencyRates?: Record<string, { conversionRate: number }>;
+} = {}) {
+  const networkConfigurations: Record<string, unknown> = {};
+  let providerConfig = {};
+
+  // Add Polygon network configuration if using Polygon chainId
+  if (chainId === CHAIN_IDS.POLYGON) {
+    networkConfigurations[CHAIN_IDS.POLYGON] = {
+      chainId: CHAIN_IDS.POLYGON,
+      name: 'Polygon',
+      nativeCurrency: 'POL',
+      ticker: 'POL',
+      rpcEndpoints: [
+        {
+          type: 'custom',
+          url: 'https://polygon-rpc.com',
+          networkClientId: 'polygon-network',
+        },
+      ],
+      defaultRpcEndpointIndex: 0,
+      blockExplorerUrls: [],
+    };
+    providerConfig = {
+      type: 'rpc',
+      chainId: CHAIN_IDS.POLYGON,
+      ticker: 'POL',
+      nickname: 'Polygon',
+      rpcUrl: 'https://polygon-rpc.com',
+    };
+  }
+
   return getMockConfirmStateForTransaction(
     genUnapprovedContractInteractionConfirmation({
       address: FROM_MOCK,
+      chainId,
       gasFeeTokens: gasFeeTokens ?? [GAS_FEE_TOKEN_MOCK],
       selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
     }),
@@ -33,6 +72,13 @@ function getState({ gasFeeTokens }: { gasFeeTokens?: GasFeeToken[] } = {}) {
         preferences: {
           showFiatInTestnets: true,
         },
+        ...(currencyRates && { currencyRates }),
+        ...(Object.keys(networkConfigurations).length > 0 && {
+          networkConfigurationsByChainId: networkConfigurations,
+        }),
+        ...(chainId === CHAIN_IDS.POLYGON && {
+          providerConfig,
+        }),
       },
     },
   );
@@ -172,6 +218,25 @@ describe('useGasFeeToken', () => {
         }),
       );
     });
+  });
+
+  it('returns fiat amount with < prefix when less than 0.01', () => {
+    const smallAmountToken: GasFeeToken = {
+      ...GAS_FEE_TOKEN_MOCK,
+      amount: toHex(1), // Very small amount
+    };
+
+    const state = getState({
+      gasFeeTokens: [smallAmountToken],
+      currencyRates: { ETH: { conversionRate: 1 } },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useGasFeeToken({ tokenAddress: smallAmountToken.tokenAddress }),
+      state,
+    );
+
+    expect(result.current.amountFiat).toBe('< $0.01');
   });
 
   describe('useSelectedGasFeeToken', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
@@ -8,16 +8,19 @@ import { BigNumber } from 'bignumber.js';
 import { useSelector } from 'react-redux';
 import { Interface } from '@ethersproject/abi';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
-
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../shared/constants/transaction';
-import { useConfirmContext } from '../../../../context/confirm';
-import { useEthFiatAmount } from '../../../../../../hooks/useEthFiatAmount';
-import { formatAmount } from '../../../simulation-details/formatAmount';
+import { getNetworkConfigurationsByChainId } from '../../../../../../../shared/modules/selectors/networks';
+import { getCurrencyRates } from '../../../../../../ducks/metamask/metamask';
 import { getIntlLocale } from '../../../../../../ducks/locale/locale';
+import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
+import { useEthFiatAmount } from '../../../../../../hooks/useEthFiatAmount';
 import {
+  getShouldShowFiat,
   selectNetworkConfigurationByChainId,
   selectTransactionAvailableBalance,
 } from '../../../../../../selectors';
+import { formatAmount } from '../../../simulation-details/formatAmount';
+import { useConfirmContext } from '../../../../context/confirm';
 import { useFeeCalculations } from './useFeeCalculations';
 
 export const RATE_WEI_NATIVE = '0xDE0B6B3A7640000'; // 1x10^18
@@ -28,7 +31,7 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
 
   const locale = useSelector(getIntlLocale);
   const nativeFeeToken = useNativeGasFeeToken();
-  const { gasFeeTokens } = transactionMeta ?? {};
+  const { gasFeeTokens, chainId } = transactionMeta ?? {};
 
   let gasFeeToken = gasFeeTokens?.find(
     (token) => token.tokenAddress.toLowerCase() === tokenAddress?.toLowerCase(),
@@ -50,9 +53,24 @@ export function useGasFeeToken({ tokenAddress }: { tokenAddress?: Hex }) {
     new BigNumber(amount).shift(-decimals),
   );
 
-  const amountFiat = useFiatTokenValue(gasFeeToken, gasFeeToken?.amount);
-  const balanceFiat = useFiatTokenValue(gasFeeToken, gasFeeToken?.balance);
-  const metamaskFeeFiat = useFiatTokenValue(gasFeeToken, metaMaskFee);
+  const amountFiat = useFiatTokenValue(
+    gasFeeToken,
+    gasFeeToken?.amount,
+    'AMOUNT',
+    chainId,
+  );
+  const balanceFiat = useFiatTokenValue(
+    gasFeeToken,
+    gasFeeToken?.balance,
+    'BALANCE',
+    chainId,
+  );
+  const metamaskFeeFiat = useFiatTokenValue(
+    gasFeeToken,
+    metaMaskFee,
+    'FEE',
+    chainId,
+  );
 
   const transferTransaction =
     tokenAddress === NATIVE_TOKEN_ADDRESS
@@ -121,8 +139,23 @@ function useNativeGasFeeToken(): GasFeeToken {
 function useFiatTokenValue(
   gasFeeToken: GasFeeToken | undefined,
   tokenValue: Hex | undefined,
+  _label: string,
+  chainId?: Hex,
 ) {
   const { decimals, rateWei } = gasFeeToken ?? { decimals: 0, rateWei: '0x0' };
+
+  const currencyRates = useSelector(getCurrencyRates);
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+  const showFiat = useSelector(getShouldShowFiat);
+  const fiatFormatter = useFiatFormatter();
+
+  // Get the correct conversion rate for the transaction's chainId
+  const conversionRateForChain = chainId
+    ? currencyRates?.[networkConfigurationsByChainId[chainId]?.nativeCurrency]
+        ?.conversionRate
+    : undefined;
 
   const nativeWei = new BigNumber(tokenValue ?? '0x0')
     .shift(-decimals)
@@ -130,9 +163,27 @@ function useFiatTokenValue(
 
   const nativeEth = nativeWei.shift(-18);
 
-  const fiatValue = useEthFiatAmount(nativeEth, {}, true);
+  // Always call the hook (even if not used) to avoid conditional hook errors
+  const fallbackFiatValue = useEthFiatAmount(nativeEth, {}, true);
 
-  return gasFeeToken ? fiatValue : '';
+  // Calculate fiat value using the correct conversion rate
+  if (!gasFeeToken || !tokenValue || !showFiat) {
+    return '';
+  }
+
+  const conversionRate = conversionRateForChain;
+
+  if (!conversionRate || conversionRate <= 0) {
+    return fallbackFiatValue ?? '';
+  }
+
+  const fiatAmount = nativeEth.times(conversionRate);
+
+  if (fiatAmount.lt(new BigNumber(0.01)) && fiatAmount.gt(new BigNumber(0))) {
+    return `< ${fiatFormatter(0.01)}`;
+  }
+
+  return fiatFormatter(fiatAmount.toNumber());
 }
 
 function getTokenTransferTransaction(


### PR DESCRIPTION
## **Description**
Shows correct balance values in fiat for gas tokens.

## **Changelog**

CHANGELOG entry: Show correct balance values in fiat for gas tokens

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37979

## **Manual testing steps**

1. Have a network that is not Polygon selected in the home page, e.g. Ethereum mainnet
2. Start a send on Polygon
3. Open the gas token picker
4. Notice how fiat values for balances are correct now (not inflated)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="523" height="783" alt="image" src="https://github.com/user-attachments/assets/6d9400f2-fde7-44ac-807d-3e6718d81475" />

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Calculates gas token fiat amounts/balances using the transaction chain’s conversion rate, adds "< $0.01" formatting for very small values, and updates tests (incl. Polygon setup).
> 
> - **Confirmations UI**:
>   - **Fiat calculation**: `useGasFeeToken` now derives fiat values via `currencyRates` and `networkConfigurationsByChainId` for the tx `chainId`, with fallback to `useEthFiatAmount`.
>   - **Formatting**: Shows "< $0.01" for tiny fiat amounts; uses `useFiatFormatter`; respects `getShouldShowFiat`.
>   - **API changes**: `useFiatTokenValue` accepts `chainId`; callers pass labels and `chainId` for amount/balance/fee.
> - **Tests**:
>   - Extend test harness to inject `chainId`, `currencyRates`, and Polygon network config.
>   - Add assertion for "< $0.01" fiat display.
>   - Keep existing validations for selected token, formatting, and transfer transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0463fe937adf0316e842d24c5f85f5c4d530b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->