### PR TITLE
ci: Replace use of `github-tools` workflows with versioned actions

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   add-team-label:
-    if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: metamask/github-tools/.github/workflows/add-team-label.yml@7fe185fdb0e60981c898e88d82e44ff33f604daa
-    secrets:
-      TEAM_LABEL_TOKEN: ${{ secrets.TEAM_LABEL_TOKEN }}
+    name: Add team label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add team label
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: MetaMask/github-tools/.github/actions/add-team-label@v1
+        with:
+          team-label-token: ${{ secrets.TEAM_LABEL_TOKEN }}

--- a/.github/workflows/automated-rca.yml
+++ b/.github/workflows/automated-rca.yml
@@ -10,9 +10,14 @@ permissions:
 
 jobs:
   automated-rca:
-    uses: MetaMask/github-tools/.github/workflows/post-gh-rca.yml@5da154078ddf6c022ed89dc3dbf378594afb8266
-    with:
-      repo-owner: ${{ github.repository_owner }}
-      repo-name: ${{ github.event.repository.name }}
-      issue-number: ${{ github.event.issue.number }}
-      issue-labels: '["Sev0-urgent", "Sev1-high"]'
+    name: Automated RCA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automated RCA
+        uses: MetaMask/github-tools/.github/actions/post-gh-rca@v1
+        with:
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ github.event.repository.name }}
+          issue-number: ${{ github.event.issue.number }}
+          issue-labels: '["Sev0-urgent", "Sev1-high"]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload 'storybook-build' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}

--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload 'ts-migration-dashboard' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,18 +5,19 @@ on:
     types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
-  check_changelog:
+  check-changelog:
+    name: Check Changelog
+    runs-on: ubuntu-latest
     # Asking engineers to update CHANGELOG.md increases the potential for
     # conflicts across all pull requests.
     # Disable this workflow until we can refine the new changelog process.
     if: false
-
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@91e349d177db2c569e03c7aa69d2acb404b62f75
-    with:
-      base-branch: ${{ github.event.pull_request.base.ref }}
-      head-ref: ${{ github.head_ref }}
-      labels: ${{ toJSON(github.event.pull_request.labels) }}
-      pr-number: ${{ github.event.pull_request.number }}
-      repo: ${{ github.repository }}
-    secrets:
-      gh-token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check changelog
+        uses: MetaMask/github-tools/.github/actions/check-changelog@v1
+        with:
+          base-branch: ${{ github.event.pull_request.base.ref }}
+          head-ref: ${{ github.head_ref }}
+          labels: ${{ toJSON(github.event.pull_request.labels) }}
+          pr-number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}

--- a/.github/workflows/create-release-pr-legacy.yml
+++ b/.github/workflows/create-release-pr-legacy.yml
@@ -15,17 +15,20 @@ on:
 jobs:
   create-release-pr:
     name: Create Release Pull Request using Github Tools
-    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@3b4244a675e7bb1eec7309a11e89697f53a25d9a
-    with:
-      platform: extension
-      base-branch: ${{ inputs.base-branch }}
-      semver-version: ${{ inputs.semver-version }}
-      previous-version-tag: release/${{ inputs.previous-semver-version }}
-      github-tools-version: 3b4244a675e7bb1eec7309a11e89697f53a25d9a
-    secrets:
-      # This token needs write permissions to metamask-extension & read permissions to metamask-planning
-      github-token: ${{ secrets.PR_TOKEN }}
-      google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    steps:
+      - name: Create release pull request
+        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1
+        with:
+          platform: extension
+          semver-version: ${{ inputs.semver-version }}
+          release-pr-base-branch: ${{ inputs.base-branch }}
+          checkout-base-branch: ${{ inputs.base-branch }}
+          google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+          previous-version-ref: release/${{ inputs.previous-semver-version }}
+          # This token needs write permissions to metamask-extension & read
+          # permissions to metamask-planning.
+          github-token: ${{ secrets.PR_TOKEN }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -82,7 +82,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Create Release PR
-        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1.1.3
+        uses: MetaMask/github-tools/.github/actions/create-release-pr@v1
         with:
           platform: extension
           checkout-base-branch: ${{ needs.resolve-bases.outputs.checkout_base }}

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -128,7 +128,7 @@ jobs:
           path: ${{ env.HTML_REPORT_PATH }}
 
       - name: Upload html report to S3
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
@@ -170,7 +170,7 @@ jobs:
           path: ${{ env.HTML_REPORT_PATH }}
 
       - name: Upload html report to S3
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}

