### PR TITLE
chore: scan delegation delegate address in trust middleware

### DIFF
--- a/app/scripts/lib/transaction/delegation.ts
+++ b/app/scripts/lib/transaction/delegation.ts
@@ -39,7 +39,7 @@ export const ROOT_AUTHORITY =
 
 export const ANY_BENEFICIARY = '0x0000000000000000000000000000000000000a11';
 
-const PRIMARY_TYPE_DELEGATION = 'Delegation';
+export const PRIMARY_TYPE_DELEGATION = 'Delegation';
 const DOMAIN_NAME = 'DelegationManager';
 
 const ABI_TYPES_CAVEAT = [

--- a/app/scripts/lib/trust-signals/trust-signals-middleware.ts
+++ b/app/scripts/lib/trust-signals/trust-signals-middleware.ts
@@ -11,6 +11,7 @@ import {
   parseApprovalTransactionData,
 } from '../../../../shared/modules/transaction.utils';
 import { PRIMARY_TYPES_PERMIT } from '../../../../shared/constants/signatures';
+import { PRIMARY_TYPE_DELEGATION } from '../transaction/delegation';
 import { isSecurityAlertsAPIEnabled } from '../ppom/security-alerts-api';
 import { mapChainIdToSupportedEVMChain } from '../../../../shared/lib/trust-signals';
 import { scanAddressAndAddToCache } from './security-alerts-api';
@@ -205,6 +206,24 @@ function handleEthSignTypedData(
       ).catch((error) => {
         console.error(
           '[createTrustSignalsMiddleware] error scanning spender address for permit:',
+          error,
+        );
+      });
+    }
+  }
+
+  // If this is a delegation signature, scan the delegate address
+  if (primaryType === PRIMARY_TYPE_DELEGATION) {
+    const delegateAddress = typedDataMessage.message?.delegate;
+    if (delegateAddress) {
+      scanAddressAndAddToCache(
+        delegateAddress,
+        appStateController.getAddressSecurityAlertResponse,
+        appStateController.addAddressSecurityAlertResponse,
+        supportedEVMChain,
+      ).catch((error) => {
+        console.error(
+          '[createTrustSignalsMiddleware] error scanning delegate address for delegation:',
           error,
         );
       });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR extends the trust signals middleware to scan delegate addresses when processing delegation signatures (EIP-7710 Delegations).

**Reason for the change:**
When a user signs a delegation, the delegate address is a critical security parameter—it determines who will have delegated authority over the user's account. Currently, the trust signals middleware scans verifying contracts and spender addresses (for permits), but does not scan the delegate address in delegation signatures. This leaves a gap in our security scanning coverage.

**Improvement/solution:**
- Extended `handleEthSignTypedData` in the trust signals middleware to detect delegation signatures (via `PRIMARY_TYPE_DELEGATION`) and scan the delegate address using the existing `scanAddressAndAddToCache` mechanism
- Exported `PRIMARY_TYPE_DELEGATION` constant from `delegation.ts` to enable reuse across modules
- Added comprehensive test coverage for the new functionality, including:
  - Verifying both the verifying contract and delegate addresses are scanned
  - Graceful error handling when delegate scanning fails
  - Edge case handling when delegate address is not present

The implementation follows the existing patterns established for permit signature scanning.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38710?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Manual testing steps**

1. Create a new permission and sign it.
2. In the signing step delegate scan should be triggered.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scan delegate addresses for delegation typed-data signatures and export PRIMARY_TYPE_DELEGATION, with comprehensive tests and error handling.
> 
> - **Trust Signals Middleware**:
>   - Scan `delegate` address for EIP-712 delegation signatures (`primaryType: "Delegation"`) alongside the `verifyingContract`.
>   - Leverages `PRIMARY_TYPE_DELEGATION` for detection and adds graceful error handling on delegate scan failures.
> - **Transactions/Delegation**:
>   - Export `PRIMARY_TYPE_DELEGATION` from `app/scripts/lib/transaction/delegation.ts` for cross-module use.
> - **Tests**:
>   - Add tests to verify scanning of both `verifyingContract` and `delegate`, error handling on delegate scan failures, and no-scan when `delegate` is absent.
>   - Introduce `DELEGATE` test address constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80403528581456031b2d522ea83ce9245cd6a359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->