### PR TITLE
feat: shield plan save last used payment method on token select

### DIFF
--- a/ui/pages/shield-plan/shield-plan.tsx
+++ b/ui/pages/shield-plan/shield-plan.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import classnames from 'classnames';
 import {
   PAYMENT_TYPES,
@@ -7,9 +7,10 @@ import {
   RECURRING_INTERVALS,
   RecurringInterval,
 } from '@metamask/subscription-controller';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { Checkbox, TextVariant } from '@metamask/design-system-react';
+import { Hex } from '@metamask/utils';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
   NETWORK_TO_NAME_MAP,
@@ -81,6 +82,8 @@ import {
   getIsTrialedSubscription,
 } from '../../../shared/modules/shield';
 import ApiErrorHandler from '../../components/app/api-error-handler';
+import { MetaMaskReduxDispatch } from '../../store/store';
+import { setLastUsedSubscriptionPaymentDetails } from '../../store/actions';
 import { ShieldPaymentModal } from './shield-payment-modal';
 import { Plan } from './types';
 import { getProductPrice } from './utils';
@@ -270,6 +273,24 @@ const ShieldPlan = () => {
     isTrialed,
     useTestClock: enableStripeTestClock,
   });
+
+  const dispatch = useDispatch<MetaMaskReduxDispatch>();
+  const handleUserChangeToken = useCallback(
+    async (token: TokenWithApprovalAmount) => {
+      setSelectedToken(token);
+      // update last used subscription payment details everytime user select token
+      await dispatch(
+        setLastUsedSubscriptionPaymentDetails(PRODUCT_TYPES.SHIELD, {
+          type: PAYMENT_TYPES.byCrypto,
+          paymentTokenAddress: token.address as Hex,
+          paymentTokenSymbol: token.symbol,
+          plan: selectedPlan,
+          useTestClock: enableStripeTestClock,
+        }),
+      );
+    },
+    [dispatch, selectedPlan, enableStripeTestClock, setSelectedToken],
+  );
 
   const loading =
     subscriptionsLoading ||
@@ -530,7 +551,7 @@ const ShieldPlan = () => {
                 selectedPaymentMethod={selectedPaymentMethod}
                 hasStableTokenWithBalance={hasAvailableToken}
                 setSelectedPaymentMethod={setSelectedPaymentMethod}
-                onAssetChange={setSelectedToken}
+                onAssetChange={handleUserChangeToken}
                 availableTokenBalances={availableTokenBalances}
                 tokensSupported={tokensSupported}
               />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR in shield plan screen, save shield subscription last used payment detail everytime user select a token so that it's saved between plan change.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38314?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: shield plan save last payment detail everytime user select token

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go shield plan page
2. Select card and press continue without complete card payment
3. Back to shield plan
4. select an available token and change plan, payment method shouldn't change back to card

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Saves the selected crypto token and related payment details when a user changes assets in Shield Plan, wiring the handler through the payment modal.
> 
> - **Shield Plan (`ui/pages/shield-plan/shield-plan.tsx`)**
>   - Add `handleUserChangeToken` to persist last-used payment details via `dispatch(setLastUsedSubscriptionPaymentDetails(PRODUCT_TYPES.SHIELD, ...))` when a token is selected.
>   - Wire `onAssetChange` in `ShieldPaymentModal` to `handleUserChangeToken` to save selections from the modal.
>   - Update imports to support the change (`useDispatch`, `Hex`, `MetaMaskReduxDispatch`, `setLastUsedSubscriptionPaymentDetails`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a3a2e933d38083fa1c2fd0b12eb34ab94b905b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->