### PR TITLE
test(dx-papercuts):  disable Jest warning

### DIFF
--- a/app/scripts/controllers/swaps/swaps.test.ts
+++ b/app/scripts/controllers/swaps/swaps.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable jest/no-commented-out-tests -- quality-sprint-dec-2025 */
+
 import { BigNumber } from '@ethersproject/bignumber';
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import { ChainId, InfuraNetworkType } from '@metamask/controller-utils';


### PR DESCRIPTION
## **Description**

Quality Sprint December 2025 -- DX papercuts

Eliminates these distracting warnings in the GitHub Actions summary.  The other warnings are all Rules of Hooks, and not as simple to deal with.

<img width="582" height="867" alt="Capture" src="https://github.com/user-attachments/assets/6cbcaa0a-dc21-4075-a46b-1a79ea842ba1" />


## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable Jest lint rule `jest/no-commented-out-tests` in `app/scripts/controllers/swaps/swaps.test.ts` to silence warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a2ea81c966c510234f3b3a772a86f78424ef2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->