### PR TITLE
fix: shield approval token decode name and term of use url cp-13.11.0

### DIFF
--- a/shared/lib/shield.ts
+++ b/shared/lib/shield.ts
@@ -5,6 +5,7 @@ import {
   RECURRING_INTERVALS,
   RecurringInterval,
   Subscription,
+  SUBSCRIPTION_STATUSES,
   SubscriptionCryptoPaymentMethod,
 } from '@metamask/subscription-controller';
 import {
@@ -69,6 +70,17 @@ export function getIsShieldSubscriptionPaused(
   }
 
   return PausedSubscriptionStatuses.includes(shieldSubscription.status);
+}
+
+export function getIsShieldSubscriptionTrialing(
+  subscriptions: Subscription | Subscription[],
+): boolean {
+  const shieldSubscription = getShieldSubscription(subscriptions);
+  return (
+    shieldSubscription?.status === SUBSCRIPTION_STATUSES.trialing ||
+    (shieldSubscription?.status === SUBSCRIPTION_STATUSES.provisional &&
+      Boolean(shieldSubscription?.trialPeriodDays)) // subscription in provisional status and has trial info is considered trialing
+  );
 }
 
 export function getIsShieldSubscriptionEndingSoon(

--- a/shared/lib/ui-utils.js
+++ b/shared/lib/ui-utils.js
@@ -32,4 +32,4 @@ export const HYPERLIQUID_REFERRAL_LEARN_MORE_URL =
   'https://hyperliquid.gitbook.io/hyperliquid-docs/referrals';
 
 export const SHIELD_TERMS_OF_USE_URL =
-  'https://consensys.io/transaction-shield-supplemental-terms';
+  'https://consensys.io/transaction-shield-supplemental-terms-and-privacy-notice';

--- a/ui/hooks/useDecodedTransactionData.ts
+++ b/ui/hooks/useDecodedTransactionData.ts
@@ -29,6 +29,13 @@ export function useDecodedTransactionData({
   }, [data, to, chainId]);
 }
 
+const TRANSACTION_DATA_VALUE_PARAM_NAMES = [
+  'value',
+  'amount',
+  '_value',
+  '_amount',
+];
+
 export function useDecodedTransactionDataValue(
   transactionMeta?: TransactionMeta,
 ) {
@@ -39,8 +46,8 @@ export function useDecodedTransactionDataValue(
   });
   const value = useMemo(
     () =>
-      decodeResponse?.value?.data?.[0]?.params?.find(
-        (param) => param.name === 'value' || param.name === 'amount',
+      decodeResponse?.value?.data?.[0]?.params?.find((param) =>
+        TRANSACTION_DATA_VALUE_PARAM_NAMES.includes(param.name ?? ''),
       )?.value,
     [decodeResponse],
   );

--- a/ui/hooks/useDecodedTransactionData.ts
+++ b/ui/hooks/useDecodedTransactionData.ts
@@ -31,9 +31,11 @@ export function useDecodedTransactionData({
 
 const TRANSACTION_DATA_VALUE_PARAM_NAMES = [
   'value',
-  'amount',
   '_value',
+  'value_',
+  'amount',
   '_amount',
+  'amount_',
 ];
 
 export function useDecodedTransactionDataValue(

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -71,6 +71,7 @@ import { ConfirmInfoRowAddress } from '../../../components/app/confirm/info/row'
 import {
   getIsShieldSubscriptionEndingSoon,
   getIsShieldSubscriptionPaused,
+  getIsShieldSubscriptionTrialing,
 } from '../../../../shared/lib/shield';
 import { useAsyncResult } from '../../../hooks/useAsync';
 import { useTimeout } from '../../../hooks/useTimeout';
@@ -174,6 +175,7 @@ const TransactionShield = () => {
   const isCancelled =
     displayedShieldSubscription?.status === SUBSCRIPTION_STATUSES.canceled;
   const isPaused = getIsShieldSubscriptionPaused(subscriptions);
+  const isTrialing = getIsShieldSubscriptionTrialing(subscriptions);
   const isMembershipInactive = isCancelled || isPaused;
   const isSubscriptionEndingSoon =
     getIsShieldSubscriptionEndingSoon(subscriptions);
@@ -710,8 +712,7 @@ const TransactionShield = () => {
                     ? t('shieldTxMembershipInactive')
                     : t('shieldTxMembershipActive')}
                 </Text>
-                {currentShieldSubscription?.status ===
-                  SUBSCRIPTION_STATUSES.trialing && (
+                {isTrialing && (
                   <Tag
                     label={t('shieldTxMembershipFreeTrial')}
                     labelProps={{


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- This PR fixes an issue where Shield subscription approval transactions were failing to decode the approval amount value when token contracts use underscored parameter names (`_value` or `_amount`, `amount_`) instead of the standard `value` or `amount` parameter names.
- Fix issue where subscription in provisional state and in trial but UI not showing `free trial`
- **URL update**: Updated the Shield Terms of Use URL to include the privacy notice link.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38285?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where Shield subscription approval amounts were not displayed correctly for tokens using underscored parameter names in their approval functions.
CHANGELOG entry: Updated the Shield Terms of Use URL to include the privacy notice link.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38289

## **Manual testing steps**

1. Navigate to Shield subscription settings and initiate a subscription approval transaction with a token that uses `_value` or `_amount`, `amount_` parameter names in its approval function. (mUSD, USDT)

2. Verify that the approval amount is correctly decoded and displayed in the transaction confirmation screen.

3. Verify that the approval amount calculation and display in the Shield subscription approval info component works correctly.

4. Test with tokens using standard `value`/`amount` parameter names to ensure backward compatibility. (USDC)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands token approval amount decoding to alternate param names, adds a helper to detect trialing Shield subscriptions and uses it in UI, and updates the Shield Terms of Use URL.
> 
> - **Hooks**:
>   - `ui/hooks/useDecodedTransactionData.ts`: Decode approval amount from additional param names (`value`, `_value`, `value_`, `amount`, `_amount`, `amount_`).
> - **Shared lib**:
>   - `shared/lib/shield.ts`: Add `getIsShieldSubscriptionTrialing` (handles `trialing` and `provisional` with trials); import `SUBSCRIPTION_STATUSES`.
> - **UI**:
>   - `ui/pages/settings/transaction-shield-tab/transaction-shield.tsx`: Use `getIsShieldSubscriptionTrialing` to show the free trial tag.
> - **Utils**:
>   - `shared/lib/ui-utils.js`: Update `SHIELD_TERMS_OF_USE_URL` to the new terms-and-privacy URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b880280aba97b0996ff410a92b824a6bb66c4b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->