### PR TITLE
fix: Balance empty state incorrectly shown when price conversion unavailable

### DIFF
--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1076,10 +1076,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     const state = createMockStateWithEVMNetworks();
 
     // Add accountsByChainId with non-zero EVM balance
-    // @ts-expect-error - Adding test data to mock state
     state.metamask.accountsByChainId = {
       '0x1': {
         '0x0': {
+          address: '0x0',
           balance: '0x8ac7230489e80000', // 10 ETH
         },
       },
@@ -1112,10 +1112,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     const state = createMockStateWithEVMNetworks();
 
     // Add accountsByChainId with zero EVM balance
-    // @ts-expect-error - Adding test data to mock state
     state.metamask.accountsByChainId = {
       '0x1': {
         '0x0': {
+          address: '0x0',
           balance: '0x0',
         },
       },
@@ -1130,10 +1130,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     const state = createMockStateWithEVMNetworks();
 
     // Add accountsByChainId with small positive EVM balance
-    // @ts-expect-error - Adding test data to mock state
     state.metamask.accountsByChainId = {
       '0x1': {
         '0x0': {
+          address: '0x0',
           balance: '0x2386f26fc10000', // 0.01 ETH
         },
       },
@@ -1148,7 +1148,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     const state = createMockStateWithEVMNetworks();
 
     // No balances set at all
-    // @ts-expect-error - Adding test data to mock state
     state.metamask.accountsByChainId = {};
     state.metamask.balances = {};
 
@@ -1161,17 +1160,18 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     const state = createMockStateWithEVMNetworks(true); // Include EVM testnets
 
     // Add balances for both mainnet and testnet
-    // @ts-expect-error - Adding test data to mock state
     state.metamask.accountsByChainId = {
       '0x1': {
         // Ethereum mainnet
         '0x0': {
+          address: '0x0',
           balance: '0x0', // Zero on mainnet
         },
       },
       '0xaa36a7': {
         // Sepolia testnet (should be ignored)
         '0x0': {
+          address: '0x0',
           balance: '0x8ac7230489e80000', // 10 ETH on testnet
         },
       },
@@ -1213,10 +1213,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       const state = createMockStateWithEVMNetworks();
 
       // Add accountsByChainId with non-zero EVM balance
-      // @ts-expect-error - Adding test data to mock state
       state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
+            address: '0x0',
             balance: '0x8ac7230489e80000', // 10 ETH
           },
         },
@@ -1249,10 +1249,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       const state = createMockStateWithEVMNetworks();
 
       // Add accountsByChainId with zero EVM balance
-      // @ts-expect-error - Adding test data to mock state
       state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
+            address: '0x0',
             balance: '0x0',
           },
         },
@@ -1288,10 +1288,10 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       const state = createMockStateWithEVMNetworks();
 
       // Add accountsByChainId with zero EVM balance
-      // @ts-expect-error - Adding test data to mock state
       state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
