### PR TITLE
chore: bump extension-port-stream from v5.0.0 to v5.0.2

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -79,3 +79,4 @@ npmPreapprovedPackages:
   - 'lavamoat-browserify'
   - 'lavamoat-tofu'
   - 'lavamoat-node'
+  - 'extension-port-stream'

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "eth-lattice-keyring": "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch",
     "eth-method-registry": "^4.0.0",
     "ethereumjs-util": "^7.0.10",
-    "extension-port-stream": "^5.0.0",
+    "extension-port-stream": "^5.0.1",
     "fast-json-patch": "^3.1.1",
     "fuse.js": "^3.2.0",
     "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "eth-lattice-keyring": "patch:eth-lattice-keyring@npm%3A0.12.4#~/.yarn/patches/eth-lattice-keyring-npm-0.12.4-c5fb3fcf54.patch",
     "eth-method-registry": "^4.0.0",
     "ethereumjs-util": "^7.0.10",
-    "extension-port-stream": "^5.0.1",
+    "extension-port-stream": "^5.0.2",
     "fast-json-patch": "^3.1.1",
     "fuse.js": "^3.2.0",
     "he": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25418,14 +25418,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extension-port-stream@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "extension-port-stream@npm:5.0.0"
+"extension-port-stream@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "extension-port-stream@npm:5.0.1"
   dependencies:
     readable-stream: "npm:^3.6.2 || ^4.4.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/92de1e57dea50692a6483767a6eebc66980218c34f70b813a367da965b1ced565dec0d0aeb1b658a0b354e2eb4fef0103d95f7edc5b02bbbda353411eeff612c
+  checksum: 10/17dbdeac918724a487bc856b38491b8a6747b8790ad59341717caa1379646100cf85a61fdb94df38f96b12518316402a5e5f8778fc10c235bdb758e18317ebe1
   languageName: node
   linkType: hard
 
@@ -33139,7 +33139,7 @@ __metadata:
     eth-method-registry: "npm:^4.0.0"
     ethereumjs-util: "npm:^7.0.10"
     ethers: "npm:^5.7.0"
-    extension-port-stream: "npm:^5.0.0"
+    extension-port-stream: "npm:^5.0.1"
     fake-indexeddb: "npm:^6.1.0"
     fancy-log: "npm:^1.3.3"
     fast-glob: "npm:^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25418,14 +25418,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extension-port-stream@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "extension-port-stream@npm:5.0.1"
+"extension-port-stream@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "extension-port-stream@npm:5.0.2"
   dependencies:
     readable-stream: "npm:^3.6.2 || ^4.4.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/17dbdeac918724a487bc856b38491b8a6747b8790ad59341717caa1379646100cf85a61fdb94df38f96b12518316402a5e5f8778fc10c235bdb758e18317ebe1
+  checksum: 10/edb942e69bcccc4924ed401a729e5e418601ace7cdc834cf262b4a00a79203d4c130273fc881ae582557008a075b6a2e625a4271eacabbea6394beaaee59952d
   languageName: node
   linkType: hard
 
@@ -33139,7 +33139,7 @@ __metadata:
     eth-method-registry: "npm:^4.0.0"
     ethereumjs-util: "npm:^7.0.10"
     ethers: "npm:^5.7.0"
-    extension-port-stream: "npm:^5.0.1"
+    extension-port-stream: "npm:^5.0.2"
     fake-indexeddb: "npm:^6.1.0"
     fancy-log: "npm:^1.3.3"
     fast-glob: "npm:^3.2.2"


### PR DESCRIPTION
## **Description**

Bumps `extension-port-stream` from `5.0.0` to `5.0.2`.

### Changes in 5.0.1

**1. Chromium Error Message Compatibility Fix**

Chromium changed the error message format for oversized messages around November 2025 ([chromium-review](https://chromium-review.googlesource.com/c/chromium/src/+/7147681)). This release adds support for both the old and new error message formats to ensure backward compatibility with older Chrome versions while supporting newer versions.

**2. Port Disconnect Handling Improvement**

Changed the port disconnect handler to cleanly destroy without throwing an error, providing cleaner stream cleanup when browser ports disconnect, and avoiding [Port disconnected](https://metamask.sentry.io/issues/6986654426/?environment=production&project=273505&query=release%3A%22metamask-extension%4013.7.0%22&referrer=release-issue-stream) logged in the console when Extension starts.

**3. LavaMoat Security Configuration**

Added LavaMoat security configuration to the package for improved supply chain security.

### Changes in 5.0.2

Gracefully end stream on port disconnect to prevent "Premature close" errors: https://github.com/MetaMask/extension-port-stream/pull/86

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38719?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - Dependency maintenance

## **Manual testing steps**

1. Build the extension with `yarn build`
2. Load the extension in Chrome
3. Verify extension loads and operates correctly
4. Verify no [Port disconnected](https://metamask.sentry.io/issues/6986654426/?environment=production&project=273505&query=release%3A%22metamask-extension%4013.7.0%22&referrer=release-issue-stream) errors in the console

## **Screenshots/Recordings**

### **Before**

N/A - No visual changes

### **After**

N/A - No visual changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `extension-port-stream` from 5.0.0 to 5.0.2, refresh lockfile, and add it to Yarn `npmPreapprovedPackages`.
> 
> - **Dependencies**:
>   - Bump `extension-port-stream` to `^5.0.2` in `package.json`; update `yarn.lock`.
> - **Tooling/Config**:
>   - Add `extension-port-stream` to Yarn `npmPreapprovedPackages` in `.yarnrc.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b258569dc37e9c1521e45594defc613c81fd43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->