### PR TITLE
feat(analytics): Add rpc_domain property to custom RPC analytics events

### DIFF
--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -75,6 +75,7 @@ describe('onRpcEndpointUnavailable', () => {
         event: 'RPC Service Unavailable',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
         },
       });
@@ -104,6 +105,7 @@ describe('onRpcEndpointUnavailable', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
+          rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
         },
       });
@@ -132,6 +134,7 @@ describe('onRpcEndpointUnavailable', () => {
         event: 'RPC Service Unavailable',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
         },
       });
@@ -228,6 +231,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
         },
       });
@@ -257,6 +261,7 @@ describe('onRpcEndpointDegraded', () => {
         properties: {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
+          rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
         },
       });
@@ -285,6 +290,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
         },
       });

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -137,13 +137,16 @@ export function trackRpcEndpointEvent(
     return;
   }
 
+  const sanitizedUrl = isPublicEndpointUrl(endpointUrl, infuraProjectId)
+    ? onlyKeepHost(endpointUrl)
+    : 'custom';
+
   // The names of Segment properties have a particular case.
   /* eslint-disable @typescript-eslint/naming-convention */
   const properties = {
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
-    rpc_endpoint_url: isPublicEndpointUrl(endpointUrl, infuraProjectId)
-      ? onlyKeepHost(endpointUrl)
-      : 'custom',
+    rpc_domain: sanitizedUrl,
+    rpc_endpoint_url: sanitizedUrl, // @deprecated - Will be removed in a future release.
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -188,6 +188,7 @@ describe('useNetworkConnectionBanner', () => {
               /* eslint-disable @typescript-eslint/naming-convention */
               banner_type: 'degraded',
               chain_id_caip: 'eip155:1',
+              rpc_domain: 'mainnet.infura.io',
               rpc_endpoint_url: 'mainnet.infura.io',
               /* eslint-enable @typescript-eslint/naming-convention */
             },
@@ -294,6 +295,7 @@ describe('useNetworkConnectionBanner', () => {
             /* eslint-disable @typescript-eslint/naming-convention */
             banner_type: 'unavailable',
             chain_id_caip: 'eip155:1',
+            rpc_domain: 'mainnet.infura.io',
             rpc_endpoint_url: 'mainnet.infura.io',
             /* eslint-enable @typescript-eslint/naming-convention */
           },

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -117,7 +117,8 @@ export const useNetworkConnectionBanner =
           properties: {
             banner_type: bannerType,
             chain_id_caip: `eip155:${chainIdAsDecimal}`,
-            rpc_endpoint_url: sanitizedRpcUrl,
+            rpc_domain: sanitizedRpcUrl,
+            rpc_endpoint_url: sanitizedRpcUrl, // @deprecated - Will be removed in a future release.
           },
           /* eslint-enable @typescript-eslint/naming-convention */
         });


### PR DESCRIPTION
## **Description**

Adds `rpc_domain` property to custom RPC UX analytics events while retaining the existing `rpc_endpoint_url` property.

## Changes

- Added `rpc_domain` property to RPC analytics events:
  - `RPC_SERVICE_UNAVAILABLE`
  - `RPC_SERVICE_DEGRADED`
  - `NETWORK_CONNECTION_BANNER_SHOWN`
  - `NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED`
- Both `rpc_domain` and `rpc_endpoint_url` now track the same value:
  - `'custom'` for custom RPC endpoints
  - Domain host for public endpoints (e.g., `'mainnet.infura.io'`)
- Marked `rpc_endpoint_url` as deprecated for future removal
- Updated unit tests to assert both properties

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38319?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-133

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds rpc_domain to RPC-related analytics and mirrors the value in deprecated rpc_endpoint_url, updating logic and tests accordingly.
> 
> - **Analytics**:
>   - Add `rpc_domain` to RPC event properties; mirror value in `rpc_endpoint_url` (now marked as deprecated).
>   - Centralize URL sanitization (`sanitizedUrl`) for public vs custom endpoints.
> - **Events Affected**:
>   - `RpcServiceUnavailable` and `RpcServiceDegraded` in `app/scripts/lib/network-controller/messenger-action-handlers.ts`.
>   - `NetworkConnectionBannerShown` in `ui/hooks/useNetworkConnectionBanner.ts`.
> - **Tests**:
>   - Update unit tests to assert `rpc_domain` alongside `rpc_endpoint_url` and include `http_status` where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e58387bf98b3a10e20c2084ed24b4a7f71626d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->