### PR TITLE
feat(STX-267): enable gasless crosschain swaps

### DIFF
--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -33,6 +33,7 @@ import {
   getToTokenConversionRate,
   getFromTokenBalance,
   getFromAccount,
+  getIsGasIncluded,
 } from './selectors';
 import { toBridgeToken } from './utils';
 
@@ -2328,6 +2329,119 @@ describe('Bridge selectors', () => {
         usd: 1.2,
         valueInCurrency: 1.1,
       });
+    });
+  });
+
+  describe('getIsGasIncluded', () => {
+    it('returns true when both smart transactions are enabled and chain supports gas-included swaps', () => {
+      const state = createBridgeMockStore({
+        metamaskStateOverrides: {
+          ...mockNetworkState({
+            id: 'network-configuration-id-1',
+            chainId: CHAIN_IDS.MAINNET,
+            rpcUrl: 'https://mainnet.infura.io/v3/',
+          }),
+          accounts: {
+            '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
+              address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+              balance: '0x15f6f0b9d4f8d000',
+            },
+          },
+          preferences: {
+            smartTransactionsOptInStatus: true,
+          },
+          smartTransactionsState: {
+            liveness: true,
+          },
+          swapsState: {
+            swapsFeatureFlags: {
+              ethereum: {
+                extensionActive: true,
+                mobileActive: true,
+                smartTransactions: {
+                  expectedDeadline: 45,
+                  maxDeadline: 150,
+                  returnTxHashAsap: false,
+                  extensionActive: true,
+                },
+              },
+              smartTransactions: {
+                expectedDeadline: 45,
+                maxDeadline: 150,
+                returnTxHashAsap: false,
+                extensionActive: true,
+              },
+            },
+          },
+        },
+      });
+
+      const result = getIsGasIncluded(state as never, true);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when smart transactions are enabled but chain does not support gas-included swaps', () => {
+      const state = createBridgeMockStore({
+        metamaskStateOverrides: {
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+          preferences: {
+            smartTransactionsOptInStatus: true,
+          },
+          smartTransactionsState: {
+            liveness: true,
+          },
+          swapsState: {
+            swapsFeatureFlags: {
+              ethereum: {
+                extensionActive: true,
+                mobileActive: true,
+                smartTransactions: {
+                  expectedDeadline: 45,
+                  maxDeadline: 150,
+                  returnTxHashAsap: false,
+                  extensionActive: true,
+                },
+              },
+              smartTransactions: {
+                expectedDeadline: 45,
+                maxDeadline: 150,
+                returnTxHashAsap: false,
+              },
+            },
+          },
+        },
+      });
+
+      const result = getIsGasIncluded(state as never, false);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when smart transactions are disabled but chain supports gas-included swaps', () => {
+      const state = createBridgeMockStore({
+        metamaskStateOverrides: {
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+          preferences: {
+            smartTransactionsOptInStatus: false,
+          },
+        },
+      });
+
+      const result = getIsGasIncluded(state as never, true);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when both smart transactions are disabled and chain does not support gas-included swaps', () => {
+      const state = createBridgeMockStore({
+        metamaskStateOverrides: {
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+          preferences: {
+            smartTransactionsOptInStatus: false,
+          },
+        },
+      });
+
+      const result = getIsGasIncluded(state as never, false);
+      expect(result).toBe(false);
     });
   });
 });

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -16,7 +16,6 @@ import {
   selectBridgeFeatureFlags,
   selectMinimumBalanceForRentExemptionInSOL,
   isValidQuoteRequest,
-  isCrossChain,
 } from '@metamask/bridge-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import {
@@ -1081,16 +1080,14 @@ export const selectNoFeeAssets = createSelector(
 const getIsGasIncludedSwapSupported = createSelector(
   [
     (state) => getFromChain(state)?.chainId,
-    (state) => getToChain(state)?.chainId,
     (_, isSendBundleSupportedForChain: boolean) =>
       isSendBundleSupportedForChain,
   ],
-  (fromChainId, toChainId, isSendBundleSupportedForChain) => {
+  (fromChainId, isSendBundleSupportedForChain) => {
     if (!fromChainId) {
       return false;
     }
-    const isSwap = !isCrossChain(fromChainId, toChainId);
-    return isSwap && isSendBundleSupportedForChain;
+    return isSendBundleSupportedForChain;
   },
 );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Support gasless crosschain swaps with STX and eth_sendBundle (the feature is disabled in the backend for now in PROD).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38325?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: support gasless crosschain swaps with STX and eth_sendBundle

## **Related issues**

Relates to: https://consensyssoftware.atlassian.net/browse/STX-267

## **Manual testing steps**

https://docs.google.com/document/d/1zzO__oq1nTsTcZSBoiywd68wtRWwCv3f0KkOl_6LRRg/edit?tab=t.0#heading=h.4ovp75auub7

## **Screenshots/Recordings**

With a build pointing to the tx-sentinel and bridge-api DEV deployments where gasless crosschain swap is enabled for Etheruem-mainnet.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Uploading Screen Recording 2025-11-26 at 9.32.09 AM.mov…


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes gas-included eligibility depend solely on STX enablement and chain sendBundle support; adds targeted unit tests for multiple scenarios.
> 
> - **Bridge selectors**
>   - `getIsGasIncludedSwapSupported`: remove swap vs cross-chain check; now returns `isSendBundleSupportedForChain` when `fromChainId` exists.
>   - `getIsGasIncluded`: continues to combine `getIsStxEnabled` with `getIsGasIncludedSwapSupported` (behavior now applies to cross-chain as well).
> - **Tests**
>   - Add `getIsGasIncluded` tests covering combinations of STX opt-in/liveness and chain support flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21f5ad11997834f421058f50debeb6fad1132965. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->