### PR TITLE
fix: flaky test Vault Decryptor cp-13.12.0

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -91,11 +91,17 @@ jobs:
     # This if statement is equivalent to IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     with:
       test-suite-name: test-e2e-chrome-dist
       build-artifact: build-dist-browserify
       test-command: yarn test:e2e:chrome:dist
       builds-from-run: ${{ inputs.builds-from-run }}
+      matrix-index: ${{ matrix.index }}
+      matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-api-specs:
     uses: ./.github/workflows/run-e2e.yml

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -91,17 +91,11 @@ jobs:
     # This if statement is equivalent to IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     with:
       test-suite-name: test-e2e-chrome-dist
       build-artifact: build-dist-browserify
       test-command: yarn test:e2e:chrome:dist
       builds-from-run: ${{ inputs.builds-from-run }}
-      matrix-index: ${{ matrix.index }}
-      matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-api-specs:
     uses: ./.github/workflows/run-e2e.yml

--- a/test/e2e/dist/vault-decryption-chrome.spec.ts
+++ b/test/e2e/dist/vault-decryption-chrome.spec.ts
@@ -211,6 +211,8 @@ describe('Vault Decryptor Page', function () {
         await privacySettings.completeRevealSrpQuiz();
         await privacySettings.fillPasswordToRevealSrp(WALLET_PASSWORD);
         const seedPhrase = await privacySettings.getSrpInRevealSrpDialog();
+
+        // Closing MetaMask completely
         await privacySettings.closeRevealSrpDialog();
         await settingsPage.closeSettingsPage();
         const headerNavbar = new HeaderNavbar(driver);
@@ -218,6 +220,7 @@ describe('Vault Decryptor Page', function () {
         await headerNavbar.lockMetaMask();
         await driver.closeWindow();
         await driver.switchToWindowWithTitle('Extensions');
+        await driver.delay(10000);
 
         // Retry-logic to ensure the file is ready before uploading it to mitigate flakiness when Chrome hasn't finished writing
         await waitUntilFileIsWritten({ driver });

--- a/test/e2e/dist/vault-decryption-chrome.spec.ts
+++ b/test/e2e/dist/vault-decryption-chrome.spec.ts
@@ -164,6 +164,7 @@ async function closePopoverIfPresent(driver: Driver) {
 }
 
 describe('Vault Decryptor Page', function () {
+  this.timeout(160000);
   it('is able to decrypt the vault uploading the log file in the vault-decryptor webapp', async function () {
     if (process.env.SELENIUM_BROWSER !== 'chrome') {
       // TODO: Get this working on Firefox

--- a/test/e2e/dist/vault-decryption-chrome.spec.ts
+++ b/test/e2e/dist/vault-decryption-chrome.spec.ts
@@ -131,7 +131,7 @@ async function waitUntilFileIsWritten({
 }
 
 describe('Vault Decryptor Page', function () {
-  it.only('is able to decrypt the vault uploading the log file in the vault-decryptor webapp', async function () {
+  it('is able to decrypt the vault uploading the log file in the vault-decryptor webapp', async function () {
     if (process.env.SELENIUM_BROWSER !== 'chrome') {
       // TODO: Get this working on Firefox
       this.skip();

--- a/test/e2e/dist/vault-decryption-chrome.spec.ts
+++ b/test/e2e/dist/vault-decryption-chrome.spec.ts
@@ -211,6 +211,8 @@ describe('Vault Decryptor Page', function () {
         await privacySettings.completeRevealSrpQuiz();
         await privacySettings.fillPasswordToRevealSrp(WALLET_PASSWORD);
         const seedPhrase = await privacySettings.getSrpInRevealSrpDialog();
+        await privacySettings.closeRevealSrpDialog();
+        await settingsPage.closeSettingsPage();
 
         // Retry-logic to ensure the file is ready before uploading it to mitigate flakiness when Chrome hasn't finished writing
         await waitUntilFileIsWritten({ driver });

--- a/test/e2e/dist/vault-decryption-chrome.spec.ts
+++ b/test/e2e/dist/vault-decryption-chrome.spec.ts
@@ -213,6 +213,11 @@ describe('Vault Decryptor Page', function () {
         const seedPhrase = await privacySettings.getSrpInRevealSrpDialog();
         await privacySettings.closeRevealSrpDialog();
         await settingsPage.closeSettingsPage();
+        const headerNavbar = new HeaderNavbar(driver);
+        await headerNavbar.checkPageIsLoaded();
+        await headerNavbar.lockMetaMask();
+        await driver.closeWindow();
+        await driver.switchToWindowWithTitle('Extensions');
 
         // Retry-logic to ensure the file is ready before uploading it to mitigate flakiness when Chrome hasn't finished writing
         await waitUntilFileIsWritten({ driver });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The spec is flaky and there are 2 changes which mitigate the issues:

1. Instead of trying to upload the original file (which can change and be written when we are trying to read it), we are now creating a copy of the file once it's ready. Then, we upload the copy of the file instead of the original one. This is what we already did for the 2nd test, but not for the 1st one (the flaky one)
2. I've detected the following behaviour: the spec file is written and it's 'ready' as it has a minimum size. But then, if some time happens, the file can be written again and the size can decrease to a very minimal size (meaning most of the contents are deleted). Once this happens, no matter if we wait for 40seconds, the file stays that small.
To avoid that. I've changed the order in which we do the actions: now, right after the onboarding, we get the file as soon as it's ready and copy it. Then we perform the rest of steps. --- Note that I'm unsure on the intrinsics on why this happens (file contents being mostly removed), and I don't know if it's an issue with Chrome itself, and/or if this could happen in a real environment -- also note that we are using the .log file not the ldb file, so maybe that's why, those are more unstable, according to 'the internet'

[Update] It actually might be this happens in a real environment too. Under investigation now -- I've been able to reproduce this manually. I can get the error sometimes and if I try a couple of times of uploading the file, at some point it works. I suspect because the file is being modified at that precise time 🤔 
We've seen with Maggie that if we wait for some idle time and even disable the extension, then the file works as expected in both `13.11.2` as well as in the latest version.

<img width="611" height="272" alt="image" src="https://github.com/user-attachments/assets/665dce79-e109-4022-81eb-ec8f2946678f" />


<img width="970" height="750" alt="image" src="https://github.com/user-attachments/assets/5b66c7c0-ecfb-42e6-a384-16eacf4555ba" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38541?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
4. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

I run that multiple times in ci and the fixes are working

<img width="223" height="328" alt="image" src="https://github.com/user-attachments/assets/164b7062-108c-4966-95a9-fda0337189d8" />


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the vault decryptor Chrome e2e by copying extension storage to a temp dir before upload, reordering the flow to decrypt first then fetch SRP, and removing unused popover handling.
> 
> - **Tests (e2e)**:
>   - **Vault decryptor flow (`test/e2e/dist/vault-decryption-chrome.spec.ts`)**:
>     - Copy extension storage directory to a temp location (`copyDirectoryToTmp`) after `waitUntilFileIsWritten`, upload the copied log (`getExtensionLogFile`), and clean up with `fs.remove`.
>     - Reorder steps: navigate to Vault Decryptor and decrypt using temp log first, then return to MetaMask to reveal SRP, and finally verify by switching back to the decryptor page.
>     - Update window switching to support the new order (`switchToWindowWithTitle`).
>     - Remove `closePopoverIfPresent` helper and its usages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa92e6ebde81a2fc78be6513f691a7fe94dd24dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->