### PR TITLE
feat: Gas modals refactor II

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -411,6 +411,12 @@
   "advancedDetailsNonceTooltip": {
     "message": "This is the transaction number of an account. Nonce for the first transaction is 0 and it increases in sequential order."
   },
+  "advancedEIP1559ModalTitle": {
+    "message": "Advanced Network Fee"
+  },
+  "advancedGasPriceModalTitle": {
+    "message": "Advanced Network Fee"
+  },
   "advancedGasFeeDefaultOptIn": {
     "message": "Save these values as my default for the $1 network.",
     "description": "$1 is the current network name."
@@ -1802,8 +1808,20 @@
   "currentAccountNotConnected": {
     "message": "Your current account is not connected"
   },
+  "currentEstimatedBaseFee": {
+    "message": "Current: $1 GWEI"
+  },
+  "currentEstimatedPriorityFeeRange": {
+    "message": "Current: $1 - $2 GWEI"
+  },
   "currentExtension": {
     "message": "Current extension page"
+  },
+  "currentHistoricalBaseFeeRange": {
+    "message": "12 hr: $1 - $2 GWEI"
+  },
+  "currentHistoricalPriorityFeeRange": {
+    "message": "12 hr: $1 - $2 GWEI"
   },
   "currentLanguage": {
     "message": "Current language"
@@ -2655,6 +2673,9 @@
   "feeDetails": {
     "message": "Fee details"
   },
+  "fieldRequired": {
+    "message": "$1 is required"
+  },
   "fileImportFail": {
     "message": "File import not working? Click here!",
     "description": "Helps user import their account from a JSON file"
@@ -2789,6 +2810,9 @@
   },
   "gasOption": {
     "message": "Gas option"
+  },
+  "gasPrice": {
+    "message": "Gas price"
   },
   "gasPriceExcessive": {
     "message": "Your gas fee is set unnecessarily high. Consider lowering the amount."
@@ -3651,6 +3675,9 @@
   "maxBaseFee": {
     "message": "Max base fee"
   },
+  "maxBaseFeeMustBeGreaterThanPriorityFee": {
+    "message": "Max base fee must be greater than priority fee"
+  },
   "maxFee": {
     "message": "Max fee"
   },
@@ -3962,6 +3989,9 @@
   "negativeOrZeroAmountToken": {
     "message": "Cannot send negative or zero amounts of asset."
   },
+  "negativeValuesNotAllowed": {
+    "message": "Negative values are not allowed"
+  },
   "network": {
     "message": "Network"
   },
@@ -4257,6 +4287,9 @@
   },
   "noWebcamFoundTitle": {
     "message": "Webcam not found"
+  },
+  "noZeroValue": {
+    "message": "$1 must be greater than 0"
   },
   "nonContractAddressAlertDesc": {
     "message": "You're sending call data to an address that isn't a contract. This could cause you to lose funds. Make sure you're using the correct address and network before continuing."
@@ -4594,6 +4627,12 @@
   "onlyConnectTrust": {
     "message": "Only connect with sites you trust. $1",
     "description": "Text displayed above the buttons for connection confirmation. $1 is the link to the learn more web page."
+  },
+  "onlyIntegersAllowed": {
+    "message": "Only whole numbers are allowed"
+  },
+  "onlyNumbersAllowed": {
+    "message": "Only numbers are allowed"
   },
   "openFullScreen": {
     "message": "Open full screen"
@@ -5069,6 +5108,9 @@
   },
   "priorityFeeProperCase": {
     "message": "Priority Fee"
+  },
+  "priorityFeeTooHigh": {
+    "message": "Priority fee must be less than max base fee"
   },
   "privacy": {
     "message": "Privacy"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -414,15 +414,15 @@
   "advancedEIP1559ModalTitle": {
     "message": "Advanced Network Fee"
   },
-  "advancedGasPriceModalTitle": {
-    "message": "Advanced Network Fee"
-  },
   "advancedGasFeeDefaultOptIn": {
     "message": "Save these values as my default for the $1 network.",
     "description": "$1 is the current network name."
   },
   "advancedGasFeeModalTitle": {
     "message": "Advanced gas fee"
+  },
+  "advancedGasPriceModalTitle": {
+    "message": "Advanced Network Fee"
   },
   "advancedGasPriceTitle": {
     "message": "Gas price"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -411,12 +411,18 @@
   "advancedDetailsNonceTooltip": {
     "message": "This is the transaction number of an account. Nonce for the first transaction is 0 and it increases in sequential order."
   },
+  "advancedEIP1559ModalTitle": {
+    "message": "Advanced Network Fee"
+  },
   "advancedGasFeeDefaultOptIn": {
     "message": "Save these values as my default for the $1 network.",
     "description": "$1 is the current network name."
   },
   "advancedGasFeeModalTitle": {
     "message": "Advanced gas fee"
+  },
+  "advancedGasPriceModalTitle": {
+    "message": "Advanced Network Fee"
   },
   "advancedGasPriceTitle": {
     "message": "Gas price"
@@ -1802,8 +1808,20 @@
   "currentAccountNotConnected": {
     "message": "Your current account is not connected"
   },
+  "currentEstimatedBaseFee": {
+    "message": "Current: $1 GWEI"
+  },
+  "currentEstimatedPriorityFeeRange": {
+    "message": "Current: $1 - $2 GWEI"
+  },
   "currentExtension": {
     "message": "Current extension page"
+  },
+  "currentHistoricalBaseFeeRange": {
+    "message": "12 hr: $1 - $2 GWEI"
+  },
+  "currentHistoricalPriorityFeeRange": {
+    "message": "12 hr: $1 - $2 GWEI"
   },
   "currentLanguage": {
     "message": "Current language"
@@ -2655,6 +2673,9 @@
   "feeDetails": {
     "message": "Fee details"
   },
+  "fieldRequired": {
+    "message": "$1 is required"
+  },
   "fileImportFail": {
     "message": "File import not working? Click here!",
     "description": "Helps user import their account from a JSON file"
@@ -2789,6 +2810,9 @@
   },
   "gasOption": {
     "message": "Gas option"
+  },
+  "gasPrice": {
+    "message": "Gas price"
   },
   "gasPriceExcessive": {
     "message": "Your gas fee is set unnecessarily high. Consider lowering the amount."
@@ -3651,6 +3675,9 @@
   "maxBaseFee": {
     "message": "Max base fee"
   },
+  "maxBaseFeeMustBeGreaterThanPriorityFee": {
+    "message": "Max base fee must be greater than priority fee"
+  },
   "maxFee": {
     "message": "Max fee"
   },
@@ -3962,6 +3989,9 @@
   "negativeOrZeroAmountToken": {
     "message": "Cannot send negative or zero amounts of asset."
   },
+  "negativeValuesNotAllowed": {
+    "message": "Negative values are not allowed"
+  },
   "network": {
     "message": "Network"
   },
@@ -4257,6 +4287,9 @@
   },
   "noWebcamFoundTitle": {
     "message": "Webcam not found"
+  },
+  "noZeroValue": {
+    "message": "$1 must be greater than 0"
   },
   "nonContractAddressAlertDesc": {
     "message": "You're sending call data to an address that isn't a contract. This could cause you to lose funds. Make sure you're using the correct address and network before continuing."
@@ -4594,6 +4627,12 @@
   "onlyConnectTrust": {
     "message": "Only connect with sites you trust. $1",
     "description": "Text displayed above the buttons for connection confirmation. $1 is the link to the learn more web page."
+  },
+  "onlyIntegersAllowed": {
+    "message": "Only whole numbers are allowed"
+  },
+  "onlyNumbersAllowed": {
+    "message": "Only numbers are allowed"
   },
   "openFullScreen": {
     "message": "Open full screen"
@@ -5069,6 +5108,9 @@
   },
   "priorityFeeProperCase": {
     "message": "Priority Fee"
+  },
+  "priorityFeeTooHigh": {
+    "message": "Priority fee must be less than max base fee"
   },
   "privacy": {
     "message": "Privacy"

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`Info renders info section for approve request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>
@@ -623,7 +623,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>
@@ -1091,7 +1091,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`Info renders info section for approve request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -345,7 +345,7 @@ exports[`Info renders info section for approve request 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
@@ -623,7 +623,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -655,7 +655,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
@@ -1091,7 +1091,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -1123,7 +1123,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -379,7 +379,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
         <p
@@ -417,7 +417,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -379,7 +379,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
         <p

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -293,7 +293,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -445,7 +445,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`NativeTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -475,7 +475,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
@@ -275,6 +275,9 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
               class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
             />
           </button>
+          <button>
+            Edit Gas
+          </button>
           <p
             class="mm-box mm-text mm-text--body-md"
             data-testid="native-currency"
@@ -347,7 +350,7 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
@@ -275,9 +275,6 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
               class="mm-box mm-text mm-text--inherit mm-box--color-primary-default"
             />
           </button>
-          <button>
-            Edit Gas
-          </button>
           <p
             class="mm-box mm-text mm-text--body-md"
             data-testid="native-currency"

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -1,6 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import { useSelector } from 'react-redux';
 import { TEST_CHAINS } from '../../../../../../../../shared/constants/network';
 import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
@@ -27,7 +27,6 @@ import { useBalanceChanges } from '../../../../simulation-details/useBalanceChan
 import { useSelectedGasFeeToken } from '../../hooks/useGasFeeToken';
 import { EditGasIconButton } from '../edit-gas-icon/edit-gas-icon-button';
 import { SelectedGasFeeToken } from '../selected-gas-fee-token';
-import { GasFeeModal } from '../../../../modals/gas-fee-modal/gas-fee-modal';
 
 export const EditGasFeesRow = ({
   fiatFee,
@@ -47,9 +46,6 @@ export const EditGasFeesRow = ({
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { isQuotedSwapDisplayedInInfo } = useDappSwapContext();
-
-  const [showNewTransactionGasModal, setShowNewTransactionGasModal] =
-    useState(false);
 
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
@@ -77,9 +73,6 @@ export const EditGasFeesRow = ({
   // by the user and 7702 is not supported in the chain.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
-
-  const shouldShowEditGasIcon =
-    !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
@@ -110,20 +103,14 @@ export const EditGasFeesRow = ({
                 {t('paidByMetaMask')}
               </Text>
             )}
-            {shouldShowEditGasIcon && (
-              <EditGasIconButton
-                supportsEIP1559={supportsEIP1559}
-                setShowCustomizeGasPopover={setShowCustomizeGasPopover}
-              />
-            )}
-            {shouldShowEditGasIcon && (
-              <button onClick={() => setShowNewTransactionGasModal(true)}>
-                Edit Gas
-              </button>
-            )}
-            {showNewTransactionGasModal && (
-              <GasFeeModal setGasModalVisible={setShowNewTransactionGasModal} />
-            )}
+            {!isQuotedSwapDisplayedInInfo &&
+              !gasFeeToken &&
+              !isGasFeeSponsored && (
+                <EditGasIconButton
+                  supportsEIP1559={supportsEIP1559}
+                  setShowCustomizeGasPopover={setShowCustomizeGasPopover}
+                />
+              )}
             {showFiat && !showAdvancedDetails && !isGasFeeSponsored && (
               <FiatValue
                 fullValue={fiatFeeWith18SignificantDigits}

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -1,6 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { TEST_CHAINS } from '../../../../../../../../shared/constants/network';
 import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
@@ -27,6 +27,7 @@ import { useBalanceChanges } from '../../../../simulation-details/useBalanceChan
 import { useSelectedGasFeeToken } from '../../hooks/useGasFeeToken';
 import { EditGasIconButton } from '../edit-gas-icon/edit-gas-icon-button';
 import { SelectedGasFeeToken } from '../selected-gas-fee-token';
+import { GasFeeModal } from '../../../../modals/gas-fee-modal/gas-fee-modal';
 
 export const EditGasFeesRow = ({
   fiatFee,
@@ -46,6 +47,9 @@ export const EditGasFeesRow = ({
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { isQuotedSwapDisplayedInInfo } = useDappSwapContext();
+
+  const [showNewTransactionGasModal, setShowNewTransactionGasModal] =
+    useState(false);
 
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
@@ -73,6 +77,9 @@ export const EditGasFeesRow = ({
   // by the user and 7702 is not supported in the chain.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
+
+  const shouldShowEditGasIcon =
+    !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
@@ -103,14 +110,20 @@ export const EditGasFeesRow = ({
                 {t('paidByMetaMask')}
               </Text>
             )}
-            {!isQuotedSwapDisplayedInInfo &&
-              !gasFeeToken &&
-              !isGasFeeSponsored && (
-                <EditGasIconButton
-                  supportsEIP1559={supportsEIP1559}
-                  setShowCustomizeGasPopover={setShowCustomizeGasPopover}
-                />
-              )}
+            {shouldShowEditGasIcon && (
+              <EditGasIconButton
+                supportsEIP1559={supportsEIP1559}
+                setShowCustomizeGasPopover={setShowCustomizeGasPopover}
+              />
+            )}
+            {shouldShowEditGasIcon && (
+              <button onClick={() => setShowNewTransactionGasModal(true)}>
+                Edit Gas
+              </button>
+            )}
+            {showNewTransactionGasModal && (
+              <GasFeeModal setGasModalVisible={setShowNewTransactionGasModal} />
+            )}
             {showFiat && !showAdvancedDetails && !isGasFeeSponsored && (
               <FiatValue
                 fullValue={fiatFeeWith18SignificantDigits}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-             
+
           </p>
         </div>
       </div>
@@ -456,7 +456,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
           <p
             class="mm-box mm-text mm-text--body-md mm-box--padding-inline-end-2 mm-box--color-text-alternative"
           >
-            🦊 Market
+            Market
           </p>
           <p
             class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`TokenTransferInfo renders correctly 1`] = `
             class="mm-box mm-text mm-text--body-sm mm-box--padding-bottom-0 mm-box--color-text-alternative"
             data-testid="gas-fee-token-fee"
           >
-
+             
           </p>
         </div>
       </div>

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
@@ -77,7 +77,7 @@ describe('GasDetailsItem', () => {
   it('should render label', async () => {
     await render();
     await waitFor(() => {
-      expect(screen.queryAllByText('🦊 Market')[0]).toBeInTheDocument();
+      expect(screen.queryAllByText('Market')[0]).toBeInTheDocument();
       expect(screen.queryByText('Max fee:')).toBeInTheDocument();
       expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
     });
@@ -153,7 +153,7 @@ describe('GasDetailsItem', () => {
   it('should not return null even if there is simulationError if user acknowledged gasMissing warning', async () => {
     await render();
     await waitFor(() => {
-      expect(screen.queryAllByText('🦊 Market')[0]).toBeInTheDocument();
+      expect(screen.queryAllByText('Market')[0]).toBeInTheDocument();
       expect(screen.queryByText('Max fee:')).toBeInTheDocument();
       expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
     });

--- a/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.test.tsx
+++ b/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.test.tsx
@@ -2,13 +2,9 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { GasOption } from '../../types/gas';
-import {
-  GasEstimateListHeader,
-  GasEstimateListItem,
-} from './gas-estimate-list-item';
+import { GasEstimateListItem } from './gas-estimate-list-item';
 
 const mockOption: GasOption = {
-  emoji: '🚀',
   estimatedTime: '15 sec',
   isSelected: false,
   key: 'fast',
@@ -18,15 +14,6 @@ const mockOption: GasOption = {
   valueInFiat: '$0.25',
 };
 
-describe('GasEstimateListHeader', () => {
-  it('renders header with gas option and max fee labels', () => {
-    const { getByText } = renderWithProvider(<GasEstimateListHeader />);
-
-    expect(getByText('Gas option')).toBeInTheDocument();
-    expect(getByText('Max fee')).toBeInTheDocument();
-  });
-});
-
 describe('GasEstimateListItem', () => {
   it('renders list item with option details', () => {
     const { getByText, getByTestId } = renderWithProvider(
@@ -34,7 +21,6 @@ describe('GasEstimateListItem', () => {
     );
 
     expect(getByTestId('gas-option-Fast')).toBeInTheDocument();
-    expect(getByText('🚀')).toBeInTheDocument();
     expect(getByText('Fast')).toBeInTheDocument();
     expect(getByText('15 sec')).toBeInTheDocument();
     expect(getByText('0.0001 ETH')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.test.tsx
+++ b/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.test.tsx
@@ -58,23 +58,4 @@ describe('GasEstimateListItem', () => {
     const infoIcon = container.querySelector('[data-testid="icon"]');
     expect(infoIcon).not.toBeInTheDocument();
   });
-
-  it('renders info icon when tooltipProps is provided', () => {
-    const optionWithTooltip: GasOption = {
-      ...mockOption,
-      tooltipProps: {
-        priorityLevel: 'high',
-        maxFeePerGas: '100',
-        maxPriorityFeePerGas: '10',
-        gasLimit: 21000,
-      },
-    };
-
-    const { container } = renderWithProvider(
-      <GasEstimateListItem option={optionWithTooltip} />,
-    );
-
-    const infoIcon = container.querySelector('.mm-icon');
-    expect(infoIcon).toBeInTheDocument();
-  });
 });

--- a/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.tsx
+++ b/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.tsx
@@ -2,23 +2,19 @@ import React from 'react';
 import classnames from 'classnames';
 import {
   Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  FontWeight,
   Icon,
+  IconColor,
   IconName,
   IconSize,
   Text,
-} from '../../../../components/component-library';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
-import {
-  AlignItems,
-  BackgroundColor,
-  BorderRadius,
-  Display,
-  FlexDirection,
-  IconColor,
-  TextAlign,
   TextColor,
   TextVariant,
-} from '../../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { type GasOption, type GasOptionTooltipProps } from '../../types/gas';
 import Tooltip from '../../../../components/ui/tooltip';
 import EditGasToolTip from '../edit-gas-fee-popover/edit-gas-tooltip/edit-gas-tooltip';
@@ -26,15 +22,13 @@ import EditGasToolTip from '../edit-gas-fee-popover/edit-gas-tooltip/edit-gas-to
 const SelectedIndicator = () => {
   return (
     <Box
-      borderRadius={BorderRadius.pill}
-      backgroundColor={BackgroundColor.primaryDefault}
-      className="gas-fee-token-list-item__selected-indicator"
+      backgroundColor={BoxBackgroundColor.PrimaryDefault}
+      className="gas-fee-token-list-item__selected-indicator rounded-full"
     />
   );
 };
 
 const ListItem = ({
-  icon,
   name,
   isSelected,
   time,
@@ -43,7 +37,6 @@ const ListItem = ({
   onClick,
   tooltipProps,
 }: {
-  icon: React.ReactNode;
   name: string;
   isSelected?: boolean;
   time?: string;
@@ -57,9 +50,8 @@ const ListItem = ({
   return (
     <Box
       data-testid={`gas-option-${name}`}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      backgroundColor={isSelected ? BackgroundColor.primaryMuted : undefined}
+      flexDirection={BoxFlexDirection.Row}
+      backgroundColor={isSelected ? BoxBackgroundColor.PrimaryMuted : undefined}
       padding={2}
       paddingTop={4}
       paddingBottom={4}
@@ -70,20 +62,21 @@ const ListItem = ({
     >
       {isSelected && <SelectedIndicator />}
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
         paddingLeft={2}
         gap={4}
         style={{ flex: 1 }}
       >
-        {icon}
-        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-          <Text variant={TextVariant.bodyMdMedium}>{name}</Text>
+        <Box flexDirection={BoxFlexDirection.Column} marginLeft={2}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {name}
+          </Text>
           <Text
-            variant={TextVariant.bodySmMedium}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
             color={
-              isSelected ? TextColor.primaryDefault : TextColor.textAlternative
+              isSelected ? TextColor.PrimaryDefault : TextColor.TextAlternative
             }
           >
             {time}
@@ -91,20 +84,21 @@ const ListItem = ({
         </Box>
       </Box>
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
         gap={2}
       >
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          textAlign={TextAlign.Right}
+          flexDirection={BoxFlexDirection.Column}
+          style={{ textAlign: 'right' }}
         >
-          <Text variant={TextVariant.bodyMdMedium}>{feeInFiat}</Text>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {feeInFiat}
+          </Text>
           <Text
-            variant={TextVariant.bodySmMedium}
-            color={TextColor.textAlternative}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {fee}
           </Text>
@@ -128,7 +122,7 @@ const ListItem = ({
             <Icon
               name={IconName.Info}
               size={IconSize.Sm}
-              color={IconColor.iconAlternative}
+              color={IconColor.IconAlternative}
             />
           </Tooltip>
         )}
@@ -137,46 +131,8 @@ const ListItem = ({
   );
 };
 
-export const GasEstimateListHeader = () => {
-  const t = useI18nContext();
-
-  return (
-    <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
-      padding={2}
-      paddingTop={2}
-      paddingBottom={2}
-    >
-      <Box paddingLeft={2} style={{ flex: 1 }}>
-        <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
-          {t('gasOption')}
-        </Text>
-      </Box>
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        gap={2}
-      >
-        <Text
-          variant={TextVariant.bodySm}
-          color={TextColor.textAlternative}
-          textAlign={TextAlign.Right}
-        >
-          {t('maxFee')}
-        </Text>
-        {/* Spacer for info icon alignment */}
-        <Box style={{ width: 16 }} />
-      </Box>
-    </Box>
-  );
-};
-
 export const GasEstimateListItem = ({ option }: { option: GasOption }) => {
   const {
-    emoji,
     estimatedTime,
     isSelected,
     name,
@@ -188,7 +144,6 @@ export const GasEstimateListItem = ({ option }: { option: GasOption }) => {
 
   return (
     <ListItem
-      icon={<Text variant={TextVariant.bodyMd}>{emoji}</Text>}
       name={name}
       isSelected={isSelected}
       time={estimatedTime}

--- a/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.tsx
+++ b/ui/pages/confirmations/components/gas-estimate-list-item/gas-estimate-list-item.tsx
@@ -11,6 +11,7 @@ import {
   IconName,
   IconSize,
   Text,
+  TextAlign,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
@@ -88,17 +89,19 @@ const ListItem = ({
         alignItems={BoxAlignItems.Center}
         gap={2}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          style={{ textAlign: 'right' }}
-        >
-          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        <Box flexDirection={BoxFlexDirection.Column}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            textAlign={TextAlign.Right}
+          >
             {feeInFiat}
           </Text>
           <Text
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}
             color={TextColor.TextAlternative}
+            textAlign={TextAlign.Right}
           >
             {fee}
           </Text>

--- a/ui/pages/confirmations/components/gas-input/gas-input.test.tsx
+++ b/ui/pages/confirmations/components/gas-input/gas-input.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { GasInput } from './gas-input';
+
+const render = (props = {}) => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
+  const mockOnChange = jest.fn();
+  const mockOnErrorChange = jest.fn();
+
+  const result = renderWithConfirmContextProvider(
+    <GasInput
+      onChange={mockOnChange}
+      onErrorChange={mockOnErrorChange}
+      {...props}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockOnChange,
+    mockOnErrorChange,
+  };
+};
+
+describe('GasInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the input with label', () => {
+    const { getByTestId, getByText } = render();
+
+    expect(getByTestId('gas-input')).toBeInTheDocument();
+    expect(getByText('Gas limit')).toBeInTheDocument();
+  });
+
+  it('calls onChange when value changes', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('gas-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '21000' } });
+
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('calls onErrorChange with error for invalid input', () => {
+    const { getByTestId, mockOnErrorChange } = render();
+
+    const input = getByTestId('gas-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockOnErrorChange).toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/components/gas-input/gas-input.test.tsx
+++ b/ui/pages/confirmations/components/gas-input/gas-input.test.tsx
@@ -68,4 +68,16 @@ describe('GasInput', () => {
 
     expect(mockOnErrorChange).toHaveBeenCalled();
   });
+
+  it('does not call onChange when input is invalid', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('gas-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    mockOnChange.mockClear();
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });

--- a/ui/pages/confirmations/components/gas-input/gas-input.tsx
+++ b/ui/pages/confirmations/components/gas-input/gas-input.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { add0x, Hex } from '@metamask/utils';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../context/confirm';
+import {
+  hexToDecimal,
+  decimalToHex,
+} from '../../../../../shared/modules/conversion.utils';
+import { FormTextField } from '../../../../components/component-library';
+import { validateGas } from '../../utils/gasValidations';
+
+export const GasInput = ({
+  onChange,
+  onErrorChange,
+}: {
+  onChange: (value: Hex) => void;
+  onErrorChange: (error: string | undefined) => void;
+}) => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const initialGasLimit = hexToDecimal(
+    currentConfirmation?.txParams?.gas as string,
+  ).toString();
+  const [value, setValue] = useState(initialGasLimit);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const validateGasCallback = useCallback(
+    (valueToBeValidated: string) => {
+      const validationError = validateGas(valueToBeValidated, t);
+      setError(validationError);
+    },
+    [t],
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      validateGasCallback(newValue);
+      setValue(newValue);
+      const updatedGasLimitHex = add0x(decimalToHex(newValue)) as Hex;
+      onChange(updatedGasLimitHex);
+    },
+    [onChange, validateGasCallback],
+  );
+
+  useEffect(() => {
+    validateGasCallback(value);
+  }, [validateGasCallback, value]);
+
+  useEffect(() => {
+    onErrorChange(error);
+  }, [error, onErrorChange]);
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      <FormTextField
+        id="gas-input"
+        data-testid="gas-input"
+        error={Boolean(error)}
+        helpText={error}
+        onChange={handleChange}
+        label={t('gasLimit')}
+        value={value}
+      />
+    </Box>
+  );
+};

--- a/ui/pages/confirmations/components/gas-input/gas-input.tsx
+++ b/ui/pages/confirmations/components/gas-input/gas-input.tsx
@@ -29,9 +29,10 @@ export const GasInput = ({
   const [error, setError] = useState<string | undefined>(undefined);
 
   const validateGasCallback = useCallback(
-    (valueToBeValidated: string) => {
+    (valueToBeValidated: string): string | undefined => {
       const validationError = validateGas(valueToBeValidated, t);
       setError(validationError);
+      return validationError;
     },
     [t],
   );
@@ -39,10 +40,12 @@ export const GasInput = ({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value;
-      validateGasCallback(newValue);
+      const validationError = validateGasCallback(newValue);
       setValue(newValue);
-      const updatedGasLimitHex = add0x(decimalToHex(newValue)) as Hex;
-      onChange(updatedGasLimitHex);
+      if (!validationError) {
+        const updatedGasLimitHex = add0x(decimalToHex(newValue)) as Hex;
+        onChange(updatedGasLimitHex);
+      }
     },
     [onChange, validateGasCallback],
   );

--- a/ui/pages/confirmations/components/gas-input/gas-input.tsx
+++ b/ui/pages/confirmations/components/gas-input/gas-input.tsx
@@ -51,10 +51,6 @@ export const GasInput = ({
   );
 
   useEffect(() => {
-    validateGasCallback(value);
-  }, [validateGasCallback, value]);
-
-  useEffect(() => {
     onErrorChange(error);
   }, [error, onErrorChange]);
 

--- a/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
+++ b/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { GasPriceInput } from './gas-price-input';
+
+const render = (props = {}) => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
+  const mockOnChange = jest.fn();
+  const mockOnErrorChange = jest.fn();
+
+  const result = renderWithConfirmContextProvider(
+    <GasPriceInput
+      onChange={mockOnChange}
+      onErrorChange={mockOnErrorChange}
+      {...props}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockOnChange,
+    mockOnErrorChange,
+  };
+};
+
+describe('GasPriceInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the input with label', () => {
+    const { getByTestId, getByText } = render();
+
+    expect(getByTestId('gas-price-input')).toBeInTheDocument();
+    expect(getByText('Gas price')).toBeInTheDocument();
+  });
+
+  it('renders the GWEI unit', () => {
+    const { getByText } = render();
+
+    expect(getByText('GWEI')).toBeInTheDocument();
+  });
+
+  it('calls onChange when value changes', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('gas-price-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '10' } });
+
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('calls onErrorChange with error for invalid input', () => {
+    const { getByTestId, mockOnErrorChange } = render();
+
+    const input = getByTestId('gas-price-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockOnErrorChange).toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
+++ b/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { CHAIN_IDS, TransactionMeta } from '@metamask/transaction-controller';
 import configureStore from '../../../../store/store';
 import { renderWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
@@ -10,7 +10,12 @@ import { GasPriceInput } from './gas-price-input';
 const render = (props = {}) => {
   const contractInteraction = genUnapprovedContractInteractionConfirmation({
     chainId: CHAIN_IDS.GOERLI,
-  });
+  }) as TransactionMeta;
+
+  contractInteraction.txParams = {
+    ...contractInteraction.txParams,
+    gasPrice: '0x3b9aca00', // 1 GWEI
+  };
 
   const store = configureStore(
     getMockConfirmStateForTransaction(contractInteraction),

--- a/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
+++ b/ui/pages/confirmations/components/gas-price-input/gas-price-input.test.tsx
@@ -79,4 +79,16 @@ describe('GasPriceInput', () => {
 
     expect(mockOnErrorChange).toHaveBeenCalled();
   });
+
+  it('does not call onChange when input is invalid', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('gas-price-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    mockOnChange.mockClear();
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });

--- a/ui/pages/confirmations/components/gas-price-input/gas-price-input.tsx
+++ b/ui/pages/confirmations/components/gas-price-input/gas-price-input.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Hex } from '@metamask/utils';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  Box,
+  BoxFlexDirection,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useConfirmContext } from '../../context/confirm';
+import {
+  hexWEIToDecGWEI,
+  decGWEIToHexWEI,
+} from '../../../../../shared/modules/conversion.utils';
+import { FormTextField } from '../../../../components/component-library';
+import { validateGasPrice } from '../../utils/gasValidations';
+
+export const GasPriceInput = ({
+  onChange,
+  onErrorChange,
+}: {
+  onChange: (value: Hex) => void;
+  onErrorChange: (error: string | undefined) => void;
+}) => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const initialGasPrice = hexWEIToDecGWEI(
+    currentConfirmation?.txParams?.gasPrice as string,
+  ).toString();
+  const [value, setValue] = useState(initialGasPrice);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const validateGasPriceCallback = useCallback(
+    (valueToBeValidated: string) => {
+      const validationError = validateGasPrice(valueToBeValidated, t);
+      setError(validationError);
+    },
+    [t],
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      validateGasPriceCallback(newValue);
+      setValue(newValue);
+      const updatedGasPrice = decGWEIToHexWEI(newValue) as Hex;
+      onChange(updatedGasPrice);
+    },
+    [onChange, validateGasPriceCallback],
+  );
+
+  useEffect(() => {
+    validateGasPriceCallback(value);
+  }, [validateGasPriceCallback, value]);
+
+  useEffect(() => {
+    onErrorChange(error);
+  }, [error, onErrorChange]);
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      <FormTextField
+        id="gas-price-input"
+        data-testid="gas-price-input"
+        error={Boolean(error)}
+        helpText={error}
+        onChange={handleChange}
+        endAccessory={
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('gwei')}
+          </Text>
+        }
+        label={t('gasPrice')}
+        value={value}
+      />
+    </Box>
+  );
+};

--- a/ui/pages/confirmations/components/gas-price-input/gas-price-input.tsx
+++ b/ui/pages/confirmations/components/gas-price-input/gas-price-input.tsx
@@ -35,9 +35,10 @@ export const GasPriceInput = ({
   const [error, setError] = useState<string | undefined>(undefined);
 
   const validateGasPriceCallback = useCallback(
-    (valueToBeValidated: string) => {
+    (valueToBeValidated: string): string | undefined => {
       const validationError = validateGasPrice(valueToBeValidated, t);
       setError(validationError);
+      return validationError;
     },
     [t],
   );
@@ -45,10 +46,12 @@ export const GasPriceInput = ({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value;
-      validateGasPriceCallback(newValue);
+      const validationError = validateGasPriceCallback(newValue);
       setValue(newValue);
-      const updatedGasPrice = decGWEIToHexWEI(newValue) as Hex;
-      onChange(updatedGasPrice);
+      if (!validationError) {
+        const updatedGasPrice = decGWEIToHexWEI(newValue) as Hex;
+        onChange(updatedGasPrice);
+      }
     },
     [onChange, validateGasPriceCallback],
   );

--- a/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
+++ b/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
@@ -136,10 +136,9 @@ export default function GasTiming({
 
   const estimateToUse =
     estimateUsed || transactionData.userFeeLevel || 'medium';
-  const estimateEmoji = PRIORITY_LEVEL_ICON_MAP[estimateToUse];
 
   const textTKey = estimateToUse === 'low' ? 'gasTimingLow' : estimateToUse;
-  let text = estimateEmoji ? `${estimateEmoji} ${t(textTKey)}` : t(textTKey);
+  let text = t(textTKey);
   let time = '';
 
   // Anything medium or faster is positive

--- a/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
+++ b/ui/pages/confirmations/components/gas-timing/gas-timing.component.js
@@ -20,10 +20,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import {
-  GAS_FORM_ERRORS,
-  PRIORITY_LEVEL_ICON_MAP,
-} from '../../../../helpers/constants/gas';
+import { GAS_FORM_ERRORS } from '../../../../helpers/constants/gas';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { getGasFeeTimeEstimate } from '../../../../store/actions';
 import { useDraftTransactionWithTxParams } from '../../hooks/useDraftTransactionWithTxParams';

--- a/ui/pages/confirmations/components/gas-timing/gas-timing.component.test.js
+++ b/ui/pages/confirmations/components/gas-timing/gas-timing.component.test.js
@@ -48,7 +48,7 @@ describe('Gas timing', () => {
     const screen = renderWithProvider(<GasTiming {...props} />, mockStore);
 
     await waitFor(() => {
-      expect(screen.queryByText('🦊 Market')).toBeTruthy();
+      expect(screen.queryByText('Market')).toBeTruthy();
       expect(screen.getByTestId('gas-timing-time')).toBeInTheDocument();
     });
   });
@@ -66,7 +66,7 @@ describe('Gas timing', () => {
     const screen = renderWithProvider(<GasTiming {...props} />, mockStore);
 
     await waitFor(() => {
-      expect(screen.queryByText('⬆ 10% increase')).toBeTruthy();
+      expect(screen.queryByText('10% increase')).toBeTruthy();
     });
   });
 });

--- a/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.test.tsx
+++ b/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { MaxBaseFeeInput } from './max-base-fee-input';
+
+jest.mock('../../../../hooks/useGasFeeEstimates', () => ({
+  useGasFeeEstimates: () => ({
+    gasFeeEstimates: {},
+  }),
+}));
+
+const render = (props = {}) => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
+  const mockOnChange = jest.fn();
+  const mockOnErrorChange = jest.fn();
+
+  const result = renderWithConfirmContextProvider(
+    <MaxBaseFeeInput
+      maxPriorityFeePerGas="0x3b9aca00"
+      onChange={mockOnChange}
+      onErrorChange={mockOnErrorChange}
+      {...props}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockOnChange,
+    mockOnErrorChange,
+  };
+};
+
+describe('MaxBaseFeeInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the input with label', () => {
+    const { getByTestId, getByText } = render();
+
+    expect(getByTestId('max-base-fee-input')).toBeInTheDocument();
+    expect(getByText('Max base fee')).toBeInTheDocument();
+  });
+
+  it('renders the GWEI unit', () => {
+    const { getByText } = render();
+
+    expect(getByText('GWEI')).toBeInTheDocument();
+  });
+
+  it('calls onChange when value changes', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('max-base-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '10' } });
+
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('calls onErrorChange with error for invalid input', () => {
+    const { getByTestId, mockOnErrorChange } = render();
+
+    const input = getByTestId('max-base-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockOnErrorChange).toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.test.tsx
+++ b/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.test.tsx
@@ -81,4 +81,16 @@ describe('MaxBaseFeeInput', () => {
 
     expect(mockOnErrorChange).toHaveBeenCalled();
   });
+
+  it('does not call onChange when input is invalid', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('max-base-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    mockOnChange.mockClear();
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });

--- a/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
+++ b/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Hex } from '@metamask/utils';
+import { GasFeeEstimates } from '@metamask/gas-fee-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useGasFeeEstimates } from '../../../../hooks/useGasFeeEstimates';
+import { useConfirmContext } from '../../context/confirm';
+import {
+  hexWEIToDecGWEI,
+  decGWEIToHexWEI,
+} from '../../../../../shared/modules/conversion.utils';
+import { FormTextField } from '../../../../components/component-library';
+import { limitToMaximumDecimalPlaces } from '../../utils/number';
+import { validateMaxBaseFee } from '../../utils/gasValidations';
+
+export const MaxBaseFeeInput = ({
+  maxPriorityFeePerGas,
+  onChange,
+  onErrorChange,
+}: {
+  maxPriorityFeePerGas: Hex;
+  onChange: (value: Hex) => void;
+  onErrorChange: (error: string | undefined) => void;
+}) => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const initialMaxBaseFee = hexWEIToDecGWEI(
+    currentConfirmation?.txParams?.maxFeePerGas as string,
+  ).toString();
+  const [value, setValue] = useState(initialMaxBaseFee);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const { gasFeeEstimates } = useGasFeeEstimates(
+    currentConfirmation?.networkClientId,
+  );
+
+  const validateMaxBaseFeeCallback = useCallback(
+    (valueToBeValidated: string) => {
+      const maxPriorityFeeInDec =
+        hexWEIToDecGWEI(maxPriorityFeePerGas).toString();
+
+      const validationError = validateMaxBaseFee(
+        valueToBeValidated,
+        maxPriorityFeeInDec,
+        t,
+      );
+      setError(validationError);
+    },
+    [maxPriorityFeePerGas, t],
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      validateMaxBaseFeeCallback(newValue);
+      setValue(newValue);
+      const updatedMaxBaseFee = decGWEIToHexWEI(newValue) as Hex;
+      onChange(updatedMaxBaseFee);
+    },
+    [onChange, validateMaxBaseFeeCallback],
+  );
+
+  useEffect(() => {
+    validateMaxBaseFeeCallback(value);
+  }, [validateMaxBaseFeeCallback, value]);
+
+  useEffect(() => {
+    onErrorChange(error);
+  }, [error, onErrorChange]);
+
+  const { estimatedBaseFee, historicalBaseFeeRange } =
+    (gasFeeEstimates as GasFeeEstimates) || {};
+
+  const feeRangesExists = estimatedBaseFee && historicalBaseFeeRange;
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      <FormTextField
+        id="max-base-fee-input"
+        data-testid="max-base-fee-input"
+        error={Boolean(error)}
+        helpText={error}
+        onChange={handleChange}
+        endAccessory={
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('gwei')}
+          </Text>
+        }
+        label={t('maxBaseFee')}
+        value={value}
+      />
+      {feeRangesExists && (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentEstimatedBaseFee', [
+              limitToMaximumDecimalPlaces(parseFloat(estimatedBaseFee), 2),
+            ])}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentHistoricalBaseFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalBaseFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalBaseFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
+++ b/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
@@ -45,7 +45,7 @@ export const MaxBaseFeeInput = ({
   );
 
   const validateMaxBaseFeeCallback = useCallback(
-    (valueToBeValidated: string) => {
+    (valueToBeValidated: string): string | undefined => {
       const maxPriorityFeeInDec =
         hexWEIToDecGWEI(maxPriorityFeePerGas).toString();
 
@@ -55,6 +55,7 @@ export const MaxBaseFeeInput = ({
         t,
       );
       setError(validationError);
+      return validationError;
     },
     [maxPriorityFeePerGas, t],
   );
@@ -62,10 +63,12 @@ export const MaxBaseFeeInput = ({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value;
-      validateMaxBaseFeeCallback(newValue);
+      const validationError = validateMaxBaseFeeCallback(newValue);
       setValue(newValue);
-      const updatedMaxBaseFee = decGWEIToHexWEI(newValue) as Hex;
-      onChange(updatedMaxBaseFee);
+      if (!validationError) {
+        const updatedMaxBaseFee = decGWEIToHexWEI(newValue) as Hex;
+        onChange(updatedMaxBaseFee);
+      }
     },
     [onChange, validateMaxBaseFeeCallback],
   );
@@ -104,23 +107,33 @@ export const MaxBaseFeeInput = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
         >
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {t('currentEstimatedBaseFee', [
-              limitToMaximumDecimalPlaces(parseFloat(estimatedBaseFee), 2),
-            ])}
-          </Text>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {t('currentHistoricalBaseFeeRange', [
-              limitToMaximumDecimalPlaces(
-                parseFloat(historicalBaseFeeRange?.[0]),
-                2,
-              ),
-              limitToMaximumDecimalPlaces(
-                parseFloat(historicalBaseFeeRange?.[1]),
-                2,
-              ),
-            ])}
-          </Text>
+          {estimatedBaseFee && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {t('currentEstimatedBaseFee', [
+                limitToMaximumDecimalPlaces(parseFloat(estimatedBaseFee), 2),
+              ])}
+            </Text>
+          )}
+          {historicalBaseFeeRange && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {t('currentHistoricalBaseFeeRange', [
+                limitToMaximumDecimalPlaces(
+                  parseFloat(historicalBaseFeeRange?.[0]),
+                  2,
+                ),
+                limitToMaximumDecimalPlaces(
+                  parseFloat(historicalBaseFeeRange?.[1]),
+                  2,
+                ),
+              ])}
+            </Text>
+          )}
         </Box>
       )}
     </Box>

--- a/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
+++ b/ui/pages/confirmations/components/max-base-fee-input/max-base-fee-input.tsx
@@ -107,33 +107,23 @@ export const MaxBaseFeeInput = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
         >
-          {estimatedBaseFee && (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {t('currentEstimatedBaseFee', [
-                limitToMaximumDecimalPlaces(parseFloat(estimatedBaseFee), 2),
-              ])}
-            </Text>
-          )}
-          {historicalBaseFeeRange && (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {t('currentHistoricalBaseFeeRange', [
-                limitToMaximumDecimalPlaces(
-                  parseFloat(historicalBaseFeeRange?.[0]),
-                  2,
-                ),
-                limitToMaximumDecimalPlaces(
-                  parseFloat(historicalBaseFeeRange?.[1]),
-                  2,
-                ),
-              ])}
-            </Text>
-          )}
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentEstimatedBaseFee', [
+              limitToMaximumDecimalPlaces(parseFloat(estimatedBaseFee), 2),
+            ])}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentHistoricalBaseFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalBaseFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalBaseFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
         </Box>
       )}
     </Box>

--- a/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.test.tsx
@@ -1,23 +1,88 @@
 import React from 'react';
-import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { GasModalType } from '../../../constants/gas';
 import { AdvancedEIP1559Modal } from './advanced-eip1559-modal';
 
-describe('AdvancedEIP1559Modal', () => {
+jest.mock('../../max-base-fee-input/max-base-fee-input', () => ({
+  MaxBaseFeeInput: () => (
+    <div data-testid="max-base-fee-input">Max Base Fee Input</div>
+  ),
+}));
+
+jest.mock('../../priority-fee-input/priority-fee-input', () => ({
+  PriorityFeeInput: () => (
+    <div data-testid="priority-fee-input">Priority Fee Input</div>
+  ),
+}));
+
+jest.mock('../../gas-input/gas-input', () => ({
+  GasInput: () => <div data-testid="gas-input">Gas Input</div>,
+}));
+
+const render = () => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
   const mockSetActiveModal = jest.fn();
   const mockHandleCloseModals = jest.fn();
 
+  const result = renderWithConfirmContextProvider(
+    <AdvancedEIP1559Modal
+      setActiveModal={mockSetActiveModal}
+      handleCloseModals={mockHandleCloseModals}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockSetActiveModal,
+    mockHandleCloseModals,
+  };
+};
+
+describe('AdvancedEIP1559Modal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders the modal with header', () => {
-    const { getByText } = renderWithProvider(
-      <AdvancedEIP1559Modal
-        setActiveModal={mockSetActiveModal}
-        handleCloseModals={mockHandleCloseModals}
-      />,
-    );
+    const { getByText } = render();
+    expect(getByText('Advanced Network Fee')).toBeInTheDocument();
+  });
 
-    expect(getByText('Advanced EIP1559')).toBeInTheDocument();
+  it('renders all gas input components', () => {
+    const { getByTestId } = render();
+
+    expect(getByTestId('max-base-fee-input')).toBeInTheDocument();
+    expect(getByTestId('priority-fee-input')).toBeInTheDocument();
+    expect(getByTestId('gas-input')).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Save buttons', () => {
+    const { getByText } = render();
+
+    expect(getByText('Cancel')).toBeInTheDocument();
+    expect(getByText('Save')).toBeInTheDocument();
+  });
+
+  it('navigates to EstimatesModal when Cancel is clicked', () => {
+    const { getByText, mockSetActiveModal } = render();
+
+    fireEvent.click(getByText('Cancel'));
+
+    expect(mockSetActiveModal).toHaveBeenCalledWith(
+      GasModalType.EstimatesModal,
+    );
   });
 });

--- a/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.tsx
@@ -1,25 +1,173 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Hex } from '@metamask/utils';
+import {
+  TransactionMeta,
+  UserFeeLevel,
+} from '@metamask/transaction-controller';
+import {
+  Box,
+  Button,
+  BoxFlexDirection,
+  ButtonVariant,
+  BoxAlignItems,
+  ButtonSize,
+} from '@metamask/design-system-react';
+import { useDispatch } from 'react-redux';
+import { pickBy } from 'lodash';
+
 import {
   Modal,
-  ModalOverlay,
+  ModalBody,
   ModalContent,
+  ModalContentSize,
+  ModalFooter,
   ModalHeader,
+  ModalOverlay,
 } from '../../../../../components/component-library';
 import { GasModalType } from '../../../constants/gas';
+import { MaxBaseFeeInput } from '../../max-base-fee-input/max-base-fee-input';
+import { PriorityFeeInput } from '../../priority-fee-input/priority-fee-input';
+import { GasInput } from '../../gas-input/gas-input';
+import { useConfirmContext } from '../../../context/confirm';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { updateTransactionGasFees } from '../../../../../store/actions';
 
 export const AdvancedEIP1559Modal = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setActiveModal,
   handleCloseModals,
 }: {
   setActiveModal: (modal: GasModalType) => void;
   handleCloseModals: () => void;
 }) => {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+
+  const { gas, maxFeePerGas, maxPriorityFeePerGas } =
+    transactionMeta?.txParams || {};
+
+  const [gasParams, setGasParams] = useState<{
+    gas: Hex;
+    maxFeePerGas: Hex;
+    maxPriorityFeePerGas: Hex;
+  }>({
+    gas: gas as Hex,
+    maxFeePerGas: maxFeePerGas as Hex,
+    maxPriorityFeePerGas: maxPriorityFeePerGas as Hex,
+  });
+
+  const [errors, setErrors] = useState<{
+    gas: string | undefined;
+    maxFeePerGas: string | undefined;
+    maxPriorityFeePerGas: string | undefined;
+  }>({
+    gas: undefined,
+    maxFeePerGas: undefined,
+    maxPriorityFeePerGas: undefined,
+  });
+  const hasError = Boolean(
+    errors.gas || errors.maxFeePerGas || errors.maxPriorityFeePerGas,
+  );
+
+  const handleSaveClick = useCallback(() => {
+    dispatch(
+      updateTransactionGasFees(transactionMeta.id, {
+        userFeeLevel: UserFeeLevel.CUSTOM,
+        ...pickBy(gasParams, Boolean),
+      }),
+    );
+    handleCloseModals();
+  }, [transactionMeta.id, gasParams, handleCloseModals]);
+
+  const navigateToEstimatesModal = useCallback(() => {
+    setActiveModal(GasModalType.EstimatesModal);
+  }, [setActiveModal]);
+
+  const createChangeHandler = useCallback(
+    (key: 'gas' | 'maxFeePerGas' | 'maxPriorityFeePerGas') => (value: Hex) =>
+      setGasParams((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
+  const handleGasLimitChange = useMemo(
+    () => createChangeHandler('gas'),
+    [createChangeHandler],
+  );
+  const handleMaxFeePerGasChange = useMemo(
+    () => createChangeHandler('maxFeePerGas'),
+    [createChangeHandler],
+  );
+  const handleMaxPriorityFeePerGasChange = useMemo(
+    () => createChangeHandler('maxPriorityFeePerGas'),
+    [createChangeHandler],
+  );
+
+  const createErrorHandler = useCallback(
+    (key: 'gas' | 'maxFeePerGas' | 'maxPriorityFeePerGas') =>
+      (error: string | undefined) =>
+        setErrors((prev) => ({ ...prev, [key]: error })),
+    [],
+  );
+  const handleGasError = useMemo(
+    () => createErrorHandler('gas'),
+    [createErrorHandler],
+  );
+  const handleMaxFeePerGasError = useMemo(
+    () => createErrorHandler('maxFeePerGas'),
+    [createErrorHandler],
+  );
+  const handleMaxPriorityFeePerGasError = useMemo(
+    () => createErrorHandler('maxPriorityFeePerGas'),
+    [createErrorHandler],
+  );
+
   return (
     <Modal isOpen={true} onClose={handleCloseModals}>
       <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Advanced EIP1559</ModalHeader>
+      <ModalContent size={ModalContentSize.Md}>
+        <ModalHeader>{t('advancedEIP1559ModalTitle')}</ModalHeader>
+        <ModalBody>
+          <MaxBaseFeeInput
+            onChange={handleMaxFeePerGasChange}
+            maxPriorityFeePerGas={gasParams.maxPriorityFeePerGas}
+            onErrorChange={handleMaxFeePerGasError}
+          />
+          <Box marginBottom={4} />
+          <PriorityFeeInput
+            onChange={handleMaxPriorityFeePerGasChange}
+            maxFeePerGas={gasParams.maxFeePerGas}
+            onErrorChange={handleMaxPriorityFeePerGasError}
+          />
+          <Box marginBottom={4} />
+          <GasInput
+            onChange={handleGasLimitChange}
+            onErrorChange={handleGasError}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Box
+            alignItems={BoxAlignItems.Stretch}
+            flexDirection={BoxFlexDirection.Row}
+            gap={4}
+          >
+            <Button
+              style={{ flex: 1 }}
+              size={ButtonSize.Lg}
+              variant={ButtonVariant.Secondary}
+              onClick={navigateToEstimatesModal}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              style={{ flex: 1 }}
+              size={ButtonSize.Lg}
+              isDisabled={hasError}
+              onClick={handleSaveClick}
+            >
+              {t('save')}
+            </Button>
+          </Box>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
@@ -1,23 +1,82 @@
 import React from 'react';
-import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { GasModalType } from '../../../constants/gas';
 import { AdvancedGasPriceModal } from './advanced-gas-price-modal';
 
-describe('AdvancedGasPriceModal', () => {
+jest.mock('../../gas-price-input/gas-price-input', () => ({
+  GasPriceInput: () => (
+    <div data-testid="gas-price-input">Gas Price Input</div>
+  ),
+}));
+
+jest.mock('../../gas-input/gas-input', () => ({
+  GasInput: () => <div data-testid="gas-input">Gas Input</div>,
+}));
+
+const render = () => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
   const mockSetActiveModal = jest.fn();
   const mockHandleCloseModals = jest.fn();
 
+  const result = renderWithConfirmContextProvider(
+    <AdvancedGasPriceModal
+      setActiveModal={mockSetActiveModal}
+      handleCloseModals={mockHandleCloseModals}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockSetActiveModal,
+    mockHandleCloseModals,
+  };
+};
+
+describe('AdvancedGasPriceModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders the modal with header', () => {
-    const { getByText } = renderWithProvider(
-      <AdvancedGasPriceModal
-        setActiveModal={mockSetActiveModal}
-        handleCloseModals={mockHandleCloseModals}
-      />,
-    );
+    const { getByText } = render();
 
-    expect(getByText('Advanced Gas Price')).toBeInTheDocument();
+    expect(getByText('Advanced Network Fee')).toBeInTheDocument();
+  });
+
+  it('renders all gas input components', () => {
+    const { getByTestId } = render();
+
+    expect(getByTestId('gas-price-input')).toBeInTheDocument();
+    expect(getByTestId('gas-input')).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Save buttons', () => {
+    const { getByText } = render();
+
+    expect(getByText('Cancel')).toBeInTheDocument();
+    expect(getByText('Save')).toBeInTheDocument();
+  });
+
+  it('navigates to EstimatesModal when Cancel is clicked', () => {
+    const { getByText, mockSetActiveModal } = render();
+
+    fireEvent.click(getByText('Cancel'));
+
+    expect(mockSetActiveModal).toHaveBeenCalledWith(
+      GasModalType.EstimatesModal,
+    );
   });
 });

--- a/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
@@ -9,9 +9,7 @@ import { GasModalType } from '../../../constants/gas';
 import { AdvancedGasPriceModal } from './advanced-gas-price-modal';
 
 jest.mock('../../gas-price-input/gas-price-input', () => ({
-  GasPriceInput: () => (
-    <div data-testid="gas-price-input">Gas Price Input</div>
-  ),
+  GasPriceInput: () => <div data-testid="gas-price-input">Gas Price Input</div>,
 }));
 
 jest.mock('../../gas-input/gas-input', () => ({

--- a/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.tsx
@@ -1,25 +1,146 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Hex } from '@metamask/utils';
+import {
+  TransactionMeta,
+  UserFeeLevel,
+} from '@metamask/transaction-controller';
+import { pickBy } from 'lodash';
+import {
+  Box,
+  Button,
+  BoxFlexDirection,
+  ButtonVariant,
+  BoxAlignItems,
+  ButtonSize,
+} from '@metamask/design-system-react';
+import { useDispatch } from 'react-redux';
+
 import {
   Modal,
-  ModalOverlay,
+  ModalBody,
   ModalContent,
+  ModalContentSize,
+  ModalFooter,
   ModalHeader,
+  ModalOverlay,
 } from '../../../../../components/component-library';
 import { GasModalType } from '../../../constants/gas';
+import { GasPriceInput } from '../../gas-price-input/gas-price-input';
+import { GasInput } from '../../gas-input/gas-input';
+import { useConfirmContext } from '../../../context/confirm';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { updateTransactionGasFees } from '../../../../../store/actions';
 
 export const AdvancedGasPriceModal = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setActiveModal,
   handleCloseModals,
 }: {
   setActiveModal: (modal: GasModalType) => void;
   handleCloseModals: () => void;
 }) => {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+
+  const { gas, gasPrice } = transactionMeta?.txParams || {};
+
+  const [gasParams, setGasParams] = useState<{
+    gas: Hex;
+    gasPrice: Hex;
+  }>({
+    gas: gas as Hex,
+    gasPrice: gasPrice as Hex,
+  });
+
+  const [errors, setErrors] = useState<{
+    gas: string | undefined;
+    gasPrice: string | undefined;
+  }>({
+    gas: undefined,
+    gasPrice: undefined,
+  });
+  const hasError = Boolean(errors.gas || errors.gasPrice);
+
+  const handleSaveClick = useCallback(() => {
+    dispatch(
+      updateTransactionGasFees(transactionMeta.id, {
+        userFeeLevel: UserFeeLevel.CUSTOM,
+        ...pickBy(gasParams, Boolean),
+      }),
+    );
+    handleCloseModals();
+  }, [transactionMeta.id, gasParams, handleCloseModals]);
+
+  const navigateToEstimatesModal = useCallback(() => {
+    setActiveModal(GasModalType.EstimatesModal);
+  }, [setActiveModal]);
+
+  const createChangeHandler = useCallback(
+    (key: 'gas' | 'gasPrice') => (value: Hex) =>
+      setGasParams((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
+  const handleGasChange = useMemo(
+    () => createChangeHandler('gas'),
+    [createChangeHandler],
+  );
+  const handleGasPriceChange = useMemo(
+    () => createChangeHandler('gasPrice'),
+    [createChangeHandler],
+  );
+
+  const createErrorHandler = useCallback(
+    (key: 'gas' | 'gasPrice') => (error: string | undefined) =>
+      setErrors((prev) => ({ ...prev, [key]: error })),
+    [],
+  );
+  const handleGasError = useMemo(
+    () => createErrorHandler('gas'),
+    [createErrorHandler],
+  );
+  const handleGasPriceError = useMemo(
+    () => createErrorHandler('gasPrice'),
+    [createErrorHandler],
+  );
+
   return (
     <Modal isOpen={true} onClose={handleCloseModals}>
       <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Advanced Gas Price</ModalHeader>
+      <ModalContent size={ModalContentSize.Md}>
+        <ModalHeader>{t('advancedGasPriceModalTitle')}</ModalHeader>
+        <ModalBody>
+          <GasPriceInput
+            onChange={handleGasPriceChange}
+            onErrorChange={handleGasPriceError}
+          />
+          <Box marginBottom={4} />
+          <GasInput onChange={handleGasChange} onErrorChange={handleGasError} />
+        </ModalBody>
+        <ModalFooter>
+          <Box
+            alignItems={BoxAlignItems.Stretch}
+            flexDirection={BoxFlexDirection.Row}
+            gap={4}
+          >
+            <Button
+              style={{ flex: 1 }}
+              size={ButtonSize.Lg}
+              variant={ButtonVariant.Secondary}
+              onClick={navigateToEstimatesModal}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              style={{ flex: 1 }}
+              size={ButtonSize.Lg}
+              isDisabled={hasError}
+              onClick={handleSaveClick}
+            >
+              {t('save')}
+            </Button>
+          </Box>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/ui/pages/confirmations/components/modals/estimates-modal/estimates-modal.tsx
+++ b/ui/pages/confirmations/components/modals/estimates-modal/estimates-modal.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import {
   Box,
+  Text,
+  TextColor,
+  TextVariant,
+  TextAlign,
+} from '@metamask/design-system-react';
+
+import {
   Modal,
   ModalBody,
   ModalContent,
   ModalContentSize,
   ModalHeader,
   ModalOverlay,
-  Text,
 } from '../../../../../components/component-library';
 import NetworkStatistics from '../../edit-gas-fee-popover/network-statistics/network-statistics';
 import { GasModalType } from '../../../constants/gas';
@@ -16,14 +22,8 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   Display,
   FlexDirection,
-  TextColor,
-  TextVariant,
-  TextAlign,
 } from '../../../../../helpers/constants/design-system';
-import {
-  GasEstimateListHeader,
-  GasEstimateListItem,
-} from '../../gas-estimate-list-item/gas-estimate-list-item';
+import { GasEstimateListItem } from '../../gas-estimate-list-item/gas-estimate-list-item';
 import ZENDESK_URLS from '../../../../../helpers/constants/zendesk-url';
 
 export const EstimatesModal = ({
@@ -52,7 +52,6 @@ export const EstimatesModal = ({
           paddingLeft={0}
           paddingRight={0}
         >
-          <GasEstimateListHeader />
           {options.map((option) => (
             <GasEstimateListItem key={option.key} option={option} />
           ))}
@@ -62,9 +61,8 @@ export const EstimatesModal = ({
             <Text
               className="edit-gas-fee-popover__know-more"
               textAlign={TextAlign.Center}
-              color={TextColor.textAlternative}
-              variant={TextVariant.bodySm}
-              as="h6"
+              color={TextColor.TextAlternative}
+              variant={TextVariant.BodySm}
             >
               {t('learnMoreAboutGas', [
                 <a

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import configureStore from '../../../../store/store';
+import { renderWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
+import { PriorityFeeInput } from './priority-fee-input';
+
+jest.mock('../../../../hooks/useGasFeeEstimates', () => ({
+  useGasFeeEstimates: () => ({
+    gasFeeEstimates: {},
+  }),
+}));
+
+const render = (props = {}) => {
+  const contractInteraction = genUnapprovedContractInteractionConfirmation({
+    chainId: CHAIN_IDS.GOERLI,
+  });
+
+  const store = configureStore(
+    getMockConfirmStateForTransaction(contractInteraction),
+  );
+
+  const mockOnChange = jest.fn();
+  const mockOnErrorChange = jest.fn();
+
+  const result = renderWithConfirmContextProvider(
+    <PriorityFeeInput
+      maxFeePerGas="0x3b9aca00"
+      onChange={mockOnChange}
+      onErrorChange={mockOnErrorChange}
+      {...props}
+    />,
+    store,
+  );
+
+  return {
+    ...result,
+    mockOnChange,
+    mockOnErrorChange,
+  };
+};
+
+describe('PriorityFeeInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the input with label', () => {
+    const { getByTestId, getByText } = render();
+
+    expect(getByTestId('priority-fee-input')).toBeInTheDocument();
+    expect(getByText('Priority fee')).toBeInTheDocument();
+  });
+
+  it('renders the GWEI unit', () => {
+    const { getByText } = render();
+
+    expect(getByText('GWEI')).toBeInTheDocument();
+  });
+
+  it('calls onChange when value changes', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('priority-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2' } });
+
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('calls onErrorChange with error for invalid input', () => {
+    const { getByTestId, mockOnErrorChange } = render();
+
+    const input = getByTestId('priority-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockOnErrorChange).toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
@@ -27,7 +27,7 @@ const render = (props = {}) => {
 
   const result = renderWithConfirmContextProvider(
     <PriorityFeeInput
-      maxFeePerGas="0x3b9aca00"
+      maxFeePerGas="0x2540be400"
       onChange={mockOnChange}
       onErrorChange={mockOnErrorChange}
       {...props}

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.test.tsx
@@ -81,4 +81,16 @@ describe('PriorityFeeInput', () => {
 
     expect(mockOnErrorChange).toHaveBeenCalled();
   });
+
+  it('does not call onChange when input is invalid', () => {
+    const { getByTestId, mockOnChange } = render();
+
+    const input = getByTestId('priority-fee-input').querySelector(
+      'input',
+    ) as HTMLInputElement;
+    mockOnChange.mockClear();
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
@@ -1,0 +1,134 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Hex } from '@metamask/utils';
+import { GasFeeEstimates } from '@metamask/gas-fee-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useGasFeeEstimates } from '../../../../hooks/useGasFeeEstimates';
+import { useConfirmContext } from '../../context/confirm';
+import {
+  hexWEIToDecGWEI,
+  decGWEIToHexWEI,
+} from '../../../../../shared/modules/conversion.utils';
+import { FormTextField } from '../../../../components/component-library';
+import { limitToMaximumDecimalPlaces } from '../../utils/number';
+import { validatePriorityFee } from '../../utils/gasValidations';
+
+export const PriorityFeeInput = ({
+  maxFeePerGas,
+  onChange,
+  onErrorChange,
+}: {
+  maxFeePerGas: Hex;
+  onChange: (value: Hex) => void;
+  onErrorChange: (error: string | undefined) => void;
+}) => {
+  const t = useI18nContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const initialPriorityFee = hexWEIToDecGWEI(
+    currentConfirmation?.txParams?.maxPriorityFeePerGas as string,
+  ).toString();
+  const [value, setValue] = useState(initialPriorityFee);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const { gasFeeEstimates } = useGasFeeEstimates(
+    currentConfirmation?.networkClientId,
+  );
+
+  const validatePriorityFeeCallback = useCallback(
+    (valueToBeValidated: string) => {
+      const maxFeePerGasInDec = hexWEIToDecGWEI(maxFeePerGas).toString();
+
+      const validationError = validatePriorityFee(
+        valueToBeValidated,
+        maxFeePerGasInDec,
+        t,
+      );
+      setError(validationError);
+    },
+    [maxFeePerGas, t],
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      validatePriorityFeeCallback(newValue);
+      setValue(newValue);
+      const updatedPriorityFee = decGWEIToHexWEI(newValue) as Hex;
+      onChange(updatedPriorityFee);
+    },
+    [onChange, validatePriorityFeeCallback],
+  );
+
+  useEffect(() => {
+    validatePriorityFeeCallback(value);
+  }, [validatePriorityFeeCallback, value]);
+
+  useEffect(() => {
+    onErrorChange(error);
+  }, [error, onErrorChange]);
+
+  const { latestPriorityFeeRange, historicalPriorityFeeRange } =
+    (gasFeeEstimates as GasFeeEstimates) || {};
+
+  const feeRangesExists = latestPriorityFeeRange && historicalPriorityFeeRange;
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+      <FormTextField
+        id="priority-fee-input"
+        data-testid="priority-fee-input"
+        error={Boolean(error)}
+        helpText={error}
+        onChange={handleChange}
+        endAccessory={
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('gwei')}
+          </Text>
+        }
+        label={t('priorityFee')}
+        value={value}
+      />
+      {feeRangesExists && (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentEstimatedPriorityFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(latestPriorityFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(latestPriorityFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentHistoricalPriorityFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalPriorityFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalPriorityFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
@@ -45,7 +45,7 @@ export const PriorityFeeInput = ({
   );
 
   const validatePriorityFeeCallback = useCallback(
-    (valueToBeValidated: string) => {
+    (valueToBeValidated: string): string | undefined => {
       const maxFeePerGasInDec = hexWEIToDecGWEI(maxFeePerGas).toString();
 
       const validationError = validatePriorityFee(
@@ -54,6 +54,7 @@ export const PriorityFeeInput = ({
         t,
       );
       setError(validationError);
+      return validationError;
     },
     [maxFeePerGas, t],
   );
@@ -61,10 +62,12 @@ export const PriorityFeeInput = ({
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value;
-      validatePriorityFeeCallback(newValue);
+      const validationError = validatePriorityFeeCallback(newValue);
       setValue(newValue);
-      const updatedPriorityFee = decGWEIToHexWEI(newValue) as Hex;
-      onChange(updatedPriorityFee);
+      if (!validationError) {
+        const updatedPriorityFee = decGWEIToHexWEI(newValue) as Hex;
+        onChange(updatedPriorityFee);
+      }
     },
     [onChange, validatePriorityFeeCallback],
   );
@@ -103,30 +106,40 @@ export const PriorityFeeInput = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
         >
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {t('currentEstimatedPriorityFeeRange', [
-              limitToMaximumDecimalPlaces(
-                parseFloat(latestPriorityFeeRange?.[0]),
-                2,
-              ),
-              limitToMaximumDecimalPlaces(
-                parseFloat(latestPriorityFeeRange?.[1]),
-                2,
-              ),
-            ])}
-          </Text>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {t('currentHistoricalPriorityFeeRange', [
-              limitToMaximumDecimalPlaces(
-                parseFloat(historicalPriorityFeeRange?.[0]),
-                2,
-              ),
-              limitToMaximumDecimalPlaces(
-                parseFloat(historicalPriorityFeeRange?.[1]),
-                2,
-              ),
-            ])}
-          </Text>
+          {latestPriorityFeeRange && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {t('currentEstimatedPriorityFeeRange', [
+                limitToMaximumDecimalPlaces(
+                  parseFloat(latestPriorityFeeRange?.[0]),
+                  2,
+                ),
+                limitToMaximumDecimalPlaces(
+                  parseFloat(latestPriorityFeeRange?.[1]),
+                  2,
+                ),
+              ])}
+            </Text>
+          )}
+          {historicalPriorityFeeRange && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {t('currentHistoricalPriorityFeeRange', [
+                limitToMaximumDecimalPlaces(
+                  parseFloat(historicalPriorityFeeRange?.[0]),
+                  2,
+                ),
+                limitToMaximumDecimalPlaces(
+                  parseFloat(historicalPriorityFeeRange?.[1]),
+                  2,
+                ),
+              ])}
+            </Text>
+          )}
         </Box>
       )}
     </Box>

--- a/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
+++ b/ui/pages/confirmations/components/priority-fee-input/priority-fee-input.tsx
@@ -106,40 +106,30 @@ export const PriorityFeeInput = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
         >
-          {latestPriorityFeeRange && (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {t('currentEstimatedPriorityFeeRange', [
-                limitToMaximumDecimalPlaces(
-                  parseFloat(latestPriorityFeeRange?.[0]),
-                  2,
-                ),
-                limitToMaximumDecimalPlaces(
-                  parseFloat(latestPriorityFeeRange?.[1]),
-                  2,
-                ),
-              ])}
-            </Text>
-          )}
-          {historicalPriorityFeeRange && (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {t('currentHistoricalPriorityFeeRange', [
-                limitToMaximumDecimalPlaces(
-                  parseFloat(historicalPriorityFeeRange?.[0]),
-                  2,
-                ),
-                limitToMaximumDecimalPlaces(
-                  parseFloat(historicalPriorityFeeRange?.[1]),
-                  2,
-                ),
-              ])}
-            </Text>
-          )}
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentEstimatedPriorityFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(latestPriorityFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(latestPriorityFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('currentHistoricalPriorityFeeRange', [
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalPriorityFeeRange?.[0]),
+                2,
+              ),
+              limitToMaximumDecimalPlaces(
+                parseFloat(historicalPriorityFeeRange?.[1]),
+                2,
+              ),
+            ])}
+          </Text>
         </Box>
       )}
     </Box>

--- a/ui/pages/confirmations/constants/gas.ts
+++ b/ui/pages/confirmations/constants/gas.ts
@@ -4,13 +4,4 @@ export enum GasModalType {
   AdvancedGasPriceModal = 'advancedGasPriceModal',
 }
 
-export enum GasOptionIcon {
-  Advanced = '⚙️',
-  GasPrice = '⛓️',
-  High = '🦍',
-  Low = '🐢',
-  Medium = '🦊',
-  SiteSuggested = '🌐',
-}
-
 export const EMPTY_VALUE_STRING = '--';

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
@@ -7,11 +7,7 @@ import {
   UserFeeLevel as UserFeeLevelType,
 } from '@metamask/transaction-controller';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
-import {
-  EMPTY_VALUE_STRING,
-  GasModalType,
-  GasOptionIcon,
-} from '../../constants/gas';
+import { EMPTY_VALUE_STRING, GasModalType } from '../../constants/gas';
 import { type GasOption } from '../../types/gas';
 import { useConfirmContext } from '../../context/confirm';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -117,7 +113,6 @@ export const useAdvancedGasFeeOption = ({
   const memoizedGasOption = useMemo(
     () => [
       {
-        emoji: GasOptionIcon.Advanced,
         estimatedTime: '',
         isSelected: isAdvancedGasFeeSelected,
         key: 'advanced',

--- a/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
@@ -8,7 +8,7 @@ import { useDispatch } from 'react-redux';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { updateTransactionGasFees } from '../../../../store/actions';
 import { type GasOption } from '../../types/gas';
-import { EMPTY_VALUE_STRING, GasOptionIcon } from '../../constants/gas';
+import { EMPTY_VALUE_STRING } from '../../constants/gas';
 import { useConfirmContext } from '../../context/confirm';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
@@ -80,7 +80,6 @@ export const useDappSuggestedGasFeeOption = ({
       });
 
     options.push({
-      emoji: GasOptionIcon.SiteSuggested,
       estimatedTime: undefined,
       isSelected: isDappSuggestedGasFeeSelected,
       key: 'site_suggested',

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
@@ -134,4 +134,57 @@ describe('useGasFeeEstimateLevelOptions', () => {
     expect(result.current[2].key).toBe(GasFeeEstimateLevel.High);
     expect(result.current[1].isSelected).toBe(true);
   });
+
+  it('skips high option when it has the same fees as medium for FeeMarket type', () => {
+    mockUseConfirmContext.mockReturnValue({
+      currentConfirmation: {
+        id: '1',
+        networkClientId: 'mainnet',
+        userFeeLevel: 'medium',
+        gasLimitNoBuffer: '0x5208',
+        gasFeeEstimates: {
+          type: GasFeeEstimateType.FeeMarket,
+          [GasFeeEstimateLevel.Low]: {
+            maxFeePerGas: '0x1',
+            maxPriorityFeePerGas: '0x1',
+          },
+          [GasFeeEstimateLevel.Medium]: {
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x2',
+          },
+          [GasFeeEstimateLevel.High]: {
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x2',
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useConfirmContext>);
+
+    mockUseGasFeeEstimates.mockReturnValue({
+      gasFeeEstimates: {
+        [GasFeeEstimateLevel.Low]: {
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        [GasFeeEstimateLevel.Medium]: {
+          minWaitTimeEstimate: 10000,
+          maxWaitTimeEstimate: 20000,
+        },
+        [GasFeeEstimateLevel.High]: {
+          minWaitTimeEstimate: 5000,
+          maxWaitTimeEstimate: 10000,
+        },
+      },
+    } as unknown as ReturnType<typeof useGasFeeEstimates>);
+
+    const { result } = renderHook(() =>
+      useGasFeeEstimateLevelOptions({
+        handleCloseModals: mockHandleCloseModals,
+      }),
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].key).toBe(GasFeeEstimateLevel.Low);
+    expect(result.current[1].key).toBe(GasFeeEstimateLevel.Medium);
+  });
 });

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
@@ -14,18 +14,12 @@ import { useGasFeeEstimates } from '../../../../hooks/useGasFeeEstimates';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
 import { updateTransactionGasFees } from '../../../../store/actions';
 import { type GasOption } from '../../types/gas';
-import { EMPTY_VALUE_STRING, GasOptionIcon } from '../../constants/gas';
+import { EMPTY_VALUE_STRING } from '../../constants/gas';
 import { toHumanEstimatedTimeRange } from '../../utils/time';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
 import { hexWEIToDecGWEI } from '../../../../../shared/modules/conversion.utils';
 
 const HEX_ZERO = '0x0';
-
-const GasEstimateFeeLevelEmojis = {
-  [GasFeeEstimateLevel.Low]: GasOptionIcon.Low,
-  [GasFeeEstimateLevel.Medium]: GasOptionIcon.Medium,
-  [GasFeeEstimateLevel.High]: GasOptionIcon.High,
-};
 
 export const useGasFeeEstimateLevelOptions = ({
   handleCloseModals,
@@ -110,7 +104,6 @@ export const useGasFeeEstimateLevelOptions = ({
         });
 
       options.push({
-        emoji: GasEstimateFeeLevelEmojis[level],
         estimatedTime,
         isSelected: userFeeLevel === level,
         key: level,

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
@@ -67,6 +67,26 @@ export const useGasFeeEstimateLevelOptions = ({
 
   if (shouldIncludeGasFeeEstimateLevelOptions) {
     Object.values(GasFeeEstimateLevel).forEach((level) => {
+      // Skip adding the high option if it has the same fees as the medium option
+      if (
+        level === GasFeeEstimateLevel.High &&
+        transactionGasFeeEstimates?.type === GasFeeEstimateType.FeeMarket
+      ) {
+        const mediumEstimates =
+          transactionGasFeeEstimates[GasFeeEstimateLevel.Medium];
+        const highEstimates =
+          transactionGasFeeEstimates[GasFeeEstimateLevel.High];
+
+        const hasSameFees =
+          mediumEstimates?.maxFeePerGas === highEstimates?.maxFeePerGas &&
+          mediumEstimates?.maxPriorityFeePerGas ===
+            highEstimates?.maxPriorityFeePerGas;
+
+        if (hasSameFees) {
+          return;
+        }
+      }
+
       const estimatedTime = toHumanEstimatedTimeRange(
         networkGasFeeEstimates[level].minWaitTimeEstimate,
         networkGasFeeEstimates[level].maxWaitTimeEstimate,

--- a/ui/pages/confirmations/hooks/gas/useGasOptions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasOptions.test.ts
@@ -23,7 +23,6 @@ describe('useGasOptions', () => {
   );
 
   const mockAdvancedOption: GasOption = {
-    emoji: '⚙️',
     estimatedTime: '',
     isSelected: false,
     key: 'advanced',
@@ -34,7 +33,6 @@ describe('useGasOptions', () => {
   };
 
   const mockLowLevelOption: GasOption = {
-    emoji: '🐢',
     estimatedTime: '~1 min',
     isSelected: false,
     key: 'low',
@@ -45,7 +43,6 @@ describe('useGasOptions', () => {
   };
 
   const mockMediumLevelOption: GasOption = {
-    emoji: '🦊',
     estimatedTime: '~30 sec',
     isSelected: true,
     key: 'medium',
@@ -56,7 +53,6 @@ describe('useGasOptions', () => {
   };
 
   const mockGasPriceOption: GasOption = {
-    emoji: '⛽️',
     estimatedTime: '',
     isSelected: false,
     key: 'gasPrice',
@@ -67,7 +63,6 @@ describe('useGasOptions', () => {
   };
 
   const mockDappSuggestedOption: GasOption = {
-    emoji: '🌐',
     estimatedTime: '',
     isSelected: false,
     key: 'site_suggested',

--- a/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
@@ -14,7 +14,7 @@ import { useConfirmContext } from '../../context/confirm';
 import { useGasFeeEstimates } from '../../../../hooks/useGasFeeEstimates';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
 import { type GasOption } from '../../types/gas';
-import { EMPTY_VALUE_STRING, GasOptionIcon } from '../../constants/gas';
+import { EMPTY_VALUE_STRING } from '../../constants/gas';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
 import { hexWEIToDecGWEI } from '../../../../../shared/modules/conversion.utils';
 
@@ -120,7 +120,6 @@ export const useGasPriceEstimateOption = ({
 
     return [
       {
-        emoji: GasOptionIcon.GasPrice,
         estimatedTime: undefined,
         isSelected: isGasPriceEstimateSelected,
         key: 'gasPrice',

--- a/ui/pages/confirmations/types/gas.ts
+++ b/ui/pages/confirmations/types/gas.ts
@@ -7,7 +7,6 @@ export type GasOptionTooltipProps = {
 };
 
 export type GasOption = {
-  emoji: string;
   estimatedTime?: string;
   isSelected: boolean;
   key: string;

--- a/ui/pages/confirmations/utils/gasValidations.test.ts
+++ b/ui/pages/confirmations/utils/gasValidations.test.ts
@@ -1,0 +1,171 @@
+import {
+  validateGas,
+  validatePriorityFee,
+  validateMaxBaseFee,
+  validateGasPrice,
+} from './gasValidations';
+
+const mockT = ((key: string, args?: string | string[]) => {
+  const translations: Record<string, string> = {
+    gasLimit: 'Gas Limit',
+    priorityFee: 'Priority Fee',
+    maxBaseFee: 'Max Base Fee',
+    gasPrice: 'Gas price',
+    onlyNumbersAllowed: 'Only numbers are allowed',
+    onlyIntegersAllowed: 'Only whole numbers are allowed',
+    gasLimitTooLow: 'Gas limit must be greater than 21000',
+    priorityFeeTooHigh: 'Priority fee must be less than max base fee',
+    maxBaseFeeMustBeGreaterThanPriorityFee:
+      'Max base fee must be greater than priority fee',
+    negativeValuesNotAllowed: 'Negative values are not allowed',
+  };
+
+  if (key === 'fieldRequired' && Array.isArray(args)) {
+    return `${args[0]} is required`;
+  }
+
+  if (key === 'noZeroValue' && args) {
+    const field = Array.isArray(args) ? args[0] : args;
+    return `${field} must be greater than 0`;
+  }
+
+  return translations[key] || key;
+}) as ReturnType<typeof import('../../../hooks/useI18nContext').useI18nContext>;
+
+describe('gas-validations', () => {
+  describe('validateGas', () => {
+    it('return error message when gas is empty', () => {
+      expect(validateGas('', mockT)).toBe('Gas Limit is required');
+    });
+
+    it('return error message when gas is not a number', () => {
+      expect(validateGas('abc', mockT)).toBe('Only numbers are allowed');
+    });
+
+    it('return error message when gas is zero', () => {
+      expect(validateGas('0', mockT)).toBe('Gas Limit must be greater than 0');
+    });
+
+    it('return error message when gas is negative', () => {
+      expect(validateGas('-1', mockT)).toBe('Only numbers are allowed');
+    });
+
+    it('return error message when gas is less than 21000', () => {
+      expect(validateGas('20000', mockT)).toBe(
+        'Gas limit must be greater than 21000',
+      );
+    });
+
+    it('return error message when gas is not an integer', () => {
+      expect(validateGas('21000.5', mockT)).toBe(
+        'Only whole numbers are allowed',
+      );
+    });
+
+    it('return undefined when gas is valid', () => {
+      expect(validateGas('21000', mockT)).toBeUndefined();
+      expect(validateGas('30000', mockT)).toBeUndefined();
+    });
+  });
+
+  describe('validatePriorityFee', () => {
+    it('return error message when priority fee is empty', () => {
+      expect(validatePriorityFee('', '10', mockT)).toBe(
+        'Priority Fee is required',
+      );
+    });
+
+    it('return error message when priority fee is not a number', () => {
+      expect(validatePriorityFee('abc', '10', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
+    it('return error message when priority fee is zero', () => {
+      expect(validatePriorityFee('0', '10', mockT)).toBe(
+        'Priority Fee must be greater than 0',
+      );
+    });
+
+    it('return error message when priority fee is negative', () => {
+      expect(validatePriorityFee('-1', '10', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
+    it('return error message when priority fee is greater than max fee', () => {
+      expect(validatePriorityFee('15', '10', mockT)).toBe(
+        'Priority fee must be less than max base fee',
+      );
+    });
+
+    it('return undefined when priority fee is valid', () => {
+      expect(validatePriorityFee('5', '10', mockT)).toBeUndefined();
+      expect(validatePriorityFee('10', '10', mockT)).toBeUndefined();
+      expect(validatePriorityFee('10.5', '10.5', mockT)).toBeUndefined();
+    });
+  });
+
+  describe('validateMaxBaseFee', () => {
+    it('return error message when max base fee is empty', () => {
+      expect(validateMaxBaseFee('', '5', mockT)).toBe(
+        'Max Base Fee is required',
+      );
+    });
+
+    it('return error message when max base fee is not a number', () => {
+      expect(validateMaxBaseFee('abc', '5', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
+    it('return error message when max base fee is zero', () => {
+      expect(validateMaxBaseFee('0', '5', mockT)).toBe(
+        'Max Base Fee must be greater than 0',
+      );
+    });
+
+    it('return error message when max base fee is negative', () => {
+      expect(validateMaxBaseFee('-1', '5', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
+    it('return error message when max base fee is less than max priority fee', () => {
+      expect(validateMaxBaseFee('3', '5', mockT)).toBe(
+        'Max base fee must be greater than priority fee',
+      );
+    });
+
+    it('return undefined when max base fee is valid', () => {
+      expect(validateMaxBaseFee('6', '5', mockT)).toBeUndefined();
+      expect(validateMaxBaseFee('10', '5', mockT)).toBeUndefined();
+      expect(validateMaxBaseFee('10.5', '5', mockT)).toBeUndefined();
+    });
+  });
+
+  describe('validateGasPrice', () => {
+    it('return error message when gas price is empty', () => {
+      expect(validateGasPrice('', mockT)).toBe('Gas price is required');
+    });
+
+    it('return error message when gas price is not a number', () => {
+      expect(validateGasPrice('abc', mockT)).toBe('Only numbers are allowed');
+    });
+
+    it('return error message when gas price is zero', () => {
+      expect(validateGasPrice('0', mockT)).toBe(
+        'Gas price must be greater than 0',
+      );
+    });
+
+    it('return error message when gas price is negative', () => {
+      expect(validateGasPrice('-1', mockT)).toBe('Only numbers are allowed');
+    });
+
+    it('return undefined when gas price is valid', () => {
+      expect(validateGasPrice('1', mockT)).toBeUndefined();
+      expect(validateGasPrice('10.5', mockT)).toBeUndefined();
+    });
+  });
+});

--- a/ui/pages/confirmations/utils/gasValidations.test.ts
+++ b/ui/pages/confirmations/utils/gasValidations.test.ts
@@ -42,6 +42,10 @@ describe('gas-validations', () => {
       expect(validateGas('abc', mockT)).toBe('Only numbers are allowed');
     });
 
+    it('return error message when gas is a lone decimal point', () => {
+      expect(validateGas('.', mockT)).toBe('Only numbers are allowed');
+    });
+
     it('return error message when gas is zero', () => {
       expect(validateGas('0', mockT)).toBe('Gas Limit must be greater than 0');
     });
@@ -77,6 +81,12 @@ describe('gas-validations', () => {
 
     it('return error message when priority fee is not a number', () => {
       expect(validatePriorityFee('abc', '10', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
+    it('return error message when priority fee is a lone decimal point', () => {
+      expect(validatePriorityFee('.', '10', mockT)).toBe(
         'Only numbers are allowed',
       );
     });
@@ -119,6 +129,12 @@ describe('gas-validations', () => {
       );
     });
 
+    it('return error message when max base fee is a lone decimal point', () => {
+      expect(validateMaxBaseFee('.', '5', mockT)).toBe(
+        'Only numbers are allowed',
+      );
+    });
+
     it('return error message when max base fee is zero', () => {
       expect(validateMaxBaseFee('0', '5', mockT)).toBe(
         'Max Base Fee must be greater than 0',
@@ -153,6 +169,10 @@ describe('gas-validations', () => {
       expect(validateGasPrice('abc', mockT)).toBe('Only numbers are allowed');
     });
 
+    it('return error message when gas price is a lone decimal point', () => {
+      expect(validateGasPrice('.', mockT)).toBe('Only numbers are allowed');
+    });
+
     it('return error message when gas price is zero', () => {
       expect(validateGasPrice('0', mockT)).toBe(
         'Gas price must be greater than 0',
@@ -166,6 +186,8 @@ describe('gas-validations', () => {
     it('return undefined when gas price is valid', () => {
       expect(validateGasPrice('1', mockT)).toBeUndefined();
       expect(validateGasPrice('10.5', mockT)).toBeUndefined();
+      expect(validateGasPrice('.5', mockT)).toBeUndefined();
+      expect(validateGasPrice('5.', mockT)).toBeUndefined();
     });
   });
 });

--- a/ui/pages/confirmations/utils/gasValidations.test.ts
+++ b/ui/pages/confirmations/utils/gasValidations.test.ts
@@ -13,7 +13,7 @@ const mockT = ((key: string, args?: string | string[]) => {
     gasPrice: 'Gas price',
     onlyNumbersAllowed: 'Only numbers are allowed',
     onlyIntegersAllowed: 'Only whole numbers are allowed',
-    gasLimitTooLow: 'Gas limit must be greater than 21000',
+    gasLimitTooLow: 'Gas limit must be at least 21000',
     priorityFeeTooHigh: 'Priority fee must be less than max base fee',
     maxBaseFeeMustBeGreaterThanPriorityFee:
       'Max base fee must be greater than priority fee',
@@ -56,7 +56,7 @@ describe('gas-validations', () => {
 
     it('return error message when gas is less than 21000', () => {
       expect(validateGas('20000', mockT)).toBe(
-        'Gas limit must be greater than 21000',
+        'Gas limit must be at least 21000',
       );
     });
 

--- a/ui/pages/confirmations/utils/gasValidations.ts
+++ b/ui/pages/confirmations/utils/gasValidations.ts
@@ -1,0 +1,160 @@
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+type TranslateFunction = ReturnType<typeof useI18nContext>;
+
+function normalizeGasInput(value: string) {
+  return value.replace(',', '.');
+}
+
+export const validateGas = (
+  value: string,
+  t: TranslateFunction,
+): string | undefined => {
+  const field = t('gasLimit');
+  return (
+    validateValueExists(value, field, t) ||
+    validateValueIsNumber(value, t) ||
+    validateValueIsInteger(value, t) ||
+    validateValueIsPositive(value, field, t) ||
+    validateGasLimitValueIsGreaterThanMinimum(value, t) ||
+    undefined
+  );
+};
+
+export const validatePriorityFee = (
+  value: string,
+  maxFeePerGasInDec: string,
+  t: TranslateFunction,
+): string | undefined => {
+  const field = t('priorityFee');
+  return (
+    validateValueExists(value, field, t) ||
+    validateValueIsNumber(value, t) ||
+    validateValueIsPositive(value, field, t) ||
+    validatePriorityFeeValueIsLessThanMaxFeePerGas(value, maxFeePerGasInDec, t) ||
+    undefined
+  );
+};
+
+export const validateMaxBaseFee = (
+  value: string,
+  maxPriorityFeePerGasInDec: string,
+  t: TranslateFunction,
+): string | undefined => {
+  const field = t('maxBaseFee');
+  return (
+    validateValueExists(value, field, t) ||
+    validateValueIsNumber(value, t) ||
+    validateValueIsPositive(value, field, t) ||
+    validateMaxBaseFeeValueIsGreaterThanMaxPriorityFeePerGas(
+      value,
+      maxPriorityFeePerGasInDec,
+      t,
+    ) ||
+    undefined
+  );
+};
+
+export const validateGasPrice = (
+  value: string,
+  t: TranslateFunction,
+): string | undefined => {
+  const field = t('gasPrice');
+  return (
+    validateValueExists(value, field, t) ||
+    validateValueIsNumber(value, t) ||
+    validateValueIsPositive(value, field, t) ||
+    undefined
+  );
+};
+
+function validateMaxBaseFeeValueIsGreaterThanMaxPriorityFeePerGas(
+  value: string,
+  maxPriorityFeePerGasInDec: string,
+  t: TranslateFunction,
+): string | false {
+  const normalizedValue = normalizeGasInput(value);
+  const normalizedMaxPriorityFeePerGasInDec = normalizeGasInput(
+    maxPriorityFeePerGasInDec,
+  );
+  if (
+    parseFloat(normalizedValue) >=
+    parseFloat(normalizedMaxPriorityFeePerGasInDec)
+  ) {
+    return false;
+  }
+  return t('maxBaseFeeMustBeGreaterThanPriorityFee');
+}
+
+function validatePriorityFeeValueIsLessThanMaxFeePerGas(
+  value: string,
+  maxFeePerGasInDec: string,
+  t: TranslateFunction,
+): string | false {
+  const normalizedValue = normalizeGasInput(value);
+  const normalizedMaxFeePerGasInDec = normalizeGasInput(maxFeePerGasInDec);
+  if (parseFloat(normalizedValue) <= parseFloat(normalizedMaxFeePerGasInDec)) {
+    return false;
+  }
+  return t('priorityFeeTooHigh');
+}
+
+function validateValueExists(
+  value: string,
+  field: string,
+  t: TranslateFunction,
+): string | false {
+  if (value) {
+    return false;
+  }
+
+  return t('fieldRequired', [field]);
+}
+
+function validateValueIsNumber(
+  value: string,
+  t: TranslateFunction,
+): string | false {
+  const normalizedValue = normalizeGasInput(value);
+  if (/^\d*\.?\d*$/.test(normalizedValue)) {
+    return false;
+  }
+  return t('onlyNumbersAllowed');
+}
+
+function validateValueIsPositive(
+  value: string,
+  field: string,
+  t: TranslateFunction,
+): string | false {
+  if (parseFloat(value) > 0) {
+    return false;
+  }
+
+  if (parseFloat(value) === 0) {
+    return t('noZeroValue', field);
+  }
+
+  return t('negativeValuesNotAllowed');
+}
+
+function validateGasLimitValueIsGreaterThanMinimum(
+  value: string,
+  t: TranslateFunction,
+): string | false {
+  if (parseFloat(value) >= 21000) {
+    return false;
+  }
+  return t('gasLimitTooLow');
+}
+
+function validateValueIsInteger(
+  value: string,
+  t: TranslateFunction,
+): string | false {
+  const normalizedValue = normalizeGasInput(value);
+  if (/^\d+$/.test(normalizedValue)) {
+    return false;
+  }
+  return t('onlyIntegersAllowed');
+}

--- a/ui/pages/confirmations/utils/gasValidations.ts
+++ b/ui/pages/confirmations/utils/gasValidations.ts
@@ -31,7 +31,11 @@ export const validatePriorityFee = (
     validateValueExists(value, field, t) ||
     validateValueIsNumber(value, t) ||
     validateValueIsPositive(value, field, t) ||
-    validatePriorityFeeValueIsLessThanMaxFeePerGas(value, maxFeePerGasInDec, t) ||
+    validatePriorityFeeValueIsLessThanMaxFeePerGas(
+      value,
+      maxFeePerGasInDec,
+      t,
+    ) ||
     undefined
   );
 };
@@ -116,7 +120,7 @@ function validateValueIsNumber(
   t: TranslateFunction,
 ): string | false {
   const normalizedValue = normalizeGasInput(value);
-  if (/^\d*\.?\d*$/.test(normalizedValue)) {
+  if (/^\d*\.?\d*$/u.test(normalizedValue)) {
     return false;
   }
   return t('onlyNumbersAllowed');
@@ -153,7 +157,7 @@ function validateValueIsInteger(
   t: TranslateFunction,
 ): string | false {
   const normalizedValue = normalizeGasInput(value);
-  if (/^\d+$/.test(normalizedValue)) {
+  if (/^\d+$/u.test(normalizedValue)) {
     return false;
   }
   return t('onlyIntegersAllowed');

--- a/ui/pages/confirmations/utils/gasValidations.ts
+++ b/ui/pages/confirmations/utils/gasValidations.ts
@@ -120,7 +120,8 @@ function validateValueIsNumber(
   t: TranslateFunction,
 ): string | false {
   const normalizedValue = normalizeGasInput(value);
-  if (/^\d*\.?\d*$/u.test(normalizedValue)) {
+  // Require at least one digit - matches numbers like "123", "123.45", ".45", "123."
+  if (/^(\d+\.?\d*|\d*\.\d+)$/u.test(normalizedValue)) {
     return false;
   }
   return t('onlyNumbersAllowed');

--- a/ui/pages/confirmations/utils/gasValidations.ts
+++ b/ui/pages/confirmations/utils/gasValidations.ts
@@ -131,12 +131,13 @@ function validateValueIsPositive(
   field: string,
   t: TranslateFunction,
 ): string | false {
-  if (parseFloat(value) > 0) {
+  const normalizedValue = normalizeGasInput(value);
+  if (parseFloat(normalizedValue) > 0) {
     return false;
   }
 
-  if (parseFloat(value) === 0) {
-    return t('noZeroValue', field);
+  if (parseFloat(normalizedValue) === 0) {
+    return t('noZeroValue', [field]);
   }
 
   return t('negativeValuesNotAllowed');
@@ -146,7 +147,8 @@ function validateGasLimitValueIsGreaterThanMinimum(
   value: string,
   t: TranslateFunction,
 ): string | false {
-  if (parseFloat(value) >= 21000) {
+  const normalizedValue = normalizeGasInput(value);
+  if (parseFloat(normalizedValue) >= 21000) {
     return false;
   }
   return t('gasLimitTooLow');

--- a/ui/pages/confirmations/utils/number.test.ts
+++ b/ui/pages/confirmations/utils/number.test.ts
@@ -1,0 +1,29 @@
+import { limitToMaximumDecimalPlaces } from './number';
+
+describe('number util', () => {
+  describe('limitToMaximumDecimalPlaces', () => {
+    it('limits number to default 5 decimal places', () => {
+      expect(limitToMaximumDecimalPlaces(1.123456789)).toBe('1.12346');
+    });
+
+    it('limits number to specified decimal places', () => {
+      expect(limitToMaximumDecimalPlaces(1.123456789, 2)).toBe('1.12');
+    });
+
+    it('returns number as string if no decimal limiting needed', () => {
+      expect(limitToMaximumDecimalPlaces(5, 2)).toBe('5');
+    });
+
+    it('handles NaN input', () => {
+      expect(limitToMaximumDecimalPlaces(NaN)).toBe('NaN');
+    });
+
+    it('handles NaN maxDecimalPlaces', () => {
+      expect(limitToMaximumDecimalPlaces(1.234, NaN)).toBe('1.234');
+    });
+
+    it('rounds correctly', () => {
+      expect(limitToMaximumDecimalPlaces(1.999, 2)).toBe('2');
+    });
+  });
+});

--- a/ui/pages/confirmations/utils/number.ts
+++ b/ui/pages/confirmations/utils/number.ts
@@ -1,8 +1,9 @@
 /**
  * Limits a number to a max decimal places.
- * @param {number} num
- * @param {number} maxDecimalPlaces
- * @returns {string}
+ *
+ * @param num - The number to limit
+ * @param maxDecimalPlaces - The maximum number of decimal places
+ * @returns The number limited to the maximum decimal places
  */
 export function limitToMaximumDecimalPlaces(
   num: number,

--- a/ui/pages/confirmations/utils/number.ts
+++ b/ui/pages/confirmations/utils/number.ts
@@ -1,0 +1,16 @@
+/**
+ * Limits a number to a max decimal places.
+ * @param {number} num
+ * @param {number} maxDecimalPlaces
+ * @returns {string}
+ */
+export function limitToMaximumDecimalPlaces(
+  num: number,
+  maxDecimalPlaces = 5,
+): string {
+  if (isNaN(num) || isNaN(maxDecimalPlaces)) {
+    return num.toString();
+  }
+  const base = Math.pow(10, maxDecimalPlaces);
+  return (Math.round(num * base) / base).toString();
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR implements the second step of https://github.com/MetaMask/MetaMask-planning/issues/6067

Note that new gas modal UI is not enabled yet until very last step. Hence no changelog included.

The recording is manually enabled on local.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38712?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: Step II of https://github.com/MetaMask/MetaMask-planning/issues/6067

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/10d8b032-dd1c-40ec-b985-293ce8fd0f93



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Advanced Network Fee modals with new gas inputs and validations, refactors gas options UI (removing emojis), and updates hooks, i18n, and tests.
> 
> - **Confirmations UI/Modals**:
>   - Implement `AdvancedEIP1559Modal` and `AdvancedGasPriceModal` with save/cancel, wired to `updateTransactionGasFees`.
>   - Update `EstimatesModal` to use redesigned `GasEstimateListItem`.
> - **Inputs & Validation**:
>   - Add `GasInput`, `GasPriceInput`, `MaxBaseFeeInput`, `PriorityFeeInput` components with error handling.
>   - Introduce `gasValidations` utility (gas limit, gas price, priority/base fee rules) and `number` utils; integrate into inputs.
> - **Hooks/Logic**:
>   - Update gas option hooks (`useAdvancedGasFeeOption`, `useGasPriceEstimateOption`, `useDappSuggestedGasFeeOption`) to new `GasOption` (no emoji) and tooltips; navigation to advanced modals.
>   - `useGasFeeEstimateLevelOptions`: skip High when equal to Medium; compute times; use new constants.
> - **UI Cleanup**:
>   - Refactor `GasEstimateListItem` to `@metamask/design-system-react`; remove header and emojis; adjust colors/variants.
>   - `GasTiming`: remove emojis/symbols in labels (e.g., "Market", "10% increase").
> - **i18n**:
>   - Add strings for advanced modal titles, current fee ranges, validation messages (required, numbers only, negative/zero checks).
> - **Tests**:
>   - Add/adjust tests and snapshots across new inputs, modals, gas timing, list items, and hooks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ea7ed8fdeae8a6ced4f3a4a1d99cb504090e3e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->