+            address: '0x0',
             balance: '0x0', // No ETH
           },
         },

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1229,7 +1229,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Add multichainBalancesState with non-zero Solana balance
-      // @ts-expect-error - Adding test data to mock state
       state.metamask.balances = {
         account2: {
           'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -3,6 +3,7 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { cloneDeep } from 'lodash';
 import {
+  calculateBalanceForAllWallets,
   calculateBalanceChangeForAllWallets,
   selectAssetsBySelectedAccountGroup,
 } from '@metamask/assets-controllers';
@@ -38,6 +39,10 @@ jest.mock('@metamask/assets-controllers', () => {
   const actual = jest.requireActual('@metamask/assets-controllers');
   return {
     ...actual,
+    calculateBalanceForAllWallets: jest.fn(() => ({
+      wallets: {},
+      userCurrency: 'usd',
+    })),
     calculateBalanceChangeForAllWallets: jest.fn(() => ({
       period: '1d',
       currentTotalInUserCurrency: 0,
@@ -1067,23 +1072,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
     };
   };
 
-  const createMockBalanceResult = (balance = 750.25) => ({
-    wallets: {
-      'entropy:wallet1': {
-        totalBalanceInUserCurrency: balance * 2,
-        groups: {
-          'entropy:wallet1/group1': {
-            walletId: 'entropy:wallet1',
-            groupId: 'entropy:wallet1/group1',
-            totalBalanceInUserCurrency: balance,
-            userCurrency: 'usd',
-          },
-        },
-      },
-    },
-    userCurrency: 'usd',
-  });
-
   it('should return true when balance is greater than 0 for EVM networks', () => {
     const state = createMockStateWithEVMNetworks();
 
@@ -1361,7 +1349,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       };
 
       // Add tokenBalances with ERC-20 tokens
-      // @ts-expect-error - Adding test data to mock state
       state.metamask.tokenBalances = {
         '0x0': {
           // account address

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1299,24 +1299,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       expect(result).toBe(true);
     });
 
-    it('should handle edge case with hex string "0" for EVM balance', () => {
-      const state = createMockStateWithEVMNetworks();
-
-      // Test both "0x0" and "0" as zero values
-      // @ts-expect-error - Adding test data to mock state
-      state.metamask.accountsByChainId = {
-        '0x1': {
-          '0x0': {
-            balance: '0', // String "0" instead of "0x0"
-          },
-        },
-      };
-
-      const result = selectAccountGroupBalanceForEmptyState(state);
-
-      expect(result).toBe(false);
-    });
-
     it('should return false when non-EVM balance is decimal zero like "0.0" or "0.00"', () => {
       const state = createMockStateWithNonEVMNetworks();
 

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1266,39 +1266,6 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       expect(result).toBe(false);
     });
 
-    it('should handle mixed state with both EVM and non-EVM balances', () => {
-      const state = createMockStateWithEVMNetworks();
-
-      // Add accountsByChainId with non-zero EVM balance
-      // @ts-expect-error - Adding test data to mock state
-      state.metamask.accountsByChainId = {
-        '0x1': {
-          '0x0': {
-            balance: '0x8ac7230489e80000', // 10 ETH
-          },
-        },
-        '0x89': {
-          '0x0': {
-            balance: '0x0', // 0 MATIC
-          },
-        },
-      };
-
-      // Add multichainBalancesState with non-zero balance
-      state.metamask.balances = {
-        account2: {
-          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
-            amount: '5.25',
-            unit: 'SOL',
-          },
-        },
-      };
-
-      const result = selectAccountGroupBalanceForEmptyState(state);
-
-      expect(result).toBe(true);
-    });
-
     it('should return false when non-EVM balance is decimal zero like "0.0" or "0.00"', () => {
       const state = createMockStateWithNonEVMNetworks();
 

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -1207,7 +1207,8 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Add accountsByChainId with non-zero EVM balance
-      (state.metamask as any).accountsByChainId = {
+      // @ts-expect-error - Adding test data to mock state
+      state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
             balance: '0x8ac7230489e80000', // 10 ETH
@@ -1228,7 +1229,8 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Add multichainBalancesState with non-zero Solana balance
-      (state.metamask as any).balances = {
+      // @ts-expect-error - Adding test data to mock state
+      state.metamask.balances = {
         account2: {
           'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
             amount: '10.5',
@@ -1250,7 +1252,8 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Add accountsByChainId with zero EVM balance
-      (state.metamask as any).accountsByChainId = {
+      // @ts-expect-error - Adding test data to mock state
+      state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
             balance: '0x0',
@@ -1259,7 +1262,7 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       };
 
       // Add multichainBalancesState with zero balance
-      (state.metamask as any).balances = {};
+      state.metamask.balances = {};
 
       const result = selectAccountGroupBalanceForEmptyState(state);
 
@@ -1274,7 +1277,8 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Add accountsByChainId with non-zero EVM balance
-      (state.metamask as any).accountsByChainId = {
+      // @ts-expect-error - Adding test data to mock state
+      state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
             balance: '0x8ac7230489e80000', // 10 ETH
@@ -1288,7 +1292,7 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       };
 
       // Add multichainBalancesState with non-zero balance
-      (state.metamask as any).balances = {
+      state.metamask.balances = {
         account2: {
           'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
             amount: '5.25',
@@ -1310,7 +1314,8 @@ describe('selectAccountGroupBalanceForEmptyState', () => {
       );
 
       // Test both "0x0" and "0" as zero values
-      (state.metamask as any).accountsByChainId = {
+      // @ts-expect-error - Adding test data to mock state
+      state.metamask.accountsByChainId = {
         '0x1': {
           '0x0': {
             balance: '0', // String "0" instead of "0x0"

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -720,9 +720,15 @@ const selectEnabledNetworkMapForBalances = createSelector(
 
 /**
  * Provides accountsByChainId for checking EVM native balances.
+ *
+ * @param state - The application state.
+ * @returns The accounts by chain ID object.
  */
 const selectAccountsByChainIdForBalances = createSelector(
-  [(state: BalanceCalculationState) => getMetamaskState(state).accountsByChainId],
+  [
+    (state: BalanceCalculationState) =>
+      getMetamaskState(state).accountsByChainId,
+  ],
   (accountsByChainId) => accountsByChainId ?? EMPTY_OBJECT,
 );
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -95,6 +95,10 @@ export type BalanceCalculationState = {
       conversionRates?: Record<string, unknown>;
       historicalPrices?: Record<string, unknown>;
       networkConfigurationsByChainId?: Record<string, unknown>;
+      accountsByChainId?: Record<
+        string,
+        Record<string, { balance: string; address: string }>
+      >;
     };
 };
 
@@ -731,7 +735,6 @@ const selectEnabledNetworkMapForBalances = createSelector(
 const selectAccountsByChainIdForBalances = createSelector(
   [
     (state: BalanceCalculationState) =>
-      // @ts-expect-error - accountsByChainId exists at runtime
       getMetamaskState(state).accountsByChainId,
   ],
   (accountsByChainId) => accountsByChainId ?? EMPTY_OBJECT,

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1058,12 +1058,18 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
 
     // Check EVM native token balances from accountsByChainId
     const hasEvmBalance = Object.values(accountsByChainId || {}).some(
-      (chainAccounts: any) => {
+      (chainAccounts) => {
         if (!chainAccounts || typeof chainAccounts !== 'object') {
           return false;
         }
-        return Object.values(chainAccounts).some((account: any) => {
-          const balanceValue = account?.balance || '0x0';
+        return Object.values(chainAccounts).some((account) => {
+          if (typeof account !== 'object' || !account) {
+            return false;
+          }
+          const balanceValue =
+            'balance' in account && typeof account.balance === 'string'
+              ? account.balance
+              : '0x0';
           return balanceValue !== '0x0' && balanceValue !== '0';
         });
       },
@@ -1072,12 +1078,18 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
     // Check multichain balances for any non-zero non-EVM native token balances
     const hasNonEvmBalance = Object.values(
       multichainBalancesState?.balances || {},
-    ).some((accountBalances: any) => {
+    ).some((accountBalances) => {
       if (!accountBalances || typeof accountBalances !== 'object') {
         return false;
       }
-      return Object.values(accountBalances).some((balance: any) => {
-        const balanceValue = balance?.amount || '0';
+      return Object.values(accountBalances).some((balanceData) => {
+        if (typeof balanceData !== 'object' || !balanceData) {
+          return false;
+        }
+        const balanceValue =
+          'amount' in balanceData && typeof balanceData.amount === 'string'
+            ? balanceData.amount
+            : '0';
         return balanceValue !== '0' && balanceValue !== '0x0';
       });
     });

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1112,11 +1112,8 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
             return false;
           }
           const balanceValue = getBalanceOrDefault(account, 'balance', '0x0');
-          // Use isEmptyHexString to properly handle all hex zero formats
-          // Also check for plain "0" as a fallback edge case
-          return (
-            !isEmptyHexString(balanceValue) && (balanceValue as string) !== '0'
-          );
+          // Use isEmptyHexString to properly handle all hex zero formats (0x0, 0x, etc.)
+          return !isEmptyHexString(balanceValue);
         });
       },
     );
@@ -1174,9 +1171,8 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
             if (typeof balance !== 'string') {
               return false;
             }
-            // Use isEmptyHexString to check if token balance is non-zero
-            // Also check for plain "0" as a fallback edge case
-            return !isEmptyHexString(balance) && balance !== '0';
+            // Use isEmptyHexString to check if token balance is non-zero (0x0, 0x, etc.)
+            return !isEmptyHexString(balance);
           });
         },
       );

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1099,9 +1099,7 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
               ? account.balance
               : '0x0';
           // Use isEmptyHexString to properly handle all hex zero formats, plus check for plain "0"
-          return (
-            !isEmptyHexString(balanceValue) && balanceValue !== '0'
-          );
+          return !isEmptyHexString(balanceValue) && balanceValue !== '0';
         });
       },
     );
@@ -1117,25 +1115,23 @@ export const selectAccountGroupBalanceForEmptyState = createSelector(
       if (!accountBalances || typeof accountBalances !== 'object') {
         return false;
       }
-      return Object.entries(accountBalances).some(
-        ([assetId, balanceData]) => {
-          // Extract chainId from the asset ID (format: "chainId/assetType")
-          const chainId = assetId.split('/')[0];
-          // Only check mainnet chains
-          if (!mainnetNonEvmChainIds.has(chainId)) {
-            return false;
-          }
-          if (typeof balanceData !== 'object' || !balanceData) {
-            return false;
-          }
-          const balanceValue =
-            'amount' in balanceData && typeof balanceData.amount === 'string'
-              ? balanceData.amount
-              : '0';
-          // Use isZeroAmount to properly handle decimal zeros like "0.0", "0.00", etc.
-          return !isZeroAmount(balanceValue);
-        },
-      );
+      return Object.entries(accountBalances).some(([assetId, balanceData]) => {
+        // Extract chainId from the asset ID (format: "chainId/assetType")
+        const chainId = assetId.split('/')[0];
+        // Only check mainnet chains
+        if (!mainnetNonEvmChainIds.has(chainId)) {
+          return false;
+        }
+        if (typeof balanceData !== 'object' || !balanceData) {
+          return false;
+        }
+        const balanceValue =
+          'amount' in balanceData && typeof balanceData.amount === 'string'
+            ? balanceData.amount
+            : '0';
+        // Use isZeroAmount to properly handle decimal zeros like "0.0", "0.00", etc.
+        return !isZeroAmount(balanceValue);
+      });
     });
 
     // Check ERC-20 token balances (only for accounts in this group and mainnet chains)


### PR DESCRIPTION
## **Description**

This PR fixes an issue where the balance empty state incorrectly appears when users have token balances, particularly on chains without price conversion data.

**The problem:**
PR #37366 introduced a balance empty state feature that shows a "Fund your wallet" message when accounts have $0 balance. However, the `selectAccountGroupBalanceForEmptyState` selector only checked `totalBalanceInUserCurrency` (fiat value) to determine if an account has a balance.

This approach had multiple issues:
1. When price conversion data is unavailable (custom networks, price API failures), fiat balance equals $0 even when native tokens are present
2. The expensive `calculateBalanceForAllWallets()` function was called unnecessarily
3. The logic didn't check for actual token possession, which is what determines if a user can transact

The issue became visible after PR #37004 turned on BIP-44 by default. Users with native tokens on custom networks (like Anvil chainId 1338) would see the empty state despite having a 10 ETH balance.

**The solution:**
The selector now directly checks for token balances (native and non-native) instead of relying on fiat conversion:

1. **Native token checks:**
   - **EVM chains**: Check `accountsByChainId` for non-zero hex balances (e.g., `0x8ac7230489e80000`)
   - **Non-EVM chains**: Check `multichainBalancesState.balances` for non-zero amounts (Solana, Bitcoin, etc.)

2. **Non-native token checks:**
   - **ERC-20 tokens**: Check `tokenBalancesState` for non-zero hex balances
   - **Other tokens**: Future support for SPL tokens, etc.

**Code quality improvements:**
- Uses established utilities from `@metamask/utils` (`isObject`, `hasProperty`) for robust type checking
- Added helper function `getBalanceOrDefault()` for safe balance extraction
- Uses `isEmptyHexString()` and `isZeroAmount()` utilities for reliable zero detection
- Removed unnecessary defensive checks for unrealistic edge cases
- Better performance: no longer calls expensive `calculateBalanceForAllWallets()`

The empty state now correctly appears only when users have NO tokens (neither native nor non-native), regardless of price API availability.

## **Changelog**

CHANGELOG entry: Fixed balance empty state incorrectly showing when price conversion data is unavailable but tokens are present

## **Related issues**

Fixes: Issue exposed by #37004, related to #37366

## **Manual testing steps**

1. Set up a local Anvil node: `anvil --port 8546 --chain-id 1338`
2. Add custom network in MetaMask: RPC URL `http://localhost:8546`, Chain ID `1338`
3. Send ETH to your account: `cast send <address> --value 10ether --rpc-url http://localhost:8546 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
4. Verify that the balance empty state does NOT appear
5. Create a fresh account with no balance
6. Verify that the balance empty state DOES appear correctly

Alternative test without Anvil:
1. Use browser DevTools to mock price API failures
2. Verify accounts with native tokens don't show empty state
3. Verify accounts with $0 balance AND no native tokens DO show empty state

## **Screenshots/Recordings**

### **Before**
Empty state incorrectly shown despite 10 ETH balance on custom network (chainId 1338)

https://github.com/user-attachments/assets/ec78382f-4928-41c8-88fe-c25fc380f69c

### **After**
Empty state correctly hidden when native token balances are present, regardless of price conversion availability

https://github.com/user-attachments/assets/63997e02-3bf5-4511-a545-ca89b1a9dd6f

Balance empty state displays as intended on completely empty account groups

https://github.com/user-attachments/assets/0f12fd69-ee78-46f6-8de1-a8ce54cb56a1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors balance-empty-state logic to check actual token balances (EVM native, non-EVM native, ERC‑20) on mainnets and updates tests accordingly.
> 
> - **Selectors**:
>   - Replace fiat-based check in `selectAccountGroupBalanceForEmptyState` with direct token presence checks:
>     - EVM native via `accountsByChainId` (hex non-zero using `isEmptyHexString`).
>     - Non-EVM native via `multichainBalances` (decimal non-zero using `isZeroAmount`).
>     - ERC-20 via `tokenBalances` (hex non-zero).
>   - Exclude all testnets using `selectAllMainnetNetworksEnabledMap`; only mainnet chains considered.
>   - Add helpers: `getBalanceOrDefault`, `selectAccountsByChainIdForBalances`; import `hasProperty`, `isObject`, `isEmptyHexString`, `isZeroAmount`.
> - **Tests** (`ui/selectors/assets.test.ts`):
>   - Update to assert new balance-detection logic, including:
>     - Positive/zero balances for EVM and Solana.
>     - Ignoring EVM and non-EVM testnets.
>     - Decimal-zero handling (e.g., "0.00").
>     - ERC-20 tokens without native balance.
>   - Mock `selectAssetsBySelectedAccountGroup` to return `{}` by default; remove reliance on `calculateBalanceForAllWallets` in these tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 039fe7e355b0b017affb4e05b033d3325b3d35cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->