### PR TITLE
refactor: update network switching metrics to include chain ID and custom network status

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -54,8 +54,12 @@ import {
   FEATURED_RPCS,
   TEST_CHAINS,
   CHAIN_ID_PORTFOLIO_LANDING_PAGE_URL_MAP,
+  BUILT_IN_NETWORKS,
 } from '../../../../shared/constants/network';
-import { MULTICHAIN_NETWORK_TO_ACCOUNT_TYPE_NAME } from '../../../../shared/constants/multichain/networks';
+import {
+  MULTICHAIN_NETWORK_TO_ACCOUNT_TYPE_NAME,
+  MultichainNetworks,
+} from '../../../../shared/constants/multichain/networks';
 import {
   getShowTestNetworks,
   getOriginOfCurrentTab,
@@ -423,6 +427,28 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
       ? convertCaipToHexChainId(currentChainId)
       : currentChainId;
 
+    // Check if the destination network is custom (not built-in, featured, or multichain)
+    const hexChainId = chain.isEvm
+      ? convertCaipToHexChainId(chain.chainId)
+      : chain.chainId;
+
+    const isBuiltInNetwork = Object.values(BUILT_IN_NETWORKS).some(
+      (builtInNetwork) => builtInNetwork.chainId === hexChainId,
+    );
+    const isFeaturedRpc = FEATURED_RPCS.some(
+      (featuredRpc) => featuredRpc.chainId === hexChainId,
+    );
+    const isMultichainProviderConfig = Object.values(MultichainNetworks).some(
+      (multichainNetwork) =>
+        multichainNetwork === chain.chainId ||
+        (chain.isEvm
+          ? convertCaipToHexChainId(chain.chainId)
+          : chain.chainId) === multichainNetwork,
+    );
+
+    const isCustomNetwork =
+      !isBuiltInNetwork && !isFeaturedRpc && !isMultichainProviderConfig;
+
     trackEvent({
       event: MetaMetricsEventName.NavNetworkSwitched,
       category: MetaMetricsEventCategory.Network,
@@ -437,6 +463,9 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
         // eslint-disable-next-line @typescript-eslint/naming-convention
         to_network: chainIdToTrack,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        custom_network: isCustomNetwork,
       },
     });
   };

--- a/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts
@@ -23,6 +23,11 @@ import {
   getSelectedMultichainNetworkChainId,
 } from '../../../../selectors';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import {
+  BUILT_IN_NETWORKS,
+  FEATURED_RPCS,
+} from '../../../../../shared/constants/network';
+import { MultichainNetworks } from '../../../../../shared/constants/multichain/networks';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -143,6 +148,28 @@ export const useNetworkChangeHandlers = () => {
         ? convertCaipToHexChainId(currentChainId)
         : currentChainId;
 
+      // Check if the destination network is custom (not built-in, featured, or multichain)
+      const hexChainId = chain.isEvm
+        ? convertCaipToHexChainId(chain.chainId)
+        : chain.chainId;
+
+      const isBuiltInNetwork = Object.values(BUILT_IN_NETWORKS).some(
+        (builtInNetwork) => builtInNetwork.chainId === hexChainId,
+      );
+      const isFeaturedRpc = FEATURED_RPCS.some(
+        (featuredRpc) => featuredRpc.chainId === hexChainId,
+      );
+      const isMultichainProviderConfig = Object.values(MultichainNetworks).some(
+        (multichainNetwork) =>
+          multichainNetwork === chain.chainId ||
+          (chain.isEvm
+            ? convertCaipToHexChainId(chain.chainId)
+            : chain.chainId) === multichainNetwork,
+      );
+
+      const isCustomNetwork =
+        !isBuiltInNetwork && !isFeaturedRpc && !isMultichainProviderConfig;
+
       trackEvent({
         event: MetaMetricsEventName.NavNetworkSwitched,
         category: MetaMetricsEventCategory.Network,
@@ -157,6 +184,9 @@ export const useNetworkChangeHandlers = () => {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           to_network: chainIdToTrack,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          custom_network: isCustomNetwork,
         },
       });
     },

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -18,7 +18,12 @@ import {
   NETWORKS_BYPASSING_VALIDATION,
 } from '@metamask/controller-utils';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
-import { CHAIN_SPEC_URL } from '../../../../shared/constants/network';
+import {
+  CHAIN_SPEC_URL,
+  BUILT_IN_NETWORKS,
+  FEATURED_RPCS,
+} from '../../../../shared/constants/network';
+import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
 import {
   MetaMetricsEventCategory,
@@ -476,6 +481,23 @@ export default function ConfirmationPage({
       pendingConfirmation?.requestData?.fromNetworkConfiguration?.chainId &&
       pendingConfirmation?.requestData?.toNetworkConfiguration?.chainId
     ) {
+      // Check if the destination network is custom (not built-in, featured, or multichain)
+      const toChainId =
+        pendingConfirmation.requestData.toNetworkConfiguration.chainId;
+
+      const isBuiltInNetwork = Object.values(BUILT_IN_NETWORKS).some(
+        (builtInNetwork) => builtInNetwork.chainId === toChainId,
+      );
+      const isFeaturedRpc = FEATURED_RPCS.some(
+        (featuredRpc) => featuredRpc.chainId === toChainId,
+      );
+      const isMultichainProviderConfig = Object.values(MultichainNetworks).some(
+        (multichainNetwork) => multichainNetwork === toChainId,
+      );
+
+      const isCustomNetwork =
+        !isBuiltInNetwork && !isFeaturedRpc && !isMultichainProviderConfig;
+
       trackEvent({
         category: MetaMetricsEventCategory.Network,
         event: MetaMetricsEventName.NavNetworkSwitched,
@@ -485,6 +507,7 @@ export default function ConfirmationPage({
             pendingConfirmation.requestData.fromNetworkConfiguration.chainId,
           to_network:
             pendingConfirmation.requestData.toNetworkConfiguration.chainId,
+          custom_network: isCustomNetwork,
           referrer: {
             url: window.location.origin,
           },


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the Network Switched analytics event to include additional properties: to_network (chain ID) and custom_network (boolean indicating if the destination network is custom).

The changes ensure that when users switch networks, we track:

1. The destination chain ID (to_network)
2. Whether the destination is a custom network (custom_network) - i.e., not a built-in, featured RPC, or multichain network

This applies to three network switching scenarios:

- Network list menu selection
- Network manager handlers
- Confirmation page network switches

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38524?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-213

## **Manual testing steps**

1. Open MetaMask extension
2. Switch networks using the network list menu
3. Verify the Network Switched event is tracked with to_network (chain ID) and custom_network properties
4. Test switching to a built-in network (e.g., Ethereum Mainnet) - custom_network should be false
5. Test switching to a custom network - custom_network should be true
6. Test network switching from the confirmation page
7. Test network switching via network manager

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances NavNetworkSwitched telemetry to include destination chain ID and a custom_network flag across menu, manager, and confirmation flows.
> 
> - **Analytics**
>   - Augment `NavNetworkSwitched` event with:
>     - `to_network` (destination chain ID) and `custom_network` (boolean) in:
>       - `ui/components/multichain/network-list-menu/network-list-menu.tsx`
>       - `ui/components/multichain/network-manager/hooks/useNetworkChangeHandlers.ts`
>       - `ui/pages/confirmations/confirmation/confirmation.js`
>   - Determine `custom_network` by checking against `BUILT_IN_NETWORKS`, `FEATURED_RPCS`, and `MultichainNetworks` (non-EVM/EVM-aware via `convertCaipToHexChainId`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 944f23207d3e8b1c7fe02470218883d91d6a06f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->