### PR TITLE
fix: useHistoricalPricesEvm uses chainId to defined showFiat selector

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,69 +13,33 @@ logFilters:
 nodeLinker: node-modules
 
 npmAuditIgnoreAdvisories:
-  ### Advisories:
-
-  # Issue: Regular Expression Denial of Service (ReDOS)
-  # URL: https://github.com/advisories/GHSA-257v-vj4p-3w2h
-  # color-string is listed as a dependency of 'color' which is brought in by
-  # @metamask/jazzicon v2.0.0 but there is work done on that repository to
-  # remove the color dependency. We should upgrade
   - 1089718
-
-  # Issue: Issue: Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
-  # We are ignoring this on April 24, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
   - 1104001
-
-  # Issue: `glob` vulnerability, already fixed in the version we're using (v10.5.0) but the
-  # advisory range hasn't been updated yet.
-  # URL: https://github.com/advisories/GHSA-5j98-mcp5-4vw2
   - 1109809
-
-  # Issue: `body-parser` denial of service vulnerability
-  # Seemingly only impacts v2.2.0, but we're on v1. The advisory range is overly wide.
-  # The attack vector also does not apply to how we use the package.
-  # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
   - 1110857
+  - popper.js (deprecation)
+  - "@material-ui/core (deprecation)"
+  - "@material-ui/styles (deprecation)"
+  - "@material-ui/pickers (deprecation)"
+  - cids (deprecation)
+  - multibase (deprecation)
+  - multicodec (deprecation)
+  - react-beautiful-dnd (deprecation)
+  - ethereumjs-wallet (deprecation)
 
-  ### Package Deprecations:
+npmMinimalAgeGate: 4320
 
-  # React-tippy brings in popper.js and react-tippy has not been updated in
-  # three years.
-  - 'popper.js (deprecation)'
-
-  # Material UI dependencies are planned for removal
-  - '@material-ui/core (deprecation)'
-  - '@material-ui/styles (deprecation)'
-  - '@material-ui/pickers (deprecation)'
-
-  # Dependencies brought in by @truffle/decoder that are deprecated:
-  - 'cids (deprecation)' # via @ensdomains/content-hash
-  - 'multibase (deprecation)' # via cids
-  - 'multicodec (deprecation)' # via cids
-
-  # Currently in use for the network list drag and drop functionality.
-  # Maintenance has stopped and the project will be archived in 2025.
-  - 'react-beautiful-dnd (deprecation)'
-  # New package name format for new versions: @ethereumjs/wallet.
-  - 'ethereumjs-wallet (deprecation)'
+npmPreapprovedPackages:
+  - "@metamask/*"
+  - "@metamask-previews/*"
+  - "@lavamoat/*"
+  - lavamoat-core
+  - lavamoat-browserify
+  - lavamoat-tofu
+  - lavamoat-node
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
-    spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
-
-# Configure the NPM minimal age gate to 3 days, meaning packages must be at
-# least 3 days old to be installed.
-npmMinimalAgeGate: 4320 # 3 days (in minutes)
-
-# Override the minimal age gate, allowing certain packages to be installed
-# regardless of their publish age.
-npmPreapprovedPackages:
-  - '@metamask/*'
-  - '@metamask-previews/*'
-  - '@lavamoat/*'
-  - 'lavamoat-core'
-  - 'lavamoat-browserify'
-  - 'lavamoat-tofu'
-  - 'lavamoat-node'
+    spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"

--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -12,6 +12,7 @@ import { Point } from 'chart.js';
 import { useDispatch, useSelector } from 'react-redux';
 import { MINUTE } from '../../../../shared/constants/time';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
