### PR TITLE
chore: use multicall for rpc token detection

### DIFF
--- a/app/scripts/controller-init/messengers/token-detection-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/token-detection-controller-messenger.ts
@@ -28,6 +28,7 @@ import {
   TokensControllerAddTokensAction,
   TokensControllerGetStateAction,
   AssetsContractControllerGetBalancesInSingleCallAction,
+  AssetsContractControllerGetBalancesUsingMulticallAction,
 } from '@metamask/assets-controllers';
 import { TransactionControllerTransactionConfirmedEvent } from '@metamask/transaction-controller';
 import {
@@ -127,7 +128,7 @@ export function getTokenDetectionControllerMessenger(
 }
 
 type AllowedInitializationActions =
-  | AssetsContractControllerGetBalancesInSingleCallAction
+  | AssetsContractControllerGetBalancesUsingMulticallAction
   | MetaMetricsControllerTrackEventAction
   | NetworkControllerGetStateAction
   | PreferencesControllerGetStateAction;
@@ -157,7 +158,7 @@ export function getTokenDetectionControllerInitMessenger(
   messenger.delegate({
     messenger: controllerInitMessenger,
     actions: [
-      'AssetsContractController:getBalancesInSingleCall',
+      'AssetsContractController:getBalancesUsingMulticall',
       'MetaMetricsController:trackEvent',
       'PreferencesController:getState',
     ],

--- a/app/scripts/controller-init/token-detection-controller-init.ts
+++ b/app/scripts/controller-init/token-detection-controller-init.ts
@@ -13,9 +13,9 @@ export const TokenDetectionControllerInit: ControllerInitFunction<
   const controller = new TokenDetectionController({
     // @ts-expect-error: TODO: Investigate type mismatch.
     messenger: controllerMessenger,
-    getBalancesInSingleCall: (...args) =>
+    getBalancesUsingMulticall: (...args) =>
       initMessenger.call(
-        'AssetsContractController:getBalancesInSingleCall',
+        'AssetsContractController:getBalancesUsingMulticall',
         ...args,
       ),
     trackMetaMetricsEvent: (...args) =>

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3512,6 +3512,8 @@ export default class MetamaskController extends EventEmitter {
       ignoreTokens: tokensController.ignoreTokens.bind(tokensController),
       getBalancesInSingleCall: (...args) =>
         this.assetsContractController.getBalancesInSingleCall(...args),
+      getBalancesUsingMulticall: (...args) =>
+        this.assetsContractController.getBalancesUsingMulticall(...args),
 
       // Authentication Controller
       performSignIn: authenticationController.performSignIn.bind(


### PR DESCRIPTION
🚧 
## **Description**

dnt merge before this goes in https://github.com/MetaMask/core/pull/7290
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38633?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
