### PR TITLE
fix: Disable dapp swap comparison feature

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -455,6 +455,9 @@ env:
   # Metamask Shield
   - METAMASK_SHIELD_ENABLED: 'true'
 
+  # Enable Dapp Swap Comparison UI - short living feature flag will never be enabled in production
+  - ENABLE_DAPP_SWAP_COMPARISON_UI: 'false'
+
   # Snaps
   - AUTO_UPDATE_PREINSTALLED_SNAPS: 'true'
   # This should only be used for local testing, and should not be enabled in any

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -120,6 +120,7 @@ describe('<DappSwapComparisonBanner />', () => {
       dappSwapUi: { enabled: true, threshold: 0.01 },
     });
     mockUseDappSwapComparisonRewardText.mockReturnValue(null);
+    process.env.ENABLE_DAPP_SWAP_COMPARISON_UI = 'true';
   });
 
   it('renders component without errors', () => {

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -134,7 +134,7 @@ const DappSwapComparisonInner = () => {
   );
 
   const swapComparisonDisplayed =
-    dappSwapUi?.enabled &&
+    process.env.ENABLE_DAPP_SWAP_COMPARISON_UI === 'true' &&
     (selectedQuoteValueDifference >=
       (dappSwapUi?.threshold ?? DAPP_SWAP_THRESHOLD) ||
       (dappSwapQa?.enabled && selectedQuote));

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -135,6 +135,7 @@ const DappSwapComparisonInner = () => {
 
   const swapComparisonDisplayed =
     process.env.ENABLE_DAPP_SWAP_COMPARISON_UI === 'true' &&
+    dappSwapUi?.enabled &&
     (selectedQuoteValueDifference >=
       (dappSwapUi?.threshold ?? DAPP_SWAP_THRESHOLD) ||
       (dappSwapQa?.enabled && selectedQuote));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to disable Dapp swap comparison feature for `13.11.x` builds. As we are aiming to still release this feature in `13.12.0` this short living fix will only be merged into `13.11.x` release branch.

New environment variable called `ENABLE_DAPP_SWAP_COMPARISON_UI` will never be settled to `true`, this means feature is disabled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38338?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38272

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ENABLE_DAPP_SWAP_COMPARISON_UI` (default `false`) and gates the Dapp Swap Comparison UI and tests on this flag.
> 
> - **Build/Config**:
>   - Add `ENABLE_DAPP_SWAP_COMPARISON_UI` env var (default `'false'`) in `builds.yml`.
> - **UI**:
>   - Gate display logic in `dapp-swap-comparison-banner.tsx` on `process.env.ENABLE_DAPP_SWAP_COMPARISON_UI === 'true'`.
> - **Tests**:
>   - Set `process.env.ENABLE_DAPP_SWAP_COMPARISON_UI = 'true'` in `dapp-swap-comparison-banner.test.tsx` setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb564326caa6d5126c1d98739220c7acb73df3f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->