+import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
 import { getShouldShowFiat } from '../../../selectors';
 import { getHistoricalPrices } from '../../../selectors/assets';
 import {
@@ -52,6 +53,21 @@ export const DEFAULT_USE_HISTORICAL_PRICES_METADATA: HistoricalPrices['metadata'
     yMin: Infinity,
     yMax: -Infinity,
   };
+
+/**
+ * Converts a chain ID to hex format. If the chain ID is already in hex format, returns it as-is.
+ * If it's a CAIP chain ID, converts it to hex. Returns null if conversion fails.
+ *
+ * @param chainId - The chain ID to convert (Hex or CaipChainId).
+ * @returns The hex chain ID, or null if conversion fails.
+ */
+const toHexChainId = (chainId: Hex | CaipChainId): Hex | null => {
+  try {
+    return isCaipChainId(chainId) ? convertCaipToHexChainId(chainId) : chainId;
+  } catch (e) {
+    return null;
+  }
+};
 
 type UseHistoricalPricesParams = {
   chainId: Hex | CaipChainId;
@@ -99,7 +115,10 @@ const useHistoricalPricesEvm = ({
   timeRange,
 }: UseHistoricalPricesParams) => {
   const isEvm = isEvmChainId(chainId);
-  const showFiat: boolean = useSelector(getShouldShowFiat);
+  const hexChainId = toHexChainId(chainId);
+  const showFiat: boolean = useSelector((state) =>
+    getShouldShowFiat(state, hexChainId),
+  );
 
   const [loading, setLoading] = useState<boolean>(false);
   const [prices, setPrices] = useState<Point[]>([]);
@@ -113,7 +132,11 @@ const useHistoricalPricesEvm = ({
       return;
     }
 
-    const chainSupported = showFiat && chainSupportsPricing(chainId as Hex);
+    if (!hexChainId) {
+      return;
+    }
+
+    const chainSupported = showFiat && chainSupportsPricing(hexChainId);
     if (!chainSupported) {
       return;
     }
@@ -134,7 +157,7 @@ const useHistoricalPricesEvm = ({
     setLoading(true);
     const timePeriod = fromIso8601DurationToPriceApiTimePeriod(timeRange);
     fetchWithCache({
-      url: `https://price.api.cx.metamask.io/v1/chains/${chainId}/historical-prices/${address}?vsCurrency=${currency}&timePeriod=${timePeriod}`,
+      url: `https://price.api.cx.metamask.io/v1/chains/${hexChainId}/historical-prices/${address}?vsCurrency=${currency}&timePeriod=${timePeriod}`,
       cacheOptions: { cacheRefreshTime: 5 * MINUTE },
       functionName: 'GetAssetHistoricalPrices',
       fetchOptions: { headers: { 'X-Client-Id': 'extension' } },
@@ -152,7 +175,7 @@ const useHistoricalPricesEvm = ({
         });
         setLoading(false);
       });
-  }, [isEvm, chainId, address, currency, timeRange, showFiat]);
+  }, [isEvm, hexChainId, address, currency, timeRange, showFiat]);
 
   // Compute the metadata
   useEffect(() => {

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
@@ -85,6 +85,20 @@ describe('Confirm Recovery Phrase Component', () => {
 
   const mockStore = configureMockStore([thunk])(mockState);
 
+  it('should redirect to onboarding metametrics page if seed phrase is already backed up', () => {
+    const store = configureMockStore()({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        seedPhraseBackedUp: true,
+      },
+    });
+    renderWithProvider(<ConfirmRecoveryPhrase {...props} />, store);
+
+    expect(mockUseNavigate).toHaveBeenCalledWith(ONBOARDING_METAMETRICS, {
+      replace: true,
+    });
+  });
   it('should have 3 recovery phrase inputs', () => {
     const { queryAllByTestId } = renderWithProvider(
       <ConfirmRecoveryPhrase {...props} />,

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
@@ -47,6 +47,7 @@ import {
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { TraceName } from '../../../../shared/lib/trace';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+import { getSeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
 import ConfirmSrpModal from './confirm-srp-modal';
 import RecoveryPhraseChips from './recovery-phrase-chips';
 
@@ -88,6 +89,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
   const trackEvent = useContext(MetaMetricsContext);
   const { bufferedEndTrace } = trackEvent;
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
+  const hasSeedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
 
   const splitSecretRecoveryPhrase = useMemo(
     () => (secretRecoveryPhrase ? secretRecoveryPhrase.split(' ') : []),
@@ -121,8 +123,23 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
         }`,
         { replace: true },
       );
+    } else if (hasSeedPhraseBackedUp) {
+      const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
+      // if user has already done the Secure Wallet flow, we can redirect to the next page
+      navigate(
+        isFirefox || isFromReminder
+          ? ONBOARDING_COMPLETION_ROUTE
+          : ONBOARDING_METAMETRICS,
+        { replace: true },
+      );
     }
-  }, [navigate, secretRecoveryPhrase, nextRouteQueryString]);
+  }, [
+    navigate,
+    secretRecoveryPhrase,
+    nextRouteQueryString,
+    hasSeedPhraseBackedUp,
+    isFromReminder,
+  ]);
 
   const resetQuizWords = useCallback(() => {
     const newQuizWords = generateQuizWords(splitSecretRecoveryPhrase);

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
@@ -186,6 +186,7 @@ export default function RecoveryPhraseChips({
             const isTargetIndex = index === indexToFocus;
             return isQuizWord || !confirmPhase ? (
               <Box
+                key={index}
                 as={isQuizWord ? 'button' : 'div'}
                 data-testid={`recovery-phrase-chip-${index}`}
                 className="recovery-phrase__text"

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -1,5 +1,6 @@
-import React, { FormEvent, useCallback, useState } from 'react';
+import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   Text,
@@ -28,9 +29,14 @@ import {
 import { getSeedPhrase } from '../../../store/actions';
 import {
   DEFAULT_ROUTE,
+  ONBOARDING_COMPLETION_ROUTE,
+  ONBOARDING_METAMETRICS,
   ONBOARDING_REVIEW_SRP_ROUTE,
   REVEAL_SRP_LIST_ROUTE,
 } from '../../../helpers/constants/routes';
+import { getSeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
+import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -45,6 +51,7 @@ export default function RevealRecoveryPhrase({
   const searchParams = new URLSearchParams(search);
   const isFromReminder = searchParams.get('isFromReminder');
   const isFromSettingsSecurity = searchParams.get('isFromSettingsSecurity');
+  const hasSeedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
   const queryParams = new URLSearchParams();
   if (isFromReminder) {
     queryParams.set('isFromReminder', isFromReminder);
@@ -57,6 +64,16 @@ export default function RevealRecoveryPhrase({
   const [password, setPassword] = useState('');
   const [isIncorrectPasswordError, setIsIncorrectPasswordError] =
     useState(false);
+
+  useEffect(() => {
+    if (hasSeedPhraseBackedUp) {
+      const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
+      navigate(
+        isFirefox ? ONBOARDING_COMPLETION_ROUTE : ONBOARDING_METAMETRICS,
+        { replace: true },
+      );
+    }
+  }, [navigate, hasSeedPhraseBackedUp]);
 
   const onSubmit = useCallback(
     async (_password) => {

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import {
   ONBOARDING_CONFIRM_SRP_ROUTE,
+  ONBOARDING_METAMETRICS,
   REVEAL_SRP_LIST_ROUTE,
 } from '../../../helpers/constants/routes';
 import RecoveryPhrase from './review-recovery-phrase';
@@ -19,7 +20,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-const mockStore = configureMockStore()({
+const mockState = {
   metamask: {
     internalAccounts: {
       accounts: {
@@ -39,7 +40,9 @@ const mockStore = configureMockStore()({
       },
     ],
   },
-});
+};
+
+const mockStore = configureMockStore()(mockState);
 
 describe('Review Recovery Phrase Component', () => {
   beforeEach(() => {
@@ -63,6 +66,21 @@ describe('Review Recovery Phrase Component', () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should redirect to onboarding metametrics page if seed phrase is already backed up', () => {
+    const store = configureMockStore()({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        seedPhraseBackedUp: true,
+      },
+    });
+    renderWithProvider(<RecoveryPhrase {...props} />, store);
+
+    expect(mockUseNavigate).toHaveBeenCalledWith(ONBOARDING_METAMETRICS, {
+      replace: true,
+    });
   });
 
   it('should match snapshot after reveal recovery button is clicked', () => {

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
@@ -45,6 +45,7 @@ import { TraceName } from '../../../../shared/lib/trace';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
+import { getSeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
 import RecoveryPhraseChips from './recovery-phrase-chips';
 
 type RecoveryPhraseProps = {
@@ -61,6 +62,7 @@ export default function RecoveryPhrase({
   const { search } = useLocation();
   const dispatch = useDispatch();
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
+  const hasSeedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
   const trackEvent = useContext(MetaMetricsContext);
   const { bufferedEndTrace } = trackEvent;
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
@@ -90,8 +92,20 @@ export default function RecoveryPhrase({
           replace: true,
         },
       );
+    } else if (hasSeedPhraseBackedUp) {
+      // if user has already done the Secure Wallet flow, we can redirect to the next page
+      const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
+      navigate(
+        isFirefox ? ONBOARDING_COMPLETION_ROUTE : ONBOARDING_METAMETRICS,
+        { replace: true },
+      );
     }
-  }, [navigate, secretRecoveryPhrase, nextRouteQueryString]);
+  }, [
+    navigate,
+    secretRecoveryPhrase,
+    nextRouteQueryString,
+    hasSeedPhraseBackedUp,
+  ]);
 
   const handleContinue = useCallback(() => {
     trackEvent({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Add toHexChainId helper function to convert CAIP chain IDs to hex format
- Convert chainId to hexChainId in useHistoricalPricesEvm hook
- Pass hexChainId to getShouldShowFiat selector instead of raw chainId
- Use hexChainId in chainSupportsPricing check and API URL
- Add null check for hexChainId before proceeding with price fetch

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38727?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show token details charts after adding another evm chain

## **Related issues**

Fixes: #38298

## **Manual testing steps**

See issue repro steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes chainId to hex in historical price hook and adds redirects to skip SRP onboarding when seed phrase is already backed up, with tests and minor config updates.
> 
> - **Asset Prices (EVM)**:
>   - Add `toHexChainId` helper using `convertCaipToHexChainId` and guard on failure.
>   - Use hex `chainId` for `getShouldShowFiat`, `chainSupportsPricing`, and price API URL.
>   - Update effect deps accordingly.
> - **Onboarding SRP Flow**:
>   - Use `getSeedPhraseBackedUp` to redirect past SRP steps to `ONBOARDING_METAMETRICS` (or `ONBOARDING_COMPLETION_ROUTE` on Firefox/reminder) in `reveal`, `review`, and `confirm` screens.
>   - Minor UI fix: add `key` to recovery phrase chip element.
> - **Tests**:
>   - Add/adjust tests to assert redirect when `seedPhraseBackedUp` is true and Firefox-specific path.
> - **Config**:
>   - Update `.yarnrc.yml` advisories/deprecations, enable `npmMinimalAgeGate`, and set `npmPreapprovedPackages`; standardize plugin specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62156f08b5c75167340171c0b1daffd9af7d5b21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->