### PR TITLE
fix: dismiss import nft modal on timeout

### DIFF
--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -151,11 +151,15 @@ export const ImportNftsModal = ({ onClose }) => {
     }
     dispatch(setNewNftAddedMessage('success'));
 
-    const tokenDetails = await getTokenStandardAndDetails(
-      nftAddress,
-      null,
-      tokenId.toString(),
-    ).catch(() => ({}));
+    const tokenDetails = await Promise.race([
+      getTokenStandardAndDetails(nftAddress, null, tokenId.toString()),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('getTokenStandardAndDetails timeout')),
+          3000,
+        ),
+      ),
+    ]).catch(() => ({}));
 
     trackEvent({
       event: MetaMetricsEventName.TokenAdded,


### PR DESCRIPTION
## **Description**

The import NFT modal does not dismiss on Firefox/Sepolia. Added a timeout to automatically close the modal if the call to get details hangs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38713?quickstart=1)

## **Changelog**


CHANGELOG entry: Fixes hanging import nft modal on Sepolia/firefox

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29633

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 3-second timeout around fetching NFT token standard/details in the Import NFTs modal to prevent hanging.
> 
> - **Frontend**
>   - **Import NFTs Modal (`ui/components/multichain/import-nfts-modal/import-nfts-modal.js`)**:
>     - Wrap `getTokenStandardAndDetails` with `Promise.race` to enforce a 3s timeout; fall back to `{}` on error/timeout.
>     - No changes to import flow; metrics still tracked using resolved `tokenDetails` when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf062eec1ae3c7a4b635ffd19fefabd4bb05abd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->