### PR TITLE
test: improve privacy snapshot generation

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -454,7 +454,7 @@ async function withFixtures(options, testSuite) {
       if (process.env.UPDATE_PRIVACY_SNAPSHOT === 'true') {
         writeFileSync(
           './privacy-snapshot.json',
-          JSON.stringify(mergedReport, null, 2),
+          `${JSON.stringify(mergedReport, null, 2)}\n`, // must add trailing newline to satisfy prettier
         );
       } else {
         throw new Error(

--- a/ui/helpers/utils/display-critical-error.test.ts
+++ b/ui/helpers/utils/display-critical-error.test.ts
@@ -22,8 +22,8 @@ jest.mock('webextension-polyfill', () => ({
 
 // Mock environment variables before importing the module
 const MOCK_SENTRY_DSN =
-  'https://3567c198f8a8412082d32655da2961d0@o124216.ingest.us.sentry.io/273505';
-const MOCK_SENTRY_DSN_DEV = 'https://dev123@o124216.ingest.us.sentry.io/273505';
+  'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505';
+const MOCK_SENTRY_DSN_DEV = 'https://dev123@sentry.io/273505';
 
 const originalEnv = process.env;
 process.env = {
@@ -237,12 +237,9 @@ describe('displayCriticalError', () => {
 
 describe('extractEnvelopeUrlFromDsn', () => {
   it('should extract correct envelope URL from valid DSN', () => {
-    const dsn =
-      'https://3567c198f8a8412082d32655da2961d0@o124216.ingest.us.sentry.io/273505';
+    const dsn = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505';
     const result = extractEnvelopeUrlFromDsn(dsn);
-    expect(result).toBe(
-      'https://o124216.ingest.us.sentry.io/api/273505/envelope/',
-    );
+    expect(result).toBe('https://sentry.io/api/273505/envelope/');
   });
 
   it('should handle different regions', () => {


### PR DESCRIPTION
## **Description**

- Our code was generating new privacy snapshots that did not end with a newline, and then failed Prettier lint.  It now ends with a newline.
- One of the unit tests was using `o124216.ingest.us.sentry.io`, which works, but lands at the same place as the simpler `sentry.io` we use everywhere else.  I changed it to be simpler and more consistent.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a trailing newline when writing `privacy-snapshot.json` and updates Sentry DSN test URLs/expectations to `sentry.io`.
> 
> - **Tests**:
>   - **E2E (`test/e2e/helpers.js`)**: Write `privacy-snapshot.json` with a trailing newline to satisfy prettier.
>   - **Unit (`ui/helpers/utils/display-critical-error.test.ts`)**: Update mocked DSNs to `sentry.io` and adjust `extractEnvelopeUrlFromDsn` expected envelope URL accordingly; regional DSN test remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 827f326bce5dcd29f18bcd94a6a6ee27026b09ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->