### PR TITLE
fix: test actions missing awaits

### DIFF
--- a/test/e2e/page-objects/pages/dialog/confirm-alert.ts
+++ b/test/e2e/page-objects/pages/dialog/confirm-alert.ts
@@ -24,17 +24,17 @@ class ConfirmAlertModal {
   }
 
   async rejectFromAlertModal() {
-    this.driver.clickElement(this.alertModalCancelButton);
+    await this.driver.clickElement(this.alertModalCancelButton);
   }
 
   async confirmFromAlertModal() {
-    this.driver.clickElement(this.alertModalAcknowledgeCheckBox);
-    this.driver.clickElement(this.alertModalSubmitButton);
+    await this.driver.clickElement(this.alertModalAcknowledgeCheckBox);
+    await this.driver.clickElement(this.alertModalSubmitButton);
   }
 
   async acknowledgeAlert() {
-    this.driver.clickElement(this.alertModalAcknowledgeCheckBox);
-    this.driver.clickElement(this.alertModalButton);
+    await this.driver.clickElement(this.alertModalAcknowledgeCheckBox);
+    await this.driver.clickElement(this.alertModalButton);
   }
 
   async verifyNetworkDisplay(networkName: string): Promise<void> {

--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -239,10 +239,19 @@ class SendTokenPage {
     await this.driver.pasteIntoField(this.hexInput, hex);
   }
 
-  async getHexInputValue(): Promise<string> {
+  async waitForHexDataCleared(): Promise<string> {
     console.log('Getting value from hex input');
     const hexInputElement = await this.driver.waitForSelector(this.hexInput);
-    await this.driver.waitForNonEmptyElement(hexInputElement);
+    await this.driver.waitUntil(
+      async () => {
+        const value = await hexInputElement.getAttribute('value');
+        return value === '';
+      },
+      {
+        timeout: 5000,
+        interval: 500,
+      },
+    );
     const value = await hexInputElement.getAttribute('value');
     console.log(`Hex input value: ${value}`);
     return value;

--- a/test/e2e/page-objects/pages/send/send-token-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-page.ts
@@ -242,7 +242,7 @@ class SendTokenPage {
   async getHexInputValue(): Promise<string> {
     console.log('Getting value from hex input');
     const hexInputElement = await this.driver.waitForSelector(this.hexInput);
-    this.driver.waitForNonEmptyElement(hexInputElement);
+    await this.driver.waitForNonEmptyElement(hexInputElement);
     const value = await hexInputElement.getAttribute('value');
     console.log(`Hex input value: ${value}`);
     return value;

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -232,12 +232,7 @@ describe('Change assets', function () {
         await sendTokenPage.fillAmount('2');
 
         // Make sure hex data is cleared after switching assets
-        const hexDataValue = await sendTokenPage.getHexInputValue();
-        assert.equal(
-          hexDataValue,
-          '',
-          'Hex data has not been cleared after switching assets.',
-        );
+        await sendTokenPage.waitForHexDataCleared();
 
         // Make sure gas is updated by resetting amount and hex data
         // Note: this is needed until the race condition is fixed on the wallet level (issue #25243)

--- a/test/e2e/tests/transaction/change-assets.spec.ts
+++ b/test/e2e/tests/transaction/change-assets.spec.ts
@@ -1,4 +1,3 @@
-import assert from 'assert/strict';
 import { withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Some async methods were missing the `await` key. This has been added and has surfaced an issue with a method, which has also been fixed.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38381?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds awaited click actions in dialog/send pages and replaces hex data assertion with a wait-based helper, updating tests accordingly.
> 
> - **E2E Page Objects**:
>   - `test/e2e/page-objects/pages/dialog/confirm-alert.ts`: Add `await` to alert modal interactions (`rejectFromAlertModal`, `confirmFromAlertModal`, `acknowledgeAlert`).
>   - `test/e2e/page-objects/pages/send/send-token-page.ts`:
>     - Replace `getHexInputValue` with `waitForHexDataCleared`, which waits until the hex input is empty using `waitUntil`.
>     - Minor: continue to await interactions and maintain logging.
> - **E2E Tests**:
>   - `test/e2e/tests/transaction/change-assets.spec.ts`:
>     - Remove direct assertion on hex input and call `waitForHexDataCleared()` instead.
>     - Drop unused strict assert import.
>     - Keep flow the same while ensuring hex data clears before continuing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c58a864d633251f26c0974d369af37cfb695112c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->