### PR TITLE
chore: Disable `consistent-return` ESLint rule for TypeScript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -243,6 +243,8 @@ module.exports = {
             allowNumber: true,
           },
         ],
+        // TODO: Remove once `@metamask/eslint-config-typescript` is updated to a version with this setting.
+        'consistent-return': 'off',
       },
       settings: {
         'import/resolver': {
@@ -342,7 +344,6 @@ module.exports = {
         'react/no-children-prop': 'off',
         'react/jsx-key': 'warn', // TODO - increase this into 'error' level
         'react-hooks/rules-of-hooks': 'error',
-        'consistent-return': 'off',
       },
       settings: {
         react: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -342,6 +342,7 @@ module.exports = {
         'react/no-children-prop': 'off',
         'react/jsx-key': 'warn', // TODO - increase this into 'error' level
         'react-hooks/rules-of-hooks': 'error',
+        'consistent-return': 'off',
       },
       settings: {
         react: {

--- a/ui/hooks/useGasFeeEstimates.js
+++ b/ui/hooks/useGasFeeEstimates.js
@@ -61,9 +61,7 @@ export function useGasFeeEstimates(_networkClientId, enabled = true) {
 
   useEffect(() => {
     if (!enabled) {
-      return () => {
-        // No cleanup needed when disabled
-      };
+      return;
     }
 
     let isMounted = true;

--- a/ui/hooks/useGasFeeEstimates.js
+++ b/ui/hooks/useGasFeeEstimates.js
@@ -61,7 +61,9 @@ export function useGasFeeEstimates(_networkClientId, enabled = true) {
 
   useEffect(() => {
     if (!enabled) {
-      return;
+      return () => {
+        // No cleanup needed when disabled
+      };
     }
 
     let isMounted = true;

--- a/ui/hooks/usePolling.ts
+++ b/ui/hooks/usePolling.ts
@@ -29,9 +29,7 @@ const usePolling = <PollingInput>(
 
   useEffect(() => {
     if (usePollingOptions.enabled === false || !hasPollingInputChanged) {
-      return () => {
-        // noop
-      };
+      return;
     }
 
     const cleanup = () => {

--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -206,9 +206,7 @@ const useHistoricalPricesNonEvm = ({
    */
   useEffect(() => {
     if (isEvm) {
-      return () => {
-        // No clean up needed
-      };
+      return;
     }
 
     // On non-EVM, we fetch the prices from the snap, then store them in the redux state, and grab them from the redux state


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- TypeScript prevents the mistake `consistent-return` intends to guard against (e.g. accidentally returning nothing when a value is expected). 
- `consistent-return` causes confusion and warning fatigue by flagging correct, idiomatic code (e.g. returning void on early exit) and enforcing counterintuitive, unhelpful patterns (e.g. returning unnecessary noop callback in `useEffect` hooks).

See https://github.com/MetaMask/metamask-extension/pull/38339#discussion_r2608303698

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38740?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `consistent-return` for TS and removes unnecessary noop cleanup returns in React hooks.
> 
> - **ESLint/Config**
>   - Disable `consistent-return` for TypeScript files in `.eslintrc.js`.
> - **UI/Hooks**
>   - `ui/hooks/usePolling.ts`: Simplify `useEffect` early return (remove noop cleanup function).
>   - `ui/pages/asset/hooks/useHistoricalPrices.ts`: Simplify `useEffect` early return in non-EVM path (remove noop cleanup function).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a0871fc49f56cbc32edbbb6acc700b82ab943e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->