### PR TITLE
fix: Checksum EVM addresses in the address list

### DIFF
--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
@@ -26,8 +26,6 @@ import { shortenAddress } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-// eslint-disable-next-line import/no-restricted-paths
-import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 export type CopyParams = {
   /**
@@ -62,7 +60,7 @@ type MultichainAddressRowProps = {
    */
   networkName: string;
   /**
-   * Address string to display (will be truncated)
+   * Address string to display (should be pre-normalized, will be truncated for display)
    */
   address: string;
   /**
@@ -94,11 +92,7 @@ export const MultichainAddressRow = ({
       : chainId,
   );
 
-  const formattedAddress = useMemo(() => {
-    return normalizeSafeAddress(address);
-  }, [address]);
-
-  const truncatedAddress = shortenAddress(formattedAddress); // Shorten address for display
+  const truncatedAddress = shortenAddress(address); // Shorten address for display
   const [subText, setSubText] = useState(truncatedAddress); // Message below the network name
   const [copyIcon, setCopyIcon] = useState(IconName.Copy); // Default copy icon state
   const [addressCopied, setAddressCopied] = useState(false);
@@ -147,7 +141,7 @@ export const MultichainAddressRow = ({
   // Handle "QR Code" button click
   const handleQrClick = () => {
     qrActionParams?.callback(
-      formattedAddress,
+      address,
       networkName,
       formatChainIdToCaip(chainId),
       networkImageSrc,

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -60,7 +60,7 @@ type MultichainAddressRowProps = {
    */
   networkName: string;
   /**
-   * Address string to display (should be pre-normalized, will be truncated for display)
+   * Address string to display (will be truncated)
    */
   address: string;
   /**

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { CaipChainId, KnownCaipNamespace } from '@metamask/utils';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
@@ -26,6 +26,8 @@ import { shortenAddress } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+// eslint-disable-next-line import/no-restricted-paths
+import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 
 export type CopyParams = {
   /**
@@ -92,7 +94,11 @@ export const MultichainAddressRow = ({
       : chainId,
   );
 
-  const truncatedAddress = shortenAddress(address); // Shorten address for display
+  const formattedAddress = useMemo(() => {
+    return normalizeSafeAddress(address);
+  }, [address]);
+
+  const truncatedAddress = shortenAddress(formattedAddress); // Shorten address for display
   const [subText, setSubText] = useState(truncatedAddress); // Message below the network name
   const [copyIcon, setCopyIcon] = useState(IconName.Copy); // Default copy icon state
   const [addressCopied, setAddressCopied] = useState(false);
@@ -141,7 +147,7 @@ export const MultichainAddressRow = ({
   // Handle "QR Code" button click
   const handleQrClick = () => {
     qrActionParams?.callback(
-      address,
+      formattedAddress,
       networkName,
       formatChainIdToCaip(chainId),
       networkImageSrc,


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
The EVM address on the address list page was not checksummed while it was on on the home page. This is important for users so that their addresses match what they see in the ecosystem.
2. What is the improvement/solution?
Call the following formatting function.

```ts
/**
 * Normalize an address to a "safer" representation. The address might be returned as-is, if
 * there's no normalizer available.
 *
 * @param address - An address to normalize.
 * @returns The "safer" normalized address.
 */
export function normalizeSafeAddress(address: string): string {
  // NOTE: We assume that the overhead over checking the address format
  // at runtime is small
  return isEthAddress(address) ? toChecksumHexAddress(address) : address;
}
```



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38539?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug where the EVM addresses were not checksummed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1325

## **Manual testing steps**

1. Create/impor a wallet
2. hover address list via the network icons below the account name
3. notice the address for ETH
4. click view all
5. you will be taken to the address list
6. verify that the addresses for the EVm networks are checksummed
7. verify that copying the address results in a checksummed address
8. verify that the qr code is checksummed
9. verify that the non evm addresses are NOT checksummed

## **Screenshots/Recordings**

### **Before**

<img width="405" height="625" alt="Screenshot 2025-12-03 at 11 54 18 PM" src="https://github.com/user-attachments/assets/815cf104-55d5-4922-83cc-a0ed521874a6" />

<img width="413" height="624" alt="Screenshot 2025-12-03 at 11 54 24 PM" src="https://github.com/user-attachments/assets/d597d6a3-a3dc-4968-8e7d-8b18dc9c6db4" />


### **After**

<img width="425" height="633" alt="Screenshot 2025-12-03 at 8 10 56 PM" src="https://github.com/user-attachments/assets/2f5dccf2-3c78-41c2-a9aa-e0ee150e7516" />

<img width="414" height="621" alt="Screenshot 2025-12-03 at 8 10 48 PM" src="https://github.com/user-attachments/assets/152123c8-3691-4add-8616-1b8e7cdef993" />

<img width="447" height="630" alt="Screenshot 2025-12-03 at 8 11 24 PM" src="https://github.com/user-attachments/assets/b213f18d-315b-418d-aa05-03c0c392ccd6" />



https://github.com/user-attachments/assets/9cef5a93-4e0f-4de9-880a-744eaaa3465a



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Checksums EVM addresses for display, copy, and search in the multichain address list while preserving non‑EVM formats, with accompanying tests.
> 
> - **UI**
>   - Use `normalizeSafeAddress` to provide a normalized `address` for `MultichainAddressRow` and for copy actions.
>   - Search now matches against `normalizedAddress` in addition to network name.
>   - Memoize `normalizedAddress` per item and render list using the normalized values.
>   - Generalize `sortByPriorityNetworks` with a generic type.
> - **Tests**
>   - Add tests verifying EVM addresses are checksummed for display/copy and searchable by checksummed form.
>   - Confirm non‑EVM addresses (e.g., Bitcoin) remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 221ffd65f71fa2ceb9885aa4b8dc5a945bbd2c05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->