### PR TITLE
feat(STX-325): remove STX status page

### DIFF
--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -61,6 +61,7 @@ export type FeatureFlags = {
     maxDeadline?: number;
     extensionReturnTxHashAsap?: boolean;
     extensionReturnTxHashAsapBatch?: boolean;
+    extensionSkipSmartTransactionStatusPage?: boolean;
   };
 };
 
@@ -95,6 +96,7 @@ class SmartTransactionHook {
       maxDeadline?: number;
       extensionReturnTxHashAsap?: boolean;
       extensionReturnTxHashAsapBatch?: boolean;
+      extensionSkipSmartTransactionStatusPage?: boolean;
     };
   };
 
@@ -140,10 +142,21 @@ class SmartTransactionHook {
     this.#chainId = transactionMeta.chainId;
     this.#txParams = transactionMeta.txParams;
     this.#transactions = transactions;
-    this.#shouldShowStatusPage = Boolean(
-      (transactionMeta.type !== TransactionType.bridge &&
-        transactionMeta.type !== TransactionType.shieldSubscriptionApprove) ||
-        (this.#transactions && this.#transactions.length > 0),
+    const extensionSkipSmartTransactionStatusPage =
+      featureFlags?.smartTransactions?.extensionSkipSmartTransactionStatusPage;
+
+    this.#shouldShowStatusPage = extensionSkipSmartTransactionStatusPage
+      ? false
+      : Boolean(
+          (transactionMeta.type !== TransactionType.bridge &&
+            transactionMeta.type !==
+              TransactionType.shieldSubscriptionApprove) ||
+            (this.#transactions && this.#transactions.length > 0),
+        );
+
+    log.info(
+      '[SmartTransaction] shouldShowStatusPage:',
+      this.#shouldShowStatusPage,
     );
   }
 

--- a/shared/modules/selectors/feature-flags.ts
+++ b/shared/modules/selectors/feature-flags.ts
@@ -30,6 +30,7 @@ export type SmartTransactionNetwork = {
   sentinelUrl?: string;
   extensionReturnTxHashAsap?: boolean;
   extensionReturnTxHashAsapBatch?: boolean;
+  extensionSkipSmartTransactionStatusPage?: boolean;
   batchStatusPollingInterval?: number;
 };
 
@@ -63,18 +64,32 @@ export function getFeatureFlagsByChainId(
   }
   const smartTransactionsNetworks =
     state.metamask.remoteFeatureFlags?.smartTransactionsNetworks;
-  const defaultConfig = smartTransactionsNetworks?.default;
-  const extensionReturnTxHashAsap =
-    defaultConfig?.extensionReturnTxHashAsap ?? false;
-  const extensionReturnTxHashAsapBatch =
-    defaultConfig?.extensionReturnTxHashAsapBatch ?? false;
+  const defaultConfig = smartTransactionsNetworks?.default ?? {};
+  const chainSpecificConfig =
+    smartTransactionsNetworks?.[effectiveChainId as Hex] ?? {};
+
+  // Merge with fallback precedence: chainSpecific > default > hardcoded defaults (false)
+  // TODO: this is temporary until we deprecate this file and implement a better flag system.
+  const remoteFlags = {
+    extensionReturnTxHashAsap:
+      chainSpecificConfig.extensionReturnTxHashAsap ??
+      defaultConfig.extensionReturnTxHashAsap ??
+      false,
+    extensionReturnTxHashAsapBatch:
+      chainSpecificConfig.extensionReturnTxHashAsapBatch ??
+      defaultConfig.extensionReturnTxHashAsapBatch ??
+      false,
+    extensionSkipSmartTransactionStatusPage:
+      chainSpecificConfig.extensionSkipSmartTransactionStatusPage ??
+      defaultConfig.extensionSkipSmartTransactionStatusPage ??
+      false,
+  };
 
   return {
     smartTransactions: {
       ...featureFlags.smartTransactions,
       ...featureFlags[networkName].smartTransactions,
-      extensionReturnTxHashAsap,
-      extensionReturnTxHashAsapBatch,
+      ...remoteFlags,
     },
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes the smart transaction status page from the transaction submission flow

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38460?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove smart transaction status page

## **Related issues**

Relates to: https://consensyssoftware.atlassian.net/browse/STX-325

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `extensionSkipSmartTransactionStatusPage` flag, updates smart-transaction flow to honor it, enhances remote flag merging, and adds focused tests.
> 
> - **Smart Transactions flow**
>   - Add `extensionSkipSmartTransactionStatusPage` to feature flags and use it to force `shouldShowStatusPage` to `false`; otherwise retain existing type-based/batch logic.
>   - Log `shouldShowStatusPage` value; no change to non-STX or legacy fallbacks.
> - **Selectors**
>   - Extend `SmartTransactionNetwork` and `getFeatureFlagsByChainId` to include `extensionSkipSmartTransactionStatusPage`.
>   - Implement merged remote flag precedence: chain-specific > default > hardcoded defaults.
> - **Tests**
>   - Add/expand cases validating status-page visibility across transaction types, batch submissions, and the new skip flag (true/false/undefined).
>   - Update feature-flag selector tests to cover remote overrides and new flag defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c31127e9295622e98e7b6aa8ab120fa8d7f5ab5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->