--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -10,9 +10,12 @@ on:
 
 jobs:
   get-release-timelines:
-    uses: metamask/github-tools/.github/workflows/get-release-timelines.yml@3b4244a675e7bb1eec7309a11e89697f53a25d9a
-    with:
-      version: ${{ inputs.version }}
-    secrets:
-      RUNWAY_APP_ID: ${{ secrets.RUNWAY_APP_ID }}
-      RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY }}
+    name: Get release timelines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/github-tools/.github/actions/get-release-timelines@v1
+        with:
+          version: ${{ inputs.version }}
+          runway-app-id: ${{ secrets.RUNWAY_APP_ID }}
+          runway-api-key: ${{ secrets.RUNWAY_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
   lint-workflows:
     name: Lint workflows
-    uses: metamask/github-tools/.github/workflows/lint-workflows.yml@1299bb1de0c6974ae6d0a32c7e8897fe168239ac
+    uses: MetaMask/github-tools/.github/workflows/lint-workflows.yml@v1
 
   test-lint:
     needs:
@@ -308,7 +308,7 @@ jobs:
 
       - name: Upload 'bundle-size' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
@@ -401,7 +401,7 @@ jobs:
 
       - name: Upload 'source-map-explorer' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
@@ -479,7 +479,7 @@ jobs:
 
       - name: Upload 'build-viz' to S3
         if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
@@ -612,9 +612,12 @@ jobs:
     if: ${{ github.event_name == 'merge_group' && failure() && !github.event.repository.fork }}
     needs:
       - all-jobs-pass
-    uses: metamask/github-tools/.github/workflows/log-merge-group-failure.yml@6bbad335a01fce1a9ec1eabd9515542c225d46c0
-    secrets:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-      SPREADSHEET_ID: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
-      SHEET_NAME: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log merge group failure
+        uses: MetaMask/github-tools/.github/actions/log-merge-group-failure@v1
+        with:
+          google-application-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          spreadsheet-id: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
+          sheet-name: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}

--- a/.github/workflows/merge-stable-sync-pr.yml
+++ b/.github/workflows/merge-stable-sync-pr.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER'
       )
-    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@7c0ab4db1e9c1d5673fe7958e8959f1842edbebd
+    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@v1
     with:
       pr-number: ${{ github.event.issue.number }}
       # Merge PRs from stable-main-X.Y.Z into main

--- a/.github/workflows/merge-version-bump-pr.yml
+++ b/.github/workflows/merge-version-bump-pr.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER'
       )
-    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@7c0ab4db1e9c1d5673fe7958e8959f1842edbebd
+    uses: MetaMask/github-tools/.github/workflows/merge-approved-pr.yml@v1
     with:
       pr-number: ${{ github.event.issue.number }}
       # Merge PRs from version-bump/X.Y.Z into main

--- a/.github/workflows/remove-rca-needed-label-sheets.yml
+++ b/.github/workflows/remove-rca-needed-label-sheets.yml
@@ -12,10 +12,12 @@ permissions:
 jobs:
   remove-rca-labels:
     name: Remove RCA-needed Labels
-    uses: MetaMask/github-tools/.github/workflows/remove-rca-needed-label-sheets.yml@d354252842b91355deb6d57c752812f745f99679
-    with:
-      spreadsheet_id: '1Y16QEnDwZuR3DAQIe3T5LTWy1ye07GNYqxIei_cMg24'
-      sheet_name: 'Form Responses 1'
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove RCA-needed label
+        uses: MetaMask/github-tools/.github/actions/remove-rca-needed-label-sheets@v1
+        with:
+          spreadsheet-id: '1Y16QEnDwZuR3DAQIe3T5LTWy1ye07GNYqxIei_cMg24'
+          sheet-name: 'Form Responses 1'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload '${{ env.OUTPUT_NAME }}' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload 'builds' to S3
         if: ${{ env.SHOULD_BUILD == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: metamask/github-tools/.github/actions/upload-s3@1233659b3850eb84824d7375e2e0c58eb237701d
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -44,4 +44,4 @@ jobs:
           semver-version: ${{ needs.get-next-version.outputs.next-version }}
           repo-type: 'extension'
           stable-branch-name: 'stable'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.STABLE_SYNC_TOKEN }}

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -36,11 +36,12 @@ jobs:
   run-stable-sync:
     name: Run Stable branch sync
     needs: get-next-version
