### PR TITLE
fix: migration script of update MegaETH testnet v2

### DIFF
--- a/app/scripts/migrations/184.test.ts
+++ b/app/scripts/migrations/184.test.ts
@@ -220,6 +220,69 @@ describe(`migration #${VERSION}`, () => {
     expect(newStorage).toStrictEqual(expectedStorage);
   });
 
+  it('merges the megaeth testnet v2 network configuration if user already has it', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: {
+            [MEGAETH_TESTNET_V2_CONFIG.chainId]: {
+              ...MEGAETH_TESTNET_V2_CONFIG,
+              name: 'MegaETH Testnet custom',
+              rpcEndpoints: [
+                {
+                  networkClientId: 'some-network-client-id',
+                  type: RpcEndpointType.Custom,
+                  url: 'https://timothy.megaeth.com/rpc',
+                  failoverUrls: [],
+                },
+              ],
+            },
+          },
+        },
+        NetworkEnablementController: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              [MEGAETH_TESTNET_V2_CONFIG.chainId]: true,
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: {
+            [MEGAETH_TESTNET_V2_CONFIG.chainId]: {
+              ...MEGAETH_TESTNET_V2_CONFIG,
+              rpcEndpoints: [
+                {
+                  networkClientId: 'some-network-client-id',
+                  type: RpcEndpointType.Custom,
+                  url: 'https://timothy.megaeth.com/rpc',
+                  failoverUrls: [],
+                },
+              ],
+            },
+          },
+        },
+        NetworkEnablementController: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              [MEGAETH_TESTNET_V2_CONFIG.chainId]: true,
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
   // @ts-expect-error 'each' function is not recognized by TypeScript types
   it.each(['megaeth-testnet', 'random-network-client-id'])(
     'switchs to mainnet when the selected network client id is in MegaETH Testnet v1 - %s',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fix the migration script 184,
to not replace the network configuration for a user if he already has megaETH testnet v2 exist
instead we only merge the information


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38573?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the migration script for adding MegaETH testnet v2

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install a extension without MegaETH testnet v2
2. Manually add MegaETH testnet v2 config
```
MEGAETH_TESTNET_V2_CONFIG = {
  chainId: '0x18c7', // 6343
  name: 'MegaETH Testnet',
  nativeCurrency: 'MegaETH',
  blockExplorerUrls: ['https://megaeth-testnet-v2.blockscout.com'],
  defaultRpcEndpointIndex: 0,
  defaultBlockExplorerUrlIndex: 0,
  rpcEndpoints: [
    {
      type: RpcEndpointType.Custom,
      url: 'https://timothy.megaeth.com/rpc',
    },
  ],
};
```
3. select the MegaETH testnet v2 as current network
4. update the extension to have the migration run
5. the network should remain the same

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b5eba40d-f044-45a9-8c17-6349e56c886a" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/f8de66ef-37f7-4762-a5f7-af129519b265" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update migration 184 to merge an existing MegaETH Testnet v2 config instead of overwriting, add it to the enabled map only if missing, and retain v1-to-mainnet switching; add a test for the merge path.
> 
> - **Migration 184**:
>   - Merge existing `MEGAETH_TESTNET_V2_CONFIG` instead of overwriting:
>     - Update `name` and `nativeCurrency`.
>     - Append missing RPC endpoint and block explorer URL; set default indices accordingly.
>   - Add v2 to `enabledNetworkMap` only if absent.
>   - Keep logic to switch selected client from v1 to `mainnet` and remove v1 config.
> - **Tests**:
>   - Add test to verify merging behavior when v2 already exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b4283dce4c4ebb35ec8fbcb51b29d3e730cba9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->