### PR TITLE
fix: add nft modal enabled button logic

### DIFF
--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -102,8 +102,10 @@ export const ImportNftsModal = ({ onClose }) => {
 
   const [selectedNetworkForCustomImport, setSelectedNetworkForCustomImport] =
     useState(null);
-  const [selectedNetworkClientIdForCustomImport, setSelectedNetworkClientIdForCustomImport] =
-    useState(null);
+  const [
+    selectedNetworkClientIdForCustomImport,
+    setSelectedNetworkClientIdForCustomImport,
+  ] = useState(null);
 
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
 
@@ -122,8 +124,12 @@ export const ImportNftsModal = ({ onClose }) => {
   const handleAddNft = async () => {
     trace({ name: TraceName.ImportNfts });
     try {
-      dispatch(
-        addNftVerifyOwnership(nftAddress, tokenId, selectedNetworkClientIdForCustomImport),
+      await dispatch(
+        addNftVerifyOwnership(
+          nftAddress,
+          tokenId,
+          selectedNetworkClientIdForCustomImport,
+        ),
       );
       const newNftDropdownState = {
         ...nftsDropdownState,

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.test.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.test.js
@@ -50,12 +50,21 @@ describe('ImportNftsModal', () => {
     jest.restoreAllMocks();
   });
 
-  it('should enable the "Import" button when valid entries are input into both Address and TokenId fields', () => {
-    const { getByText, getByPlaceholderText } = renderWithProvider(
+  it('should enable the "Import" button when valid entries are input into both Address and TokenId fields and a network is selected', () => {
+    const { getByText, getByPlaceholderText, getByTestId } = renderWithProvider(
       <ImportNftsModal onClose={jest.fn()} />,
       store,
     );
     expect(getByText('Import')).not.toBeEnabled();
+
+    // Select a network first
+    const networkSelectorButton = getByTestId(
+      'test-import-tokens-drop-down-custom-import',
+    );
+    fireEvent.click(networkSelectorButton);
+    const networkItem = getByTestId('Goerli');
+    fireEvent.click(networkItem);
+
     const addressInput = getByPlaceholderText('0x...');
     const tokenIdInput = getByPlaceholderText('Enter the token id');
     fireEvent.change(addressInput, {
@@ -67,12 +76,42 @@ describe('ImportNftsModal', () => {
     expect(getByText('Import')).toBeEnabled();
   });
 
-  it('should not enable the "Import" button when an invalid entry is input into one or both Address and TokenId fields', () => {
+  it('should not enable the "Import" button when no network is selected', () => {
     const { getByText, getByPlaceholderText } = renderWithProvider(
       <ImportNftsModal onClose={jest.fn()} />,
       store,
     );
     expect(getByText('Import')).not.toBeEnabled();
+
+    // Fill in valid address and tokenId but don't select a network
+    const addressInput = getByPlaceholderText('0x...');
+    const tokenIdInput = getByPlaceholderText('Enter the token id');
+    fireEvent.change(addressInput, {
+      target: { value: VALID_ADDRESS },
+    });
+    fireEvent.change(tokenIdInput, {
+      target: { value: VALID_TOKENID },
+    });
+
+    // Button should still be disabled without network selection
+    expect(getByText('Import')).not.toBeEnabled();
+  });
+
+  it('should not enable the "Import" button when an invalid entry is input into one or both Address and TokenId fields', () => {
+    const { getByText, getByPlaceholderText, getByTestId } = renderWithProvider(
+      <ImportNftsModal onClose={jest.fn()} />,
+      store,
+    );
+    expect(getByText('Import')).not.toBeEnabled();
+
+    // Select a network first
+    const networkSelectorButton = getByTestId(
+      'test-import-tokens-drop-down-custom-import',
+    );
+    fireEvent.click(networkSelectorButton);
+    const networkItem = getByTestId('Goerli');
+    fireEvent.click(networkItem);
+
     const addressInput = getByPlaceholderText('0x...');
     const tokenIdInput = getByPlaceholderText('Enter the token id');
     fireEvent.change(addressInput, {
@@ -81,15 +120,20 @@ describe('ImportNftsModal', () => {
     fireEvent.change(tokenIdInput, {
       target: { value: VALID_TOKENID },
     });
-    expect(getByText('Import')).not.toBeEnabled();
+
+    expect(getByText('Import')).not.toBeEnabled(); // Invalid token address, valid token id
+
     fireEvent.change(addressInput, {
       target: { value: VALID_ADDRESS },
     });
-    expect(getByText('Import')).toBeEnabled();
+
+    expect(getByText('Import')).toBeEnabled(); // Valid token address, valid token id
+
     fireEvent.change(tokenIdInput, {
       target: { value: INVALID_TOKENID },
     });
-    expect(getByText('Import')).not.toBeEnabled();
+
+    expect(getByText('Import')).not.toBeEnabled(); // Valid token address, invalid token id
   });
 
   it('should call addNftVerifyOwnership, updateNftDropDownState, setNewNftAddedMessage, and ignoreTokens action with correct values (tokenId should not be in scientific notation)', async () => {
@@ -161,6 +205,15 @@ describe('ImportNftsModal', () => {
       <ImportNftsModal onClose={jest.fn()} />,
       store,
     );
+
+    // Select a network first
+    const networkSelectorButton = getByTestId(
+      'test-import-tokens-drop-down-custom-import',
+    );
+    fireEvent.click(networkSelectorButton);
+    const networkItem = getByTestId('Goerli');
+    fireEvent.click(networkItem);
+
     const addressInput = getByPlaceholderText('0x...');
     const tokenIdInput = getByPlaceholderText('Enter the token id');
     fireEvent.change(addressInput, {
@@ -249,9 +302,10 @@ describe('ImportNftsModal', () => {
     // Click import
     fireEvent.click(getByText('Import'));
 
-    // Get the actual networkClientId that was used in the addNftVerifyOwnership call
-    const addNftCall = addNftVerifyOwnership.mock.calls[1];
-    const usedNetworkClientId = addNftCall[2]; // Third argument is the networkClientId
+    // Get the actual networkClientId that was used in the addNftVerifyOwnership call (use last call to be robust against previous test calls)
+    const addNftCalls = addNftVerifyOwnership.mock.calls;
+    const lastCall = addNftCalls[addNftCalls.length - 1];
+    const usedNetworkClientId = lastCall[2]; // Third argument is the networkClientId
 
     expect(addNftVerifyOwnership).toHaveBeenCalledWith(
       VALID_ADDRESS,


### PR DESCRIPTION
## **Description**

This PR improves the Import NFT modal by requiring users to select a network before importing an NFT. Previously, the Import button validation only checked for a valid address and token ID, but did not enforce network selection, which lead to the button being enabled when it shouldn't have.

**Changes:**
1. Refactored the `disabled` state management to use a computed `isFormDisabled` value instead of manually syncing state across multiple validation functions
2. Added network selection as a required validation criterion for enabling the Import button
3. Renamed `selectedNetworkClientId` to `selectedNetworkClientIdForCustomImport` for clarity
4. Removed unnecessary `await` keywords from `dispatch()` calls that don't need to be awaited

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38669?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed Import NFT modal to require network selection before enabling button

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35531

## **Manual testing steps**

1. Open MetaMask extension
2. Navigate to the NFTs tab
3. Click "Import NFT"
4. Verify the Import button is disabled initially
5. Enter a valid NFT address and token ID without selecting a network
6. Verify the Import button remains disabled
7. Select a network from the network selector
8. Verify the Import button is now enabled
9. Click Import and verify the NFT is added successfully

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require network selection to enable Import in the NFT modal, refactor validation to a computed `isFormDisabled`, and update tests accordingly.
> 
> - **UI (Import NFTs Modal)**:
>   - Compute `isFormDisabled` (requires selected network, valid `nftAddress`, numeric `tokenId`, and no validation errors) and use it for the Import button.
>   - Remove manual `disabled` state; simplify validators to only set errors/values.
>   - Introduce `selectedNetworkClientIdForCustomImport` and pass it to `addNftVerifyOwnership`; reset inputs on network change.
>   - Dispatch `ignoreTokens` without `await` and keep success/error messaging and navigation flow.
> - **Tests**:
>   - Require network selection for enabling Import; add test for "no network selected" case.
>   - Update validity tests and error handling; verify large `tokenId` handling and correct `networkClientId` passed (using last call for robustness).
>   - Confirm routing on cancel/close and dropdown state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44b0a9dc7dd4e0ca8c83922f7bc50aa81656d5e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->