### PR TITLE
fix: cp-13.13.0 update migration number for decimal bounding

### DIFF
--- a/app/scripts/migrations/183.1.test.ts
+++ b/app/scripts/migrations/183.1.test.ts
@@ -1,7 +1,7 @@
-import { migrate, version } from './185';
+import { migrate, version } from './183.1';
 
 const VERSION = version;
-const oldVersion = 184;
+const oldVersion = 183;
 
 describe(`migration #${VERSION}`, () => {
   let mockedCaptureException: jest.Mock;

--- a/app/scripts/migrations/183.1.ts
+++ b/app/scripts/migrations/183.1.ts
@@ -7,7 +7,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 185;
+export const version = 183.1;
 
 /**
  * This migration rounds conversionRate and usdConversionRate values in CurrencyController

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -218,8 +218,8 @@ const migrations = [
   require('./181'),
   require('./182'),
   require('./183'),
+  require('./183.1'),
   require('./184'),
-  require('./185'),
 ];
 
 export default migrations;

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -336,5 +336,5 @@
       "rewardsSubscriptionTokens": "object"
     }
   },
-  "meta": { "version": 185 }
+  "meta": { "version": 184 }
 }


### PR DESCRIPTION
## **Description**

PR to update migration number from 185.ts to 183.1.ts.

related: https://github.com/MetaMask/metamask-extension/pull/38604

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38629?quickstart=1)

## **Changelog**

CHANGELOG entry: Pr to fix the migration number of 185.ts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38568

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renumbers the currency rates precision rounding migration to 183.1, hooks it into the migration list, and updates tests and a state snapshot version.
> 
> - **Migrations**:
>   - Add `app/scripts/migrations/183.1.ts` with version `183.1` (rounds `conversionRate`/`usdConversionRate` to 9 decimals).
>   - Update `app/scripts/migrations/index.js` to include `./183.1` and remove `./185`.
> - **Tests**:
>   - Update `app/scripts/migrations/183.1.test.ts` to target `183.1` and `oldVersion = 183`.
>   - Adjust e2e snapshot `test/e2e/.../errors-before-init-opt-in-ui-state.json` `meta.version` to `184`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5459c029a75112ffaf1de381d1b8a0f2e4a08228. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->