### PR TITLE
fix: cp-13.12.1 cp-13.13.0 patch decimal bounds to currencyRates

### DIFF
--- a/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch
+++ b/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch
@@ -1,12 +1,12 @@
 diff --git a/dist/CurrencyRateController.cjs b/dist/CurrencyRateController.cjs
-index 9329fa3772bad655112451929bd107d99d95b34e..42882b0d6fd22f67d4c880933cb98752d295a2e4 100644
+index 9329fa3772bad655112451929bd107d99d95b34e..57683eb3b5501085f8d12fabdf0720ced0479ba8 100644
 --- a/dist/CurrencyRateController.cjs
 +++ b/dist/CurrencyRateController.cjs
 @@ -42,6 +42,7 @@ const defaultState = {
          },
      },
  };
-+const boundedPrecisionNumber = (n, precision = 9) => Number(n.toFixed(precision));
++const boundedPrecisionNumber = (value, precision = 9) => Number(value.toFixed(precision));
  /**
   * Controller that passively polls on a set interval for an exchange rate from the current network
   * asset to the user's preferred currency.
@@ -37,6 +37,59 @@ index 9329fa3772bad655112451929bd107d99d95b34e..42882b0d6fd22f67d4c880933cb98752
              };
          }));
 @@ -232,8 +239,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+         const ratesFromTokenPricesService = ratesFromTokenPrices.reduce((acc, rate) => {
+             acc[rate.nativeCurrency] = {
+                 conversionDate: rate.conversionDate,
+-                conversionRate: rate.conversionRate,
+-                usdConversionRate: rate.usdConversionRate,
++                conversionRate: rate.conversionRate
++                    ? boundedPrecisionNumber(rate.conversionRate)
++                    : null,
++                usdConversionRate: rate.usdConversionRate
++                    ? boundedPrecisionNumber(rate.usdConversionRate)
++                    : null,
+             };
+             return acc;
+         }, {});
+diff --git a/dist/CurrencyRateController.mjs b/dist/CurrencyRateController.mjs
+index d9c312e93b9ea6d37ad55321b2588248a61e5442..62280a33f6f67efcc173b5699b4f9bb13eea1c05 100644
+--- a/dist/CurrencyRateController.mjs
++++ b/dist/CurrencyRateController.mjs
+@@ -39,6 +39,7 @@ const defaultState = {
+         },
+     },
+ };
++const boundedPrecisionNumber = (value, precision = 9) => Number(value.toFixed(precision));
+ /**
+  * Controller that passively polls on a set interval for an exchange rate from the current network
+  * asset to the user's preferred currency.
+@@ -165,8 +166,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             const rate = priceApiExchangeRatesResponse[fetchedCurrency.toLowerCase()];
+             acc[nativeCurrency] = {
+                 conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+-                conversionRate: rate?.value ? Number(1 / rate?.value) : null,
+-                usdConversionRate: rate?.usd ? Number(1 / rate?.usd) : null,
++                conversionRate: rate?.value
++                    ? boundedPrecisionNumber(1 / rate.value)
++                    : null,
++                usdConversionRate: rate?.usd
++                    ? boundedPrecisionNumber(1 / rate.usd)
++                    : null,
+             };
+             return acc;
+         }, {});
+@@ -207,7 +212,9 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             return {
+                 nativeCurrency,
+                 conversionDate: tokenPrice ? Date.now() / 1000 : null,
+-                conversionRate: tokenPrice?.price ?? null,
++                conversionRate: tokenPrice?.price
++                    ? boundedPrecisionNumber(tokenPrice.price)
++                    : null,
+                 usdConversionRate: null, // Token prices service doesn't provide USD rate in this context
+             };
+         }));
+@@ -228,8 +235,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
          const ratesFromTokenPricesService = ratesFromTokenPrices.reduce((acc, rate) => {
              acc[rate.nativeCurrency] = {
                  conversionDate: rate.conversionDate,

--- a/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch
+++ b/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch
@@ -1,0 +1,53 @@
+diff --git a/dist/CurrencyRateController.cjs b/dist/CurrencyRateController.cjs
+index 9329fa3772bad655112451929bd107d99d95b34e..42882b0d6fd22f67d4c880933cb98752d295a2e4 100644
+--- a/dist/CurrencyRateController.cjs
++++ b/dist/CurrencyRateController.cjs
+@@ -42,6 +42,7 @@ const defaultState = {
+         },
+     },
+ };
++const boundedPrecisionNumber = (n, precision = 9) => Number(n.toFixed(precision));
+ /**
+  * Controller that passively polls on a set interval for an exchange rate from the current network
+  * asset to the user's preferred currency.
+@@ -169,8 +170,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             const rate = priceApiExchangeRatesResponse[fetchedCurrency.toLowerCase()];
+             acc[nativeCurrency] = {
+                 conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+-                conversionRate: rate?.value ? Number(1 / rate?.value) : null,
+-                usdConversionRate: rate?.usd ? Number(1 / rate?.usd) : null,
++                conversionRate: rate?.value
++                    ? boundedPrecisionNumber(1 / rate.value)
++                    : null,
++                usdConversionRate: rate?.usd
++                    ? boundedPrecisionNumber(1 / rate.usd)
++                    : null,
+             };
+             return acc;
+         }, {});
+@@ -211,7 +216,9 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             return {
+                 nativeCurrency,
+                 conversionDate: tokenPrice ? Date.now() / 1000 : null,
+-                conversionRate: tokenPrice?.price ?? null,
++                conversionRate: tokenPrice?.price
++                    ? boundedPrecisionNumber(tokenPrice.price)
++                    : null,
+                 usdConversionRate: null, // Token prices service doesn't provide USD rate in this context
+             };
+         }));
+@@ -232,8 +239,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+         const ratesFromTokenPricesService = ratesFromTokenPrices.reduce((acc, rate) => {
+             acc[rate.nativeCurrency] = {
+                 conversionDate: rate.conversionDate,
+-                conversionRate: rate.conversionRate,
+-                usdConversionRate: rate.usdConversionRate,
++                conversionRate: rate.conversionRate
++                    ? boundedPrecisionNumber(rate.conversionRate)
++                    : null,
++                usdConversionRate: rate.usdConversionRate
++                    ? boundedPrecisionNumber(rate.usdConversionRate)
++                    : null,
+             };
+             return acc;
+         }, {});

--- a/app/scripts/migrations/185.test.ts
+++ b/app/scripts/migrations/185.test.ts
@@ -1,0 +1,318 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './185';
+
+const VERSION = version;
+const oldVersion = 184;
+
+describe(`migration #${VERSION}`, () => {
+  let mockedCaptureException: jest.Mock;
+
+  beforeEach(() => {
+    mockedCaptureException = jest.fn();
+    global.sentry = { captureException: mockedCaptureException };
+  });
+
+  afterEach(() => {
+    global.sentry = undefined;
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version: VERSION });
+  });
+
+  it('does nothing if CurrencyController is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      `Migration ${VERSION}: CurrencyController not found.`,
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('captures exception if CurrencyController is not an object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: 'invalid',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: CurrencyController is not an object: string`,
+      ),
+    );
+  });
+
+  it('does nothing if currencyRates is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {},
+      },
+    };
+
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      `Migration ${VERSION}: currencyRates not found in CurrencyController.`,
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('captures exception if currencyRates is not an object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: 'invalid',
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: currencyRates is not an object: string`,
+      ),
+    );
+  });
+
+  it('rounds conversionRate with more than 9 decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 12.9848883888222, // 13 decimal places
+            },
+            BTC: {
+              conversionRate: 50000.123456789012, // 12 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 12.984888389, // Rounded to 9 decimal places
+            },
+            BTC: {
+              conversionRate: 50000.123456789, // Rounded to 9 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('does not modify conversionRate with 9 or fewer decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 12.123456789, // Exactly 9 decimal places
+            },
+            BTC: {
+              conversionRate: 50000.12345, // 5 decimal places
+            },
+            USDC: {
+              conversionRate: 1, // No decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    // Data should remain unchanged
+    expect(newStorage.data).toStrictEqual({
+      CurrencyController: {
+        currencyRates: {
+          ETH: {
+            conversionRate: 12.123456789,
+          },
+          BTC: {
+            conversionRate: 50000.12345,
+          },
+          USDC: {
+            conversionRate: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it('handles mixed currency rate data with some needing rounding', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.1234567890123, // Needs rounding
+            },
+            BTC: {
+              conversionRate: 45000.12345, // No rounding needed
+            },
+            INVALID: {
+              // Missing conversionRate property
+            },
+            USDC: {
+              conversionRate: '1.0', // String value, should be ignored
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+            },
+            BTC: {
+              conversionRate: 45000.12345, // Unchanged
+            },
+            INVALID: {
+              // Unchanged
+            },
+            USDC: {
+              conversionRate: '1.0', // Unchanged (string)
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('handles empty currencyRates object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('handles edge case with very small numbers', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            SMALLCOIN: {
+              conversionRate: 0.0000000001234567890123, // Very small with many decimals
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            SMALLCOIN: {
+              conversionRate: 0.000000000, // Rounded to 9 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('preserves other properties in CurrencyController', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currentCurrency: 'usd',
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.1234567890123,
+              conversionDate: 1234567890,
+            },
+          },
+          otherProperty: 'should be preserved',
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currentCurrency: 'usd',
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+              conversionDate: 1234567890, // Preserved
+            },
+          },
+          otherProperty: 'should be preserved', // Preserved
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+});

--- a/app/scripts/migrations/185.test.ts
+++ b/app/scripts/migrations/185.test.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { migrate, version } from './185';
 
 const VERSION = version;
@@ -97,9 +96,7 @@ describe(`migration #${VERSION}`, () => {
 
     expect(newStorage.data).toStrictEqual(oldStorage.data);
     expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${VERSION}: currencyRates is not an object: string`,
-      ),
+      new Error(`Migration ${VERSION}: currencyRates is not an object: string`),
     );
   });
 
@@ -110,10 +107,10 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             ETH: {
-              conversionRate: 12.9848883888222, // 13 decimal places
+              conversionRate: parseFloat('12.9848883888222'), // 13 decimal places
             },
             BTC: {
-              conversionRate: 50000.123456789012, // 12 decimal places
+              conversionRate: parseFloat('50000.123456789012'), // 12 decimal places
             },
           },
         },
@@ -188,7 +185,7 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             ETH: {
-              conversionRate: 2500.1234567890123, // Needs rounding
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
             },
             BTC: {
               conversionRate: 45000.12345, // No rounding needed
@@ -266,7 +263,7 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             SMALLCOIN: {
-              conversionRate: 0.000000000, // Rounded to 9 decimal places
+              conversionRate: 0, // Rounded to 9 decimal places
             },
           },
         },
@@ -285,10 +282,10 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             ETH: {
-              usdConversionRate: 2500.1234567890123, // Needs rounding
+              usdConversionRate: parseFloat('2500.1234567890123'), // Needs rounding
             },
             BTC: {
-              usdConversionRate: 45000.123456789012, // Needs rounding
+              usdConversionRate: parseFloat('45000.123456789012'), // Needs rounding
             },
           },
         },
@@ -323,8 +320,8 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             ETH: {
-              conversionRate: 2500.1234567890123, // Needs rounding
-              usdConversionRate: 2500.9876543210987, // Needs rounding
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+              usdConversionRate: parseFloat('2500.9876543210987'), // Needs rounding
             },
             BTC: {
               conversionRate: 45000.12345, // No rounding needed
@@ -405,8 +402,8 @@ describe(`migration #${VERSION}`, () => {
         CurrencyController: {
           currencyRates: {
             ETH: {
-              conversionRate: 2500.1234567890123, // Needs rounding
-              usdConversionRate: 2500.9876543210987, // Needs rounding
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+              usdConversionRate: parseFloat('2500.9876543210987'), // Needs rounding
             },
             BTC: {
               usdConversionRate: 45000.12345, // No rounding needed
@@ -460,8 +457,8 @@ describe(`migration #${VERSION}`, () => {
           currentCurrency: 'usd',
           currencyRates: {
             ETH: {
-              conversionRate: 2500.1234567890123,
-              usdConversionRate: 2500.9876543210987,
+              conversionRate: parseFloat('2500.1234567890123'),
+              usdConversionRate: parseFloat('2500.9876543210987'),
               conversionDate: 1234567890,
             },
           },

--- a/app/scripts/migrations/185.ts
+++ b/app/scripts/migrations/185.ts
@@ -1,0 +1,98 @@
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { captureException } from '../../../shared/lib/sentry';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 185;
+
+/**
+ * This migration rounds conversionRate values in CurrencyController
+ * to a maximum of 9 decimal places to prevent precision issues.
+ *
+ * @param originalVersionedData - The original MetaMask extension state.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+
+  try {
+    transformState(versionedData.data);
+  } catch (error) {
+    console.error(error);
+    const newError = new Error(
+      `Migration #${version}: ${getErrorMessage(error)}`,
+    );
+    captureException(newError);
+    // Even though we encountered an error, we need the migration to pass for
+    // the migrator tests to work
+    versionedData.data = originalVersionedData.data;
+  }
+
+  return versionedData;
+}
+
+/**
+ * Rounds a number to a specified precision (maximum decimal places)
+ * @param value - The number to round
+ * @param precision - The maximum number of decimal places (default: 9)
+ * @returns The rounded number
+ */
+function boundedPrecisionNumber(value: number, precision = 9): number {
+  return Number(value.toFixed(precision));
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (!hasProperty(state, 'CurrencyController')) {
+    console.warn(`Migration ${version}: CurrencyController not found.`);
+    return state;
+  }
+
+  const currencyController = state.CurrencyController;
+  if (!isObject(currencyController)) {
+    captureException(
+      new Error(
+        `Migration ${version}: CurrencyController is not an object: ${typeof currencyController}`,
+      ),
+    );
+    return state;
+  }
+
+  if (!hasProperty(currencyController, 'currencyRates')) {
+    console.warn(`Migration ${version}: currencyRates not found in CurrencyController.`);
+    return state;
+  }
+
+  const currencyRates = currencyController.currencyRates;
+  if (!isObject(currencyRates)) {
+    captureException(
+      new Error(
+        `Migration ${version}: currencyRates is not an object: ${typeof currencyRates}`,
+      ),
+    );
+    return state;
+  }
+
+  // Iterate through each currency and round conversionRate values
+  Object.keys(currencyRates).forEach((currency) => {
+    const rateData = currencyRates[currency];
+    if (isObject(rateData) && hasProperty(rateData, 'conversionRate')) {
+      const conversionRate = rateData.conversionRate;
+      if (typeof conversionRate === 'number') {
+        // Check if the number has more than 9 decimal places
+        const decimalPlaces = conversionRate.toString().split('.')[1]?.length || 0;
+        if (decimalPlaces > 9) {
+          rateData.conversionRate = boundedPrecisionNumber(conversionRate);
+        }
+      }
+    }
+  });
+
+  return state;
+}

