### PR TITLE
fix: Correct styling for Snap insights

### DIFF
--- a/ui/components/ui/delineator/delineator.tsx
+++ b/ui/components/ui/delineator/delineator.tsx
@@ -127,7 +127,7 @@ const Container = ({
       className="delineator__wrapper"
       display={Display.Flex}
       flexDirection={FlexDirection.Column}
-      backgroundColor={BackgroundColor.backgroundDefault}
+      backgroundColor={BackgroundColor.backgroundSection}
       borderRadius={BorderRadius.LG}
       {...wrapperBoxProps}
     >

--- a/ui/components/ui/delineator/index.scss
+++ b/ui/components/ui/delineator/index.scss
@@ -1,4 +1,8 @@
 .delineator {
+  &__wrapper {
+    overflow: auto;
+  }
+
   &__header {
     cursor: pointer;
 

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/__snapshots__/snaps-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/__snapshots__/snaps-section.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SnapsSection renders section for typed sign request 1`] = `
     class="mm-box mm-box--margin-bottom-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column"
   >
     <div
-      class="mm-box delineator__wrapper mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-background-default mm-box--rounded-lg"
+      class="mm-box delineator__wrapper mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-background-section mm-box--rounded-lg"
     >
       <div
         class="mm-box delineator__header delineator__header--expanded mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-0 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center"
@@ -39,7 +39,7 @@ exports[`SnapsSection renders section for typed sign request 1`] = `
         class="mm-box mm-box--padding-top-0 mm-box--padding-right-0 mm-box--padding-bottom-0 mm-box--padding-left-0 mm-box--flex-direction-column"
       >
         <div
-          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-default"
+          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-section"
           style="overflow-y: auto;"
         >
           <div
@@ -68,7 +68,7 @@ exports[`SnapsSection renders section personal sign request 1`] = `
     class="mm-box mm-box--margin-bottom-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column"
   >
     <div
-      class="mm-box delineator__wrapper mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-background-default mm-box--rounded-lg"
+      class="mm-box delineator__wrapper mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-background-section mm-box--rounded-lg"
     >
       <div
         class="mm-box delineator__header delineator__header--expanded mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-0 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center"
@@ -101,7 +101,7 @@ exports[`SnapsSection renders section personal sign request 1`] = `
         class="mm-box mm-box--padding-top-0 mm-box--padding-right-0 mm-box--padding-bottom-0 mm-box--padding-left-0 mm-box--flex-direction-column"
       >
         <div
-          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-default"
+          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-section"
           style="overflow-y: auto;"
         >
           <div

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/snap-insight.tsx
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/snap-insight.tsx
@@ -75,7 +75,7 @@ export const SnapInsight: React.FunctionComponent<SnapInsightProps> = ({
         snapId={snapId}
         interfaceId={interfaceId}
         isLoading={loading}
-        contentBackgroundColor={BackgroundColor.backgroundDefault}
+        contentBackgroundColor={BackgroundColor.backgroundSection}
       />
     </Delineator>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Correct the styling for Snap insights which had been broken in another commit.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38755?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue with Snap insights styling

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="436" height="654" alt="image" src="https://github.com/user-attachments/assets/cdfb5bac-a076-407a-9a6d-13aee7ebf8c8" />

### **After**

<img width="464" height="662" alt="image" src="https://github.com/user-attachments/assets/c917a092-cc49-4b62-a8ee-ed374b5369ca" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Delineator and Snap Insight content to use section background and adds overflow handling to the wrapper.
> 
> - **UI**:
>   - **Delineator (`ui/components/ui/delineator/delineator.tsx`)**: Set `backgroundColor` to `BackgroundColor.backgroundSection`.
>   - **Styles (`ui/components/ui/delineator/index.scss`)**: Add `overflow: auto` to `.delineator__wrapper`.
>   - **Snap Insight (`.../snaps-section/snap-insight.tsx`)**: Use `BackgroundColor.backgroundSection` for `SnapUIRenderer` `contentBackgroundColor`.
> - **Tests**:
>   - Update snapshots to reflect section background classes and overflow-enabled wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec86a07b9c1da5b13a9b063202d94eb0a3d38d74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->