### PR TITLE
fix: fix scroll focus

### DIFF
--- a/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
+++ b/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
@@ -108,6 +108,7 @@ export const CustomNetworks = React.memo(() => {
           name={network.name}
           iconSrc={getNetworkIcon(network)}
           iconSize={AvatarNetworkSize.Md}
+          focus={false}
           rpcEndpoint={rpcEndpoint}
           onClick={() => handleNetworkClick(network.chainId)}
           onDeleteClick={onDelete}

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -287,6 +287,7 @@ const DefaultNetworks = memo(() => {
           name={network.name}
           iconSrc={iconSrc}
           iconSize={AvatarNetworkSize.Md}
+          focus={false}
           rpcEndpoint={
             hasMultiRpcOptions(network)
               ? getRpcDataByChainId(network.chainId, evmNetworks)
@@ -405,6 +406,7 @@ const DefaultNetworks = memo(() => {
               iconSrc={IconName.Global}
               iconSize={IconSize.Xl}
               selected={isAllPopularNetworksSelected}
+              focus={false}
             />
           </Box>
         ) : null}


### PR DESCRIPTION
## **Description**

Fix scroll issue on network modal

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38439?quickstart=1)

## **Changelog**

CHANGELOG entry: fix scroll issue on network modal.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38145

## **Manual testing steps**

1. click on network selector on main page
2. It should not be already scrolled down


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c6563970-e001-4d01-bb82-9c05f4ea75b1


### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/b9519ce4-245b-4c77-81ce-5a23907eb4fd


## **Pre-merge author checklist**




- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `focus={false}` on `NetworkListItem` across custom and default network lists (including "All popular networks") to avoid auto-scroll on open.
> 
> - **UI – Network Manager**:
>   - Set `focus={false}` on `NetworkListItem` in:
>     - `custom-networks.tsx` for custom networks entries.
>     - `default-networks.tsx` for each default network entry.
>     - `default-networks.tsx` "allPopularNetworks" aggregate item.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a6151b6ce74b74548acd648a2a1245fab31631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->