### PR TITLE
fix: RPC URL deduplication on `addEthereumChainHandler` cp-13.13.0

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -181,11 +181,12 @@ async function addEthereumChainHandler(
           name: chainName,
           nativeCurrency: ticker,
           rpcEndpoints: [
-            // Metamask may using a public RPC endpoint form FEATURED_RPCS,
-            // if the URL `firstValidRPCUrl` send from client is the same with the one in FEATURED_RPCS,
-            // it will be failed in validation due to duplication of the same URL.
+            // MetaMask may use a public RPC endpoint from FEATURED_RPCS,
+            // if the URL `firstValidRPCUrl` sent from the client is the same as the one in FEATURED_RPCS,
+            // it will fail validation due to duplication of the same URL.
             // So we only add the featured endpoint if the URL is different.
-            ...(featuredEndpoint && firstValidRPCUrl !== featuredEndpoint.url
+            ...(featuredEndpoint &&
+            !URI.equal(firstValidRPCUrl, featuredEndpoint.url)
               ? [featuredEndpoint]
               : []),
             {

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -181,7 +181,13 @@ async function addEthereumChainHandler(
           name: chainName,
           nativeCurrency: ticker,
           rpcEndpoints: [
-            ...(featuredEndpoint ? [featuredEndpoint] : []),
+            // Metamask may using a public RPC endpoint form FEATURED_RPCS,
+            // if the URL `firstValidRPCUrl` send from client is the same with the one in FEATURED_RPCS,
+            // it will be failed in validation due to duplication of the same URL.
+            // So we only add the featured endpoint if the URL is different.
+            ...(featuredEndpoint && firstValidRPCUrl !== featuredEndpoint.url
+              ? [featuredEndpoint]
+              : []),
             {
               url: firstValidRPCUrl,
               name: chainName,

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -1,5 +1,8 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  CHAIN_IDS,
+  FEATURED_RPCS,
+} from '../../../../../shared/constants/network';
 import addEthereumChain from './add-ethereum-chain';
 import EthChainUtils from './ethereum-chain-utils';
 
@@ -155,6 +158,47 @@ describe('addEthereumChainHandler', () => {
     expect(end).toHaveBeenCalledWith(
       rpcErrors.invalidParams(new Error('failed to validate params')),
     );
+  });
+
+  it('should deduplicate the featured endpoint if the URL `firstValidRPCUrl` send from client is the same with the one in FEATURED_RPCS', async () => {
+    const rpcUrl = FEATURED_RPCS.find(
+      (f) => f.chainId === CHAIN_IDS.LINEA_MAINNET,
+    )?.rpcEndpoints[0].url;
+    const { handler, mocks } = createMockedHandler();
+
+    const request = {
+      origin: 'example.com',
+      params: [
+        {
+          chainId: CHAIN_IDS.LINEA_MAINNET,
+          chainName: 'Linea',
+          rpcUrls: [rpcUrl],
+          nativeCurrency: {
+            symbol: 'ETH',
+            decimals: 18,
+          },
+          blockExplorerUrls: ['https://etherscan.io'],
+        },
+      ],
+    };
+
+    await handler(request);
+
+    expect(mocks.addNetwork).toHaveBeenCalledWith({
+      blockExplorerUrls: ['https://etherscan.io'],
+      defaultBlockExplorerUrlIndex: 0,
+      chainId: CHAIN_IDS.LINEA_MAINNET,
+      defaultRpcEndpointIndex: 0,
+      name: 'Linea',
+      nativeCurrency: 'ETH',
+      rpcEndpoints: [
+        {
+          url: rpcUrl,
+          name: 'Linea',
+          type: 'custom',
+        },
+      ],
+    });
   });
 
   it('creates a new network configuration for the given chainid and switches to it if no networkConfigurations with the same chainId exist', async () => {

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js
@@ -160,7 +160,7 @@ describe('addEthereumChainHandler', () => {
     );
   });
 
-  it('should deduplicate the featured endpoint if the URL `firstValidRPCUrl` send from client is the same with the one in FEATURED_RPCS', async () => {
+  it('should deduplicate the featured endpoint if the URL `firstValidRPCUrl` send from client is the same as the one in FEATURED_RPCS', async () => {
     const rpcUrl = FEATURED_RPCS.find(
       (f) => f.chainId === CHAIN_IDS.LINEA_MAINNET,
     )?.rpcEndpoints[0].url;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fix a issue on JSON RPC `wallet_addEthereumChain`
When client send a wallet_addEthereumChain request
and if the PRC URL from the request is same with the RPC URL in FEATURED_RPCS of that chain
there will be a error
<img width="500" alt="image" src="https://github.com/user-attachments/assets/628d8b05-8482-462b-99e3-343d8142aa17" />



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38752?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug for duplicate the RPC URL with `FEATURED_RPCS`  for `wallet_addEthereumChain`

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38756

## **Manual testing steps**

1. Go to http://chainlist.org/chain/999
2. connect wallet
3. add network
4. network should be added without error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/25e8d02e-e3aa-4d7d-a929-0f01da841602" />


### **After**

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/2d36432f-4d3a-4f29-b0d0-151285bf5e7d" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips adding the featured RPC endpoint if it matches the client-provided RPC URL in `addEthereumChain`, and adds a unit test to cover this case.
> 
> - **Handler (`app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js`)**:
>   - Deduplicates RPC endpoints by skipping the featured endpoint when `firstValidRPCUrl` equals the featured RPC URL (via `URI.equal`).
>   - Constructs `rpcEndpoints` without the featured entry in that case, keeping the client URL as the sole custom endpoint.
> - **Tests (`app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.test.js`)**:
>   - Adds test ensuring featured RPC is not duplicated when matching the client-sent URL.
>   - Updates imports to use `FEATURED_RPCS` for test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c35f4be44609a77aec9e04dce3cb9d122f679d7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->