### PR TITLE
fix: updates transaction details page with router v6 hooks

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.test.tsx
@@ -13,6 +13,17 @@ import configureStore from '../../../store/store';
 import { TransactionGroup } from '../../../hooks/useTransactionDisplayData';
 import CrossChainSwapTxDetails from './transaction-details';
 
+const mockNavigate = jest.fn();
+const mockLocation = jest.fn();
+const mockParams = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation(),
+  useParams: () => mockParams(),
+}));
+
 const getMockStore = (
   transactionGroup: TransactionGroup,
   srcTxMetaId: string,
@@ -51,37 +62,27 @@ const getMockStore = (
 };
 
 describe('transaction-details', () => {
-  const mockNavigate = jest.fn<
-    void,
-    [
-      path: string | number,
-      options?: { replace?: boolean; state?: Record<string, unknown> },
-    ]
-  >();
-
-  const mockLocation: RouterLocation = {
-    pathname: '/cross-chain/tx-details/test-id',
-    search: '',
-    hash: '',
-    state: {
-      transactionGroup: mockBridgeTxData.transactionGroup,
-      isEarliestNonce: true,
-    },
-    key: 'test-key',
-  };
-
-  const mockParams: { srcTxMetaId: string } = {
-    srcTxMetaId: mockBridgeTxData.srcTxMetaId,
-  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocation.mockReturnValue({
+      pathname: '/cross-chain/tx-details/test-id',
+      search: '',
+      hash: '',
+      state: {
+        transactionGroup: mockBridgeTxData.transactionGroup,
+        isEarliestNonce: true,
+      },
+      key: 'test-key',
+    } as RouterLocation);
+    mockParams.mockReturnValue({
+      srcTxMetaId: mockBridgeTxData.srcTxMetaId,
+    });
+  });
 
   describe('bridge snapshots', () => {
     it('should render completed bridge tx', () => {
       const { queryAllByTestId, getByText } = renderWithProvider(
-        <CrossChainSwapTxDetails
-          location={mockLocation}
-          navigate={mockNavigate}
-          params={mockParams}
-        />,
+        <CrossChainSwapTxDetails />,
         getMockStore(
           mockBridgeTxData.transactionGroup,
           mockBridgeTxData.srcTxMetaId,
@@ -109,11 +110,7 @@ describe('transaction-details', () => {
 
     it('should render pending bridge snapshot', () => {
       const { queryAllByTestId, getByText } = renderWithProvider(
-        <CrossChainSwapTxDetails
-          location={mockLocation}
-          navigate={mockNavigate}
-          params={mockParams}
-        />,
+        <CrossChainSwapTxDetails />,
         getMockStore(
           {
             ...mockBridgeTxData.transactionGroup,
@@ -152,11 +149,7 @@ describe('transaction-details', () => {
 
     it('should render confirmed bridge tx', () => {
       const { queryAllByTestId, getByText } = renderWithProvider(
-        <CrossChainSwapTxDetails
-          location={mockLocation}
-          navigate={mockNavigate}
-          params={mockParams}
-        />,
+        <CrossChainSwapTxDetails />,
         getMockStore(
           {
             ...mockBridgeTxData.transactionGroup,
@@ -195,11 +188,7 @@ describe('transaction-details', () => {
 
     it('should render bridge tx that failed on src', () => {
       const { queryAllByTestId, getByText } = renderWithProvider(
-        <CrossChainSwapTxDetails
-          location={mockLocation}
-          navigate={mockNavigate}
-          params={mockParams}
-        />,
+        <CrossChainSwapTxDetails />,
         getMockStore(
           {
             ...mockBridgeTxData.transactionGroup,
@@ -238,11 +227,7 @@ describe('transaction-details', () => {
 
     it('should render bridge tx that failed on dest', () => {
       const { queryAllByTestId, getByText } = renderWithProvider(
-        <CrossChainSwapTxDetails
-          location={mockLocation}
-          navigate={mockNavigate}
-          params={mockParams}
-        />,
+        <CrossChainSwapTxDetails />,
         getMockStore(
           {
             ...mockBridgeTxData.transactionGroup,

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
-import type { Location as RouterLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import {
   TransactionStatus,
   TransactionType,
@@ -74,26 +74,15 @@ import TransactionDetailRow from './transaction-detail-row';
 import BridgeExplorerLinks from './bridge-explorer-links';
 import BridgeStepList from './bridge-step-list';
 
-type CrossChainSwapTxDetailsProps = {
-  location?: RouterLocation;
-  navigate?: (
-    path: string | number,
-    options?: { replace?: boolean; state?: Record<string, unknown> },
-  ) => void;
-  params?: { srcTxMetaId: string };
-};
-
-const CrossChainSwapTxDetails = ({
-  location,
-  navigate,
-  params,
-}: CrossChainSwapTxDetailsProps) => {
+const CrossChainSwapTxDetails = () => {
   const t = useI18nContext();
   const locale = useSelector(getIntlLocale);
   const trackEvent = useContext(MetaMetricsContext);
   const rootState = useSelector((state) => state);
 
-  const srcTxMetaId = params?.srcTxMetaId;
+  const { srcTxMetaId } = useParams<{ srcTxMetaId: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
   const allTransactions = useSelector(
     getAllNetworkTransactions,
   ) as TransactionMeta[];


### PR DESCRIPTION
## **Description**

The swap/bridge transaction details page was broken after the React Router v5 → v6 migration. Clicking on a swap transaction in the activity list would show an empty details page with a broken back button.

**Root cause:** The `CrossChainSwapTxDetails` component was still expecting `params`, `location`, and `navigate` as props (v5 pattern), but the router migration in `e14532f7bf` changed how route components receive these - they now need to use hooks (`useParams`, `useLocation`, `useNavigate`).

**Fix:** Updated the component to use React Router v6 hooks instead of props, and updated the corresponding tests to mock the hooks.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38686?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed swap/bridge transaction details page not loading when clicking on a transaction from the activity list

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38682

## **Manual testing steps**

1. Go to the Bridge page and perform a swap (e.g., ETH to USDC)
2. Wait for the transaction to complete
3. Go to the Activity tab
4. Click on the completed swap transaction
5. Verify the transaction details page loads correctly with all info (status, amounts, gas fee, nonce, etc.)
6. Verify the back button works

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `CrossChainSwapTxDetails` to use React Router v6 hooks and updates tests, restoring correct rendering and navigation for bridge/swap transaction details.
> 
> - **UI (Bridge Transaction Details)**:
>   - Refactor `ui/pages/bridge/transaction-details/transaction-details.tsx` to use `useParams`, `useLocation`, and `useNavigate` (remove props-based `location`, `navigate`, `params`).
>   - Read `transactionGroup` and `isEarliestNonce` from `location.state`; use `navigate(PREVIOUS_ROUTE)` for back action.
> - **Tests**:
>   - Update `transaction-details.test.tsx` to mock `useNavigate`, `useLocation`, `useParams` and render `<CrossChainSwapTxDetails />` without props.
>   - Maintain snapshot/row assertions across completed, pending, confirmed, and failed states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2460f3d218506a62347629701071b5c993edb6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->