### PR TITLE
chore: adds staking tx mappings (non-evm)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5982,12 +5982,6 @@
   "sent": {
     "message": "Sent"
   },
-  "stakingDeposit": {
-    "message": "Staking Deposit"
-  },
-  "stakingWithdrawal": {
-    "message": "Staking Withdrawal"
-  },
   "sentSpecifiedTokens": {
     "message": "Sent $1",
     "description": "Symbol of the specified token"
@@ -7215,6 +7209,12 @@
   },
   "staked": {
     "message": "Staked"
+  },
+  "stakingDeposit": {
+    "message": "Staking Deposit"
+  },
+  "stakingWithdrawal": {
+    "message": "Staking Withdrawal"
   },
   "standardAccountLabel": {
     "message": "Standard Account"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5982,6 +5982,12 @@
   "sent": {
     "message": "Sent"
   },
+  "stakingDeposit": {
+    "message": "Staking Deposit"
+  },
+  "stakingWithdrawal": {
+    "message": "Staking Withdrawal"
+  },
   "sentSpecifiedTokens": {
     "message": "Sent $1",
     "description": "Symbol of the specified token"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7210,6 +7210,12 @@
   "staked": {
     "message": "Staked"
   },
+  "stakingDeposit": {
+    "message": "Staking Deposit"
+  },
+  "stakingWithdrawal": {
+    "message": "Staking Withdrawal"
+  },
   "standardAccountLabel": {
     "message": "Standard Account"
   },

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -183,6 +183,8 @@ export function MultichainTransactionDetailsModal({
     [TransactionType.Send]: t('send'),
     [TransactionType.Receive]: t('receive'),
     [TransactionType.Swap]: t('swap'),
+    [TransactionType.StakeDeposit]: t('stakingDeposit'),
+    [TransactionType.StakeWithdraw]: t('stakingWithdrawal'),
     [TransactionType.Unknown]: t('interaction'),
   };
 

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -78,6 +78,8 @@ export function useMultichainTransactionDisplay(
     [TransactionType.Swap]: `${t('swap')} ${from?.unit} ${t(
       'to',
     ).toLowerCase()} ${to?.unit}`,
+    [TransactionType.StakeDeposit]: t('stakingDeposit'),
+    [TransactionType.StakeWithdraw]: t('stakingWithdrawal'),
     [TransactionType.Unknown]: t('interaction'),
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Show txs as "Staking Deposit" and "Staking Withdrawal" in the non‑EVM transaction history lists (`useMultichainTransactionDisplay`).


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map staking deposit/withdraw transaction types in multichain views and add corresponding locale strings.
> 
> - **Frontend**:
>   - Map `TransactionType.StakeDeposit` and `TransactionType.StakeWithdraw` to titles in `ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx` and `ui/hooks/useMultichainTransactionDisplay.ts`.
> - **Localization**:
>   - Add `stakingDeposit` and `stakingWithdrawal` strings to `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a4a3799db391ebd817a3500061a11838060b7fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->