### PR TITLE
fix: `wallet_requestExecutionPermissions` RPCs failing with `Snap error` cp-13.13.0 

### DIFF
--- a/app/scripts/lib/forwardRequestToSnap.test.ts
+++ b/app/scripts/lib/forwardRequestToSnap.test.ts
@@ -3,6 +3,7 @@ import { HandlerType } from '@metamask/snaps-utils';
 import { InternalError, type SnapId } from '@metamask/snaps-sdk';
 
 import { forwardRequestToSnap } from './forwardRequestToSnap';
+import type { WalletMiddlewareContext } from '@metamask/eth-json-rpc-middleware';
 
 describe('forwardRequestToSnap', () => {
   const SNAP_ID_MOCK = 'local:test-snap' as SnapId;
@@ -14,8 +15,11 @@ describe('forwardRequestToSnap', () => {
     jsonrpc: '2.0',
     method: 'test_method',
     params: { test: 'value' },
-    origin: ORIGIN_MOCK,
-  } as JsonRpcRequest & { origin: string };
+  } as JsonRpcRequest;
+
+  const CONTEXT_MOCK = new Map([
+    ['origin', ORIGIN_MOCK],
+  ]) as WalletMiddlewareContext;
 
   const INVOKE_RESULT_MOCK = { result: { success: true } } as Record<
     string,
@@ -35,6 +39,7 @@ describe('forwardRequestToSnap', () => {
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         REQUEST_MOCK,
+        CONTEXT_MOCK,
       );
 
       expect(handleRequestMock).toHaveBeenCalledWith({
@@ -56,13 +61,13 @@ describe('forwardRequestToSnap', () => {
         id: 1,
         jsonrpc: '2.0',
         method: 'test_method',
-        origin: ORIGIN_MOCK,
-      } as JsonRpcRequest & { origin: string };
+      } as JsonRpcRequest;
 
       const result = await forwardRequestToSnap(
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         requestWithoutParams,
+        CONTEXT_MOCK,
       );
 
       expect(handleRequestMock).toHaveBeenCalledWith({
@@ -87,6 +92,7 @@ describe('forwardRequestToSnap', () => {
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         REQUEST_MOCK,
+        CONTEXT_MOCK,
       );
 
       expect(result).toBe(customResponse);
@@ -101,6 +107,7 @@ describe('forwardRequestToSnap', () => {
           { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
           { id: ID_MOCK },
           REQUEST_MOCK,
+          CONTEXT_MOCK,
         ),
       ).rejects.toThrow('Snap error');
     });
@@ -113,6 +120,7 @@ describe('forwardRequestToSnap', () => {
           { handleRequest: handleRequestMock, snapId: '' as SnapId },
           { id: ID_MOCK },
           REQUEST_MOCK,
+          CONTEXT_MOCK,
         ),
       ).rejects.toThrow(
         new InternalError('No snapId configured for method test_method'),
@@ -128,6 +136,7 @@ describe('forwardRequestToSnap', () => {
           },
           { id: ID_MOCK },
           REQUEST_MOCK,
+          CONTEXT_MOCK,
         ),
       ).rejects.toThrow(
         new InternalError('No snapId configured for method test_method'),
@@ -143,6 +152,7 @@ describe('forwardRequestToSnap', () => {
           },
           { id: ID_MOCK },
           REQUEST_MOCK,
+          CONTEXT_MOCK,
         ),
       ).rejects.toThrow(
         new InternalError('No snapId configured for method test_method'),
@@ -150,11 +160,14 @@ describe('forwardRequestToSnap', () => {
     });
 
     it('throws InternalError with method name for undefined origin', async () => {
+      const emptyContextMock = new Map() as WalletMiddlewareContext;
+
       await expect(
         forwardRequestToSnap(
           { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
           { id: ID_MOCK },
-          { ...REQUEST_MOCK, origin: undefined as unknown as string },
+          { ...REQUEST_MOCK },
+          emptyContextMock,
         ),
       ).rejects.toThrow(
         new InternalError('No origin specified for method test_method'),
@@ -172,6 +185,7 @@ describe('forwardRequestToSnap', () => {
           { handleRequest: handleRequestMock, snapId: '' as SnapId },
           { id: ID_MOCK },
           customMethodRequest,
+          CONTEXT_MOCK,
         ),
       ).rejects.toThrow(
         new InternalError('No snapId configured for method custom_method'),
@@ -191,13 +205,13 @@ describe('forwardRequestToSnap', () => {
             array: [1, 2, 3],
           },
         },
-        origin: ORIGIN_MOCK,
-      } as JsonRpcRequest & { origin: string };
+      } as JsonRpcRequest;
 
       await forwardRequestToSnap(
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         complexRequest,
+        CONTEXT_MOCK,
       );
 
       expect(handleRequestMock).toHaveBeenCalledWith({
@@ -222,6 +236,7 @@ describe('forwardRequestToSnap', () => {
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         REQUEST_MOCK,
+        CONTEXT_MOCK,
       );
 
       expect(handleRequestMock).toHaveBeenCalledWith(
@@ -236,6 +251,7 @@ describe('forwardRequestToSnap', () => {
         { handleRequest: handleRequestMock, snapId: SNAP_ID_MOCK },
         { id: ID_MOCK },
         REQUEST_MOCK,
+        CONTEXT_MOCK,
       );
 
       expect(handleRequestMock).toHaveBeenCalledWith(

--- a/app/scripts/lib/forwardRequestToSnap.test.ts
+++ b/app/scripts/lib/forwardRequestToSnap.test.ts
@@ -1,9 +1,9 @@
+import type { WalletMiddlewareContext } from '@metamask/eth-json-rpc-middleware';
 import { Hex, JsonRpcRequest } from '@metamask/utils';
 import { HandlerType } from '@metamask/snaps-utils';
 import { InternalError, type SnapId } from '@metamask/snaps-sdk';
 
 import { forwardRequestToSnap } from './forwardRequestToSnap';
-import type { WalletMiddlewareContext } from '@metamask/eth-json-rpc-middleware';
 
 describe('forwardRequestToSnap', () => {
   const SNAP_ID_MOCK = 'local:test-snap' as SnapId;

--- a/app/scripts/lib/forwardRequestToSnap.ts
+++ b/app/scripts/lib/forwardRequestToSnap.ts
@@ -2,6 +2,7 @@ import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
 import { HandlerType } from '@metamask/snaps-utils';
 import type { SnapController } from '@metamask/snaps-controllers';
 import { InternalError, type SnapId } from '@metamask/snaps-sdk';
+import { WalletMiddlewareContext } from '@metamask/eth-json-rpc-middleware';
 
 /**
  * Forwards a JSON-RPC request to a specified Snap by invoking its `handleRequest` method.
@@ -13,6 +14,7 @@ import { InternalError, type SnapId } from '@metamask/snaps-sdk';
  * @param _params - Additional parameters, including the request ID.
  * @param _params.id - The request ID.
  * @param req - The JSON-RPC request object.
+ * @param context - The WalletMiddlewareContext object.
  * @returns The response from the Snap as JSON.
  */
 export async function forwardRequestToSnap(
@@ -23,14 +25,17 @@ export async function forwardRequestToSnap(
   _params: {
     id: Hex;
   },
-  req: JsonRpcRequest & { origin: string },
+  req: JsonRpcRequest,
+  context: WalletMiddlewareContext,
 ): Promise<Json> {
-  const { method, params, origin } = req;
+  const { method, params } = req;
   const { handleRequest, snapId } = config;
 
   if (!snapId) {
     throw new InternalError(`No snapId configured for method ${method}`);
   }
+
+  const origin = context.get('origin');
 
   if (!origin) {
     throw new InternalError(`No origin specified for method ${method}`);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1147,7 +1147,7 @@ export default class MetamaskController extends EventEmitter {
           (meta) =>
             meta.hash === hash && meta.status === TransactionStatus.submitted,
         ),
-      processRequestExecutionPermissions: async (params, req) => {
+      processRequestExecutionPermissions: async (params, req, context) => {
         const enabledTypes = getEnabledAdvancedPermissions();
 
         if (!params || params.length === 0) {
@@ -1170,6 +1170,7 @@ export default class MetamaskController extends EventEmitter {
           },
           params,
           req,
+          context,
         );
       },
     });

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "@metamask/ens-resolver-snap": "^1.0.0",
     "@metamask/error-reporting-service": "^3.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^22.0.0",
+    "@metamask/eth-json-rpc-middleware": "^22.0.1",
     "@metamask/eth-ledger-bridge-keyring": "11.1.2",
     "@metamask/eth-qr-keyring": "^1.1.0",
     "@metamask/eth-sig-util": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6511,9 +6511,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "@metamask/eth-json-rpc-middleware@npm:22.0.0"
+"@metamask/eth-json-rpc-middleware@npm:^22.0.0, @metamask/eth-json-rpc-middleware@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:22.0.1"
   dependencies:
     "@metamask/eth-block-tracker": "npm:^15.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
@@ -6526,7 +6526,7 @@ __metadata:
     klona: "npm:^2.0.6"
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/c83ef0c45d1d2f00c0ed1c9e56bd0a7ea359d3db8d53f81b099167eccaecce4cbb88b10e4daa17db3e2c777be03681dc352f1581e759c58c6a728f266843c39d
+  checksum: 10/1cb47dad7eaeb104b8b8a8b25e5d36cee04c40bbe0db0a8bfa41f8abb6be4602ebb061bcadf548d22d34f0df581cf3ec64e11cb1434e653fd4cc22617d41440a
   languageName: node
   linkType: hard
 
@@ -32950,7 +32950,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^9.0.1"
     "@metamask/eslint-plugin-design-tokens": "npm:^1.1.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^22.0.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:11.1.2"
     "@metamask/eth-qr-keyring": "npm:^1.1.0"


### PR DESCRIPTION
## **Description**

In `forwardToSnap` we forward a request received on the wallet API to a specified snap. Previously we would extract the origin from the `request` object, but since the upgrade to JsonRpcMiddleware 2 this is no longer available. Now we extract the `origin` from the `context` and include that in the request.

Fixes https://github.com/MetaMask/metamask-extension/issues/38618

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38616?quickstart=1)

## **Changelog**

CHANGELOG entry: fix: `wallet_requestExecutionPermissions` RPCs failing with `Snap error`

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install Flask
2. Go to https://jeff.dripfund.xyz
3. Click "donate"

Previously: "Internal error thrown"

Now: Advanced Permissions dialog shown.


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use WalletMiddlewareContext to supply origin when forwarding Snap RPC requests, updating controller/tests and bumping eth-json-rpc-middleware.
> 
> - **Snaps RPC forwarding**:
>   - Update `forwardRequestToSnap(req, context)` to read `origin` from `WalletMiddlewareContext` instead of `req.origin`; throw `InternalError` when missing.
>   - Always set `handler: HandlerType.OnRpcRequest` and keep `jsonrpc: '2.0'` and original `params`.
> - **Controller integration**:
>   - `processRequestExecutionPermissions` now accepts `(params, req, context)` and passes `context` to `forwardRequestToSnap`.
> - **Tests**:
>   - Refactor `app/scripts/lib/forwardRequestToSnap.test.ts` to use `WalletMiddlewareContext` mocks and validate origin handling and errors.
> - **Dependencies**:
>   - Bump `@metamask/eth-json-rpc-middleware` to `^22.0.1` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2585889cf1fbf4c7cd85ce0e295b98b2c8560c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->