### PR TITLE
fix: Remove auto scroll from network filter modal

### DIFF
--- a/ui/pages/confirmations/components/send/network-filter/network-filter.tsx
+++ b/ui/pages/confirmations/components/send/network-filter/network-filter.tsx
@@ -194,6 +194,7 @@ export const NetworkFilter = ({
               iconSize={IconSize.Xl}
               selected={selectedChainId === null}
               onClick={() => handleNetworkSelection(null)}
+              focus={false}
             />
             {uniqueChainIds.map((chainId) => {
               const networkName = chainNetworkNAmeAndImageMap.get(
@@ -210,6 +211,7 @@ export const NetworkFilter = ({
                   iconSrc={networkImage || ''}
                   selected={selectedChainId === chainId}
                   onClick={() => handleNetworkSelection(chainId)}
+                  focus={false}
                 />
               );
             })}


### PR DESCRIPTION
This PR ensures that network filter modal should not auto scroll

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:removed auto scroll from network filter modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open network filter modal
2. It should not auto scroll

## **Screenshots/Recordings**


### **Before**


https://github.com/user-attachments/assets/d1e2895a-7a22-486e-9e4f-7b1728b9c70c




### **After**


https://github.com/user-attachments/assets/2d67f34a-1c02-4926-be4f-4c7f4f20e6c1


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
