### PR TITLE
fix: add fallback image for NFT items

### DIFF
--- a/ui/components/multichain/nft-item/index.scss
+++ b/ui/components/multichain/nft-item/index.scss
@@ -53,4 +53,21 @@
     width: 100%;
     height: 100%;
   }
+
+  // Fallback image
+  &__item-image,
+  &__item-image--hidden,
+  &__item-detail {
+    position: relative;
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+
+      background-image: url('/images/default_nft.png');
+      background-size: cover;
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+  }
 }

--- a/ui/components/multichain/nft-item/index.scss
+++ b/ui/components/multichain/nft-item/index.scss
@@ -59,11 +59,11 @@
   &__item-image--hidden,
   &__item-detail {
     position: relative;
+
     &::after {
       content: '';
       position: absolute;
       inset: 0;
-
       background-image: url('/images/default_nft.png');
       background-size: cover;
       background-repeat: no-repeat;

--- a/ui/components/multichain/nft-item/nft-item.tsx
+++ b/ui/components/multichain/nft-item/nft-item.tsx
@@ -91,6 +91,14 @@ export const NftItem = ({
           alt={alt}
           display={Display.Block}
           justifyContent={JustifyContent.center}
+          onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+            // Keeping failed-src in DOM for production debugging and testing purposes
+            e.currentTarget.setAttribute(
+              'data-failed-src',
+              e.currentTarget.src,
+            );
+            e.currentTarget.removeAttribute('src');
+          }}
         ></Box>
         {privacyMode && (
           <Icon


### PR DESCRIPTION
## **Description**

Add image fallback for failing NFTs.
I've kept the failing NFT src in the DOM as a data attribute as it is very useful for debugging and testing (we can have QA, PROD, and others give us the failing image to inspect).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38605?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: add fallback image for NFT items

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1768

## **Manual testing steps**

1. Load an account with NFTs with failing media (.mp4, html)
2. See fallback images rendered

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://www.loom.com/share/3a91c924e8ce40c1b0fd2ed2a488efe8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CSS-based fallback image and onError handling to NFT images, preserving failed src for debugging.
> 
> - **UI — NFT Item (`ui/components/multichain/nft-item/`)**:
>   - **Component (`nft-item.tsx`)**:
>     - Add `onError` handler to image: stores failing URL in `data-failed-src` and removes `src` to trigger fallback.
>   - **Styles (`index.scss`)**:
>     - Implement fallback image via `::after` background on `nft-item__item-image`, `--hidden`, and `__item-detail` using `/images/default_nft.png`.
>     - Ensure elements are `position: relative` for overlay fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7242169d6ccc1278f8a44fb236dbb869eb4e5e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->