### PR TITLE
fix: Update dapp swap comparison banner copy if rewards doesnt exist

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1887,6 +1887,9 @@
   "dappSwapAdvantage": {
     "message": "Save and earn with MetaMask Swaps"
   },
+  "dappSwapAdvantageSaveOnly": {
+    "message": "Save with MetaMask Swaps"
+  },
   "dappSwapBenefits": {
     "message": "Network fees refunded on failed swaps"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1887,6 +1887,9 @@
   "dappSwapAdvantage": {
     "message": "Save and earn with MetaMask Swaps"
   },
+  "dappSwapAdvantageSaveOnly": {
+    "message": "Save with MetaMask Swaps"
+  },
   "dappSwapBenefits": {
     "message": "Network fees refunded on failed swaps"
   },

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -131,7 +131,7 @@ describe('<DappSwapComparisonBanner />', () => {
     const { getByText } = render();
     expect(getByText('Market rate')).toBeInTheDocument();
     expect(getByText('MetaMask Swap')).toBeInTheDocument();
-    expect(getByText('Save and earn with MetaMask Swaps')).toBeInTheDocument();
+    expect(getByText('Save with MetaMask Swaps')).toBeInTheDocument();
     expect(getByText('Save $0.02')).toBeInTheDocument();
     expect(
       getByText('Network fees refunded on failed swaps'),
@@ -229,5 +229,6 @@ describe('<DappSwapComparisonBanner />', () => {
     });
     const { getByText } = render();
     expect(getByText(/Earn 100 points/u)).toBeInTheDocument();
+    expect(getByText('Save and earn with MetaMask Swaps')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -182,7 +182,7 @@ const DappSwapComparisonInner = () => {
             color={TextColor.TextDefault}
             variant={TextVariant.BodySm}
           >
-            {t('dappSwapAdvantage')}
+            {rewards ? t('dappSwapAdvantage') : t('dappSwapAdvantageSaveOnly')}
           </Text>
           <Text
             className="dapp-swap_text-save"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates dapp swap comparison banner copy if rewards does not exists.

Note: No changelog needed as this feature not released yet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38317?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6349

## **Manual testing steps**

1. Trigger dapp swap comparison banner
2. See no "and earn" copy if points doesn't exist
3. See "and earn" copy if points exists

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows "Save with MetaMask Swaps" when rewards are absent, adding i18n keys and updating tests accordingly.
> 
> - **UI (Confirmations)**:
>   - Update `dapp-swap-comparison-banner.tsx` to render `t('dappSwapAdvantage')` only when `rewards` exist; otherwise use `t('dappSwapAdvantageSaveOnly')`.
> - **i18n**:
>   - Add `dappSwapAdvantageSaveOnly` locale string in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> - **Tests**:
>   - Adjust expectations in `dapp-swap-comparison-banner.test.tsx` to check for "Save with MetaMask Swaps" without rewards and "Save and earn with MetaMask Swaps" when rewards are provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31dea0b45f2933e3b15df9a0b7afee69cd9c601e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->