### PR TITLE
feat: updated alert modal copywriting and alignment

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6232,7 +6232,7 @@
     "message": "This chain is not supported, so it isn't protected by MetaMask Transaction Shield. $1"
   },
   "shieldCoverageAlertMessageLearnHowCoverageWorks": {
-    "message": "See What's Covered"
+    "message": "See what's Covered"
   },
   "shieldCoverageAlertMessagePaused": {
     "message": "There was an issue with your MetaMask Transaction Shield plan payment. Please update your payment method to resume coverage."
@@ -6265,7 +6265,7 @@
     "message": "This token shows strong signs of malicious behavior. Continuing may result in loss of funds. $1."
   },
   "shieldCoverageAlertMessageTxTypeNotSupported": {
-    "message": "This transaction type is not supported, so it isn't protected by MetaMask Transaction Shield. $1."
+    "message": "This transaction type is not supported, so it isn't protected by MetaMask Transaction Shield. $1"
   },
   "shieldCoverageAlertMessageUnknown": {
     "message": "This request can't be verified, so it isn't protected by MetaMask Transaction Shield. $1."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6232,7 +6232,7 @@
     "message": "This chain is not supported, so it isn't protected by MetaMask Transaction Shield. $1"
   },
   "shieldCoverageAlertMessageLearnHowCoverageWorks": {
-    "message": "See What's Covered"
+    "message": "See what's Covered"
   },
   "shieldCoverageAlertMessagePaused": {
     "message": "There was an issue with your MetaMask Transaction Shield plan payment. Please update your payment method to resume coverage."
@@ -6265,7 +6265,7 @@
     "message": "This token shows strong signs of malicious behavior. Continuing may result in loss of funds. $1."
   },
   "shieldCoverageAlertMessageTxTypeNotSupported": {
-    "message": "This transaction type is not supported, so it isn't protected by MetaMask Transaction Shield. $1."
+    "message": "This transaction type is not supported, so it isn't protected by MetaMask Transaction Shield. $1"
   },
   "shieldCoverageAlertMessageUnknown": {
     "message": "This request can't be verified, so it isn't protected by MetaMask Transaction Shield. $1."

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -5622,7 +5622,7 @@
     "message": "Níl an t-idirbheart seo clúdaithe"
   },
   "shieldCoverageAlertMessageTxTypeNotSupported": {
-    "message": "Ní thacaítear leis an gcineál idirbhirt seo, mar sin níl sé faoi chosaint ag Transaction Shield. $1."
+    "message": "Ní thacaítear leis an gcineál idirbhirt seo, mar sin níl sé faoi chosaint ag Transaction Shield. $1"
   },
   "shieldCoverageAlertMessageUnknown": {
     "message": "Ní féidir an t-iarratas seo a fhíorú, mar sin níl sé faoi chosaint ag Transaction Shield. $1."

--- a/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
@@ -31,6 +31,7 @@ export const ShieldCoverageAlertMessage = ({
           target="_blank"
           rel="noreferrer noopener"
           color={TextColor.primaryDefault}
+          style={{ verticalAlign: 'baseline' }}
         >
           {t('shieldCoverageAlertMessageLearnHowCoverageWorks')}
         </ButtonLink>,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated text and alignment on shield coverage alert modal

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38286?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated text and alignment on shield coverage alert modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<!-- [screenshots/recordings] -->

**1. `W` is upper case and has period in the end**
**2. Link is not aligned with other text**
<img width="640" height="528" alt="image" src="https://github.com/user-attachments/assets/4ddda7c3-506b-4583-84e8-de1a8a3b1916" />


### **After**

<!-- [screenshots/recordings] -->
<img width="413" height="633" alt="Screenshot 2025-11-26 at 10 41 50 AM" src="https://github.com/user-attachments/assets/c8b9cd18-a5dd-4347-87cd-f8fe60b71372" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the “See what’s Covered” link baseline in the shield alert modal and updates related locale strings (punctuation/case) across `en`, `en_GB`, and `ga`.
> 
> - **UI**
>   - Aligns ButtonLink baseline in `ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx` via `style={{ verticalAlign: 'baseline' }}`.
> - **i18n / Copy**
>   - Updates shield coverage strings in `app/_locales/en/messages.json`, `app/_locales/en_GB/messages.json`, and `app/_locales/ga/messages.json`:
>     - Adjusts casing to "See what's Covered" in `shieldCoverageAlertMessageLearnHowCoverageWorks`.
>     - Removes trailing periods from `shieldCoverageAlertMessageTxTypeNotSupported` messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84009b60808683332eb6957d0adaab738b1d3b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->