--- a/app/scripts/migrations/185.ts
+++ b/app/scripts/migrations/185.ts
@@ -10,7 +10,7 @@ type VersionedData = {
 export const version = 185;
 
 /**
- * This migration rounds conversionRate values in CurrencyController
+ * This migration rounds conversionRate and usdConversionRate values in CurrencyController
  * to a maximum of 9 decimal places to prevent precision issues.
  *
  * @param originalVersionedData - The original MetaMask extension state.
@@ -65,7 +65,9 @@ function transformState(state: Record<string, unknown>) {
   }
 
   if (!hasProperty(currencyController, 'currencyRates')) {
-    console.warn(`Migration ${version}: currencyRates not found in CurrencyController.`);
+    console.warn(
+      `Migration ${version}: currencyRates not found in CurrencyController.`,
+    );
     return state;
   }
 
@@ -79,16 +81,34 @@ function transformState(state: Record<string, unknown>) {
     return state;
   }
 
-  // Iterate through each currency and round conversionRate values
+  // Iterate through each currency and round conversionRate and usdConversionRate values
   Object.keys(currencyRates).forEach((currency) => {
     const rateData = currencyRates[currency];
-    if (isObject(rateData) && hasProperty(rateData, 'conversionRate')) {
-      const conversionRate = rateData.conversionRate;
-      if (typeof conversionRate === 'number') {
-        // Check if the number has more than 9 decimal places
-        const decimalPlaces = conversionRate.toString().split('.')[1]?.length || 0;
-        if (decimalPlaces > 9) {
-          rateData.conversionRate = boundedPrecisionNumber(conversionRate);
+    if (isObject(rateData)) {
+      // Handle conversionRate
+      if (hasProperty(rateData, 'conversionRate')) {
+        const conversionRate = rateData.conversionRate;
+        if (typeof conversionRate === 'number') {
+          // Check if the number has more than 9 decimal places
+          const decimalPlaces =
+            conversionRate.toString().split('.')[1]?.length || 0;
+          if (decimalPlaces > 9) {
+            rateData.conversionRate = boundedPrecisionNumber(conversionRate);
+          }
+        }
+      }
+
+      // Handle usdConversionRate
+      if (hasProperty(rateData, 'usdConversionRate')) {
+        const usdConversionRate = rateData.usdConversionRate;
+        if (typeof usdConversionRate === 'number') {
+          // Check if the number has more than 9 decimal places
+          const decimalPlaces =
+            usdConversionRate.toString().split('.')[1]?.length || 0;
+          if (decimalPlaces > 9) {
+            rateData.usdConversionRate =
+              boundedPrecisionNumber(usdConversionRate);
+          }
         }
       }
     }

--- a/app/scripts/migrations/185.ts
+++ b/app/scripts/migrations/185.ts
@@ -40,6 +40,7 @@ export async function migrate(
 
 /**
  * Rounds a number to a specified precision (maximum decimal places)
+ *
  * @param value - The number to round
  * @param precision - The maximum number of decimal places (default: 9)
  * @returns The rounded number
@@ -71,7 +72,7 @@ function transformState(state: Record<string, unknown>) {
     return state;
   }
 
-  const currencyRates = currencyController.currencyRates;
+  const { currencyRates } = currencyController;
   if (!isObject(currencyRates)) {
     captureException(
       new Error(
@@ -87,7 +88,7 @@ function transformState(state: Record<string, unknown>) {
     if (isObject(rateData)) {
       // Handle conversionRate
       if (hasProperty(rateData, 'conversionRate')) {
-        const conversionRate = rateData.conversionRate;
+        const { conversionRate } = rateData;
         if (typeof conversionRate === 'number') {
           // Check if the number has more than 9 decimal places
           const decimalPlaces =
@@ -100,7 +101,7 @@ function transformState(state: Record<string, unknown>) {
 
       // Handle usdConversionRate
       if (hasProperty(rateData, 'usdConversionRate')) {
-        const usdConversionRate = rateData.usdConversionRate;
+        const { usdConversionRate } = rateData;
         if (typeof usdConversionRate === 'number') {
           // Check if the number has more than 9 decimal places
           const decimalPlaces =

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -219,6 +219,7 @@ const migrations = [
   require('./182'),
   require('./183'),
   require('./184'),
+  require('./185'),
 ];
 
 export default migrations;

--- a/package.json
+++ b/package.json
@@ -246,7 +246,10 @@
     "@endo/env-options@npm:^1.1.8": "patch:@endo/env-options@npm%3A1.1.11#~/.yarn/patches/@endo-env-options-npm-1.1.11-1b7fae374a.patch",
     "@metamask/jazzicon@npm:^2.0.0": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
     "@rive-app/canvas@npm:2.31.5": "patch:@rive-app/canvas@patch%3A@rive-app/canvas@patch%253A@rive-app/canvas@npm%25253A2.31.5%2523~/.yarn/patches/@rive-app-canvas-npm-2.31.5-df519c6e0f.patch%253A%253Aversion=2.31.5&hash=1ed092%23~/.yarn/patches/@rive-app-canvas-patch-9b746e9393.patch%3A%3Aversion=2.31.5&hash=19c5d0#~/.yarn/patches/@rive-app-canvas-patch-03752f0c3b.patch",
-    "addons-linter/glob": "^10.5.0"
+    "addons-linter/glob": "^10.5.0",
+    "@metamask/assets-controllers@npm:^92.0.0": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch",
+    "@metamask/assets-controllers@npm:^93.0.0": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch",
+    "@metamask/assets-controllers@npm:^91.0.0": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",
@@ -274,7 +277,7 @@
     "@metamask/address-book-controller": "^7.0.0",
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^8.0.0",
-    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A93.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch",
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch",
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.8.0",
     "@metamask/bridge-controller": "^64.0.0",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -113,8 +113,8 @@
     "currencyRates": {
       "ETH": {
         "conversionDate": "number",
-        "conversionRate": 1700,
-        "usdConversionRate": 1700
+        "conversionRate": 1700.0000000000002,
+        "usdConversionRate": 1700.0000000000002
       },
       "MON": {
         "conversionDate": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -113,8 +113,8 @@
     "currencyRates": {
       "ETH": {
         "conversionDate": "number",
-        "conversionRate": 1700.0000000000002,
-        "usdConversionRate": 1700.0000000000002
+        "conversionRate": 1700,
+        "usdConversionRate": 1700
       },
       "MON": {
         "conversionDate": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -122,8 +122,8 @@
     "currencyRates": {
       "ETH": {
         "conversionDate": "number",
-        "conversionRate": 1700,
-        "usdConversionRate": 1700
+        "conversionRate": 1700.0000000000002,
+        "usdConversionRate": 1700.0000000000002
       },
       "MON": {
         "conversionDate": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -122,8 +122,8 @@
     "currencyRates": {
       "ETH": {
         "conversionDate": "number",
-        "conversionRate": 1700.0000000000002,
-        "usdConversionRate": 1700.0000000000002
+        "conversionRate": 1700,
+        "usdConversionRate": 1700
       },
       "MON": {
         "conversionDate": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -311,5 +311,5 @@
     "config": "object",
     "firstTimeInfo": "object"
   },
-  "meta": { "version": 184 }
+  "meta": { "version": 185 }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5738,167 +5738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^91.0.0":
-  version: 91.0.0
-  resolution: "@metamask/assets-controllers@npm:91.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/account-tree-controller": ^4.0.0
-    "@metamask/accounts-controller": ^35.0.0
-    "@metamask/approval-controller": ^8.0.0
-    "@metamask/core-backend": ^5.0.0
-    "@metamask/keyring-controller": ^25.0.0
-    "@metamask/network-controller": ^26.0.0
-    "@metamask/permission-controller": ^12.0.0
-    "@metamask/phishing-controller": ^16.0.0
-    "@metamask/preferences-controller": ^22.0.0
-    "@metamask/providers": ^22.0.0
-    "@metamask/snaps-controllers": ^14.0.0
-    "@metamask/transaction-controller": ^62.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/8e43d631a5ae86fc4801912e79d944ad087a605bb7a5e2813de64b6e068dc26482d25d37c3e2272e435a71ee8a7dafe875edb46cbfbcd150fb474588b45e6ff4
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^92.0.0":
-  version: 92.0.0
-  resolution: "@metamask/assets-controllers@npm:92.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^4.0.0"
-    "@metamask/network-controller": "npm:^26.0.0"
-    "@metamask/permission-controller": "npm:^12.1.1"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/transaction-controller": "npm:^62.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/fa6d43e9397654ed504f76d19f74a343bf937171dcf639cf203a6135d7e7e31617ff98d302283d3cabcb2d39767632cbad5717580bb40fcd63e2aa0f948d6bb4
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^93.0.0":
-  version: 93.1.0
-  resolution: "@metamask/assets-controllers@npm:93.1.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.0"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^4.0.0"
-    "@metamask/network-controller": "npm:^27.0.0"
-    "@metamask/permission-controller": "npm:^12.1.1"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.0"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^14.0.1"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
-    "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/transaction-controller": "npm:^62.4.0"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/9511e927310959e84a6a046ffde6a7f553c9c64e122d7951010ed0cb7da4066d6f27b4ef874706ebce3c664de0662ccd792339bb66ac9359b5686ec53858e9ae
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A93.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch":
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A93.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch::version=93.0.0&hash=224a2c":
   version: 93.0.0
   resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A93.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch::version=93.0.0&hash=224a2c"
   dependencies:
@@ -5949,6 +5789,60 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/a17bf2047c38f419826b4dec56ebed4ad6160b3db94e15a1fc61e69e4264bd6450693bf0ea096ecb91a8fb547362d4b94960505df7319359becb0a3df7ee4e78
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch":
+  version: 93.0.0
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch::version=93.0.0&hash=fbb27a"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/account-tree-controller": "npm:^4.0.0"
+    "@metamask/accounts-controller": "npm:^35.0.0"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/core-backend": "npm:^5.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/keyring-controller": "npm:^25.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-account-service": "npm:^4.0.0"
+    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/permission-controller": "npm:^12.1.1"
+    "@metamask/phishing-controller": "npm:^16.1.0"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/preferences-controller": "npm:^22.0.0"
+    "@metamask/profile-sync-controller": "npm:^27.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-controllers": "npm:^14.0.1"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/snaps-utils": "npm:^11.0.0"
+    "@metamask/transaction-controller": "npm:^62.4.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/9d36f75a46ec7b4291bee131e52b7ab3f991d2a1d70e90676cba7a4cd51a3196c77922fa6ad1e87fbbfbf825e5700a350a5bd0f21fc48a3fc220c9051e7687de
   languageName: node
   linkType: hard
 
@@ -33450,7 +33344,7 @@ __metadata:
     "@metamask/announcement-controller": "npm:^8.0.0"
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A93.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch"
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch"
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5794,7 +5794,7 @@ __metadata:
 
 "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch":
   version: 93.0.0
-  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch::version=93.0.0&hash=fbb27a"
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A93.0.0%23~/.yarn/patches/@metamask-assets-controllers-npm-93.0.0-ea998cb0bd.patch%3A%3Aversion=93.0.0&hash=224a2c#~/.yarn/patches/@metamask-assets-controllers-patch-0229f60576.patch::version=93.0.0&hash=53f301"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -5842,7 +5842,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/9d36f75a46ec7b4291bee131e52b7ab3f991d2a1d70e90676cba7a4cd51a3196c77922fa6ad1e87fbbfbf825e5700a350a5bd0f21fc48a3fc220c9051e7687de
+  checksum: 10/c3451d6f98984521790c84e85d4f1c422b61d9a941f9b5a0df5c5e7d9b77d45b65a8db4637cf6d1923f1814d326b02dd1477672d16293acc2cf993e6c1010058
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

PR to patch changes to add bounds to currencyRates.

Related: https://github.com/MetaMask/core/pull/7324/files

exp value for LineaEth before migration:

```
{
  "conversionDate": 1764952984.933,
  "conversionRate": 3036.3473414258847,
  "usdConversionRate": 3036.3473414258847
}
```

after: migration

```
{
  "conversionDate": 1764952984.933,
  "conversionRate": 3036.347341426,
  "usdConversionRate": 3036.347341426
}
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38591?quickstart=1)

## **Changelog**

CHANGELOG entry: Adds bounds to currencyRates

## **Related issues**

Fixes: [new BigNumber() number type has more than 15 significant digits: 0.0037808400000000054](https://metamask.sentry.io/issues/7082247853/events/8f9c90d2a5e24c22956de16441731605/)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bounds currency rate precision to 9 decimals in assets controller and migrates existing state to the same precision, updating tests and snapshots.
> 
> - **Rates precision**:
>   - Add `boundedPrecisionNumber` and apply to `conversionRate` and `usdConversionRate` in `@metamask/assets-controllers` `CurrencyRateController.{cjs,mjs}` (limits to 9 decimals).
> - **Migration**:
>   - New migration `app/scripts/migrations/185.ts` to round `CurrencyController.currencyRates[*].{conversionRate,usdConversionRate}` to 9 decimals; added to `migrations/index.js`.
>   - Comprehensive unit tests `app/scripts/migrations/185.test.ts`.
> - **Tests/Snapshots**:
>   - Update e2e state snapshots to reflect rounded rates and bump `meta.version` to `185`.
> - **Dependencies**:
>   - Patch and pin `@metamask/assets-controllers` via Yarn patches (`package.json`, `yarn.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed5416370d95d0e9f01ab6ae05df8297b204c513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->