### PR TITLE
refactor: cleanup migration 162 error logs

### DIFF
--- a/app/scripts/migrations/162.test.ts
+++ b/app/scripts/migrations/162.test.ts
@@ -54,23 +54,6 @@ describe(`migration #${version}`, () => {
       expect(newStorage.data).toStrictEqual(oldStorage.data);
     });
 
-    it('logs an error and returns the original state if TokenBalancesController is missing', async () => {
-      const oldStorage = {
-        meta: { version: oldVersion },
-        data: {
-          TokensController: {},
-          AccountsController: {},
-        },
-      };
-
-      const newStorage = await migrate(oldStorage);
-
-      expect(global.sentry.captureException).toHaveBeenCalledWith(
-        new Error(`Migration ${version}: TokenBalancesController not found.`),
-      );
-      expect(newStorage.data).toStrictEqual(oldStorage.data);
-    });
-
     it('logs an error and returns the original state if TokensController is not an object', async () => {
       const oldStorage = {
         meta: { version: oldVersion },

--- a/app/scripts/migrations/162.test.ts
+++ b/app/scripts/migrations/162.test.ts
@@ -54,6 +54,20 @@ describe(`migration #${version}`, () => {
       expect(newStorage.data).toStrictEqual(oldStorage.data);
     });
 
+    it('returns the original state if TokenBalancesController is missing', async () => {
+      const oldStorage = {
+        meta: { version: oldVersion },
+        data: {
+          TokensController: {},
+          AccountsController: {},
+        },
+      };
+
+      const newStorage = await migrate(oldStorage);
+
+      expect(newStorage.data).toStrictEqual(oldStorage.data);
+    });
+
     it('logs an error and returns the original state if TokensController is not an object', async () => {
       const oldStorage = {
         meta: { version: oldVersion },

--- a/app/scripts/migrations/162.ts
+++ b/app/scripts/migrations/162.ts
@@ -54,9 +54,6 @@ function transformState(
   }
 
   if (!hasProperty(state, 'TokenBalancesController')) {
-    global.sentry?.captureException?.(
-      new Error(`Migration ${version}: TokenBalancesController not found.`),
-    );
     return state;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove Sentry logging for missing `TokenBalancesController` in migration 162 as part of cleanup for #34220.



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38681?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: remove migration 162 known error logs

## **Related issues**

Fixes: #34220

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 


---
<a href="https://cursor.com/background-agent?bcId=bc-4cabafa5-bafe-4c41-a219-0eb5ff274d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4cabafa5-bafe-4c41-a219-0eb5ff274d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops Sentry logging when `TokenBalancesController` is absent in migration 162 and updates tests accordingly.
> 
> - **Migration 162 (`app/scripts/migrations/162.ts`)**:
>   - Remove Sentry error logging when `TokenBalancesController` is missing; now returns original state silently.
> - **Tests (`app/scripts/migrations/162.test.ts`)**:
>   - Update test to expect no Sentry error for missing `TokenBalancesController`; adjust test name and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9486e64def09b683de43f1e16b4a47326b7b79d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->