### PR TITLE
fix: add favicon to html head to fix missing icon on firefox

### DIFF
--- a/app/html/partials/partial-head.html
+++ b/app/html/partials/partial-head.html
@@ -3,3 +3,4 @@
 <title><%= it?.title ?? "MetaMask" %></title>
 <link rel="preload" href="/_locales/en/messages.json" as="fetch" type="application/json" crossorigin="anonymous" />
 <link rel="stylesheet" href="../../../ui/css/index.scss" />
+<link rel="icon" href="../../images/icon-64.png" type="image/png" />

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -1338,7 +1338,8 @@ function renderHtmlFile({
     .replace(
       '../../vendor/trezor/usb-permissions.js',
       './vendor/trezor/usb-permissions.js',
-    );
+    )
+    .replace('../../images/icon-64.png', './images/icon-64.png');
   browserPlatforms.forEach((platform) => {
     const dest = `./dist/${platform}/${htmlName}.html`;
     // we dont have a way of creating async events atm


### PR DESCRIPTION
## **Description**

Favicons don't show on Firefox when MM is in extended view. It looks like this is only a Firefox problem because in Chrome, [the icons supplied in the manifest also get used as the favicon](https://developer.chrome.com/docs/extensions/reference/manifest/icons) in the extension's pages. On Firefox i[t doesn't seem to be the case](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons). 

Therefore this PR adds in a favicon in the normal way, by adding an icon link tag in the HTML head.

On Firefox this ensures a favicon shows when MM is in extended view. On Chrome it also uses the favicon (no visible difference to how it is currently).

64x64 size was picked over 16x16 (which is normal for favicons) as the quality looked poor up to this size.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38632?quickstart=1)

## **Changelog**

CHANGELOG entry: adds favicon for Firefox expanded view page

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/25420

## **Manual testing steps**

1. Open MM expanded view in Firefox
2. See favicon in browser tab
3. Open MM expanded view in Chrome and Brave
4. See favicon in browser tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="453" height="67" alt="image" src="https://github.com/user-attachments/assets/e3f58813-4c2a-4bcc-acdc-4a3b9149a527" />

### **After**

<img width="448" height="236" alt="image" src="https://github.com/user-attachments/assets/b7710469-6410-402c-9820-8b26f9abeedc" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add favicon to HTML head and update build script to rewrite its path in generated HTML.
> 
> - **HTML**:
>   - Add favicon link in `app/html/partials/partial-head.html` referencing `../../images/icon-64.png`.
> - **Build**:
>   - Update `development/build/scripts.js` to replace `../../images/icon-64.png` with `./images/icon-64.png` in generated HTML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c4efbe47ecbb0bd893cb9c4413148062737ce4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->