### PR TITLE
chore: Refine hidden accounts icon

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx
@@ -419,7 +419,7 @@ export const MultichainAccountList = ({
           justifyContent={JustifyContent.spaceBetween}
           alignItems={AlignItems.center}
           paddingLeft={4}
-          paddingRight={4}
+          paddingRight={6}
           paddingTop={2}
           paddingBottom={2}
           width={BlockSize.Full}
@@ -436,8 +436,8 @@ export const MultichainAccountList = ({
             name={
               isHiddenAccountsExpanded ? IconName.ArrowUp : IconName.ArrowDown
             }
-            size={IconSize.Sm}
-            color={IconColor.iconDefault}
+            size={IconSize.Md}
+            color={IconColor.iconAlternative}
           />
         </Box>
       );

--- a/ui/components/multichain/account-list-menu/hidden-account-list.js
+++ b/ui/components/multichain/account-list-menu/hidden-account-list.js
@@ -97,8 +97,8 @@ export const HiddenAccountList = ({ onClose }) => {
           </Text>
           <Icon
             name={showListItem ? IconName.ArrowUp : IconName.ArrowDown}
-            size={IconSize.Sm}
-            color={IconColor.iconDefault}
+            size={IconSize.Md}
+            color={IconColor.iconAlternative}
           />
         </Box>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR cleans up the icon for hiding accounts for consistency. It polishes the UI.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38655?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

- https://consensyssoftware.atlassian.net/browse/MDP-446?atlOrigin=eyJpIjoiZjc5OGFhYmU3ZTc3NDBmYzgyZjNiYWI3ZDVkYzc0YWEiLCJwIjoiaiJ9
- https://consensyssoftware.atlassian.net/browse/MDP-447?atlOrigin=eyJpIjoiZGUxYjg5ODdhYmM5NGUxNGIwMjk0MDA5MjAxYTU1NWYiLCJwIjoiaiJ9


## **Manual testing steps**

Ensure that icon aligns and size matches

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="399" height="598" alt="Screenshot 2025-12-10 at 9 51 30 AM" src="https://github.com/user-attachments/assets/cc894df1-74ac-447c-b284-1ba748947d04" />

### **After**

<img width="396" height="599" alt="Screenshot 2025-12-10 at 9 55 31 AM" src="https://github.com/user-attachments/assets/293a9f98-298a-43b0-bccd-230abfef7eaf" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes hidden-accounts section toggles to medium, alternative-colored arrows and increases right padding on the multichain list header.
> 
> - **UI/UX**
>   - **Hidden accounts toggles**:
>     - In `ui/components/multichain-accounts/multichain-account-list/multichain-account-list.tsx` and `ui/components/multichain/account-list-menu/hidden-account-list.js`:
>       - Update `Icon` size from `IconSize.Sm` to `IconSize.Md` and color from `IconColor.iconDefault` to `IconColor.iconAlternative` for `IconName.ArrowUp/ArrowDown`.
>     - In `multichain-account-list.tsx`: increase `paddingRight` on hidden header from `4` to `6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0675b76836ab255a5a43da17c7e24b803a2c246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->