### PR TITLE
fix: Resolve an error with significant digits cp-13.13.0

### DIFF
--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -42,7 +42,7 @@ export function useEthFiatAmount(
     return undefined;
   }
 
-  const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate);
+  const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate.toString());
   if (
     ethAmount &&
     fiatAmount.lt(new BigNumber(0.01)) &&

--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.test.ts
@@ -239,6 +239,25 @@ describe('useGasFeeToken', () => {
     expect(result.current.amountFiat).toBe('< $0.01');
   });
 
+  it('handles conversion rates with more than 15 significant digits', () => {
+    // Conversion rates from price APIs can have 16+ significant digits
+    // which would cause BigNumber to throw if passed as a number type
+    const highPrecisionRate = 3145.037142758881;
+
+    const state = getState({
+      gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+      chainId: CHAIN_IDS.POLYGON,
+      currencyRates: { POL: { conversionRate: highPrecisionRate } },
+    });
+
+    expect(() => {
+      renderHookWithConfirmContextProvider(
+        () => useGasFeeToken({ tokenAddress: GAS_FEE_TOKEN_MOCK.tokenAddress }),
+        state,
+      );
+    }).not.toThrow();
+  });
+
   describe('useSelectedGasFeeToken', () => {
     it('returns selected gas fee token', () => {
       const result = runUseSelectedGasFeeTokenHook();

--- a/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.ts
@@ -177,7 +177,7 @@ function useFiatTokenValue(
     return fallbackFiatValue ?? '';
   }
 
-  const fiatAmount = nativeEth.times(conversionRate);
+  const fiatAmount = nativeEth.times(conversionRate.toString());
 
   if (fiatAmount.lt(new BigNumber(0.01)) && fiatAmount.gt(new BigNumber(0))) {
     return `< ${fiatFormatter(0.01)}`;

--- a/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
@@ -52,7 +52,7 @@ const NativeSendHeading = () => {
   const fiatValue =
     conversionRate &&
     nativeAssetTransferValue &&
-    new BigNumber(conversionRate)
+    new BigNumber(String(conversionRate))
       .times(nativeAssetTransferValue, 10)
       .toNumber();
   const fiatFormatter = useFiatFormatter();

--- a/ui/pages/confirmations/utils/token.test.ts
+++ b/ui/pages/confirmations/utils/token.test.ts
@@ -116,6 +116,24 @@ describe('calculateTokenAmount', () => {
       new BigNumber('10000000'),
     );
   });
+
+  it('handles conversion rates with more than 15 significant digits', () => {
+    // Conversion rates from price APIs can have 16+ significant digits
+    // which would cause BigNumber to throw if passed as a number type
+    const highPrecisionRate = 3145.037142758881;
+
+    expect(() =>
+      calculateTokenAmount('1000000000000000000', 18, 10, highPrecisionRate),
+    ).not.toThrow();
+
+    const result = calculateTokenAmount(
+      '1000000000000000000',
+      18,
+      10,
+      highPrecisionRate,
+    );
+    expect(result.toNumber()).toBeCloseTo(highPrecisionRate, 10);
+  });
 });
 
 describe('getTokenValueFromRecord', () => {

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -147,7 +147,7 @@ export const calculateTokenAmount = (
   const divisor = new BigNumber(10).pow(decimals ?? 0);
   return new BigNumber(String(value), base)
     .div(divisor)
-    .times(new BigNumber(conversionRate, 10));
+    .times(new BigNumber(String(conversionRate), 10));
 };
 
 export function getTokenValueFromRecord<Type>(


### PR DESCRIPTION
## **Description**
Resolve an error with significant digits.

Explanation:
The conversion rates come from a price API and can have many decimal places: 3145.037142758881. By the time this reaches your code as a JS number, it's already been subject to float imprecision - but BigNumber can't know how imprecise, so it conservatively rejects anything over 15 digits.
tl;dr: String conversion tells BigNumber "trust me, parse this as-is" instead of "this is a potentially-imprecise float".

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38587?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Resolve an error with significant digits

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass conversion rates as strings to BigNumber to avoid precision/validation errors; add tests covering 16+ significant digits.
> 
> - **Fiat conversion logic**:
>   - Use string parsing for `conversionRate` in `BigNumber` operations to prevent errors with >15 significant digits in:
>     - `ui/hooks/useEthFiatAmount.js` (`times(conversionRate.toString())`)
>     - `ui/pages/.../useGasFeeToken.ts` (`nativeEth.times(conversionRate.toString())`)
>     - `ui/pages/.../native-send-heading.tsx` (`new BigNumber(String(conversionRate))`)
>     - `ui/pages/confirmations/utils/token.ts` (`new BigNumber(String(conversionRate), 10)`)
> - **Tests**:
>   - Add cases ensuring no throws and accurate results with high-precision rates in:
>     - `useGasFeeToken.test.ts`
>     - `token.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39d9b759375d7543ccd3c4207fd0c145e5d543b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->