### PR TITLE
fix: watch account E2E with BIP-44 enabled

### DIFF
--- a/test/e2e/flask/create-watch-account.spec.ts
+++ b/test/e2e/flask/create-watch-account.spec.ts
@@ -3,7 +3,7 @@ import { Suite } from 'mocha';
 import FixtureBuilder from '../fixtures/fixture-builder';
 import { withFixtures } from '../helpers';
 import { Driver } from '../webdriver/driver';
-import AccountDetailsModal from '../page-objects/pages/dialog/account-details-modal';
+import MultichainAccountDetailsPage from '../page-objects/pages/multichain/multichain-account-details-page';
 import AccountListPage from '../page-objects/pages/account-list-page';
 import ExperimentalSettings from '../page-objects/pages/settings/experimental-settings';
 import HeaderNavbar from '../page-objects/pages/header-navbar';
@@ -17,9 +17,7 @@ const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 const SHORTENED_EOA_ADDRESS = '0xd8dA6...96045';
 const DEFAULT_WATCHED_ACCOUNT_NAME = 'Watched Account 1';
 
-// #37563 - Creating a watch account with EOA address is not possible with BIP44 at the moment
-// eslint-disable-next-line mocha/no-skipped-tests
-describe.skip('Account-watcher snap', function (this: Suite) {
+describe('Account-watcher snap', function (this: Suite) {
   describe('Adding watched accounts', function () {
     it('adds watch account with valid EOA address', async function () {
       await withFixtures(
@@ -213,9 +211,9 @@ describe.skip('Account-watcher snap', function (this: Suite) {
           await headerNavbar.openAccountDetailsModalDetailsTab();
 
           // check 'Show private key' button should not be displayed
-          const accountDetailsModal = new AccountDetailsModal(driver);
-          await accountDetailsModal.checkPageIsLoaded();
-          await accountDetailsModal.checkShowPrivateKeyButtonIsNotDisplayed();
+          const accountDetailsPage = new MultichainAccountDetailsPage(driver);
+          await accountDetailsPage.checkPageIsLoaded();
+          await accountDetailsPage.checkShowPrivateKeyButtonIsNotDisplayed();
         },
       );
     });

--- a/test/e2e/page-objects/pages/multichain/multichain-account-details-page.ts
+++ b/test/e2e/page-objects/pages/multichain/multichain-account-details-page.ts
@@ -44,15 +44,6 @@ class MultichainAccountDetailsPage {
   private readonly secretRecoveryPhraseRow =
     '[data-testid="multichain-srp-backup"]';
 
-  private readonly showPrivateKeyButton =
-    '[data-testid="account-show-private-key-button"]';
-
-  private readonly exportSrpButton =
-    '[data-testid="account-export-srp-button"]';
-
-  private readonly exportPrivateKeyButton =
-    '[data-testid="account-export-private-key-button"]';
-
   // Account removal
   private readonly removeAccountButton =
     '[data-testid="account-details-row-remove-account"]';
@@ -166,6 +157,14 @@ class MultichainAccountDetailsPage {
     const privateKeyRow = await this.driver.findElement(this.privateKeyRow);
     await privateKeyRow.click();
     await this.driver.delay(largeDelayMs);
+  }
+
+  /**
+   * Check that the "show private key" button is not displayed
+   */
+  async checkShowPrivateKeyButtonIsNotDisplayed(): Promise<void> {
+    console.log('Check that show private key button is not displayed');
+    await this.driver.assertElementNotPresent(this.privateKeyRow);
   }
 
   /**


### PR DESCRIPTION
## **Description**

This PR fixes an E2E test that broke with the new BIP-44 UI.
⚠️ Note: this test will likely break again when we default to the BIP-44 accounts list UI in the upcoming weeks. This is fine since we'll fix it in the same PR that will default to this new UI.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38470?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1256
Fixes: https://github.com/MetaMask/metamask-extension/issues/37563

## **Manual testing steps**

1. No manual testing steps, E2E only

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables and updates watch account E2E to use `MultichainAccountDetailsPage`, adding an assertion for absence of private key controls.
> 
> - **E2E tests (`test/e2e/flask/create-watch-account.spec.ts`)**:
>   - Enable `Account-watcher snap` suite (remove `.skip`).
>   - Replace `AccountDetailsModal` with `MultichainAccountDetailsPage`.
>   - Verify absence of "Show private key" via `checkShowPrivateKeyButtonIsNotDisplayed()`.
> - **Page object (`test/e2e/page-objects/pages/multichain/multichain-account-details-page.ts`)**:
>   - Add `checkShowPrivateKeyButtonIsNotDisplayed()` asserting no `Private key` row.
>   - Clean up unused selectors related to private key/SRP export.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ba8204f559cb98e8d0f3aa414193e7785773804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->