### PR TITLE
fix: flaky test `Add existing token using search renders the balance for the chosen token`

### DIFF
--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -110,6 +110,8 @@ class AssetListPage {
   private readonly tokenImportedMessageCloseButton =
     '.actionable-message__message button[aria-label="Close"]';
 
+  private readonly tokenListComponent = '.token-list__token_component';
+
   private readonly tokenListItem =
     '[data-testid="multichain-token-list-button"]';
 
@@ -344,6 +346,8 @@ class AssetListPage {
     await this.driver.clickElement(this.importTokensButton);
     await this.driver.waitForSelector(this.importTokenModalTitle);
     await this.driver.fill(this.tokenSearchInput, tokenName);
+    // Wait until the token search matches 1 result
+    await this.waitUntilTokenSearchMatch(1);
     await this.driver.clickElement({ text: tokenName, tag: 'p' });
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.waitForSelector(this.confirmImportTokenMessage);
@@ -794,6 +798,19 @@ class AssetListPage {
    */
   async checkConversionRateDisplayed(): Promise<void> {
     await this.driver.assertElementNotPresent(this.noPriceAvailableMessage);
+  }
+
+  async waitUntilTokenSearchMatch(numberOfMatches: number) {
+    await this.driver.waitUntil(
+      async () => {
+        const matches = await this.driver.findElements(this.tokenListComponent);
+        return matches.length === numberOfMatches;
+      },
+      {
+        timeout: this.driver.timeout,
+        interval: 200,
+      },
+    );
   }
 }
 

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -118,6 +118,9 @@ class AssetListPage {
   private readonly tokenOptionsButton =
     '[data-testid="asset-list-control-bar-action-button"]';
 
+  private readonly tokenSearchSelected =
+    '.token-list__tokens-container .mm-checkbox__input--checked';
+
   private readonly tokenSymbolTitle = {
     css: '.mm-label',
     text: 'Token symbol',
@@ -346,9 +349,10 @@ class AssetListPage {
     await this.driver.clickElement(this.importTokensButton);
     await this.driver.waitForSelector(this.importTokenModalTitle);
     await this.driver.fill(this.tokenSearchInput, tokenName);
-    // Wait until the token search matches 1 result
+    // Wait until the token search matches 1 result to prevent flakiness with token result re-renders
     await this.waitUntilTokenSearchMatch(1);
     await this.driver.clickElement({ text: tokenName, tag: 'p' });
+    await this.driver.waitForSelector(this.tokenSearchSelected);
     await this.driver.clickElement(this.importTokensNextButton);
     await this.driver.waitForSelector(this.confirmImportTokenMessage);
     await this.driver.clickElementAndWaitToDisappear(

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -110,7 +110,7 @@ class AssetListPage {
   private readonly tokenImportedMessageCloseButton =
     '.actionable-message__message button[aria-label="Close"]';
 
-  private readonly tokenListComponent = '.token-list__token_component';
+  private readonly tokenSearchResults = '.token-list__token_component';
 
   private readonly tokenListItem =
     '[data-testid="multichain-token-list-button"]';
@@ -803,7 +803,7 @@ class AssetListPage {
   async waitUntilTokenSearchMatch(numberOfMatches: number) {
     await this.driver.waitUntil(
       async () => {
-        const matches = await this.driver.findElements(this.tokenListComponent);
+        const matches = await this.driver.findElements(this.tokenSearchResults);
         return matches.length === numberOfMatches;
       },
       {

--- a/test/e2e/tests/tokens/add-token-using-search.spec.ts
+++ b/test/e2e/tests/tokens/add-token-using-search.spec.ts
@@ -77,7 +77,7 @@ describe('Add existing token using search', function () {
       ...(await mockBscBridgeApi(mockServer)),
     ];
   }
-  it('renders the balance for the chosen token', async function () {
+  it('renders the balance for the chosen token TEST', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.BSC })

--- a/test/e2e/tests/tokens/add-token-using-search.spec.ts
+++ b/test/e2e/tests/tokens/add-token-using-search.spec.ts
@@ -77,7 +77,7 @@ describe('Add existing token using search', function () {
       ...(await mockBscBridgeApi(mockServer)),
     ];
   }
-  it('renders the balance for the chosen token TEST', async function () {
+  it('renders the balance for the chosen token', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.BSC })


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Next button is disabled as the click to the token took no effect, because the token list re-renders with the input fill.
Now, after we've filled the input, we wait until we see 1 match (to ensure there's no rerenders on the list) and then click the token.

<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/733ceeb6-70e3-4cfe-9684-680975a5f822" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38668?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes token import-by-search E2E flow by waiting for a single search result and confirmed selection before proceeding.
> 
> - **Tests (E2E)**:
>   - **Asset list page object (`test/e2e/page-objects/pages/home/asset-list.ts`)**:
>     - Adds selectors `tokenSearchResults` and `tokenSearchSelected`.
>     - Updates `importTokenBySearch()` to:
>       - Wait for exactly one search result via `waitUntilTokenSearchMatch(1)` after filling input.
>       - Wait for selection confirmation using `tokenSearchSelected` before continuing.
>     - Introduces helper `waitUntilTokenSearchMatch(numberOfMatches)` to poll `.token-list__token_component` count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b88950903c211d2f3468be4ccd19f595c1a95b42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->