### PR TITLE
chore: cp-13.10.4 cp-13.11.0 Address new audit advisory

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -31,6 +31,12 @@ npmAuditIgnoreAdvisories:
   # URL: https://github.com/advisories/GHSA-5j98-mcp5-4vw2
   - 1109809
 
+  # Issue: `body-parser` denial of service vulnerability
+  # Seemingly only impacts v2.2.0, but we're on v1. The advisory range is overly wide.
+  # The attack vector also does not apply to how we use the package.
+  # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
+  - 1110857
+
   ### Package Deprecations:
 
   # React-tippy brings in popper.js and react-tippy has not been updated in


### PR DESCRIPTION
## **Description**

Ignores a new advisory that is blocking CI. It does not impact us for multiple reasons.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38259?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ignores the body-parser advisory (GHSA-wqch-xfxh-vrr4, 1110857) in `.yarnrc.yml` to unblock audits/CI.
> 
> - **Security config**:
>   - Add `1110857` (body-parser DoS advisory GHSA-wqch-xfxh-vrr4) to `npmAuditIgnoreAdvisories` in `.yarnrc.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dae8e613f86f923a1d92d9f7af75c666487a7b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->