### PR TITLE
fix: send crash

### DIFF
--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -36,7 +36,8 @@ export function useEthFiatAmount(
   if (
     !showFiat ||
     currentCurrency.toUpperCase() === 'ETH' ||
-    conversionRate <= 0 ||
+    !conversionRate ||
+    conversionRate < 0 ||
     ethAmount === undefined
   ) {
     return undefined;

--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -42,8 +42,6 @@ export function useEthFiatAmount(
     return undefined;
   }
 
-  //const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate);
-
   const fiatAmount = new BigNumber(ethAmount.toString()).times(
     conversionRate.toString(),
   );

--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -42,7 +42,12 @@ export function useEthFiatAmount(
     return undefined;
   }
 
-  const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate);
+  //const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate);
+
+  const fiatAmount = new BigNumber(ethAmount.toString()).times(
+    conversionRate.toString(),
+  );
+
   if (
     ethAmount &&
     fiatAmount.lt(new BigNumber(0.01)) &&

--- a/ui/hooks/useEthFiatAmount.test.js
+++ b/ui/hooks/useEthFiatAmount.test.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+
+import mockState from '../../test/data/mock-state.json';
+import configureStore from '../store/store';
+
+import { useEthFiatAmount } from './useEthFiatAmount';
+
+const renderUseEthFiatAmount = (ethAmount, overrides, state) => {
+  const wrapper = ({ children }) => (
+    <Provider store={configureStore(state)}>{children}</Provider>
+  );
+
+  return renderHook(() => useEthFiatAmount(ethAmount, overrides), { wrapper });
+};
+
+describe('useEthFiatAmount', () => {
+  const baseState = {
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      completedOnboarding: true,
+      currentCurrency: 'usd',
+      preferences: {
+        ...mockState.metamask.preferences,
+        showFiatInTestnets: true,
+      },
+    },
+  };
+
+  describe('basic functionality', () => {
+    it('should return formatted fiat amount', () => {
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          currencyRates: { ETH: { conversionRate: 2000 } },
+        },
+      };
+
+      const { result } = renderUseEthFiatAmount('1', { showFiat: true }, state);
+      expect(result.current).toBe('$2,000.00 USD');
+    });
+
+    it('should return undefined when ethAmount is undefined', () => {
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          currencyRates: { ETH: { conversionRate: 2000 } },
+        },
+      };
+
+      const { result } = renderUseEthFiatAmount(
+        undefined,
+        { showFiat: true },
+        state,
+      );
+      expect(result.current).toBeUndefined();
+    });
+
+    it('should return undefined when conversionRate is 0', () => {
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          currencyRates: { ETH: { conversionRate: 0 } },
+        },
+      };
+
+      const { result } = renderUseEthFiatAmount('1', { showFiat: true }, state);
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe('BigNumber precision handling', () => {
+    // This test documents a bug where conversionRate with >15 significant digits
+    // causes BigNumber to throw: "times() number type has more than 15 significant digits"
+    // See: https://github.com/MikeMcl/bignumber.js/issues/11
+    //
+    // The fix is to convert conversionRate to string before passing to .times():
+    //   new BigNumber(ethAmount.toString()).times(conversionRate.toString())
+    //
+    // This test should PASS once the fix is applied.
+    it('should handle conversionRate with more than 15 significant digits', () => {
+      // 3106.9104158770647 has 17 significant digits
+      // This is a realistic ETH/USD rate that can occur
+      const highPrecisionRate = 3106.9104158770647;
+
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          currencyRates: { ETH: { conversionRate: highPrecisionRate } },
+        },
+      };
+
+      const { result } = renderUseEthFiatAmount('1', { showFiat: true }, state);
+
+      // The hook should return a valid fiat string, not throw or return undefined
+      // If BigNumber throws, result.error will be set
+      expect(result.error).toBeUndefined();
+      expect(result.current).toBeDefined();
+      expect(typeof result.current).toBe('string');
+      expect(result.current).toContain('$');
+    });
+
+    it('should handle various high-precision conversionRates without errors', () => {
+      // Various rates that could have >15 significant digits in their
+      // floating-point representation
+      const highPrecisionRates = [
+        3106.9104158770647, // 17 significant digits - actual rate from bug report
+        1234.5678901234567, // 17 significant digits
+        2999.9999999999995, // edge case near round number
+      ];
+
+      highPrecisionRates.forEach((rate) => {
+        const state = {
+          ...baseState,
+          metamask: {
+            ...baseState.metamask,
+            currencyRates: { ETH: { conversionRate: rate } },
+          },
+        };
+
+        const { result } = renderUseEthFiatAmount(
+          '0.5',
+          { showFiat: true },
+          state,
+        );
+
+        // Should not have thrown an error
+        expect(result.error).toBeUndefined();
+        // Should return a valid formatted string
+        expect(result.current).toBeDefined();
+        expect(typeof result.current).toBe('string');
+      });
+    });
+  });
+});

--- a/ui/hooks/useEthFiatAmount.test.js
+++ b/ui/hooks/useEthFiatAmount.test.js
@@ -72,6 +72,24 @@ describe('useEthFiatAmount', () => {
       const { result } = renderUseEthFiatAmount('1', { showFiat: true }, state);
       expect(result.current).toBeUndefined();
     });
+
+    it('should return undefined when conversionRate is undefined (ticker not in currencyRates)', () => {
+      // This tests the case where the ticker doesn't exist in currencyRates,
+      // resulting in conversionRate being undefined
+      const state = {
+        ...baseState,
+        metamask: {
+          ...baseState.metamask,
+          currencyRates: {}, // No ETH entry, so conversionRate will be undefined
+        },
+      };
+
+      const { result } = renderUseEthFiatAmount('1', { showFiat: true }, state);
+
+      // Should not throw TypeError when calling .toString() on undefined
+      expect(result.error).toBeUndefined();
+      expect(result.current).toBeUndefined();
+    });
   });
 
   describe('BigNumber precision handling', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes https://github.com/MetaMask/metamask-extension/issues/38657

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38663?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: handles more than 15 significant digits for conversionRate in useEthFiatAmount

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes fiat conversion to handle undefined/negative and high-precision conversion rates, and adds tests for the hook.
> 
> - **Hooks**:
>   - **`ui/hooks/useEthFiatAmount.js`**:
>     - Update guards to return `undefined` when `!conversionRate` or `conversionRate < 0`, and when currency is `ETH` or `ethAmount` is `undefined`.
>     - Use `conversionRate.toString()` in BigNumber multiplication to support >15 significant digits.
> - **Tests**:
>   - **`ui/hooks/useEthFiatAmount.test.js`**: Add tests covering basic formatting, `ethAmount` undefined, zero/undefined `conversionRate`, and high-precision rates without errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 501d7cbd790f7036e16ceb86ab07c051042acf60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->