### PR TITLE
fix: fullscreen swap confirmation cp-13.12.0

### DIFF
--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -135,27 +135,22 @@ export const ConfirmationHandler = () => {
     swapsFetchParams ||
     hasBridgeQuotes;
 
+  const isFullscreenExemption =
+    isFullscreen &&
+    !hasAllowedPopupRedirectApprovals &&
+    !hasSwapRelatedNavigation;
+
   useEffect(() => {
     if (isExemptedRoute) {
       return;
     }
 
-    if (
-      isFullscreen &&
-      !hasAllowedPopupRedirectApprovals &&
-      !hasSwapRelatedNavigation
-    ) {
+    if (isFullscreenExemption) {
       return;
     }
 
     checkStatusAndNavigate();
-  }, [
-    checkStatusAndNavigate,
-    hasAllowedPopupRedirectApprovals,
-    hasSwapRelatedNavigation,
-    isExemptedRoute,
-    isFullscreen,
-  ]);
+  }, [checkStatusAndNavigate, isExemptedRoute, isFullscreenExemption]);
 
   return null;
 };

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -22,6 +22,7 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
 import {
   selectHasApprovalFlows,
@@ -128,6 +129,20 @@ export const ConfirmationHandler = () => {
     SNAP_APPROVAL_TYPES.includes(approval.type),
   );
 
+  // Check if there are Smart Transaction status page approvals
+  const hasStxStatusPageApproval = pendingApprovals.some(
+    (approval) =>
+      approval.type ===
+      SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+  );
+
+  // Check if there are swap-related navigation needs
+  const hasSwapRelatedNavigation =
+    showAwaitingSwapScreen ||
+    hasSwapsQuotes ||
+    swapsFetchParams ||
+    hasBridgeQuotes;
+
   useEffect(() => {
     if (isExemptedRoute) {
       return;
@@ -136,8 +151,8 @@ export const ConfirmationHandler = () => {
     if (
       isFullscreen &&
       !hasAllowedPopupRedirectApprovals &&
-      !pendingApprovals.length &&
-      !hasApprovalFlows
+      !hasStxStatusPageApproval &&
+      !hasSwapRelatedNavigation
     ) {
       return;
     }
@@ -146,10 +161,10 @@ export const ConfirmationHandler = () => {
   }, [
     checkStatusAndNavigate,
     hasAllowedPopupRedirectApprovals,
+    hasStxStatusPageApproval,
+    hasSwapRelatedNavigation,
     isExemptedRoute,
     isFullscreen,
-    pendingApprovals.length,
-    hasApprovalFlows,
   ]);
 
   return null;

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -22,7 +22,6 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
-  SMART_TRANSACTION_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
 import {
   selectHasApprovalFlows,
@@ -129,13 +128,6 @@ export const ConfirmationHandler = () => {
     SNAP_APPROVAL_TYPES.includes(approval.type),
   );
 
-  // Check if there are Smart Transaction status page approvals
-  const hasStxStatusPageApproval = pendingApprovals.some(
-    (approval) =>
-      approval.type ===
-      SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
-  );
-
   // Check if there are swap-related navigation needs
   const hasSwapRelatedNavigation =
     showAwaitingSwapScreen ||
@@ -151,7 +143,6 @@ export const ConfirmationHandler = () => {
     if (
       isFullscreen &&
       !hasAllowedPopupRedirectApprovals &&
-      !hasStxStatusPageApproval &&
       !hasSwapRelatedNavigation
     ) {
       return;
@@ -161,7 +152,6 @@ export const ConfirmationHandler = () => {
   }, [
     checkStatusAndNavigate,
     hasAllowedPopupRedirectApprovals,
-    hasStxStatusPageApproval,
     hasSwapRelatedNavigation,
     isExemptedRoute,
     isFullscreen,

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -120,15 +120,16 @@ export const ConfirmationHandler = () => {
     swapsFetchParams,
   ]);
 
+  // Runs on all routes (not just home), so skip navigation on exempted routes
   const isExemptedRoute = EXEMPTED_ROUTES.some((route) =>
     pathname.startsWith(route),
   );
 
+  // Ported from home.component - hasAllowedPopupRedirectApprovals()
   const hasAllowedPopupRedirectApprovals = pendingApprovals.some((approval) =>
     SNAP_APPROVAL_TYPES.includes(approval.type),
   );
 
-  // Check if there are swap-related navigation needs
   const hasSwapRelatedNavigation =
     showAwaitingSwapScreen ||
     hasSwapsQuotes ||
@@ -140,6 +141,7 @@ export const ConfirmationHandler = () => {
     !hasAllowedPopupRedirectApprovals &&
     !hasSwapRelatedNavigation;
 
+  // Ported from home.component - componentDidUpdate()
   useEffect(() => {
     if (isExemptedRoute) {
       return;

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -133,7 +133,12 @@ export const ConfirmationHandler = () => {
       return;
     }
 
-    if (isFullscreen && !hasAllowedPopupRedirectApprovals) {
+    if (
+      isFullscreen &&
+      !hasAllowedPopupRedirectApprovals &&
+      !pendingApprovals.length &&
+      !hasApprovalFlows
+    ) {
       return;
     }
 
@@ -143,6 +148,8 @@ export const ConfirmationHandler = () => {
     hasAllowedPopupRedirectApprovals,
     isExemptedRoute,
     isFullscreen,
+    pendingApprovals.length,
+    hasApprovalFlows,
   ]);
 
   return null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the confirmation screen not appearing in fullscreen mode when swaps are completed.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38446?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: fullscreen swap confirmation

## **Related issues**

Fixes: #38421 

## **Manual testing steps**

1. Switch to Full screen mode
2. Ensure smart transactions is enabeld
3. Complete a swap

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines confirmation navigation guards to properly handle fullscreen by allowing swap/bridge flows and Snap approvals while skipping exempted routes.
> 
> - **Routing/Navigation (ConfirmationHandler)**:
>   - Introduces `isFullscreenExemption` to prevent auto-navigation only when `isFullscreen` and there are no allowed Snap approvals and no swap-related activity.
>   - Considers swap-related states (`showAwaitingSwapScreen`, `hasSwapsQuotes`, `swapsFetchParams`, `hasBridgeQuotes`) via `hasSwapRelatedNavigation` to allow appropriate redirects.
>   - Skips navigation on exempted routes globally using `EXEMPTED_ROUTES`.
>   - Updates `useEffect` to use the new guard and consolidates dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 261c489b765245163acb6709ffa9fb71b781fae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->