### PR TITLE
chore: remove migration 171 error logging

### DIFF
--- a/app/scripts/migrations/171.test.ts
+++ b/app/scripts/migrations/171.test.ts
@@ -143,7 +143,7 @@ describe(`migration #${newVersion}`, () => {
   });
 
   describe('when tokenNetworkFilter is empty', () => {
-    it('should return state unchanged and capture exception', async () => {
+    it('should return state unchanged', async () => {
       const oldState = {
         meta: {
           version: oldVersion,
@@ -162,20 +162,9 @@ describe(`migration #${newVersion}`, () => {
         },
       };
 
-      const sentrySpy = jest
-        .spyOn(global.sentry, 'captureException')
-        .mockImplementation();
-
       const newState = await migrate(oldState);
 
-      expect(sentrySpy).toHaveBeenCalledWith(
-        new Error(
-          `Migration ${newVersion}: tokenNetworkFilter is empty, expected at least one network configuration.`,
-        ),
-      );
       expect(newState.data).toStrictEqual(oldState.data);
-
-      sentrySpy.mockRestore();
     });
   });
 

--- a/app/scripts/migrations/171.ts
+++ b/app/scripts/migrations/171.ts
@@ -156,11 +156,6 @@ function transformState(
   }
 
   if (Object.keys(tokenNetworkFilter).length === 0) {
-    global.sentry?.captureException?.(
-      new Error(
-        `Migration ${version}: tokenNetworkFilter is empty, expected at least one network configuration.`,
-      ),
-    );
     return state;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove Sentry error logging for an empty `tokenNetworkFilter` in migration 171, as this is a known and expected condition.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38739?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: remove migration 171 error logging

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35295 https://consensyssoftware.atlassian.net/browse/ASSETS-2023 https://consensyssoftware.atlassian.net/browse/ASSETS-2115

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-b2e29390-a896-48f6-bdf4-ada5afe0cc4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2e29390-a896-48f6-bdf4-ada5afe0cc4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops Sentry logging for empty `tokenNetworkFilter` in migration 171 and updates the corresponding test expectations.
> 
> - **Migration 171 (`app/scripts/migrations/171.ts`)**:
>   - Remove Sentry logging when `preferences.tokenNetworkFilter` is empty; state is returned unchanged.
> - **Tests (`app/scripts/migrations/171.test.ts`)**:
>   - Update empty `tokenNetworkFilter` test to no longer expect `captureException`; still asserts state is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a13756233eb5f9e8cc4f3b044edeff04ec13f02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->