### PR TITLE
fix: hide fiat on testnet

### DIFF
--- a/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../selectors';
 import { selectBalanceBySelectedAccountGroup } from '../../../../selectors/assets';
 import * as useMultichainSelectorHook from '../../../../hooks/useMultichainSelector';
+import * as multichainSelectors from '../../../../selectors/multichain';
 import {
   AccountGroupBalance,
   AccountGroupBalanceProps,
@@ -23,6 +24,10 @@ jest.mock('../../../../selectors/assets');
 jest.mock('../../../../selectors');
 jest.mock('../../../../ducks/locale/locale');
 jest.mock('../../../../ducks/metamask/metamask');
+jest.mock('../../../../selectors/multichain', () => ({
+  getMultichainNativeCurrency: jest.fn(),
+  getMultichainIsTestnet: jest.fn(),
+}));
 
 describe('AccountGroupBalance', () => {
   const createMockBalance = (): AccountGroupBalanceType => ({
@@ -35,6 +40,7 @@ describe('AccountGroupBalance', () => {
   const arrange = (
     selectedGroupBalance: AccountGroupBalanceType | null = null,
     showNativeTokenAsMainBalance: boolean = false,
+    isTestnet: boolean = false,
   ) => {
     const mockSelectBalanceBySelectedAccountGroup = jest
       .mocked(selectBalanceBySelectedAccountGroup)
@@ -56,12 +62,17 @@ describe('AccountGroupBalance', () => {
       .mocked(getCurrentCurrency)
       .mockReturnValue('usd');
 
+    const mockGetMultichainIsTestnet = jest
+      .mocked(multichainSelectors.getMultichainIsTestnet)
+      .mockReturnValue(isTestnet);
+
     return {
       mockSelectBalanceBySelectedAccountGroup,
       mockGetPreferences,
       mockGetIntlLocale,
       mockGetCurrentCurrency,
       mockGetEnabledNetworksByNamespace,
+      mockGetMultichainIsTestnet,
     };
   };
 
@@ -134,6 +145,19 @@ describe('AccountGroupBalance', () => {
       amount: '0.000589',
       balance: '0x0217b4f7389e02',
       chainId: '0x1',
+    });
+  });
+
+  it('renders native balance when on testnet regardless of showNativeTokenAsMainBalance setting', () => {
+    jest
+      .spyOn(useMultichainSelectorHook, 'useMultichainSelector')
+      .mockReturnValue('SepoliaETH');
+    arrange(createMockBalance(), false, true);
+    actAssertBalanceContent({
+      currency: 'SepoliaETH',
+      amount: '0.000589',
+      balance: '0x0217b4f7389e02',
+      chainId: '0xaa36a7',
     });
   });
 });

--- a/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
@@ -25,7 +25,7 @@ jest.mock('../../../../selectors');
 jest.mock('../../../../ducks/locale/locale');
 jest.mock('../../../../ducks/metamask/metamask');
 jest.mock('../../../../selectors/multichain', () => ({
-  getMultichainNativeCurrency: jest.fn(),
+  ...jest.requireActual('../../../../selectors/multichain'),
   getMultichainIsTestnet: jest.fn(),
 }));
 

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -25,7 +25,10 @@ import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { Skeleton } from '../../../component-library/skeleton';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
-import { getMultichainNativeCurrency } from '../../../../selectors/multichain';
+import {
+  getMultichainNativeCurrency,
+  getMultichainIsTestnet,
+} from '../../../../selectors/multichain';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../selectors/multichain-accounts/account-tree';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
 import { hexWEIToDecETH } from '../../../../../shared/modules/conversion.utils';
@@ -69,6 +72,8 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const isEvm = isEvmChainId(chainId);
 
+  const isTestnet = useSelector(getMultichainIsTestnet);
+
   const showNativeTokenAsMain = Boolean(
     showNativeTokenAsMainBalance && Object.keys(enabledNetworks).length === 1,
   );
@@ -79,7 +84,7 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
   );
 
   let formattedNativeBalance = null;
-  if (showNativeTokenAsMain) {
+  if (showNativeTokenAsMain || isTestnet) {
     if (isEvm) {
       const decimalBalance = parseFloat(hexWEIToDecETH(balance));
 
@@ -101,7 +106,7 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
     : undefined;
 
   const formattedTotal = useMemo(() => {
-    if (showNativeTokenAsMain) {
+    if (showNativeTokenAsMain || isTestnet) {
       return formattedNativeBalance;
     }
     if (total === undefined) {
@@ -110,6 +115,7 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
     return formatCurrency(total, currency);
   }, [
     showNativeTokenAsMain,
+    isTestnet,
     total,
     formatCurrency,
     currency,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Hide aggregated fiat amounts when a testnet is selected to align with issue #31484.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38683?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: hide fiat in aggregated view when selecting a testnet

## **Related issues**

Fixes: #31484

## **Manual testing steps**

1. Enable testnets in settings
2. Select linea sepolia or eth sepolia
4. See aggregated balance

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/ec015b5c1197443696b73fb32ad63b17

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-e685744a-d2b9-4470-9893-04f7a7a93941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e685744a-d2b9-4470-9893-04f7a7a93941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> AccountGroupBalance now shows native token balance instead of fiat on testnets, with tests updated to cover this behavior.
> 
> - **Assets UI**:
>   - `ui/components/app/assets/account-group-balance/account-group-balance.tsx`:
>     - Use `getMultichainIsTestnet` to detect testnets.
>     - Render native token balance when `isTestnet` or `showNativeTokenAsMainBalance` is true.
>     - Update memoization dependencies to include `isTestnet`.
> - **Tests**:
>   - `account-group-balance.test.tsx`:
>     - Mock `getMultichainIsTestnet` and add test ensuring native balance renders on testnets regardless of settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aeecafe5f53259eaad2eb68ed2a03341005cd78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->