### PR TITLE
fix: layout inconsistencies cp-13.12.0

### DIFF
--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -412,7 +412,7 @@ export const CoinOverview = ({
       balance={
         shouldShowBalanceEmptyState ? (
           <BalanceEmptyState
-            className="w-full max-w-[420px]"
+            className="w-full max-w-[420px] self-center"
             data-testid="coin-overview-balance-empty-state"
             onClickReceive={handleReceiveOnClick}
           />

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -412,7 +412,7 @@ export const CoinOverview = ({
       balance={
         shouldShowBalanceEmptyState ? (
           <BalanceEmptyState
-            className="w-full max-w-[420px] self-center"
+            className="w-full max-w-[460px] self-center"
             data-testid="coin-overview-balance-empty-state"
             onClickReceive={handleReceiveOnClick}
           />

--- a/ui/components/multichain/pages/page/index.scss
+++ b/ui/components/multichain/pages/page/index.scss
@@ -7,13 +7,6 @@
 
   transition: padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out;
 
-  &:not(.multichain-page--has-app-header) {
-    @media screen and (min-width: design-system.$screen-sm-min) and (min-height: $height-screen-sm-min) {
-      padding-top: 32px;
-      padding-bottom: 32px;
-    }
-  }
-
   &--has-app-header {
     & .multichain-page__inner-container {
       border-radius: 0 0 2px 2px;

--- a/ui/pages/multi-srp/import-srp/index.scss
+++ b/ui/pages/multi-srp/import-srp/index.scss
@@ -24,9 +24,6 @@
   z-index: 55;
   padding: 24px;
   padding-top: 0;
-  max-width: 446px;
-  min-height: 700px;
-  height: 700px;
 
   @include design-system.screen-sm-max {
     min-height: auto;

--- a/ui/pages/multichain-accounts/account-list/account-list.scss
+++ b/ui/pages/multichain-accounts/account-list/account-list.scss
@@ -1,7 +1,0 @@
-.account-list-page {
-  max-width: 600px;
-
-  &__content {
-    padding: 0;
-  }
-}

--- a/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
+++ b/ui/pages/multichain-accounts/add-wallet-page/add-wallet-page.tsx
@@ -39,7 +39,7 @@ export const AddWalletPage = () => {
   );
 
   return (
-    <Page className="max-w-[600px]">
+    <Page>
       <Header
         textProps={{
           variant: LegacyTextVariant.headingSm,

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -102,7 +102,7 @@ export const MultichainAccountAddressListPage = ({
   }, []);
 
   return (
-    <Page className="max-w-[600px]">
+    <Page>
       <Header
         textProps={{
           variant: TextVariant.headingSm,

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
@@ -75,7 +75,7 @@ export const MultichainAccountPrivateKeyListPage = ({
   );
 
   return (
-    <Page className="max-w-[600px]">
+    <Page>
       <Header
         textProps={{
           variant: TextVariant.headingSm,

--- a/ui/pages/multichain-accounts/smart-account-page/smart-account-page.tsx
+++ b/ui/pages/multichain-accounts/smart-account-page/smart-account-page.tsx
@@ -37,7 +37,7 @@ export const SmartAccountPage = ({
   }
 
   return (
-    <Page className="max-w-[600px]">
+    <Page>
       <Header
         textProps={{
           variant: TextVariant.headingSm,

--- a/ui/pages/pages.scss
+++ b/ui/pages/pages.scss
@@ -25,7 +25,6 @@
 @import 'swaps/index';
 @import 'bridge/index';
 @import 'unlock-page/index';
-@import 'multichain-accounts/account-list/account-list';
 @import 'multichain-accounts/wallet-details-page/index';
 @import 'multi-srp/import-srp/index';
 @import 'multichain-accounts/multichain-account-details-page/index';

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -700,7 +700,7 @@ export default function Routes() {
             authenticated
             path={IMPORT_SRP_ROUTE}
             component={ImportSrpPage}
-            layout={LegacyLayout}
+            layout={RootLayout}
           />
           <RouteWithLayout
             authenticated

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -128,7 +128,6 @@ import KeyringSnapRemovalResult from '../../components/app/modals/keyring-snap-r
 import { MultichainAccountListMenu } from '../../components/multichain-accounts/multichain-account-list-menu';
 
 import { DeprecatedNetworkModal } from '../settings/deprecated-network-modal/DeprecatedNetworkModal';
-import { MultichainMetaFoxLogo } from '../../components/multichain/app-header/multichain-meta-fox-logo';
 import NetworkConfirmationPopover from '../../components/multichain/network-list-menu/network-confirmation-popover/network-confirmation-popover';
 import { ToastMaster } from '../../components/app/toast-master/toast-master';
 import { type DynamicImportType, mmLazy } from '../../helpers/utils/mm-lazy';
@@ -152,11 +151,7 @@ import { State2Wrapper } from '../../components/multichain-accounts/state2-wrapp
 import { RootLayout } from '../../layouts/root-layout';
 import { LegacyLayout } from '../../layouts/legacy-layout';
 import { RouteWithLayout } from '../../layouts/route-with-layout';
-import {
-  getConnectingLabel,
-  isConfirmTransactionRoute,
-  setTheme,
-} from './utils';
+import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationHandler } from './confirmation-handler';
 import { Modals } from './modals';
 
@@ -765,7 +760,7 @@ export default function Routes() {
           </RouteWithLayout>
           <RouteWithLayout
             path={`${CONFIRM_TRANSACTION_ROUTE}/:id?`}
-            layout={LegacyLayout}
+            layout={RootLayout}
           >
             {createV5CompatRoute<{ id?: string }>(ConfirmTransaction, {
               wrapper: AuthenticatedV5Compat,
@@ -827,7 +822,7 @@ export default function Routes() {
           </RouteWithLayout>
           <RouteWithLayout
             path={`${CONFIRMATION_V_NEXT_ROUTE}/:id?`}
-            layout={LegacyLayout}
+            layout={RootLayout}
           >
             {createV5CompatRoute<{ id?: string }>(ConfirmationPage, {
               wrapper: AuthenticatedV5Compat,
@@ -1190,9 +1185,7 @@ export default function Routes() {
       <QRHardwarePopover />
       <Modal />
       <Alert visible={alertOpen} msg={alertMessage} />
-      {isConfirmTransactionRoute(location.pathname) && (
-        <MultichainMetaFoxLogo />
-      )}
+
       {isAccountMenuOpen ? accountListMenu : null}
 
       <NetworkConfirmationPopover />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix layout inconsistencies in sidepanel and fullscreen modes

Also aligns "Fund your wallet"

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38410?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: confirmation layout in sidepanel

## **Related issues**

Fixes: #38147 and https://consensyssoftware.atlassian.net/browse/CEUX-740

## **Manual testing steps**

In sidepanel and fullscreen

- Confirmations
- Accounts list
- Import SRP
- Import PK

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

| Confirmations | Accounts |
|---|---|
|<img width="619" height="368" alt="image" src="https://github.com/user-attachments/assets/840d484c-99ff-4ee0-bf20-21fa10d947a6" />|<img width="834" height="292" alt="image" src="https://github.com/user-attachments/assets/b0e3cba9-f849-4134-8235-0c7c9a433a7b" />|


### **After**

| Confirmations | Accounts |
|---|---|
|<img width="578" height="277" alt="image" src="https://github.com/user-attachments/assets/bda115c2-5d5b-4102-b19b-ded9871c0423" />|<img width="839" height="222" alt="image" src="https://github.com/user-attachments/assets/4185ac6e-4426-4132-8a0a-3a11a6e76652" />|


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches confirmations and Import SRP to RootLayout and removes fixed widths/padding across multichain pages to align sidepanel/fullscreen layouts.
> 
> - **Routing/Layout**:
>   - Move `CONFIRM_TRANSACTION_ROUTE` and `CONFIRMATION_V_NEXT_ROUTE` to `RootLayout`.
>   - Move `IMPORT_SRP_ROUTE` to `RootLayout`.
>   - Remove `MultichainMetaFoxLogo` rendering on confirm routes and related `isConfirmTransactionRoute` import.
> - **Multichain Account Pages**:
>   - Drop fixed `max-w-[600px]` on `Page` wrappers in `add-wallet-page`, `multichain-account-address-list-page`, `multichain-account-private-key-list-page`, and `smart-account-page`.
>   - Remove `account-list` stylesheet and its import.
> - **Styles**:
>   - Remove extra padding rule for `.multichain-page` when not using app header.
>   - Import SRP: remove fixed `max-width`/`height`; keep responsive layout.
>   - Wallet overview: widen and center `BalanceEmptyState` (`max-w[460px]`, `self-center`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a5118e169ea52173de4eab27c6814774e92661e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->