### PR TITLE
chore: INFRA-2925: Adding github action to merge stable to main on comment

### DIFF
--- a/.github/workflows/merge-approved-pr.yml
+++ b/.github/workflows/merge-approved-pr.yml
@@ -1,0 +1,22 @@
+name: Merge Approved PR
+
+on:
+  # Trigger the workflow when a comment is created on an issue or pull request
+  issue_comment:
+    types: [created]
+
+jobs:
+  merge-pr:
+    # Only run if the comment is on a PR and the comment body matches exactly "Merge my PR"
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == 'Merge my PR' &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER'
+      )
+    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@30baa9da0b80d94dd8bdf0b6a932c46506664857
+    with:
+      pr-number: ${{ github.event.issue.number }}
+    secrets:
+      github-token: ${{ secrets.METAMASK_EXTENSION_BRANCH_SYNC_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Allows you to merge stable-main-X.Y.Z -> base main PRs on comment "Merge my PR"

Successful Negative tests:
Not Merging on Incorrect comment: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/55, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19683528967
Not Merging from wrong source branch: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/53, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19575100357/job/56058172525
Not Merging into wrong target branch: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/54, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19575460777/job/56059417843
Not Merging on unapproved PR: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/55, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19709760888
Not Merging on approver not in Release Team: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/55, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19709971385

Desired Successful test: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/55, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/19710071272/job/56467981022

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38441?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 32c4009edabd906753fb47d4d6df88a01af901ab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->