### PR TITLE
fix: forgot password when basic functionality toggle is off

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4869,10 +4869,11 @@ export default class MetamaskController extends EventEmitter {
       );
 
       if (completedOnboarding) {
+        // check if external services are enabled
         const { useExternalServices } = this.preferencesController.state;
         if (
           this.isMultichainAccountsFeatureState2Enabled() &&
-          useExternalServices
+          useExternalServices // skip the account sync if external services are disabled
         ) {
           ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
           await this.getSnapKeyring();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4869,7 +4869,11 @@ export default class MetamaskController extends EventEmitter {
       );
 
       if (completedOnboarding) {
-        if (this.isMultichainAccountsFeatureState2Enabled()) {
+        const { useExternalServices } = this.preferencesController.state;
+        if (
+          this.isMultichainAccountsFeatureState2Enabled() &&
+          useExternalServices
+        ) {
           ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
           await this.getSnapKeyring();
           ///: END:ONLY_INCLUDE_IF

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -970,6 +970,12 @@ describe('MetaMaskController', () => {
           .mockReturnValue({ completedOnboarding: true });
 
         jest
+          .spyOn(metamaskController.preferencesController, 'state', 'get')
+          .mockReturnValue({
+            useExternalServices: true,
+          });
+
+        jest
           .spyOn(metamaskController, 'discoverAndCreateAccounts')
           .mockResolvedValue({});
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the forgot password flow when basic functionality is turned off by skipping the multi-chain discovery feature when restoring vault.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38344?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix forgot password when basic functionality is turned off

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38113

## **Manual testing steps**

1. Turn off Basic Functionality in privacy setting.
2. Lock the wallet and forgot password.
3. Enter the SRP and restore. Restore should be successful.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Vault restore now runs multichain account sync/discovery only if the feature is enabled and `PreferencesController.state.useExternalServices` is true; otherwise it falls back to adding accounts with balance.
> 
> - **Controller (`app/scripts/metamask-controller.js`)**
>   - In `createNewVaultAndRestore`, conditionally execute `accountTreeController.syncWithUserStorageAtLeastOnce()` and `discoverAndCreateAccounts()` only when `isMultichainAccountsFeatureState2Enabled()` and `preferencesController.state.useExternalServices` are true; otherwise call `_addAccountsWithBalance()`.
> - **Tests (`app/scripts/metamask-controller.test.js`)**
>   - Update restore flow test to mock `preferencesController.state.useExternalServices = true` to verify multichain discovery path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15bbe10cfd5cd56055eeb97ebdc0895f25b1b7a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->