### PR TITLE
fix: fixed ENS Resolution for selected chain in contacts

### DIFF
--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -76,8 +76,6 @@ const AddContact = ({
 
   // Re-resolve ENS name when network changes
   useEffect(() => {
-    // Use enteredDomainName if user already selected a resolution,
-    // otherwise check if input is a valid domain name (resolution list still showing)
     const domainToResolve =
       enteredDomainName || (isValidDomainName(input) ? input : '');
 

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -76,10 +76,13 @@ const AddContact = ({
 
   // Re-resolve ENS name when network changes
   useEffect(() => {
-    const domainToResolve =
-      enteredDomainName || (isValidDomainName(input) ? input : '');
+    const domainToResolve = isValidDomainName(input)
+      ? input
+      : enteredDomainName;
 
     if (prevChainIdRef.current !== selectedChainId && domainToResolve) {
+      setInput(domainToResolve);
+      setEnteredDomainName('');
       resetDomainResolution();
       lookupDomainName(domainToResolve, selectedChainId);
     }

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useCallback,
   useMemo,
+  useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
@@ -57,6 +58,7 @@ const AddContact = ({
   domainResolutions,
   domainError,
   resetDomainResolution,
+  lookupDomainName,
 }) => {
   const t = useContext(I18nContext);
 
@@ -65,10 +67,32 @@ const AddContact = ({
   const [addressInputError, setAddressInputError] = useState('');
   const [nameInputError, setNameInputError] = useState('');
   const [input, setInput] = useState('');
+  const [enteredDomainName, setEnteredDomainName] = useState(''); // Track original ENS name for re-resolution
   const currentChainId = useSelector(getCurrentChainId);
   const [selectedChainId, setSelectedChainId] = useState(currentChainId);
   const [showModal, setShowModal] = useState(false);
   const networks = useSelector(getNetworkConfigurationsByChainId);
+  const prevChainIdRef = useRef(selectedChainId);
+
+  // Re-resolve ENS name when network changes
+  useEffect(() => {
+    // Use enteredDomainName if user already selected a resolution,
+    // otherwise check if input is a valid domain name (resolution list still showing)
+    const domainToResolve =
+      enteredDomainName || (isValidDomainName(input) ? input : '');
+
+    if (prevChainIdRef.current !== selectedChainId && domainToResolve) {
+      resetDomainResolution();
+      lookupDomainName(domainToResolve, selectedChainId);
+    }
+    prevChainIdRef.current = selectedChainId;
+  }, [
+    selectedChainId,
+    enteredDomainName,
+    input,
+    resetDomainResolution,
+    lookupDomainName,
+  ]);
 
   const validate = useCallback((value) => {
     const valid =
@@ -112,6 +136,7 @@ const AddContact = ({
         resetDomainResolution();
         setInput('');
         setSelectedAddress('');
+        setEnteredDomainName('');
       }}
       userInput={selectedAddress || input}
     />
@@ -192,6 +217,7 @@ const AddContact = ({
                   onClick={() => {
                     handleNameChange(domainName);
                     setInput(resolvedAddress);
+                    setEnteredDomainName(domainName); // Store ENS name for re-resolution on network change
                     resetDomainResolution();
                   }}
                   protocol={protocol}
@@ -242,7 +268,7 @@ const AddContact = ({
               isOpen
               onClose={() => setShowModal(false)}
               selectedChainId={selectedChainId}
-              onSelect={(chainname) => setSelectedChainId(chainname)}
+              onSelect={(chainId) => setSelectedChainId(chainId)}
             />
           )}
         </div>
@@ -279,6 +305,7 @@ AddContact.propTypes = {
   domainResolutions: PropTypes.arrayOf(PropTypes.object),
   domainError: PropTypes.string,
   resetDomainResolution: PropTypes.func,
+  lookupDomainName: PropTypes.func,
 };
 
 export default AddContact;

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -11,6 +11,7 @@ import {
   getDomainError,
   getDomainResolutions,
   resetDomainResolution,
+  lookupDomainName,
 } from '../../../../ducks/domains';
 import { getAddressBook, getInternalAccounts } from '../../../../selectors';
 import AddContact from './add-contact.component';
@@ -32,6 +33,8 @@ const mapDispatchToProps = (dispatch) => {
     scanQrCode: () => dispatch(showQrScanner()),
     qrCodeDetected: (data) => dispatch(qrCodeDetected(data)),
     resetDomainResolution: () => dispatch(resetDomainResolution()),
+    lookupDomainName: (domainName, chainId) =>
+      dispatch(lookupDomainName(domainName, chainId)),
   };
 };
 


### PR DESCRIPTION
This PR is to ensure if ENS is supported on that network, it should resolve to their corresponding address in that network

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: #34994 

## **Manual testing steps**

1. Click Contacts
2. Select Mainnet
3. Add seaona.eth see address
4. Select Sepolia
5. Add seaona.eth see address is different

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

https://github.com/user-attachments/assets/15d851b1-7617-4208-9672-2ce73aa9ac93



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-resolves ENS/domain names on network change in Add Contact by tracking the entered domain and invoking `lookupDomainName` with the selected chain, with container wiring and minor fixes.
> 
> - **Contacts UI (`ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js`)**:
>   - Add re-resolution logic on network change:
>     - Track original domain via `enteredDomainName` and previous chain via `useRef`.
>     - On `selectedChainId` change, reset resolutions and call `lookupDomainName(domain, selectedChainId)`.
>   - Update domain resolution selection:
>     - On selecting a resolution, set `enteredDomainName` and clear existing resolutions.
>   - Reset flow: clear `enteredDomainName` on input reset.
>   - Network picker: normalize `onSelect` param to `chainId`.
>   - Props: add `lookupDomainName` to `PropTypes`.
> - **Container (`add-contact.container.js`)**:
>   - Wire `lookupDomainName(domainName, chainId)` from `ducks/domains` into component props.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44b0b4531ba5957648cce2646d7d75d392af7b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->