### PR TITLE
feat: add the edge case of insufficient balance quotes for gas fees sponsored swap

### DIFF
--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -101,7 +101,7 @@ export const MultichainBridgeQuoteCard = ({
   const gasIncluded = activeQuote?.quote?.gasIncluded ?? false;
   const gasIncluded7702 = activeQuote?.quote?.gasIncluded7702 ?? false;
   const gasSponsored = activeQuote?.quote?.gasSponsored ?? false;
-  const isGasless = gasIncluded7702 || gasIncluded;
+  const isGasless = gasIncluded7702 || gasIncluded || gasSponsored;
 
   const isCurrentNetworkGasSponsored = useMemo(() => {
     if (!fromChain?.chainId || !gasFeesSponsoredNetworkEnabled) {

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -45,8 +45,8 @@ import { useRewards } from '../../../hooks/bridge/useRewards';
 import { RewardsBadge } from '../../../components/app/rewards/RewardsBadge';
 import AddRewardsAccount from '../../../components/app/rewards/AddRewardsAccount';
 import { Skeleton } from '../../../components/component-library/skeleton';
-import { BridgeQuotesModal } from './bridge-quotes-modal';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../selectors/selectors';
+import { BridgeQuotesModal } from './bridge-quotes-modal';
 
 const getTimerColor = (timeInSeconds: number) => {
   if (timeInSeconds <= 3) {
@@ -114,11 +114,29 @@ export const MultichainBridgeQuoteCard = ({
     );
   }, [fromChain?.chainId, gasFeesSponsoredNetworkEnabled]);
 
+  const shouldShowGasSponsored = useMemo(() => {
+    if (gasSponsored) {
+      return true;
+    }
 
-  const shouldShowGasSponsored =
-    gasSponsored || (insufficientBal && isCurrentNetworkGasSponsored);
+    // For the insufficientBal workaround, validate it's a same-chain swap
+    if (insufficientBal && isCurrentNetworkGasSponsored) {
+      // Gas sponsorship only applies to same-chain swaps, not cross-chain bridges
+      const isSameChain =
+        fromToken?.chainId &&
+        toToken?.chainId &&
+        fromToken.chainId === toToken.chainId;
+      return Boolean(isSameChain);
+    }
 
-
+    return false;
+  }, [
+    gasSponsored,
+    insufficientBal,
+    isCurrentNetworkGasSponsored,
+    fromToken?.chainId,
+    toToken?.chainId,
+  ]);
 
   const nativeTokenSymbol = fromChain
     ? getNativeAssetForChainId(fromChain.chainId).symbol

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -101,7 +101,6 @@ export const MultichainBridgeQuoteCard = ({
   const gasIncluded = activeQuote?.quote?.gasIncluded ?? false;
   const gasIncluded7702 = activeQuote?.quote?.gasIncluded7702 ?? false;
   const gasSponsored = activeQuote?.quote?.gasSponsored ?? false;
-  const isGasless = gasIncluded7702 || gasIncluded || gasSponsored;
 
   const isCurrentNetworkGasSponsored = useMemo(() => {
     if (!fromChain?.chainId || !gasFeesSponsoredNetworkEnabled) {
@@ -137,6 +136,8 @@ export const MultichainBridgeQuoteCard = ({
     fromToken?.chainId,
     toToken?.chainId,
   ]);
+
+  const isGasless = gasIncluded7702 || gasIncluded || shouldShowGasSponsored;
 
   const nativeTokenSymbol = fromChain
     ? getNativeAssetForChainId(fromChain.chainId).symbol


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enhances the gas fee sponsorship user experience by displaying "Paid by MetaMask" messaging even when the backend API doesn't return the `gasSponsored` field due to insufficient balance conditions.

### Problem
When users have insufficient balance for ERC20 token swaps, the bridge API doesn't return the `gasSponsored` field in the quote response due to simulation being skipped. This prevents the UI from showing that gas fees are sponsored, even when the network supports it.

### Solution
Implement a UI-level workaround that checks the `gasFeesSponsoredNetwork` feature flag to display gas sponsorship status when:
1. Backend returns `gasSponsored: true` (normal case), OR
2. User has `insufficientBal: true` AND network supports gas sponsorship AND it's a same-chain swap.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added the edge case of insufficient balance quotes for gas fees sponsored swap

## **Related issues**

Fixes: normal network fees displayed when swap quote of more than the user source balance

## **Manual testing steps**

1. Go to the swap page
2. Request a same chain swap quote with more than the user source token balance, on a chain eligible of gas fees sponsored.
3. The quote response for network fees should display "Paid By MetaMask"

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<img width="403" height="601" alt="paidbyMM" src="https://github.com/user-attachments/assets/124727bc-da9d-452b-b978-d2d0b141ec59" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays gas sponsorship when backend omits it for insufficient-balance same-chain swaps on eligible networks, and updates fee display logic accordingly.
> 
> - **Bridge UI (`ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx`)**:
>   - Add selector usage `getGasFeesSponsoredNetworkEnabled` and compute `isCurrentNetworkGasSponsored`.
>   - Introduce `shouldShowGasSponsored` (true if `gasSponsored` or `insufficientBal` && same-chain && network eligible) and update `isGasless` to include it.
>   - Update Network Fee rendering to use `shouldShowGasSponsored` instead of `gasSponsored` for sponsored/included/regular fee states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6bcefae5d1c9e9cf192a3c6c0a4d1ad5783399c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->