### PR TITLE
feat: polish Tempo token UI

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -211,6 +211,7 @@ export const CHAIN_IDS = {
   MONAD: '0x8f',
   HYPE: '0x3e7',
   X_LAYER: '0xc4',
+  TEMPO_TESTNET: '0xa5bd',
 } as const;
 
 export const CHAINLIST_CHAIN_IDS_MAP = {

--- a/shared/lib/tempo-utils.test.ts
+++ b/shared/lib/tempo-utils.test.ts
@@ -1,0 +1,45 @@
+import { isTempoNetwork, shouldHideTempoToken } from './tempo-utils';
+
+describe('isTempoNetwork', () => {
+  it('returns true for Tempo Testnet chain ID', () => {
+    expect(isTempoNetwork('0xa5bd')).toBe(true);
+  });
+
+  it('handles uppercase chain ID', () => {
+    expect(isTempoNetwork('0xA5BD')).toBe(true);
+  });
+
+  it('returns false for non-Tempo chain IDs', () => {
+    expect(isTempoNetwork('0x1')).toBe(false);
+    expect(isTempoNetwork('0x89')).toBe(false);
+  });
+});
+
+describe('shouldHideTempoToken', () => {
+  const TEMPO_CHAIN_ID = '0xa5bd';
+  const NON_TEMPO_CHAIN_ID = '0x1';
+
+  it('returns true for native tokens on Tempo', () => {
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, true, 'ETH')).toBe(true);
+  });
+
+  it('returns true for USD symbol on Tempo', () => {
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, false, 'USD')).toBe(true);
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, false, 'usd')).toBe(true);
+  });
+
+  it('returns false for other tokens on Tempo', () => {
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, false, 'USDC')).toBe(false);
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, false, 'ETH')).toBe(false);
+  });
+
+  it('returns false for tokens on non-Tempo networks', () => {
+    expect(shouldHideTempoToken(NON_TEMPO_CHAIN_ID, true, 'ETH')).toBe(false);
+    expect(shouldHideTempoToken(NON_TEMPO_CHAIN_ID, false, 'USD')).toBe(false);
+  });
+
+  it('returns false when symbol is undefined', () => {
+    expect(shouldHideTempoToken(TEMPO_CHAIN_ID, false, undefined)).toBe(false);
+  });
+});
+

--- a/shared/lib/tempo-utils.ts
+++ b/shared/lib/tempo-utils.ts
@@ -1,0 +1,42 @@
+const TEMPO_CHAIN_IDS = ['0xa5bd'] as const;
+
+/**
+ * Determines whether the given chain ID belongs to a Tempo network.
+ *
+ * @param chainId - The chain ID to check.
+ * @returns True if the chain ID is a Tempo network, false otherwise.
+ */
+export function isTempoNetwork(chainId: string): boolean {
+  return TEMPO_CHAIN_IDS.includes(
+    chainId.toLowerCase() as (typeof TEMPO_CHAIN_IDS)[number],
+  );
+}
+
+/**
+ * Determines whether a token should be hidden on Tempo networks.
+ *
+ * @param chainId - The chain ID of the token.
+ * @param isNative - Whether the token is marked as native.
+ * @param symbol - The token symbol.
+ * @returns True if the token should be hidden, false otherwise.
+ */
+export function shouldHideTempoToken(
+  chainId: string,
+  isNative: boolean | undefined,
+  symbol: string | undefined,
+): boolean {
+  if (!isTempoNetwork(chainId)) {
+    return false;
+  }
+
+  if (isNative) {
+    return true;
+  }
+
+  if (symbol?.toUpperCase() === 'USD') {
+    return true;
+  }
+
+  return false;
+}
+

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -41,6 +41,7 @@ import {
   isEvmChainId,
   isTronResource,
 } from '../../../../../shared/lib/asset-utils';
+import { shouldHideTempoToken } from '../../../../../shared/lib/tempo-utils';
 import { sortAssetsWithPriority } from '../util/sortAssetsWithPriority';
 import { useScrollContainer } from '../../../../contexts/scroll-container';
 
@@ -102,7 +103,12 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
         },
       ]);
 
-      return sortAssets([...filteredAssets], tokenSortConfig);
+      const sortedAssets = sortAssets([...filteredAssets], tokenSortConfig);
+
+      return sortedAssets.filter(
+        (asset) =>
+          !shouldHideTempoToken(asset.chainId, asset.isNative, asset.symbol),
+      );
     }
 
     const accountAssetsPreSort = Object.entries(accountGroupIdAssets).flatMap(
@@ -129,7 +135,7 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
       tokenSortConfig,
     );
 
