### PR TITLE
fix: updated navigation for asset-detail page

### DIFF
--- a/ui/helpers/utils/multichain/blockExplorer.test.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.test.ts
@@ -14,6 +14,7 @@ import { MultichainNetwork } from '../../../selectors/multichain';
 import {
   getMultichainBlockExplorerUrl,
   getMultichainAccountUrl,
+  getAssetDetailsAccountUrl,
 } from './blockExplorer';
 
 const mockEvmNetwork: MultichainNetwork = {
@@ -75,6 +76,46 @@ describe('Block Explorer Tests', () => {
       const expectedUrl = `https://mempool.space/address/${address}`;
 
       const result = getMultichainAccountUrl(address, mockNonEvmNetwork);
+
+      expect(result).toBe(expectedUrl);
+    });
+  });
+
+  describe('getAssetDetailsAccountUrl', () => {
+    it('returns the correct account URL using configured block explorer for EVM networks', () => {
+      const address = '0x1234567890abcdef';
+      // Uses the network's configured block explorer URL
+      const expectedUrl = `https://etherscan.io/address/${address}`;
+
+      const result = getAssetDetailsAccountUrl(address, mockEvmNetwork);
+
+      expect(result).toBe(expectedUrl);
+    });
+
+    it('falls back to Etherscan multichain when no block explorer is configured', () => {
+      const address = '0x1234567890abcdef';
+      const networkWithoutExplorer: MultichainNetwork = {
+        ...mockEvmNetwork,
+        network: {
+          ...mockEvmNetwork.network,
+          rpcPrefs: {
+            imageUrl: ETH_TOKEN_IMAGE_URL,
+            // No blockExplorerUrl configured
+          },
+        },
+      };
+      const expectedUrl = `https://etherscan.io/address/${address}#asset-multichain`;
+
+      const result = getAssetDetailsAccountUrl(address, networkWithoutExplorer);
+
+      expect(result).toBe(expectedUrl);
+    });
+
+    it('returns the correct account URL for non-EVM networks', () => {
+      const address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+      const expectedUrl = `https://mempool.space/address/${address}`;
+
+      const result = getAssetDetailsAccountUrl(address, mockNonEvmNetwork);
 
       expect(result).toBe(expectedUrl);
     });

--- a/ui/helpers/utils/multichain/blockExplorer.test.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.test.ts
@@ -84,7 +84,7 @@ describe('Block Explorer Tests', () => {
   describe('getAssetDetailsAccountUrl', () => {
     it('returns the correct account URL using configured block explorer for EVM networks', () => {
       const address = '0x1234567890abcdef';
-      // Uses the network's configured block explorer URL
+      // getAccountLink uses the network's configured block explorer URL
       const expectedUrl = `https://etherscan.io/address/${address}`;
 
       const result = getAssetDetailsAccountUrl(address, mockEvmNetwork);
@@ -92,7 +92,7 @@ describe('Block Explorer Tests', () => {
       expect(result).toBe(expectedUrl);
     });
 
-    it('falls back to Etherscan multichain when no block explorer is configured', () => {
+    it('falls back to default explorer when no block explorer is configured', () => {
       const address = '0x1234567890abcdef';
       const networkWithoutExplorer: MultichainNetwork = {
         ...mockEvmNetwork,
@@ -104,7 +104,8 @@ describe('Block Explorer Tests', () => {
           },
         },
       };
-      const expectedUrl = `https://etherscan.io/address/${address}#asset-multichain`;
+      // getAccountLink falls back to known explorer for mainnet
+      const expectedUrl = `https://etherscan.io/address/${address}`;
 
       const result = getAssetDetailsAccountUrl(address, networkWithoutExplorer);
 

--- a/ui/helpers/utils/multichain/blockExplorer.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.ts
@@ -1,4 +1,5 @@
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
+import { getAccountLink } from '@metamask/etherscan-link';
 import { MultichainNetwork } from '../../../selectors/multichain';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -23,6 +24,28 @@ export const getMultichainAccountUrl = (
   }
 
   // We're in a non-EVM context, so we assume we can use format URLs instead.
+  const { blockExplorerFormatUrls } =
+    network.network as MultichainProviderConfig;
+  if (blockExplorerFormatUrls) {
+    return formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
+  }
+
+  return '';
+};
+
+export const getAssetDetailsAccountUrl = (
+  address: string,
+  network: MultichainNetwork,
+): string => {
+  const { namespace } = parseCaipChainId(network.chainId);
+  if (namespace === KnownCaipNamespace.Eip155) {
+    return getAccountLink(
+      normalizeSafeAddress(address),
+      network.network.chainId,
+      network.network?.rpcPrefs,
+    );
+  }
+
   const { blockExplorerFormatUrls } =
     network.network as MultichainProviderConfig;
   if (blockExplorerFormatUrls) {

--- a/ui/pages/asset/components/token-asset.tsx
+++ b/ui/pages/asset/components/token-asset.tsx
@@ -25,7 +25,7 @@ import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { getTokenList, selectERC20TokensByChain } from '../../../selectors';
 import { showModal } from '../../../store/actions';
-import { getMultichainAccountUrl } from '../../../helpers/utils/multichain/blockExplorer';
+import { getAssetDetailsAccountUrl } from '../../../helpers/utils/multichain/blockExplorer';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { getMultichainNetwork } from '../../../selectors/multichain';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../selectors/multichain-accounts/account-tree';
@@ -112,7 +112,7 @@ const TokenAsset = ({ token, chainId }: { token: Token; chainId: Hex }) => {
 
   const blockExplorerLink = isEvm
     ? tokenTrackerLink
-    : getMultichainAccountUrl(
+    : getAssetDetailsAccountUrl(
         parseCaipAssetType(address as CaipAssetType).assetReference,
         multichainNetwork,
       );


### PR DESCRIPTION
This PR is to fix the link of "View Asset" button in asset-details page

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: #34698 

## **Manual testing steps**

1. Go to asset-details page
2. View Asset in Explorer links to asset on block explorer specified in Network details for the asset chain ID

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use network-configured block explorer for asset detail links (with fallback) and update token page to use it; add tests.
> 
> - **Utils (multichain)**:
>   - Add `getAssetDetailsAccountUrl` to build account URLs:
>     - EVM: uses `getAccountLink` with network `rpcPrefs` (falls back to known explorer).
>     - Non-EVM: uses `blockExplorerFormatUrls` via `formatBlockExplorerAddressUrl`.
> - **Asset UI**:
>   - `token-asset.tsx`: switch non-EVM block explorer link from `getMultichainAccountUrl` to `getAssetDetailsAccountUrl`.
> - **Tests**:
>   - Extend `blockExplorer.test.ts` to cover `getAssetDetailsAccountUrl` for EVM (configured and fallback) and non-EVM cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a09dc14ebd3054c699835537d3bbfac056031424. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->