### PR TITLE
fix: auto-close network added notification after 5 seconds

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -525,6 +525,8 @@ export default class Home extends PureComponent {
           key="new-network-added"
           type="success"
           className="home__new-network-notification"
+          autoHideTime={autoHideDelay}
+          onAutoHide={() => clearNewNetworkAdded()}
           message={
             <Box display={Display.InlineFlex}>
               <i className="fa fa-check-circle home__new-network-notification-icon" />


### PR DESCRIPTION
## **Description**

This PR fixes an issue where the "Network was successfully added!" notification banner did not automatically close after adding a custom network. The notification would remain visible until manually closed by clicking the X button, which was inconsistent with other success notifications in the application.

**What is the reason for the change?**
The network added notification was missing the auto-close functionality that other notifications (like NFT added, tokens imported, etc.) already had. This created an inconsistent user experience.

**What is the improvement/solution?**
Added `autoHideTime` and `onAutoHide` props to the `ActionableMessage` component for the network added notification, making it automatically close after 5 seconds (consistent with other notifications). Users can still manually close it using the X button.

## **Changelog**

CHANGELOG entry: Fixed network added notification to automatically close after 5 seconds

## **Related issues**

Fixes: Network added notification not auto-closing

## **Manual testing steps**

1. Open MetaMask extension
2. Go to Settings → Networks → Add Network
3. Add a custom network (e.g., "Xone" network)
4. Save the network
5. Observe the green success notification banner appears with message: "[Network Name] was successfully added!"
6. **Verify the notification automatically closes after 5 seconds** ✅
7. Repeat steps 2-5 and verify the X button still works for manual close ✅

## **Screenshots/Recordings**

### **Before**
<img width="786" height="789" alt="image" src="https://github.com/user-attachments/assets/a2d01cfa-fdf3-4485-9bbf-b0f0ffc24319" />

The notification banner would remain visible indefinitely until manually closed by clicking the X button.

### **After**
<img width="796" height="858" alt="image" src="https://github.com/user-attachments/assets/820379a9-6e3d-4302-ad36-473d501c5381" />

The notification banner now automatically closes after 5 seconds, matching the behavior of other success notifications in the application. Users can still manually close it using the X button if needed.

[Screenshots showing the notification appearing and then auto-closing after 5 seconds]

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).

- [x] I've completed the PR template to the best of my ability

- [x] I've included tests if applicable
  - Note: This is a UI behavior change. Existing notification tests should cover this, but manual testing confirms the fix works.

- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - Note: No new functions added, only props added to existing component usage.

- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).

- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the "Network added" success banner auto-close after 5 seconds by adding auto-hide props to its ActionableMessage.
> 
> - **UI/Home notifications (`ui/pages/home/home.component.js`)**:
>   - Add `autoHideTime` and `onAutoHide` to the `ActionableMessage` for `newNetworkAddedName`, auto-closing the success banner after 5s and clearing the notification state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943a38abf0cf7724e24889c59b1b72c30cdbae0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->