-    return accountAssets.map((asset) => {
+    const mappedAssets = accountAssets.map((asset) => {
       const token: TokenWithFiatAmount = {
         ...asset,
         tokenFiatAmount: asset.fiat?.balance,
@@ -141,6 +147,11 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
 
       return token;
     });
+
+    return mappedAssets.filter(
+      (asset) =>
+        !shouldHideTempoToken(asset.chainId, asset.isNative, asset.symbol),
+    );
   }, [
     isEvm,
     evmBalances,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -76,6 +76,7 @@ import {
 import { MultichainNetworks } from '../../../../../shared/constants/multichain/networks';
 import { Numeric } from '../../../../../shared/modules/Numeric';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
+import { shouldHideTempoToken } from '../../../../../shared/lib/tempo-utils';
 
 import { useAssetMetadata } from './hooks/useAssetMetadata';
 import type {
@@ -553,7 +554,18 @@ export function AssetPickerModal({
   );
 
   const displayedTokens = useMemo(() => {
-    return unlistedAssetMetadata ? [unlistedAssetMetadata] : filteredTokenList;
+    const tokens = unlistedAssetMetadata
+      ? [unlistedAssetMetadata]
+      : filteredTokenList;
+
+    return tokens.filter(
+      (token) =>
+        !shouldHideTempoToken(
+          token.chainId,
+          token.type === AssetType.native,
+          token.symbol,
+        ),
+    );
   }, [unlistedAssetMetadata, filteredTokenList]);
 
   const getNetworkPickerLabel = () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -3,6 +3,7 @@ import { Hex } from '@metamask/utils';
 import React, { Dispatch, SetStateAction } from 'react';
 import { useSelector } from 'react-redux';
 import { TEST_CHAINS } from '../../../../../../../../shared/constants/network';
+import { isTempoNetwork } from '../../../../../../../../shared/lib/tempo-utils';
 import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
 import { Box, Text } from '../../../../../../../components/component-library';
@@ -57,6 +58,7 @@ export const EditGasFeesRow = ({
   } = transactionMeta;
   const gasFeeToken = useSelectedGasFeeToken();
   const showFiat = useShowFiat(chainId);
+  const isTempoChain = isTempoNetwork(chainId);
   const fiatValue = gasFeeToken ? gasFeeToken.amountFiat : fiatFee;
   const tokenValue = gasFeeToken ? gasFeeToken.amountFormatted : nativeFee;
   const metamaskFeeFiat = gasFeeToken?.metamaskFeeFiat;
@@ -117,8 +119,14 @@ export const EditGasFeesRow = ({
                 roundedValue={fiatValue}
               />
             )}
-            {!(showFiat && !showAdvancedDetails) && !isGasFeeSponsored && (
-              <TokenValue roundedValue={tokenValue} />
+            {!(showFiat && !showAdvancedDetails) &&
+              !isGasFeeSponsored &&
+              !isTempoChain && <TokenValue roundedValue={tokenValue} />}
+            {showAdvancedDetails && !isGasFeeSponsored && isTempoChain && (
+              <FiatValue
+                fullValue={fiatFeeWith18SignificantDigits}
+                roundedValue={fiatValue}
+              />
             )}
             {!isGasFeeSponsored && <SelectedGasFeeToken />}
           </Box>
@@ -195,6 +203,10 @@ function FiatValue({
 
 function useShowFiat(chainId: Hex): boolean {
   type TestNetChainId = (typeof TEST_CHAINS)[number];
+
+  if (isTempoNetwork(chainId)) {
+    return true;
+  }
 
   const isTestnet = TEST_CHAINS.includes(chainId as TestNetChainId);
   const { showFiatInTestnets } = useSelector(getPreferences);

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -204,12 +204,12 @@ function FiatValue({
 function useShowFiat(chainId: Hex): boolean {
   type TestNetChainId = (typeof TEST_CHAINS)[number];
 
+  const isTestnet = TEST_CHAINS.includes(chainId as TestNetChainId);
+  const { showFiatInTestnets } = useSelector(getPreferences);
+
   if (isTempoNetwork(chainId)) {
     return true;
   }
-
-  const isTestnet = TEST_CHAINS.includes(chainId as TestNetChainId);
-  const { showFiatInTestnets } = useSelector(getPreferences);
 
   return !isTestnet || showFiatInTestnets;
 }

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -150,7 +150,7 @@ export const EditGasFeesRow = ({
                 : ' '}
             </Text>
           </Box>
-          {showAdvancedDetails && (
+          {showAdvancedDetails && !isTempoChain && (
             <FiatValue
               fullValue={fiatFeeWith18SignificantDigits}
               roundedValue={fiatValue}

--- a/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
@@ -3,6 +3,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../../shared/constants/transaction';
+import { isTempoNetwork } from '../../../../../../../../shared/lib/tempo-utils';
 import {
   Box,
   Icon,
@@ -64,7 +65,8 @@ export function SelectedGasFeeToken() {
 
   const nativeTicker = networkConfiguration?.nativeCurrency;
   const gasFeeToken = useSelectedGasFeeToken();
-  const symbol = gasFeeToken?.symbol ?? nativeTicker;
+  const isTempoChain = isTempoNetwork(chainId);
+  const symbol = gasFeeToken?.symbol ?? (isTempoChain ? 'USD' : nativeTicker);
 
   return (
     <>

--- a/ui/pages/confirmations/hooks/send/useSendAssetFilter.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendAssetFilter.test.ts
@@ -307,4 +307,28 @@ describe('useSendAssetFilter', () => {
     expect(result.current.filteredTokens).toEqual(mockTokens);
     expect(result.current.filteredNfts).toEqual(mockNfts);
   });
+
+  it('filters out USD tokens on Tempo network', () => {
+    const tempoTokens: Asset[] = [
+      { name: 'USD', symbol: 'USD', chainId: '0xa5bd', isNative: true },
+      { name: 'AlphaUSD', symbol: 'AlphaUSD', chainId: '0xa5bd' },
+      { name: 'Ethereum', symbol: 'ETH', chainId: '0x1' },
+    ];
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useSendAssetFilter({
+          tokens: tempoTokens,
+          nfts: [],
+          selectedChainId: null,
+          searchQuery: '',
+        }),
+      mockState,
+    );
+
+    expect(result.current.filteredTokens).toEqual([
+      tempoTokens[1],
+      tempoTokens[2],
+    ]);
+  });
 });

--- a/ui/pages/confirmations/hooks/send/useSendAssetFilter.ts
+++ b/ui/pages/confirmations/hooks/send/useSendAssetFilter.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { shouldHideTempoToken } from '../../../../../shared/lib/tempo-utils';
 import { type Asset } from '../../types/send';
 
 type UseSendAssetFilterProps = {
@@ -41,8 +42,17 @@ export const useSendAssetFilter = ({
       matchesSearchQuery(nft, searchQuery),
     );
 
+    const tempoFilteredTokens = filteredTokens.filter((token) => {
+      const chainId =
+        typeof token.chainId === 'string' ? token.chainId : undefined;
+      if (!chainId) {
+        return true;
+      }
+      return !shouldHideTempoToken(chainId, token.isNative, token.symbol);
+    });
+
     return {
-      filteredTokens,
+      filteredTokens: tempoFilteredTokens,
       filteredNfts,
     };
   }, [tokens, nfts, selectedChainId, searchQuery]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

There is no native token on Tempo so there's a hardcoded response for `eth_getBalance` calls. Details here: https://docs.tempo.xyz/quickstart/evm-compatibility#handling-eth-native-token-balance-checks

The proposed improvement in this PR
- filters out the "native asset" on Tempo – USD – across the UI surfaces
- makes the network fee dialog for Tempo transactions to be "< $0.01 USD"

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38734?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Filtered out native tokens on Tempo Testnet

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to https://docs.tempo.xyz/quickstart/faucet
2. Connect your Metamask wallet
3. Fund your wallet and register tokens to your wallet
4. Open your Metamask wallet
5. (Before) notice that USD with a very large number 42424242424... is visible
6. (After) notice that ^ is gone

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1714" height="1222" alt="CleanShot 2025-12-10 at 15 04 44@2x" src="https://github.com/user-attachments/assets/81dc183e-b5c2-4c36-a89c-4ccbda0a7dda" />
<img width="1734" height="716" alt="CleanShot 2025-12-10 at 15 05 07@2x" src="https://github.com/user-attachments/assets/57b250ce-9159-4433-978a-58bcc26cdab9" />
<img width="796" height="704" alt="CleanShot 2025-12-10 at 15 05 32@2x" src="https://github.com/user-attachments/assets/85dadd7a-cfc3-4468-bd43-6e9a7638a259" />


### **After**

<!-- [screenshots/recordings] -->
<img width="1744" height="1396" alt="CleanShot 2025-12-10 at 15 06 15@2x" src="https://github.com/user-attachments/assets/6836221b-7097-4d3c-864d-e67ba5ee20ee" />
<img width="1596" height="994" alt="CleanShot 2025-12-10 at 15 06 39@2x" src="https://github.com/user-attachments/assets/ec9f23e4-3b9f-4c6e-aa21-618ff13f2ead" />
<img width="788" height="1224" alt="CleanShot 2025-12-10 at 15 06 49@2x" src="https://github.com/user-attachments/assets/d99b1986-e99e-4442-9646-58f78fc50361" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Tempo Testnet support with utilities and UI changes to hide native/USD tokens and display fiat fees (USD) for Tempo.
> 
> - **Tempo support**:
>   - Add `CHAIN_IDS.TEMPO_TESTNET` (`0xa5bd`).
>   - New utils `shared/lib/tempo-utils` with `isTempoNetwork` and `shouldHideTempoToken` (+ tests).
> - **UI filtering**:
>   - Token list (`ui/components/app/assets/token-list`) and asset picker modal filter out Tempo native tokens and `USD` via `shouldHideTempoToken`.
>   - Send flow asset filter (`useSendAssetFilter`) excludes Tempo native/`USD` tokens (+ test).
> - **Gas fee display (Tempo)**:
>   - Always show fiat on Tempo; hide token value in advanced view; set selected gas fee token label to `USD` when no token is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ac5cc3bb60dcdc95ce069e3523adec72b523cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->