### PR TITLE
fix: flaky `api-specs` and `api-specs-multichain`

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -602,12 +602,11 @@ const clickNestedButton = async (driver, tabName) => {
  * @param {WebDriver} driver - The webdriver instance
  * @param {object} [options] - Options for unlocking the wallet
  * @param {boolean} [options.navigate] - Whether to navigate to the root page prior to unlocking - defaults to true
- * @param {boolean} [options.waitLoginSuccess] - Whether to wait for the login to succeed - defaults to true
  * @param {string} [options.password] - Password to unlock wallet - defaults to shared WALLET_PASSWORD
  */
 async function unlockWallet(
   driver,
-  { navigate = true, waitLoginSuccess = true, password = WALLET_PASSWORD } = {},
+  { navigate = true, password = WALLET_PASSWORD } = {},
 ) {
   if (navigate) {
     await driver.navigate();
@@ -616,9 +615,7 @@ async function unlockWallet(
   await driver.waitForSelector('#password', { state: 'enabled' });
   await driver.fill('#password', password);
   await driver.press('#password', driver.Key.ENTER);
-  if (waitLoginSuccess) {
-    await driver.assertElementNotPresent('[data-testid="unlock-page"]');
-  }
+  await driver.assertElementNotPresent('[data-testid="unlock-page"]');
 }
 
 /**

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -618,14 +618,6 @@ async function unlockWallet(
   await driver.press('#password', driver.Key.ENTER);
   if (waitLoginSuccess) {
     await driver.assertElementNotPresent('[data-testid="unlock-page"]');
-    await driver.assertElementNotPresent(
-      {
-        text: 'Fund your wallet',
-      },
-      {
-        waitAtLeastGuard: largeDelayMs,
-      },
-    );
   }
 }
 

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -192,8 +192,10 @@ async function main() {
     }) => {
       await unlockWallet(driver);
 
-      // Navigate to extension home screen
-      await driver.navigate(PAGES.HOME);
+      const homePage = new HomePage(driver);
+      await homePage.checkPageIsLoaded();
+      // We don't have balance so we expect to see Fund Your Wallet
+      await homePage.checkExpectedBalanceIsDisplayed('0', 'ETH');
 
       // Open Dapp
       await driver.openNewPage(DAPP_URL);

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -25,6 +25,7 @@ import { ACCOUNT_1, DAPP_URL } from './constants';
 import transformOpenRPCDocument from './api-specs/transform';
 import { MultichainAuthorizationConfirmationErrors } from './api-specs/MultichainAuthorizationConfirmationErrors';
 import { ConfirmationsRejectRule } from './api-specs/ConfirmationRejectionRule';
+import HomePage from './page-objects/pages/home/homepage';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const mockServer = require('@open-rpc/mock-server/build/index').default;
@@ -111,9 +112,10 @@ async function main() {
       extensionId: string;
     }) => {
       await unlockWallet(driver);
-
-      // Navigate to extension home screen
-      await driver.navigate(PAGES.HOME);
+      const homePage = new HomePage(driver);
+      await homePage.checkPageIsLoaded();
+      // We don't have balance so we expect to see Fund Your Wallet
+      await homePage.checkExpectedBalanceIsDisplayed('0', 'ETH');
 
       // Open Dapp
       await driver.openNewPage(DAPP_URL);

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -12,7 +12,7 @@ import ExamplesRule from '@open-rpc/test-coverage/build/rules/examples-rule';
 import { Call, IOptions } from '@open-rpc/test-coverage/build/coverage';
 import { InternalScopeString } from '@metamask/chain-agnostic-permission';
 import { Mockttp } from 'mockttp';
-import { Driver, PAGES } from './webdriver/driver';
+import { Driver } from './webdriver/driver';
 
 import {
   createCaip27DriverTransport,

--- a/test/e2e/run-openrpc-api-test-coverage.ts
+++ b/test/e2e/run-openrpc-api-test-coverage.ts
@@ -16,6 +16,7 @@ import FixtureBuilder from './fixtures/fixture-builder';
 import { withFixtures, unlockWallet } from './helpers';
 import { DAPP_URL, ACCOUNT_1 } from './constants';
 import transformOpenRPCDocument from './api-specs/transform';
+import HomePage from './page-objects/pages/home/homepage';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const mockServer = require('@open-rpc/mock-server/build/index').default;
@@ -44,6 +45,10 @@ async function main() {
       server.start();
 
       await unlockWallet(driver);
+      const homePage = new HomePage(driver);
+      await homePage.checkPageIsLoaded();
+      // We don't have balance so we expect to see Fund Your Wallet
+      await homePage.checkExpectedBalanceIsDisplayed('0', 'ETH');
 
       // Navigate to extension home screen
       await driver.navigate(PAGES.HOME);

--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -61,7 +61,6 @@ describe('MetaMask onboarding', function () {
 
         await unlockWallet(driver, {
           navigate: true,
-          waitLoginSuccess: true,
           password: WALLET_PASSWORD,
         });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky because we were asserting that the Fund your wallet banner is not there, but it is, given the balance is 0 (we have localNode disabled). This assert is incorrect to be placed inside the  `unlockWallet` with the `waitLoginSuccess` flag, as we can be logged in successfully, but the banner appear (because the case of 0ETH balance).
Furthermore, this flag can be removed altogether, as it's always used as its default value. 
So we can
- remove the flag as it's not needed and overcomplicates the flow
- remove the assert banner not present, as in some cases (0 balance) that will appear, and it's expected
- add the checks for balance/banner using page objects
- the unlockWallet method will be removed altogether, as it's not using POM. We should use loginWith/WithoutBalanceValidation, which uses POM flows https://consensyssoftware.atlassian.net/browse/MMQA-1208 . I'll remove all uses of unlockWallet  in a subsequent PR


<img width="814" height="669" alt="image" src="https://github.com/user-attachments/assets/fe91cf20-2ce1-4aa0-b4ed-e98ac56609f8" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38653?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused unlockWallet wait flag and updates API-spec E2E tests to use HomePage page-object balance checks instead of direct navigation, reducing flakiness.
> 
> - **E2E Helpers**:
>   - `unlockWallet`: remove `waitLoginSuccess` option and related banner assertions; always assert `unlock-page` not present.
> - **API Specs (Multichain)**:
>   - Replace `driver.navigate(PAGES.HOME)` with `HomePage` POM checks: `checkPageIsLoaded()` and `checkExpectedBalanceIsDisplayed('0', 'ETH')` before opening Dapp.
>   - Add `HomePage` import; drop unused `PAGES` import.
> - **API Specs (OpenRPC)**:
>   - Add `HomePage` POM checks after `unlockWallet`; verify `'0' ETH` balance; keep subsequent `driver.navigate(PAGES.HOME)`.
> - **Onboarding Tests**:
>   - Update `unlockWallet` call to omit removed `waitLoginSuccess` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4682dfa63a05f0d698951b1053d2f206688caa52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->