-    uses: metamask/github-tools/.github/workflows/stable-sync.yml@79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b
-    secrets:
-      github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
-    with:
-      semver-version: ${{ needs.get-next-version.outputs.next-version }}
-      repo-type: 'extension' # Accepts 'mobile' or 'extension'
-      github-tools-version: '79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b'
-      stable-branch-name: 'stable' # Defaults to `stable`
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run stable sync
+        uses: MetaMask/github-tools/.github/actions/stable-sync@v1
+        with:
+          semver-version: ${{ needs.get-next-version.outputs.next-version }}
+          repo-type: 'extension'
+          stable-branch-name: 'stable'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -15,4 +15,3 @@ jobs:
     steps:
       - name: Close stale issues and PRs
         uses: MetaMask/github-tools/.github/actions/stale-issue-pr@v1
-

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   stale:
+    name: Close stale issues and PRs
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
-    uses: metamask/github-tools/.github/workflows/stale-issue-pr.yml@566da3332757544da431707bde71a242b182b3ac
+    steps:
+      - name: Close stale issues and PRs
+        uses: MetaMask/github-tools/.github/actions/stale-issue-pr@v1
+

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -48,11 +48,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Update Release Changelog
-        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1.1.3
+        uses: MetaMask/github-tools/.github/actions/update-release-changelog@v1
         with:
           release-branch: ${{ github.ref_name }}
           repository-url: ${{ github.server_url }}/${{ github.repository }}
           platform: extension
           previous-version-ref: 'null'
-          github-tools-version: v1.1.3
           github-token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This replaces all use of `MetaMask/github-tools` _workflows_, usually referenced by a specific commit hash, with (composite) _actions_, referenced by a version. This has several benefits:

- We can update actions used simply by creating a new release in the `github-tools` repository, propagating the changes to all repositories using the version.
   - Breaking changes can still be made by creating a major release.
- Actions have access to certain variables that workflows don't have access to, letting us omit input options like `github-tools-ref`.
- In cases where we're already running other steps, using an action avoids spinning up a new runner.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38630?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces references to MetaMask/github-tools reusable workflows and pinned SHAs with versioned composite actions and updates jobs/steps accordingly across CI workflows.
> 
> - **CI Workflows**
>   - Replace reusable `MetaMask/github-tools` workflow calls with versioned composite actions (`@v1`) and inline steps in:
>     - `add-team-label.yml`, `automated-rca.yml`, `changelog-check.yml`, `create-release-pr-legacy.yml`, `create-release-pr.yml`, `get-release-timelines.yml`, `remove-rca-needed-label-sheets.yml`, `stable-branch-sync.yml`, `stale-issues-pr.yml`, `update-release-changelog.yml`.
>   - Standardize S3 uploads to `MetaMask/github-tools/.github/actions/upload-s3@v1` in:
>     - `build-storybook.yml`, `build-ts-migration-dashboard.yml`, `e2e-chrome.yml` (both alerts), `main.yml` (bundle-size, source-map-explorer, lavamoat-viz), `run-benchmarks.yml`, `run-build.yml`.
>   - Update merge helpers and linters to versioned refs:
>     - `merge-stable-sync-pr.yml`, `merge-version-bump-pr.yml` -> `merge-approved-pr.yml@v1`.
>     - `main.yml` -> `lint-workflows.yml@v1`.
>   - Add explicit `runs-on` and `steps` where converting from reusable workflows; adjust inputs and secrets (e.g., `github-token`, `google-application-creds-base64`).
>   - Normalize action owner casing to `MetaMask` and simplify tags (e.g., `@v1` instead of specific SHAs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 641dc2f93f1687fd9fc08d5402d3c9024730a066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->