### PR TITLE
chore: Improve background RPC timeout error message

### DIFF
--- a/app/scripts/lib/metaRPCClientFactory.test.js
+++ b/app/scripts/lib/metaRPCClientFactory.test.js
@@ -179,7 +179,9 @@ describe('metaRPCClientFactory', () => {
     );
 
     jest.runOnlyPendingTimers();
-    await expect(errorPromise).rejects.toThrow('No response from RPC');
+    await expect(errorPromise).rejects.toThrow(
+      `Background 'getState' call exceeded timeout`,
+    );
 
     jest.useRealTimers();
   });

--- a/app/scripts/lib/metaRPCClientFactory.ts
+++ b/app/scripts/lib/metaRPCClientFactory.ts
@@ -186,7 +186,7 @@ export class MetaRPCClient<Api extends FunctionRegistry<Api>> {
         if (payload.method === 'getState') {
           timer = setTimeout(() => {
             this.requests.delete(payload.id);
-            reject(new Error('No response from RPC'));
+            reject(new Error(`Background 'getState' call exceeded timeout`));
           }, SIXTEEN_SECONDS_AS_MILLISECONDS);
         }
         this.requests.set(payload.id, { resolve, reject, timer });


### PR DESCRIPTION
## **Description**

The error message for the `getState` timeout (from UI to background) has been re-worded to avoid misleading users into thinking that the error relates to network RPC endpoints. The current message has repeatedly been confused because we typically use the term "RPC" to refer to network RPC endpoints.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38564?quickstart=1)

## **Changelog**

CHANGELOG entry: Improve error message when UI can't retrieve state from background process

## **Related issues**

N/A

## **Manual testing steps**

I am not sure how best to reproduce this error, but it's just a copy change so I'm not sure we strictly need to manually test this.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the background RPC client’s getState timeout error message and aligns the unit test expectation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e06819c08afebf0c7208b8c15f2ac94ecc151a21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->