### PR TITLE
fix: cp bound decimals for rates for 13.12.1

### DIFF
--- a/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch
+++ b/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch
@@ -1,0 +1,102 @@
+diff --git a/dist/CurrencyRateController.cjs b/dist/CurrencyRateController.cjs
+index 94293ab5b2dcc5332f00f5b0389dddbf2b35837a..ba2295ff25bdcce5d2932f4f77eaab6624ebe5e1 100644
+--- a/dist/CurrencyRateController.cjs
++++ b/dist/CurrencyRateController.cjs
+@@ -42,6 +42,7 @@ const defaultState = {
+         },
+     },
+ };
++const boundedPrecisionNumber = (value, precision = 9) => Number(value.toFixed(precision));
+ /**
+  * Controller that passively polls on a set interval for an exchange rate from the current network
+  * asset to the user's preferred currency.
+@@ -170,10 +171,10 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             acc[nativeCurrency] = {
+                 conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+                 conversionRate: rate?.value
+-                    ? Number((1 / rate?.value).toFixed(2))
++                    ? boundedPrecisionNumber(1 / rate.value)
+                     : null,
+                 usdConversionRate: rate?.usd
+-                    ? Number((1 / rate?.usd).toFixed(2))
++                    ? boundedPrecisionNumber(1 / rate.usd)
+                     : null,
+             };
+             return acc;
+@@ -215,7 +216,9 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             return {
+                 nativeCurrency,
+                 conversionDate: tokenPrice ? Date.now() / 1000 : null,
+-                conversionRate: tokenPrice?.price ?? null,
++                conversionRate: tokenPrice?.price
++                    ? boundedPrecisionNumber(tokenPrice.price)
++                    : null,
+                 usdConversionRate: null, // Token prices service doesn't provide USD rate in this context
+             };
+         }));
+@@ -236,8 +239,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+         const ratesFromTokenPricesService = ratesFromTokenPrices.reduce((acc, rate) => {
+             acc[rate.nativeCurrency] = {
+                 conversionDate: rate.conversionDate,
+-                conversionRate: rate.conversionRate,
+-                usdConversionRate: rate.usdConversionRate,
++                conversionRate: rate.conversionRate
++                    ? boundedPrecisionNumber(rate.conversionRate)
++                    : null,
++                usdConversionRate: rate.usdConversionRate
++                    ? boundedPrecisionNumber(rate.usdConversionRate)
++                    : null,
+             };
+             return acc;
+         }, {});
+diff --git a/dist/CurrencyRateController.mjs b/dist/CurrencyRateController.mjs
+index c6a22bb4b96e1cbfcd53ed776dc3ff5b1f25985c..039ad77b342ddc69b0f7107192c8a0f1cf43591f 100644
+--- a/dist/CurrencyRateController.mjs
++++ b/dist/CurrencyRateController.mjs
+@@ -39,6 +39,7 @@ const defaultState = {
+         },
+     },
+ };
++const boundedPrecisionNumber = (value, precision = 9) => Number(value.toFixed(precision));
+ /**
+  * Controller that passively polls on a set interval for an exchange rate from the current network
+  * asset to the user's preferred currency.
+@@ -166,10 +167,10 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             acc[nativeCurrency] = {
+                 conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+                 conversionRate: rate?.value
+-                    ? Number((1 / rate?.value).toFixed(2))
++                    ? boundedPrecisionNumber(1 / rate.value)
+                     : null,
+                 usdConversionRate: rate?.usd
+-                    ? Number((1 / rate?.usd).toFixed(2))
++                    ? boundedPrecisionNumber(1 / rate.usd)
+                     : null,
+             };
+             return acc;
+@@ -211,7 +212,9 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+             return {
+                 nativeCurrency,
+                 conversionDate: tokenPrice ? Date.now() / 1000 : null,
+-                conversionRate: tokenPrice?.price ?? null,
++                conversionRate: tokenPrice?.price
++                    ? boundedPrecisionNumber(tokenPrice.price)
++                    : null,
+                 usdConversionRate: null, // Token prices service doesn't provide USD rate in this context
+             };
+         }));
+@@ -232,8 +235,12 @@ _CurrencyRateController_tokenPricesService = new WeakMap(), _CurrencyRateControl
+         const ratesFromTokenPricesService = ratesFromTokenPrices.reduce((acc, rate) => {
+             acc[rate.nativeCurrency] = {
+                 conversionDate: rate.conversionDate,
+-                conversionRate: rate.conversionRate,
+-                usdConversionRate: rate.usdConversionRate,
++                conversionRate: rate.conversionRate
++                    ? boundedPrecisionNumber(rate.conversionRate)
++                    : null,
++                usdConversionRate: rate.usdConversionRate
++                    ? boundedPrecisionNumber(rate.usdConversionRate)
++                    : null,
+             };
+             return acc;
+         }, {});

--- a/app/scripts/migrations/183.1.test.ts
+++ b/app/scripts/migrations/183.1.test.ts
@@ -1,0 +1,491 @@
+import { migrate, version } from './183.1';
+
+const VERSION = version;
+const oldVersion = 183;
+
+describe(`migration #${VERSION}`, () => {
+  let mockedCaptureException: jest.Mock;
+
+  beforeEach(() => {
+    mockedCaptureException = jest.fn();
+    global.sentry = { captureException: mockedCaptureException };
+  });
+
+  afterEach(() => {
+    global.sentry = undefined;
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version: VERSION });
+  });
+
+  it('does nothing if CurrencyController is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      `Migration ${VERSION}: CurrencyController not found.`,
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('captures exception if CurrencyController is not an object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: 'invalid',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: CurrencyController is not an object: string`,
+      ),
+    );
+  });
+
+  it('does nothing if currencyRates is missing', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {},
+      },
+    };
+
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      `Migration ${VERSION}: currencyRates not found in CurrencyController.`,
+    );
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('captures exception if currencyRates is not an object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: 'invalid',
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(`Migration ${VERSION}: currencyRates is not an object: string`),
+    );
+  });
+
+  it('rounds conversionRate with more than 9 decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: parseFloat('12.9848883888222'), // 13 decimal places
+            },
+            BTC: {
+              conversionRate: parseFloat('50000.123456789012'), // 12 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 12.984888389, // Rounded to 9 decimal places
+            },
+            BTC: {
+              conversionRate: 50000.123456789, // Rounded to 9 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('does not modify conversionRate with 9 or fewer decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 12.123456789, // Exactly 9 decimal places
+            },
+            BTC: {
+              conversionRate: 50000.12345, // 5 decimal places
+            },
+            USDC: {
+              conversionRate: 1, // No decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    // Data should remain unchanged
+    expect(newStorage.data).toStrictEqual({
+      CurrencyController: {
+        currencyRates: {
+          ETH: {
+            conversionRate: 12.123456789,
+          },
+          BTC: {
+            conversionRate: 50000.12345,
+          },
+          USDC: {
+            conversionRate: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it('handles mixed currency rate data with some needing rounding', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+            },
+            BTC: {
+              conversionRate: 45000.12345, // No rounding needed
+            },
+            INVALID: {
+              // Missing conversionRate property
+            },
+            USDC: {
+              conversionRate: '1.0', // String value, should be ignored
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+            },
+            BTC: {
+              conversionRate: 45000.12345, // Unchanged
+            },
+            INVALID: {
+              // Unchanged
+            },
+            USDC: {
+              conversionRate: '1.0', // Unchanged (string)
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('handles empty currencyRates object', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {},
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('handles edge case with very small numbers', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            SMALLCOIN: {
+              conversionRate: 0.0000000001234567890123, // Very small with many decimals
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            SMALLCOIN: {
+              conversionRate: 0, // Rounded to 9 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('rounds usdConversionRate with more than 9 decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              usdConversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+            },
+            BTC: {
+              usdConversionRate: parseFloat('45000.123456789012'), // Needs rounding
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              usdConversionRate: 2500.123456789, // Rounded to 9 decimal places
+            },
+            BTC: {
+              usdConversionRate: 45000.123456789, // Rounded to 9 decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('handles both conversionRate and usdConversionRate in same currency', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+              usdConversionRate: parseFloat('2500.9876543210987'), // Needs rounding
+            },
+            BTC: {
+              conversionRate: 45000.12345, // No rounding needed
+              usdConversionRate: 45000.987654321, // Needs rounding
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+              usdConversionRate: 2500.987654321, // Rounded
+            },
+            BTC: {
+              conversionRate: 45000.12345, // Unchanged
+              usdConversionRate: 45000.987654321, // Rounded
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('does not modify usdConversionRate with 9 or fewer decimal places', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              usdConversionRate: 12.123456789, // Exactly 9 decimal places
+            },
+            BTC: {
+              usdConversionRate: 50000.12345, // 5 decimal places
+            },
+            USDC: {
+              usdConversionRate: 1, // No decimal places
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    // Data should remain unchanged
+    expect(newStorage.data).toStrictEqual({
+      CurrencyController: {
+        currencyRates: {
+          ETH: {
+            usdConversionRate: 12.123456789,
+          },
+          BTC: {
+            usdConversionRate: 50000.12345,
+          },
+          USDC: {
+            usdConversionRate: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it('handles mixed rate data with usdConversionRate', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: parseFloat('2500.1234567890123'), // Needs rounding
+              usdConversionRate: parseFloat('2500.9876543210987'), // Needs rounding
+            },
+            BTC: {
+              usdConversionRate: 45000.12345, // No rounding needed
+            },
+            INVALID: {
+              // Missing both properties
+            },
+            USDC: {
+              conversionRate: '1.0', // String value, should be ignored
+              usdConversionRate: '1.0', // String value, should be ignored
+            },
+          },
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+              usdConversionRate: 2500.987654321, // Rounded
+            },
+            BTC: {
+              usdConversionRate: 45000.12345, // Unchanged
+            },
+            INVALID: {
+              // Unchanged
+            },
+            USDC: {
+              conversionRate: '1.0', // Unchanged (string)
+              usdConversionRate: '1.0', // Unchanged (string)
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+
+  it('preserves other properties in CurrencyController', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        CurrencyController: {
+          currentCurrency: 'usd',
+          currencyRates: {
+            ETH: {
+              conversionRate: parseFloat('2500.1234567890123'),
+              usdConversionRate: parseFloat('2500.9876543210987'),
+              conversionDate: 1234567890,
+            },
+          },
+          otherProperty: 'should be preserved',
+        },
+      },
+    };
+
+    const expectedStorage = {
+      meta: { version: VERSION },
+      data: {
+        CurrencyController: {
+          currentCurrency: 'usd',
+          currencyRates: {
+            ETH: {
+              conversionRate: 2500.123456789, // Rounded
+              usdConversionRate: 2500.987654321, // Rounded
+              conversionDate: 1234567890, // Preserved
+            },
+          },
+          otherProperty: 'should be preserved', // Preserved
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual(expectedStorage);
+  });
+});

--- a/app/scripts/migrations/183.1.ts
+++ b/app/scripts/migrations/183.1.ts
@@ -1,0 +1,119 @@
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { captureException } from '../../../shared/lib/sentry';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 183.1;
+
+/**
+ * This migration rounds conversionRate and usdConversionRate values in CurrencyController
+ * to a maximum of 9 decimal places to prevent precision issues.
+ *
+ * @param originalVersionedData - The original MetaMask extension state.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+
+  try {
+    transformState(versionedData.data);
+  } catch (error) {
+    console.error(error);
+    const newError = new Error(
+      `Migration #${version}: ${getErrorMessage(error)}`,
+    );
+    captureException(newError);
+    // Even though we encountered an error, we need the migration to pass for
+    // the migrator tests to work
+    versionedData.data = originalVersionedData.data;
+  }
+
+  return versionedData;
+}
+
+/**
+ * Rounds a number to a specified precision (maximum decimal places)
+ *
+ * @param value - The number to round
+ * @param precision - The maximum number of decimal places (default: 9)
+ * @returns The rounded number
+ */
+function boundedPrecisionNumber(value: number, precision = 9): number {
+  return Number(value.toFixed(precision));
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (!hasProperty(state, 'CurrencyController')) {
+    console.warn(`Migration ${version}: CurrencyController not found.`);
+    return state;
+  }
+
+  const currencyController = state.CurrencyController;
+  if (!isObject(currencyController)) {
+    captureException(
+      new Error(
+        `Migration ${version}: CurrencyController is not an object: ${typeof currencyController}`,
+      ),
+    );
+    return state;
+  }
+
+  if (!hasProperty(currencyController, 'currencyRates')) {
+    console.warn(
+      `Migration ${version}: currencyRates not found in CurrencyController.`,
+    );
+    return state;
+  }
+
+  const { currencyRates } = currencyController;
+  if (!isObject(currencyRates)) {
+    captureException(
+      new Error(
+        `Migration ${version}: currencyRates is not an object: ${typeof currencyRates}`,
+      ),
+    );
+    return state;
+  }
+
+  // Iterate through each currency and round conversionRate and usdConversionRate values
+  Object.keys(currencyRates).forEach((currency) => {
+    const rateData = currencyRates[currency];
+    if (isObject(rateData)) {
+      // Handle conversionRate
+      if (hasProperty(rateData, 'conversionRate')) {
+        const { conversionRate } = rateData;
+        if (typeof conversionRate === 'number') {
+          // Check if the number has more than 9 decimal places
+          const decimalPlaces =
+            conversionRate.toString().split('.')[1]?.length || 0;
+          if (decimalPlaces > 9) {
+            rateData.conversionRate = boundedPrecisionNumber(conversionRate);
+          }
+        }
+      }
+
+      // Handle usdConversionRate
+      if (hasProperty(rateData, 'usdConversionRate')) {
+        const { usdConversionRate } = rateData;
+        if (typeof usdConversionRate === 'number') {
+          // Check if the number has more than 9 decimal places
+          const decimalPlaces =
+            usdConversionRate.toString().split('.')[1]?.length || 0;
+          if (decimalPlaces > 9) {
+            rateData.usdConversionRate =
+              boundedPrecisionNumber(usdConversionRate);
+          }
+        }
+      }
+    }
+  });
+
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -218,6 +218,7 @@ const migrations = [
   require('./181'),
   require('./182'),
   require('./183'),
+  require('./183.1'),
 ];
 
 export default migrations;

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "@metamask/address-book-controller": "^7.0.0",
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^8.0.0",
-    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch",
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@patch%253A@metamask/assets-controllers@npm%25253A89.0.1%2523~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%253A%253Aversion=89.0.1&hash=6be0d3%23~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch%3A%3Aversion=89.0.1&hash=a1afd2#~/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch",
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.8.0",
     "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A61.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-61.0.0-8c413c463f.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5721,7 +5721,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch":
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch::version=89.0.1&hash=a1afd2":
   version: 89.0.1
   resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch::version=89.0.1&hash=a1afd2"
   dependencies:
@@ -5770,6 +5770,58 @@ __metadata:
     "@metamask/transaction-controller": ^61.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/0f8c82256141e95b591b0bfff17cf6015ff9e0e4b330e68e95066319d0e415320a4eca48cb6d0f3bf27f3ff68d231ea1c656aa08844bf7699624ef09cd3ed587
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@patch%253A@metamask/assets-controllers@npm%25253A89.0.1%2523~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%253A%253Aversion=89.0.1&hash=6be0d3%23~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch%3A%3Aversion=89.0.1&hash=a1afd2#~/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch":
+  version: 89.0.1
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@patch%253A@metamask/assets-controllers@npm%25253A89.0.1%2523~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%253A%253Aversion=89.0.1&hash=6be0d3%23~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch%3A%3Aversion=89.0.1&hash=a1afd2#~/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch::version=89.0.1&hash=f8df10"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.15.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/polling-controller": "npm:^15.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/snaps-utils": "npm:^11.0.0"
+    "@metamask/utils": "npm:^11.8.1"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/account-tree-controller": ^3.0.0
+    "@metamask/accounts-controller": ^34.0.0
+    "@metamask/approval-controller": ^8.0.0
+    "@metamask/core-backend": ^4.1.0
+    "@metamask/keyring-controller": ^24.0.0
+    "@metamask/network-controller": ^25.0.0
+    "@metamask/permission-controller": ^12.0.0
+    "@metamask/phishing-controller": ^15.0.0
+    "@metamask/preferences-controller": ^21.0.0
+    "@metamask/providers": ^22.0.0
+    "@metamask/snaps-controllers": ^14.0.0
+    "@metamask/transaction-controller": ^61.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/f89f344485825ca56979599c0c4f61ace76b30e5e2731b485742309a218a8fc9625b7b4348e07025cf6d25ef44539c824dc2659c9fec168b0f00fa6ca96c8c4b
   languageName: node
   linkType: hard
 
@@ -32819,7 +32871,7 @@ __metadata:
     "@metamask/announcement-controller": "npm:^8.0.0"
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@npm%253A89.0.1%23~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%3A%3Aversion=89.0.1&hash=6be0d3#~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch"
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@patch%3A@metamask/assets-controllers@patch%253A@metamask/assets-controllers@npm%25253A89.0.1%2523~/.yarn/patches/@metamask-assets-controllers-npm-89.0.1-02fa7acd54.patch%253A%253Aversion=89.0.1&hash=6be0d3%23~/.yarn/patches/@metamask-assets-controllers-patch-7c7d711c8c.patch%3A%3Aversion=89.0.1&hash=a1afd2#~/.yarn/patches/@metamask-assets-controllers-patch-47695f409e.patch"
     "@metamask/auto-changelog": "npm:^5.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.8.0"


### PR DESCRIPTION
## **Description**

PR to patch changes to add bounds to currencyRates.

Related: https://github.com/MetaMask/core/pull/7324/files

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38602?quickstart=1)

## **Changelog**

CHANGELOG entry: Adds bounds to currencyRates

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bounds currency rates to 9 decimal places in the rate controller and migrates existing `CurrencyController.currencyRates` to the same precision, with tests and dependency patch updates.
> 
> - **Assets Controllers Patch**:
>   - Add `boundedPrecisionNumber` (9dp) in `dist/CurrencyRateController.(cjs|mjs)` and use it for `conversionRate` and `usdConversionRate` derived from token price services.
> - **Migration**:
>   - Add `app/scripts/migrations/183.1.ts` to round `CurrencyController.currencyRates[*].conversionRate` and `usdConversionRate` to max 9 decimal places; handles missing/invalid shapes and preserves other fields.
>   - Register migration in `app/scripts/migrations/index.js`.
> - **Tests**:
>   - Add comprehensive unit tests in `app/scripts/migrations/183.1.test.ts` covering rounding behavior, edge cases, and error handling.
> - **Deps**:
>   - Update `package.json` and `yarn.lock` to include new patch for `@metamask/assets-controllers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d3e56f2e0479aaed852f21936c08c58f004d8b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->