### PR TITLE
chore: Increase UI<=>background RPC timeout

### DIFF
--- a/app/scripts/lib/metaRPCClientFactory.ts
+++ b/app/scripts/lib/metaRPCClientFactory.ts
@@ -9,13 +9,14 @@ import {
   hasProperty,
 } from '@metamask/utils';
 import { JsonRpcError } from '@metamask/rpc-errors';
-import { TEN_SECONDS_IN_MILLISECONDS } from '../../../shared/lib/transactions-controller-utils';
 import getNextId from '../../../shared/modules/random-id';
 // It *is* used: in TypeDoc comment, you silly goose.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type MetamaskController from '../metamask-controller';
 
 const JSON_RPC_VERSION = '2.0' as const;
+
+const SIXTEEN_SECONDS_AS_MILLISECONDS = 16000;
 
 type Timer = ReturnType<typeof setTimeout>;
 
@@ -186,7 +187,7 @@ export class MetaRPCClient<Api extends FunctionRegistry<Api>> {
           timer = setTimeout(() => {
             this.requests.delete(payload.id);
             reject(new Error('No response from RPC'));
-          }, TEN_SECONDS_IN_MILLISECONDS);
+          }, SIXTEEN_SECONDS_AS_MILLISECONDS);
         }
         this.requests.set(payload.id, { resolve, reject, timer });
         this.#connectionStream.write(payload);


### PR DESCRIPTION
## **Description**

The timeout for the `getState` call from the UI to the background has been increased from 10s to 16s. This increase may be enough to allow state to load on some slower machines where the wallet state is especially large, and at the very least if we don't see a change in error rates, we'll still learn something from this change.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38561?quickstart=1)

## **Changelog**

CHANGELOG entry: Increase timeout for UI calls to background from 10s to 16s, potentially preventing UI crash on very slow devices.

## **Related issues**

This change is a compainion to #38322, which increased a different related timeout for the same reason.

## **Manual testing steps**

I am not sure how to best test this specific timeout. The change is simply enough that I don't think it strictly needs manual testing though.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `getState` UI↔background RPC timeout from 10s to 16s and inline the new timeout constant.
> 
> - **RPC client (`app/scripts/lib/metaRPCClientFactory.ts`)**
>   - Increase `getState` request timeout from 10s to 16s using `SIXTEEN_SECONDS_AS_MILLISECONDS` in `send`.
>   - Remove use of `TEN_SECONDS_IN_MILLISECONDS` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fdc720b3cf6ece8c88c676c4c7af12bddbaff5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->