### PR TITLE
fix: flaky test `Multichain API Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested`

### DIFF
--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -491,7 +491,9 @@ describe('Multichain API', function () {
 
           await testDapp.checkConnectedAccounts([ACCOUNT_1, TREZOR_ACCOUNT]);
 
-          const newgetSessionResult = await testDapp.getSession();
+          const newgetSessionResult = await testDapp.getSession({
+            numberOfResultItems: 3,
+          });
 
           const expectedNewSessionScopes = [...OLD_SCOPES, ...NEW_SCOPES].map(
             (scope) => ({

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -21,6 +21,7 @@ import {
   getExpectedSessionScope,
   type FixtureCallbackArgs,
 } from '../testHelpers';
+import { DEFAULT_FIXTURE_ACCOUNT_LOWERCASE } from '../../../constants';
 
 describe('Multichain API', function () {
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks', function () {
@@ -443,6 +444,11 @@ describe('Multichain API', function () {
             ),
           );
 
+          // Issue #38699: Account 2 is connected but it's not imported in my wallet
+          await testDapp.checkConnectedAccounts([
+            DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+          ]);
+
           /**
            * Then we make sure to deselect the existing session scopes, and create session with new scopes
            */
@@ -460,6 +466,10 @@ describe('Multichain API', function () {
             driver,
           );
           await connectAccountConfirmation.checkPageIsLoaded();
+          await connectAccountConfirmation.checkForAccountsInPermissionList([
+            'Account 1',
+            'Trezor 1',
+          ]);
           await connectAccountConfirmation.confirmConnect();
 
           await driver.switchToWindowWithTitle(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -448,7 +448,9 @@ describe('Multichain API', function () {
           /**
            * We first make sure sessions exist
            */
-          const existinggetSessionResult = await testDapp.getSession();
+          const existinggetSessionResult = await testDapp.getSession({
+            numberOfResultItems: 1,
+          });
           OLD_SCOPES.forEach((scope) =>
             assert.strictEqual(
               isObject(existinggetSessionResult.sessionScopes[scope]),
@@ -457,7 +459,6 @@ describe('Multichain API', function () {
             ),
           );
 
-          // Issue #38699: Account 2 is connected but it's not imported in my wallet
           await testDapp.checkConnectedAccounts([ACCOUNT_1]);
 
           /**

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -477,6 +477,7 @@ describe('Multichain API', function () {
           );
           await testDapp.checkPageIsLoaded();
 
+          await driver.delay(5000);
           const newgetSessionResult = await testDapp.getSession();
 
           const expectedNewSessionScopes = [...OLD_SCOPES, ...NEW_SCOPES].map(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -327,6 +327,9 @@ describe('Multichain API', function () {
               driver,
             );
             await connectAccountConfirmation.checkPageIsLoaded();
+            await connectAccountConfirmation.checkForAccountsInPermissionList([
+              'Account 1',
+            ]);
             await connectAccountConfirmation.openEditAccountsModal();
 
             const editConnectedAccountsModal = new EditConnectedAccountsModal(
@@ -336,6 +339,11 @@ describe('Multichain API', function () {
             await editConnectedAccountsModal.addNewAccount();
 
             await connectAccountConfirmation.checkPageIsLoaded();
+
+            await connectAccountConfirmation.checkForAccountsInPermissionList([
+              'Account 1',
+              'Account 2',
+            ]);
             await connectAccountConfirmation.confirmConnect();
 
             await driver.switchToWindowWithTitle(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -23,7 +23,6 @@ import {
 } from '../testHelpers';
 
 describe('Multichain API', function () {
-  const TREZOR_ACCOUNT = '0xf68464152d7289d7ea9a2bec2e0035c45188223c';
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks', function () {
     it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
       await withFixtures(
@@ -122,7 +121,7 @@ describe('Multichain API', function () {
             WINDOW_TITLES.MultichainTestDApp,
           );
           await testDapp.checkPageIsLoaded();
-          await testDapp.checkConnectedAccounts([TREZOR_ACCOUNT]);
+          await testDapp.checkConnectedAccounts([SECOND_ACCOUNT_IN_WALLET]);
           const getSessionResult = await testDapp.getSession();
           /**
            * Accounts in scope should not include invalid account {@link ACCOUNT_NOT_IN_WALLET}, only the valid accounts.
@@ -420,6 +419,7 @@ describe('Multichain API', function () {
   describe('Dapp has existing session with 2 scopes and 1 account and then calls `wallet_createSession` with different scopes and accounts', function () {
     const OLD_SCOPES = ['eip155:1337', 'eip155:1'];
     const NEW_SCOPES = ['eip155:1338', 'eip155:1000'];
+    const TREZOR_ACCOUNT = '0xf68464152d7289d7ea9a2bec2e0035c45188223c';
 
     it('should include old session permissions as pre-selected in the connection screen along with those requested in the new `wallet_createSession` request', async function () {
       await withFixtures(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -21,9 +21,9 @@ import {
   getExpectedSessionScope,
   type FixtureCallbackArgs,
 } from '../testHelpers';
-import { DEFAULT_FIXTURE_ACCOUNT_LOWERCASE } from '../../../constants';
 
 describe('Multichain API', function () {
+  const TREZOR_ACCOUNT = '0xf68464152d7289d7ea9a2bec2e0035c45188223c';
   describe('Connect wallet to the multichain dapp via `externally_connectable`, call `wallet_createSession` with requested EVM scope that does NOT match one of the users enabled networks', function () {
     it("the specified EVM scopes that do not match the user's configured networks should be treated as if they were not requested", async function () {
       await withFixtures(
@@ -63,6 +63,9 @@ describe('Multichain API', function () {
             WINDOW_TITLES.MultichainTestDApp,
           );
           await testDapp.checkPageIsLoaded();
+
+          await testDapp.checkConnectedAccounts([ACCOUNT_1]);
+
           const getSessionResult = await testDapp.getSession();
 
           for (const scope of scopesToIgnore) {
@@ -119,6 +122,7 @@ describe('Multichain API', function () {
             WINDOW_TITLES.MultichainTestDApp,
           );
           await testDapp.checkPageIsLoaded();
+          await testDapp.checkConnectedAccounts([TREZOR_ACCOUNT]);
           const getSessionResult = await testDapp.getSession();
           /**
            * Accounts in scope should not include invalid account {@link ACCOUNT_NOT_IN_WALLET}, only the valid accounts.
@@ -236,6 +240,7 @@ describe('Multichain API', function () {
               WINDOW_TITLES.MultichainTestDApp,
             );
             await testDapp.checkPageIsLoaded();
+            await testDapp.checkConnectedAccounts([ACCOUNT_1, ACCOUNT_2]);
             const getSessionResult = await testDapp.getSession();
 
             assert.strictEqual(
@@ -350,6 +355,7 @@ describe('Multichain API', function () {
               WINDOW_TITLES.MultichainTestDApp,
             );
             await testDapp.checkPageIsLoaded();
+            await testDapp.checkConnectedAccounts([ACCOUNT_1, ACCOUNT_2]);
             const getSessionResult = await testDapp.getSession();
 
             assert.deepEqual(
@@ -414,7 +420,6 @@ describe('Multichain API', function () {
   describe('Dapp has existing session with 2 scopes and 1 account and then calls `wallet_createSession` with different scopes and accounts', function () {
     const OLD_SCOPES = ['eip155:1337', 'eip155:1'];
     const NEW_SCOPES = ['eip155:1338', 'eip155:1000'];
-    const TREZOR_ACCOUNT = '0xf68464152d7289d7ea9a2bec2e0035c45188223c';
 
     it('should include old session permissions as pre-selected in the connection screen along with those requested in the new `wallet_createSession` request', async function () {
       await withFixtures(
@@ -453,9 +458,7 @@ describe('Multichain API', function () {
           );
 
           // Issue #38699: Account 2 is connected but it's not imported in my wallet
-          await testDapp.checkConnectedAccounts([
-            DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
-          ]);
+          await testDapp.checkConnectedAccounts([ACCOUNT_1]);
 
           /**
            * Then we make sure to deselect the existing session scopes, and create session with new scopes
@@ -485,7 +488,8 @@ describe('Multichain API', function () {
           );
           await testDapp.checkPageIsLoaded();
 
-          await driver.delay(5000);
+          await testDapp.checkConnectedAccounts([ACCOUNT_1, TREZOR_ACCOUNT]);
+
           const newgetSessionResult = await testDapp.getSession();
 
           const expectedNewSessionScopes = [...OLD_SCOPES, ...NEW_SCOPES].map(

--- a/test/e2e/flask/multichain-api/evm/wallet_getSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_getSession.spec.ts
@@ -26,7 +26,9 @@ describe('Multichain API', function () {
           await testDapp.openTestDappPage();
           await testDapp.checkPageIsLoaded();
           await testDapp.connectExternallyConnectable(extensionId);
-          const parsedResult = await testDapp.getSession();
+          const parsedResult = await testDapp.getSession({
+            numberOfResultItems: 1,
+          });
 
           assert.deepStrictEqual(
             parsedResult.sessionScopes,
@@ -61,7 +63,9 @@ describe('Multichain API', function () {
           await testDapp.openTestDappPage();
           await testDapp.checkPageIsLoaded();
           await testDapp.connectExternallyConnectable(extensionId);
-          const parsedResult = await testDapp.getSession();
+          const parsedResult = await testDapp.getSession({
+            numberOfResultItems: 1,
+          });
 
           const sessionScope = parsedResult.sessionScopes[DEFAULT_SCOPE];
           const expectedSessionScope = getExpectedSessionScope(DEFAULT_SCOPE, [

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -63,9 +63,7 @@ describe('Initializing a session w/ several scopes and accounts, then calling `w
         /**
          * We verify that scopes are not empty before calling `wallet_revokeSession`
          */
-        const { sessionScopes } = await testDapp.getSession({
-          numberOfResultItems: 1,
-        });
+        const { sessionScopes } = await testDapp.getSession();
         assert.ok(
           Object.keys(sessionScopes).length > 0,
           'Should have non-empty session scopes value before calling `wallet_revokeSession`',

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -63,7 +63,9 @@ describe('Initializing a session w/ several scopes and accounts, then calling `w
         /**
          * We verify that scopes are not empty before calling `wallet_revokeSession`
          */
-        const { sessionScopes } = await testDapp.getSession();
+        const { sessionScopes } = await testDapp.getSession({
+          numberOfResultItems: 1,
+        });
         assert.ok(
           Object.keys(sessionScopes).length > 0,
           'Should have non-empty session scopes value before calling `wallet_revokeSession`',
@@ -71,7 +73,9 @@ describe('Initializing a session w/ several scopes and accounts, then calling `w
 
         await testDapp.revokeSession();
 
-        const parsedResult = await testDapp.getSession();
+        const parsedResult = await testDapp.getSession({
+          numberOfResultItems: 1,
+        });
         const resultSessionScopes = parsedResult.sessionScopes;
         assert.deepStrictEqual(
           resultSessionScopes,

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -74,7 +74,7 @@ describe('Initializing a session w/ several scopes and accounts, then calling `w
         await testDapp.revokeSession();
 
         const parsedResult = await testDapp.getSession({
-          numberOfResultItems: 2,
+          numberOfResultItems: 3,
         });
         const resultSessionScopes = parsedResult.sessionScopes;
         assert.deepStrictEqual(

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -74,7 +74,7 @@ describe('Initializing a session w/ several scopes and accounts, then calling `w
         await testDapp.revokeSession();
 
         const parsedResult = await testDapp.getSession({
-          numberOfResultItems: 1,
+          numberOfResultItems: 2,
         });
         const resultSessionScopes = parsedResult.sessionScopes;
         assert.deepStrictEqual(

--- a/test/e2e/page-objects/pages/confirmations/redesign/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/connect-account-confirmation.ts
@@ -5,7 +5,7 @@ class ConnectAccountConfirmation {
 
   private readonly accountListItem = (accountName: string) => {
     return {
-      css: 'multichain-account-cell__account-name',
+      css: '.multichain-account-cell__account-name',
       text: accountName,
     };
   };

--- a/test/e2e/page-objects/pages/confirmations/redesign/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/connect-account-confirmation.ts
@@ -3,6 +3,13 @@ import { Driver } from '../../../../webdriver/driver';
 class ConnectAccountConfirmation {
   driver: Driver;
 
+  private readonly accountListItem = (accountName: string) => {
+    return {
+      css: 'multichain-account-cell__account-name',
+      text: accountName,
+    };
+  };
+
   private readonly addSolanaAccountButton = {
     testId: 'submit-add-account-with-name',
   };
@@ -93,18 +100,8 @@ class ConnectAccountConfirmation {
 
   async createCreateSolanaAccountFromModal(): Promise<void> {
     console.log('Create Solana account from modal');
-    const createSolanaAccountModalButton = await this.driver.findElement(
-      this.createSolanaAccountModalButton,
-    );
-    await createSolanaAccountModalButton.click();
-
-    const addSolanaAccountButton = await this.driver.findClickableElement(
-      this.addSolanaAccountButton,
-      {
-        timeout: 1000,
-      },
-    );
-    await addSolanaAccountButton.click();
+    await this.driver.clickElement(this.createSolanaAccountModalButton);
+    await this.driver.clickElement(this.addSolanaAccountButton);
   }
 
   async isCreateSolanaAccountModalButtonVisible(): Promise<boolean> {
@@ -134,6 +131,12 @@ class ConnectAccountConfirmation {
     }
     console.log('Confirm button is enabled');
     return true;
+  }
+
+  async checkForAccountsInPermissionList(accounts: string[]): Promise<void> {
+    for (const account of accounts) {
+      await this.driver.waitForSelector(this.accountListItem(account));
+    }
   }
 }
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -224,7 +224,7 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
     await this.clickWalletGetSessionButton();
-    // Wait for the complete result list to be displayed
+    // Wait for the complete result list to be displayed to avoid race conditions with the results
     await this.checkResultListTotalItems(numberOfResultItems);
 
     await this.clickFirstResultSummary();

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -210,7 +210,10 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
     await this.clickWalletGetSessionButton();
+    await this.driver.delay(5000);
+
     await this.clickFirstResultSummary();
+    await this.driver.delay(5000);
 
     const getSessionRawResult = await this.driver.waitForSelector(
       this.firstSessionMethodResult,

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -36,6 +36,10 @@ class TestDappMultichain {
     testId: 'invoke-all-methods-button',
   };
 
+  private readonly sessionResultListItems = (resultNumber: number) => {
+    return `#session-method-details-${resultNumber}`;
+  };
+
   private readonly walletCreateSessionButton = '#create-session-btn';
 
   private readonly walletGetSessionButton = '#get-session-btn';
@@ -81,6 +85,12 @@ class TestDappMultichain {
       throw e;
     }
     console.log('Multichain Test Dapp page is loaded');
+  }
+
+  async checkResultListTotalItems(totalItems: number): Promise<void> {
+    await this.driver.waitForSelector(
+      this.sessionResultListItems(totalItems - 1),
+    );
   }
 
   async clickConnectExternallyConnectableButton() {
@@ -203,14 +213,19 @@ class TestDappMultichain {
   /**
    * Retrieves permitted session object.
    *
+   * @param params - The parameters for retrieving the session.
+   * @param params.numberOfResultItems - The number of result items expected. Defaults to 2.
    * @returns the session object.
    */
-  async getSession(): Promise<{
+  async getSession({
+    numberOfResultItems = 2,
+  }: { numberOfResultItems?: number } = {}): Promise<{
     sessionScopes: Record<string, NormalizedScopeObject>;
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
     await this.clickWalletGetSessionButton();
-    await this.driver.delay(5000);
+    // Wait for the complete result list to be displayed
+    await this.checkResultListTotalItems(numberOfResultItems);
 
     await this.clickFirstResultSummary();
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -36,7 +36,7 @@ class TestDappMultichain {
     testId: 'invoke-all-methods-button',
   };
 
-  private readonly sessionResultListItems = (resultNumber: number) => {
+  private readonly sessionResultListItem = (resultNumber: number) => {
     return `#session-method-details-${resultNumber}`;
   };
 
@@ -89,7 +89,7 @@ class TestDappMultichain {
 
   async checkResultListTotalItems(totalItems: number): Promise<void> {
     await this.driver.waitForSelector(
-      this.sessionResultListItems(totalItems - 1),
+      this.sessionResultListItem(totalItems - 1),
     );
   }
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -210,10 +210,8 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
     await this.clickWalletGetSessionButton();
-    await this.driver.delay(5000);
 
     await this.clickFirstResultSummary();
-    await this.driver.delay(5000);
 
     const getSessionRawResult = await this.driver.waitForSelector(
       this.firstSessionMethodResult,

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -210,6 +210,7 @@ class TestDappMultichain {
   }> {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.MultichainTestDApp);
     await this.clickWalletGetSessionButton();
+    await this.driver.delay(5000);
 
     await this.clickFirstResultSummary();
 

--- a/test/e2e/page-objects/pages/test-dapp-multichain.ts
+++ b/test/e2e/page-objects/pages/test-dapp-multichain.ts
@@ -11,6 +11,13 @@ const DAPP_URL = `http://${DAPP_HOST_ADDRESS}`;
 class TestDappMultichain {
   private readonly driver: Driver;
 
+  private readonly connectedAccount = (account: string) => {
+    return {
+      testId: 'connected-accounts-list',
+      text: account,
+    };
+  };
+
   private readonly connectExternallyConnectableButton = {
     text: 'Connect',
     tag: 'button',
@@ -430,6 +437,13 @@ class TestDappMultichain {
       css: this.walletNotifyResult,
       text: scope,
     });
+  }
+
+  async checkConnectedAccounts(expectedAccounts: string[]): Promise<void> {
+    console.log('Checking connected accounts on multichain test dapp.');
+    for (const account of expectedAccounts) {
+      await this.driver.waitForSelector(this.connectedAccount(account));
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The race condition happens because whenever we want to get the results, we take the first result of the items list, which is the last one. However, it can happen that the latest result is not yet loaded, taking the previous result thus making the assert fail.

Now we wait until the expected items are in the results list, then we read the result.


<img width="586" height="228" alt="image" src="https://github.com/user-attachments/assets/52ff5014-07e5-472b-9fe7-d0051695ccee" />

<img width="364" height="47" alt="image" src="https://github.com/user-attachments/assets/e4654210-b1b2-47ea-9068-21f20b3ddafd" />



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38701?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes multichain E2E session tests by waiting for expected result items before parsing and adding account verification helpers, updating specs accordingly.
> 
> - **E2E utilities**:
>   - `TestDappMultichain.getSession` now accepts `numberOfResultItems` and waits for the full results list before parsing to avoid race conditions; added `checkResultListTotalItems`, `checkConnectedAccounts`, and related selectors.
>   - `ConnectAccountConfirmation` adds `checkForAccountsInPermissionList` and simplifies Solana account creation clicks.
> - **Tests updated**:
>   - `wallet_createSession.spec.ts`, `wallet_getSession.spec.ts`, `wallet_revokeSession.spec.ts` use the new `getSession({ numberOfResultItems })` and account checks; add assertions for connected accounts and permission list; minor refactors to increase reliability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aadfc3b946e9258233f5468350a60d1eb3e7d721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->