### PR TITLE
Sync v13.11.0 with stable

### DIFF
--- a/.yarn/patches/@metamask-assets-controllers-npm-88.0.0-3dfc0ab8f1.patch
+++ b/.yarn/patches/@metamask-assets-controllers-npm-88.0.0-3dfc0ab8f1.patch
@@ -46,3 +46,16 @@ index 420934fb16ed6151b5b80fb7be04f81352b4aaf4..d735379adcaf77cbd46b4659f9bfd320
                      }
                  }
              });
+diff --git a/dist/token-prices-service/codefi-v2.cjs b/dist/token-prices-service/codefi-v2.cjs
+index f3c24e32ab755ae5c00e7d439600c4bab1587c71..df2932739853ab963f41a1d1270b1a6769c0ce88 100644
+--- a/dist/token-prices-service/codefi-v2.cjs
++++ b/dist/token-prices-service/codefi-v2.cjs
+@@ -98,6 +98,8 @@ exports.SUPPORTED_CURRENCIES = [
+     'mxn',
+     // Malaysian Ringgit
+     'myr',
++    // Monad
++    'mon',
+     // Nigerian Naira
+     'ngn',
+     // Norwegian Krone

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -80,6 +80,12 @@ npmAuditIgnoreAdvisories:
   - 'ts-custom-error (deprecation)'
   - 'text-encoding (deprecation)'
 
+  # Issue: `body-parser` denial of service vulnerability
+  # Seemingly only impacts v2.2.0, but we're on v1. The advisory range is overly wide.
+  # The attack vector also does not apply to how we use the package.
+  # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
+  - 1110857
+
   ### Package Deprecations:
 
   # React-tippy brings in popper.js and react-tippy has not been updated in

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,12 +37,6 @@ npmAuditIgnoreAdvisories:
   # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
   - 1110857
 
-  # Issue: `body-parser` denial of service vulnerability
-  # Seemingly only impacts v2.2.0, but we're on v1. The advisory range is overly wide.
-  # The attack vector also does not apply to how we use the package.
-  # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
-  - 1110857
-
   ### Package Deprecations:
 
   # React-tippy brings in popper.js and react-tippy has not been updated in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [13.10.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.10.4]
+
+### Fixed
+
+- Removes sidepanel from chrome manifest files (#38242)
+
 ## [13.10.3]
 
 ### Fixed
@@ -1239,7 +1245,8 @@ authorized by the user.` error until the user fully revoked dapp
 - This changelog was split off with 12.22.0
 - All older changes can be found in [docs/CHANGELOG_older.md](https://github.com/MetaMask/metamask-extension/blob/main/docs/CHANGELOG_older.md)
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.10.3...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.10.4...HEAD
+[13.10.4]: https://github.com/MetaMask/metamask-extension/compare/v13.10.3...v13.10.4
 [13.10.3]: https://github.com/MetaMask/metamask-extension/compare/v13.10.2...v13.10.3
 [13.10.2]: https://github.com/MetaMask/metamask-extension/compare/v13.10.1...v13.10.2
 [13.10.1]: https://github.com/MetaMask/metamask-extension/compare/v13.10.0...v13.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Signed deep links with empty `sig_params` with extra params as valid (#38142)
+- Adds mon as currency to fetch prices (#38261)
 - Removes sidepanel from chrome manifest files (#38242)
 
 ## [13.10.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [13.10.3]
+
+### Fixed
+
+- Feature flags sidepanel context menu (#38220)
 
 ## [13.10.2]
 
 ### Fixed
 
-- fixed entry modal closed error (#38188)
+- Fixes entry modal closed error (#38188)
 
 ## [13.10.1]
 
@@ -1233,7 +1237,8 @@ authorized by the user.` error until the user fully revoked dapp
 - This changelog was split off with 12.22.0
 - All older changes can be found in [docs/CHANGELOG_older.md](https://github.com/MetaMask/metamask-extension/blob/main/docs/CHANGELOG_older.md)
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.10.2...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.10.3...HEAD
+[13.10.3]: https://github.com/MetaMask/metamask-extension/compare/v13.10.2...v13.10.3
 [13.10.2]: https://github.com/MetaMask/metamask-extension/compare/v13.10.1...v13.10.2
 [13.10.1]: https://github.com/MetaMask/metamask-extension/compare/v13.10.0...v13.10.1
 [13.10.0]: https://github.com/MetaMask/metamask-extension/compare/v13.9.0...v13.10.0

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -81,7 +81,6 @@
     "webRequest",
     "offscreen",
     "identity",
-    "sidePanel",
     "contextMenus"
   ],
   "sandbox": {

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -10,8 +10,5 @@
     "matches": ["http://*/*", "https://*/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "115",
-  "side_panel": {
-    "default_path": "sidepanel.html"
-  }
+  "minimum_chrome_version": "115"
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -55,6 +55,7 @@ import {
   CorruptionHandler,
   hasVault,
 } from './lib/state-corruption/state-corruption-recovery';
+import { initSidePanelContextMenu } from './lib/sidepanel-context-menu';
 import {
   backedUpStateKeys,
   PersistenceManager,
@@ -175,7 +176,10 @@ const ONE_SECOND_IN_MILLISECONDS = 1_000;
 // Timeout for initializing phishing warning page.
 const PHISHING_WARNING_PAGE_TIMEOUT = ONE_SECOND_IN_MILLISECONDS;
 
-lazyListener.once('runtime', 'onInstalled').then(handleOnInstalled);
+lazyListener.once('runtime', 'onInstalled').then((details) => {
+  handleOnInstalled(details);
+  handleSidePanelContextMenu();
+});
 
 /**
  * This deferred Promise is used to track whether initialization has finished.
@@ -1672,26 +1676,14 @@ function onInstall() {
     platform.openExtensionInBrowser();
   }
 }
-// Only register sidepanel context menu for browsers that support it (Chrome/Edge/Brave)
-// and when the feature flag is enabled
-if (
-  browser.contextMenus &&
-  browser.sidePanel &&
-  process.env.IS_SIDEPANEL?.toString() === 'true'
-) {
-  browser.runtime.onInstalled.addListener(() => {
-    browser.contextMenus.create({
-      id: 'openSidePanel',
-      title: 'MetaMask Sidepanel',
-      contexts: ['all'],
-    });
-  });
-  browser.contextMenus.onClicked.addListener((info, tab) => {
-    if (info.menuItemId === 'openSidePanel') {
-      // This will open the panel in all the pages on the current window.
-      browser.sidePanel.open({ windowId: tab.windowId });
-    }
-  });
+
+/**
+ * Handles the onInstalled event for sidepanel context menu creation.
+ * This is registered via lazyListener to catch the event at module load time.
+ */
+async function handleSidePanelContextMenu() {
+  await isInitialized;
+  await initSidePanelContextMenu(controller);
 }
 
 // // On first install, open a new tab with MetaMask

--- a/app/scripts/lib/sidepanel-context-menu.ts
+++ b/app/scripts/lib/sidepanel-context-menu.ts
@@ -1,0 +1,63 @@
+import browser from 'webextension-polyfill';
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+import type MetamaskController from '../metamask-controller';
+
+const MENU_ITEM_ID = 'openSidePanel';
+
+// Type augmentation for sidePanel API (not yet in webextension-polyfill types)
+type BrowserWithSidePanel = typeof browser & {
+  sidePanel?: {
+    open: (options: { windowId: number }) => Promise<void>;
+  };
+};
+
+export async function initSidePanelContextMenu(
+  controller: MetamaskController,
+): Promise<void> {
+  const browserWithSidePanel = browser as BrowserWithSidePanel;
+
+  if (
+    !browser.contextMenus ||
+    !browserWithSidePanel.sidePanel ||
+    process.env.IS_SIDEPANEL?.toString() !== 'true'
+  ) {
+    return;
+  }
+
+  const isEnabled = (state?: {
+    remoteFeatureFlags?: { extensionUxSidepanel?: boolean };
+  }) => state?.remoteFeatureFlags?.extensionUxSidepanel !== false;
+
+  const createMenu = () => {
+    browser.contextMenus.create({
+      id: MENU_ITEM_ID,
+      title: 'MetaMask Sidepanel',
+      contexts: ['all'],
+    });
+  };
+
+  const removeMenu = () => {
+    browser.contextMenus.remove(MENU_ITEM_ID);
+  };
+
+  if (isEnabled(controller?.remoteFeatureFlagController?.state)) {
+    createMenu();
+  }
+
+  browser.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === MENU_ITEM_ID && tab?.windowId) {
+      browserWithSidePanel.sidePanel?.open({ windowId: tab.windowId });
+    }
+  });
+
+  controller?.controllerMessenger?.subscribe(
+    'RemoteFeatureFlagController:stateChange',
+    (state: RemoteFeatureFlagControllerState) => {
+      if (isEnabled(state)) {
+        createMenu();
+      } else {
+        removeMenu();
+      }
+    },
+  );
+}

--- a/builds.yml
+++ b/builds.yml
@@ -33,7 +33,7 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.2.3/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_PROD_CLIENT_ID
       - APPLE_PROD_CLIENT_ID
@@ -67,7 +67,7 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.2.3/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_BETA_CLIENT_ID
       - APPLE_BETA_CLIENT_ID
@@ -136,7 +136,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://metamask.github.io/snaps-directory-staging/main/account-management
       - EIP_4337_ENTRYPOINT: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
-      - IS_SIDEPANEL: true
+      - IS_SIDEPANEL: false
       # for seedless onboarding (social login)
       - GOOGLE_FLASK_CLIENT_ID
       - APPLE_FLASK_CLIENT_ID

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.10.3",
+  "version": "13.10.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.10.2",
+  "version": "13.10.3",
   "private": true,
   "repository": {
     "type": "git",

--- a/shared/lib/deep-links/canonicalize.test.ts
+++ b/shared/lib/deep-links/canonicalize.test.ts
@@ -82,4 +82,36 @@ describe('canonicalize', () => {
     expect(original.searchParams.get(SIG_PARAM)).toBe('abc');
     expect(original.searchParams.get(SIG_PARAMS_PARAM)).toBe('a,b');
   });
+
+  it('removes all params when `sig_params` is present but empty (no params signed)', () => {
+    const url = new URL(
+      `https://example.com/path?a=2&b=1&${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}`,
+    );
+    // No a or b params should be included, only sig_params= should remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('removes all params when `sig_params=` is present but empty (no params signed)', () => {
+    const url = new URL(
+      `https://example.com/path?a=2&b=1&${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}=`,
+    );
+    // No a or b params should be included,  only sig_params= should remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('treats URLs with `sig_params` (when no other params are included) as valid sig_params', () => {
+    const url = new URL(
+      `https://example.com/path?${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}`,
+    );
+    // No params were included, but sig_params should still remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
+
+  it('treats URLs with `sig_params=` (when no other params are included) as valid sig_params', () => {
+    const url = new URL(
+      `https://example.com/path?${SIG_PARAM}=abc&${SIG_PARAMS_PARAM}=`,
+    );
+    // No params were included, but sig_params should still remain
+    expect(canonicalize(url)).toBe('https://example.com/path?sig_params=');
+  });
 });

--- a/shared/lib/deep-links/canonicalize.ts
+++ b/shared/lib/deep-links/canonicalize.ts
@@ -13,14 +13,18 @@ export function canonicalize(url: URL): string {
 
   const sigParams = url.searchParams.get(SIG_PARAMS_PARAM);
 
-  if (sigParams) {
-    const allowedParams = sigParams.split(',');
+  if (typeof sigParams === 'string') {
     const signedParams = new URLSearchParams();
+    // sigParams might be "" (empty), in which case we
+    // don't need to split and search
+    if (sigParams) {
+      const allowedParams = sigParams.split(',');
 
-    for (const allowedParam of allowedParams) {
-      const values = url.searchParams.getAll(allowedParam);
-      for (const value of values) {
-        signedParams.append(allowedParam, value);
+      for (const allowedParam of allowedParams) {
+        const values = url.searchParams.getAll(allowedParam);
+        for (const value of values) {
+          signedParams.append(allowedParam, value);
+        }
       }
     }
 

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -33,6 +33,11 @@ export function addRoute(route: Route) {
   routes.set(route.pathname, route);
 }
 
+if (process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS || process.env.IN_TEST) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, node/global-require
+  addRoute(require('./test-route').default);
+}
+
 addRoute(buy);
 addRoute(home);
 addRoute(notifications);

--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -11,6 +11,7 @@ export {
   NOTIFICATIONS_ROUTE,
   SHIELD_PLAN_ROUTE,
   SETTINGS_ROUTE,
+  DEVELOPER_OPTIONS_ROUTE,
 } from '../../../../ui/helpers/constants/routes';
 
 /**

--- a/shared/lib/deep-links/routes/test-route.ts
+++ b/shared/lib/deep-links/routes/test-route.ts
@@ -1,0 +1,14 @@
+import { DEVELOPER_OPTIONS_ROUTE, Route } from './route';
+
+export default new Route({
+  pathname: '/test',
+  getTitle: (_: URLSearchParams) => 'deepLink_thePerpsPage',
+  handler: function handler(params: URLSearchParams) {
+    return {
+      // we use the developer options route for testing purposes
+      // because it doesn't rewrite query params
+      path: DEVELOPER_OPTIONS_ROUTE,
+      query: params,
+    };
+  },
+});

--- a/test/e2e/tests/deep-link/deep-link.spec.ts
+++ b/test/e2e/tests/deep-link/deep-link.spec.ts
@@ -592,20 +592,68 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl =
-          'https://link.metamask.io/home?foo=0&foo=1&bar=2&baz=3&sig_params=foo,bar';
-        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
+        const rawUrl = 'https://link.metamask.io/test?foo=0&foo=1&bar=2';
+        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl)}&baz=3`;
 
         await driver.openNewURL(signedUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['0', '1']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['2']);
         assert.equal(hashParams.has('baz'), false);
+      },
+    );
+  });
+
+  it('signed with empty sig_params, but url has extra params added, does not expose extra params', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/test';
+        const signedUrl = `${await signDeepLink(keyPair.privateKey, rawUrl)}&foo=0&foo=1&bar=2&baz=3`;
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        await deepLink.clickContinueButton();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+
+        assert.deepStrictEqual(hashParams.size, 0);
+      },
+    );
+  });
+
+  it('signed with sig_params, url has no extra params added, works', async function () {
+    await withFixtures(
+      await getConfig(this.test?.fullTitle()),
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+
+        const rawUrl = 'https://link.metamask.io/test';
+        const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl);
+
+        await driver.openNewURL(signedUrl);
+        const deepLink = new DeepLink(driver);
+        await deepLink.checkPageIsLoaded();
+        await deepLink.clickContinueButton();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
+
+        assert.deepStrictEqual(hashParams.size, 0);
       },
     );
   });
@@ -621,15 +669,14 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl = 'https://link.metamask.io/home?foo=1&bar=2&baz=3';
+        const rawUrl = 'https://link.metamask.io/test?foo=1&bar=2&baz=3';
         const signedUrl = await signDeepLink(keyPair.privateKey, rawUrl, false);
 
         await driver.openNewURL(signedUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['1']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['2']);
@@ -649,14 +696,13 @@ and we'll take you to the right place.`
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        const rawUrl = 'https://link.metamask.io/home?foo=1&foo=2&bar=3';
+        const rawUrl = 'https://link.metamask.io/test?foo=1&foo=2&bar=3';
 
         await driver.openNewURL(rawUrl);
         const deepLink = new DeepLink(driver);
         await deepLink.checkPageIsLoaded();
-        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
         await deepLink.clickContinueButton();
-        await homePage.checkPageIsLoaded();
+        const hashParams = getHashParams(new URL(await driver.getCurrentUrl()));
 
         assert.deepStrictEqual(hashParams.getAll('foo'), ['1', '2']);
         assert.deepStrictEqual(hashParams.getAll('bar'), ['3']);

--- a/test/e2e/tests/deep-link/helpers.ts
+++ b/test/e2e/tests/deep-link/helpers.ts
@@ -38,10 +38,8 @@ export async function signDeepLink(
   if (withSigParams) {
     const sigParams = [...new Set(signedUrl.searchParams.keys())];
 
-    if (sigParams.length) {
-      signedUrl.searchParams.append(SIG_PARAMS_PARAM, sigParams.join(','));
-      signedUrl.searchParams.sort();
-    }
+    signedUrl.searchParams.append(SIG_PARAMS_PARAM, sigParams.join(','));
+    signedUrl.searchParams.sort();
   }
 
   const signed = await crypto.subtle.sign(
@@ -98,9 +96,5 @@ export function cartesianProduct<T extends unknown[][]>(...sets: T) {
 export function getHashParams(url: URL) {
   const hash = url.hash.slice(1); // remove leading '#'
   const hashQuery = hash.split('?')[1] ?? '';
-  const hashParams = new URLSearchParams(hashQuery);
-  const encodedUrl = hashParams.get('u') ?? '';
-  const decodedUrl = decodeURIComponent(encodedUrl);
-  const decodedQuery = decodedUrl.split('?')[1] ?? '';
-  return new URLSearchParams(decodedQuery);
+  return new URLSearchParams(hashQuery);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5645,7 +5645,7 @@ __metadata:
 
 "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A88.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-88.0.0-3dfc0ab8f1.patch":
   version: 88.0.0
-  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A88.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-88.0.0-3dfc0ab8f1.patch::version=88.0.0&hash=ab5ccb"
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A88.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-88.0.0-3dfc0ab8f1.patch::version=88.0.0&hash=323fbe"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -5691,7 +5691,7 @@ __metadata:
     "@metamask/snaps-controllers": ^14.0.0
     "@metamask/transaction-controller": ^61.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/17587884760c7856d4459c2f60a1acff0d2430b4ae0f9710bff15076e7d21f726d2a1380781d427d32859f1e6e7568eda48e277093d3b85aaffab82021a14c0c
+  checksum: 10/d3e7c1d52fef37270c4060a0811cccb905a690cef1546c4713ede6d7a1e75c810c5efb71225092cfd8a3975676f2141a81b59456a6f2f41a160598565d36dfd8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32614,7 +32614,7 @@ __metadata:
     "@metamask/announcement-controller": "npm:^8.0.0"
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A89.0.1#~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch"
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch"
     "@metamask/auto-changelog": "npm:^5.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.6.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The diff we observe in this stable sync PR comes from this PR, which were merged to main AFTER the 13.11.0 release cut, but were cherry-picked into 13.10.3 and 13.10.4:

- 13.10.3
  - https://github.com/MetaMask/metamask-extension/pull/38220 ([cherry-pick PR](https://github.com/MetaMask/metamask-extension/pull/38234))
- 13.10.4
  - https://github.com/MetaMask/metamask-extension/pull/38261 ([cherry-pick PR](https://github.com/MetaMask/metamask-extension/pull/38268))
  - https://github.com/MetaMask/metamask-extension/pull/38242 ([cherry-pick PR](https://github.com/MetaMask/metamask-extension/pull/38277))
  - https://github.com/MetaMask/metamask-extension/pull/38142 ([cherry-pick PR](https://github.com/MetaMask/metamask-extension/pull/38269))

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38303?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles empty signed deep links and updates tests, removes Chrome sidepanel manifest/permission with context-menu refactor, and adds `mon` currency support.
> 
> - **Deep Links**:
>   - Treat empty `sig_params` as valid in `shared/lib/deep-links/canonicalize.ts`; ensure only signed params are forwarded. Update unit and E2E tests; add `/test` route (dev/test only) and export `DEVELOPER_OPTIONS_ROUTE`.
>   - Simplify hash param extraction in E2E helpers.
> - **Sidepanel**:
>   - Remove `sidePanel` permission and Chrome `side_panel` config from `app/manifest/v3` files.
>   - Refactor context menu setup into `app/scripts/lib/sidepanel-context-menu.ts` and initialize via `background.js` onInstalled; gate by `IS_SIDEPANEL` and remote feature flag. Set `IS_SIDEPANEL: false` for `main`, `beta`, and `flask` builds (keep experimental true).
> - **Prices/Dependencies**:
>   - Add `mon` currency to `@metamask/assets-controllers` via Yarn patch; update `package.json` and `yarn.lock` patch refs.
> - **Changelog**:
>   - Add `13.10.3` and `13.10.4` sections and update comparison links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98678a96b0b6a72a897367eaab3a92913b940f0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->