### PR TITLE
refactor: cp-13.13.0 gate `ProfileMetricsController` with `pna25Acknowledged`

### DIFF
--- a/app/scripts/controller-init/profile-metrics-controller-init.ts
+++ b/app/scripts/controller-init/profile-metrics-controller-init.ts
@@ -24,9 +24,12 @@ export const ProfileMetricsControllerInit: ControllerInitFunction<
     'RemoteFeatureFlagController',
   );
   const metaMetricsController = getController('MetaMetricsController');
+  const appStateController = getController('AppStateController');
   const assertUserOptedIn = () =>
     remoteFeatureFlagController.state.remoteFeatureFlags.extensionUxPna25 ===
-      true && metaMetricsController.state.participateInMetaMetrics === true;
+      true &&
+    appStateController.state.pna25Acknowledged === true &&
+    metaMetricsController.state.participateInMetaMetrics === true;
 
   const controller = new ProfileMetricsController({
     messenger: controllerMessenger,

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -77,7 +77,7 @@ async function waitForEndpointToBeCalled(
 }
 
 describe('Profile Metrics', function () {
-  describe('when MetaMetrics is enabled, the feature flag is on, and the user acknoledged the privacy change', function () {
+  describe('when MetaMetrics is enabled, the feature flag is on, and the user acknowledged the privacy change', function () {
     it('sends exising accounts to the API on wallet unlock after activating MetaMetrics', async function () {
       await withFixtures(
         {

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -77,13 +77,16 @@ async function waitForEndpointToBeCalled(
 }
 
 describe('Profile Metrics', function () {
-  describe('when MetaMetrics is enabled and the feature flag is on', function () {
+  describe('when MetaMetrics is enabled, the feature flag is on, and the user acknoledged the privacy change', function () {
     it('sends exising accounts to the API on wallet unlock after activating MetaMetrics', async function () {
       await withFixtures(
         {
           fixtures: new FixtureBuilder()
             .withMetaMetricsController({
               participateInMetaMetrics: true,
+            })
+            .withAppStateController({
+              pna25Acknowledged: true,
             })
             .build(),
           testSpecificMock: async (server: Mockttp) => [
@@ -120,6 +123,9 @@ describe('Profile Metrics', function () {
           fixtures: new FixtureBuilder()
             .withMetaMetricsController({
               participateInMetaMetrics: true,
+            })
+            .withAppStateController({
+              pna25Acknowledged: true,
             })
             .build(),
           testSpecificMock: async (server: Mockttp) => [
@@ -159,77 +165,67 @@ describe('Profile Metrics', function () {
     });
   });
 
-  describe('when MetaMetrics is disabled or the feature flag is off', function () {
-    it('does not send existing accounts to the API on wallet unlock if MetaMetrics is disabled', async function () {
-      await withFixtures(
-        {
-          fixtures: new FixtureBuilder()
-            .withMetaMetricsController({
-              participateInMetaMetrics: false,
-            })
-            .build(),
-          testSpecificMock: async (server: Mockttp) => [
-            await mockAuthService(server),
-            await mockSendFeatureFlag(true)(server),
-          ],
-          title: this.test?.fullTitle(),
-        },
-        async ({
-          driver,
-          mockedEndpoint,
-        }: {
-          driver: Driver;
-          mockedEndpoint: MockedEndpoint[];
-        }) => {
-          await loginWithBalanceValidation(driver);
+  [
+    {
+      title: 'MetaMetrics is disabled',
+      participateInMetaMetrics: false,
+      featureFlag: true,
+      pna25Acknowledged: true,
+    },
+    {
+      title: 'feature flag is off',
+      participateInMetaMetrics: true,
+      featureFlag: false,
+      pna25Acknowledged: true,
+    },
+    {
+      title: 'user has not acknowledged the privacy change',
+      participateInMetaMetrics: true,
+      featureFlag: true,
+      pna25Acknowledged: false,
+    },
+  ].forEach(
+    ({ title, participateInMetaMetrics, featureFlag, pna25Acknowledged }) => {
+      describe(title, function () {
+        it('does not send existing accounts to the API on wallet unlock', async function () {
+          await withFixtures(
+            {
+              fixtures: new FixtureBuilder()
+                .withMetaMetricsController({
+                  participateInMetaMetrics,
+                })
+                .withAppStateController({
+                  pna25Acknowledged,
+                })
+                .build(),
+              testSpecificMock: async (server: Mockttp) => [
+                await mockAuthService(server),
+                await mockSendFeatureFlag(featureFlag)(server),
+              ],
+              title: this.test?.fullTitle(),
+            },
+            async ({
+              driver,
+              mockedEndpoint,
+            }: {
+              driver: Driver;
+              mockedEndpoint: MockedEndpoint[];
+            }) => {
+              await loginWithBalanceValidation(driver);
 
-          await driver.delay(5000);
+              await driver.delay(5000);
 
-          const [authCall] = mockedEndpoint;
-          const requests = await authCall.getSeenRequests();
-          assert.equal(
-            requests.length,
-            0,
-            'Expected no requests to the auth API.',
+              const [authCall] = mockedEndpoint;
+              const requests = await authCall.getSeenRequests();
+              assert.equal(
+                requests.length,
+                0,
+                'Expected no requests to the auth API.',
+              );
+            },
           );
-        },
-      );
-    });
-
-    it('does not send existing accounts to the API on wallet unlock if feature flag is disabled', async function () {
-      await withFixtures(
-        {
-          fixtures: new FixtureBuilder()
-            .withMetaMetricsController({
-              participateInMetaMetrics: true,
-            })
-            .build(),
-          testSpecificMock: async (server: Mockttp) => [
-            await mockAuthService(server),
-            await mockSendFeatureFlag(false)(server),
-          ],
-          title: this.test?.fullTitle(),
-        },
-        async ({
-          driver,
-          mockedEndpoint,
-        }: {
-          driver: Driver;
-          mockedEndpoint: MockedEndpoint[];
-        }) => {
-          await loginWithBalanceValidation(driver);
-
-          await driver.delay(5000);
-
-          const [authCall] = mockedEndpoint;
-          const requests = await authCall.getSeenRequests();
-          assert.equal(
-            requests.length,
-            0,
-            'Expected no requests to the auth API.',
-          );
-        },
-      );
-    });
-  });
+        });
+      });
+    },
+  );
 });

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -167,19 +167,19 @@ describe('Profile Metrics', function () {
 
   [
     {
-      title: 'MetaMetrics is disabled',
+      title: 'when MetaMetrics is disabled',
       participateInMetaMetrics: false,
       featureFlag: true,
       pna25Acknowledged: true,
     },
     {
-      title: 'feature flag is off',
+      title: 'when the relevant feature flag is off',
       participateInMetaMetrics: true,
       featureFlag: false,
       pna25Acknowledged: true,
     },
     {
-      title: 'user has not acknowledged the privacy change',
+      title: 'when the user has not acknowledged the privacy change',
       participateInMetaMetrics: true,
       featureFlag: true,
       pna25Acknowledged: false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The PR adds an additional check to the `assertUserOptedIn` function passed to the `ProfileMetricsController` to ensure that profile metrics are only collected after the user has acknowledged the PNA25 notice.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38562?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates profile metrics collection behind `pna25Acknowledged` and updates E2E tests to cover acknowledgment and other gating conditions.
> 
> - **Controller init**:
>   - Update `assertUserOptedIn` in `app/scripts/controller-init/profile-metrics-controller-init.ts` to also require `AppStateController.state.pna25Acknowledged === true` alongside the feature flag and MetaMetrics opt-in.
> - **E2E tests** (`test/e2e/tests/profile-metrics/profile-metrics.spec.ts`):
>   - Positive path: include `.withAppStateController({ pna25Acknowledged: true })` when MetaMetrics is enabled and the feature flag is on; verify existing and new accounts trigger API calls.
>   - Negative paths: parameterize cases to assert no API calls when MetaMetrics is disabled, the feature flag is off, or the user has not acknowledged the privacy change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1424dce9531f7e9774f42e99eafdcfae4ae12833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->