### PR TITLE
fix: tron icon in activity list details modal

### DIFF
--- a/ui/components/app/multichain-bridge-transaction-details-modal/multichain-bridge-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-bridge-transaction-details-modal/multichain-bridge-transaction-details-modal.tsx
@@ -401,11 +401,13 @@ const MultichainBridgeTransactionDetailsModal = ({
                         : ''
                     }
                     src={
-                      CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
-                        destNetwork?.isEvm
-                          ? formatChainIdToHex(destNetwork?.chainId)
-                          : (destNetwork?.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP)
-                      ] || ''
+                      destNetwork?.isEvm
+                        ? CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
+                            formatChainIdToHex(destNetwork?.chainId)
+                          ] || ''
+                        : (destNetwork?.chainId &&
+                            MULTICHAIN_TOKEN_IMAGE_MAP[destNetwork.chainId]) ||
+                          ''
                     }
                     borderColor={BorderColor.backgroundDefault}
                   />

--- a/ui/hooks/bridge/useBridgeChainInfo.ts
+++ b/ui/hooks/bridge/useBridgeChainInfo.ts
@@ -7,17 +7,13 @@ import {
   formatChainIdToCaip,
   formatChainIdToHex,
   getNativeAssetForChainId,
-  isSolanaChainId,
-  isBitcoinChainId,
+  isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../shared/constants/common';
 import { type ChainInfo } from '../../pages/bridge/utils/tx-details';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../shared/constants/bridge';
-import {
-  SOLANA_BLOCK_EXPLORER_URL,
-  BITCOIN_BLOCK_EXPLORER_URL,
-} from '../../../shared/constants/multichain/networks';
+import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../../shared/constants/multichain/networks';
 
 const getSourceAndDestChainIds = ({ quote }: BridgeHistoryItem) => {
   const { srcChainId, destChainId } = quote;
@@ -79,10 +75,9 @@ export default function useBridgeChainInfo({
   }
 
   // Source chain info
-  const normalizedSrcChainId =
-    isSolanaChainId(srcChainId) || isBitcoinChainId(srcChainId)
-      ? srcChainIdInCaip
-      : formatChainIdToHex(srcChainId);
+  const normalizedSrcChainId = isNonEvmChainId(srcChainId)
+    ? srcChainIdInCaip
+    : formatChainIdToHex(srcChainId);
 
   const commonSrcNetworkFields = {
     chainId: srcChainIdInCaip,
@@ -93,13 +88,13 @@ export default function useBridgeChainInfo({
 
   const srcNetwork = {
     ...commonSrcNetworkFields,
-    ...(isSolanaChainId(srcChainIdInCaip) || isBitcoinChainId(srcChainIdInCaip)
+    ...(isNonEvmChainId(srcChainIdInCaip)
       ? ({
           isEvm: false,
           nativeCurrency: srcNativeAsset?.assetId,
-          blockExplorerUrl: isSolanaChainId(srcChainIdInCaip)
-            ? SOLANA_BLOCK_EXPLORER_URL
-            : BITCOIN_BLOCK_EXPLORER_URL,
+          blockExplorerUrl:
+            MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[srcChainIdInCaip]
+              ?.url,
         } as const)
       : {
           defaultBlockExplorerUrlIndex: 0,
@@ -114,10 +109,9 @@ export default function useBridgeChainInfo({
   };
 
   // Dest chain info
-  const normalizedDestChainId =
-    isSolanaChainId(destChainId) || isBitcoinChainId(destChainId)
-      ? destChainIdInCaip
-      : formatChainIdToHex(destChainId);
+  const normalizedDestChainId = isNonEvmChainId(destChainId)
+    ? destChainIdInCaip
+    : formatChainIdToHex(destChainId);
 
   const commonDestNetworkFields = {
     chainId: destChainIdInCaip,
@@ -128,14 +122,13 @@ export default function useBridgeChainInfo({
 
   const destNetwork = {
     ...commonDestNetworkFields,
-    ...(isSolanaChainId(destChainIdInCaip) ||
-    isBitcoinChainId(destChainIdInCaip)
+    ...(isNonEvmChainId(destChainIdInCaip)
       ? ({
           isEvm: false,
           nativeCurrency: destNativeAsset?.assetId,
-          blockExplorerUrl: isSolanaChainId(destChainIdInCaip)
-            ? SOLANA_BLOCK_EXPLORER_URL
-            : BITCOIN_BLOCK_EXPLORER_URL,
+          blockExplorerUrl:
+            MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[destChainIdInCaip]
+              ?.url,
         } as const)
       : {
           defaultBlockExplorerUrlIndex: 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves the activity list details modal to show ALL non evm icons. Future proofs this by importing proper utils so new nonevm networks will be detected automatically.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38264?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed a bug where the tron icon was not showing in the activity list details modal

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38123

## **Manual testing steps**

1. Go a tron bridge or swap
2. click the activity to see the details
3. tron icon should show correctly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes destination network icon rendering and generalizes non‑EVM chain handling (incl. block explorer URLs) in bridge transaction details.
> 
> - **UI (bridge details modal)**:
>   - Fix destination network avatar `src` to use `MULTICHAIN_TOKEN_IMAGE_MAP` for non‑EVM chains and `CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP` for EVM chains.
> - **Bridge hook (`useBridgeChainInfo`)**:
>   - Replace `isSolanaChainId`/`isBitcoinChainId` checks with `isNonEvmChainId` for generic non‑EVM detection.
>   - Use `MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP` for non‑EVM `blockExplorerUrl` instead of chain-specific constants.
>   - Normalize chain IDs with CAIP for non‑EVM and hex for EVM; populate `nativeCurrency` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a7e9435ed98dd3e38336a593cee66c49cde8a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->