### PR TITLE
feat: cp-13.13.0 remove sidepanel for arc browser

### DIFF
--- a/shared/modules/environment.ts
+++ b/shared/modules/environment.ts
@@ -54,5 +54,13 @@ export const getIsSidePanelFeatureEnabled = (): boolean => {
     return false;
   }
 
+  // Arc browser doesn't support sidepanel properly
+  if (
+    typeof window !== 'undefined' &&
+    window.navigator?.userAgent?.includes('Arc/')
+  ) {
+    return false;
+  }
+
   return true;
 };

--- a/shared/modules/environment.ts
+++ b/shared/modules/environment.ts
@@ -54,12 +54,19 @@ export const getIsSidePanelFeatureEnabled = (): boolean => {
     return false;
   }
 
-  // Arc browser doesn't support sidepanel properly
-  if (
-    typeof window !== 'undefined' &&
-    window.navigator?.userAgent?.includes('Arc/')
-  ) {
-    return false;
+  // Arc browser doesn't support sidepanel properly.
+  // Arc uses a Chrome-identical user agent, so we detect it via its unique CSS variable.
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    try {
+      const arcPaletteTitle = getComputedStyle(
+        document.documentElement,
+      ).getPropertyValue('--arc-palette-title');
+      if (arcPaletteTitle) {
+        return false;
+      }
+    } catch (error) {
+      console.warn('Arc browser detection failed:', error);
+    }
   }
 
   return true;

--- a/ui/hooks/useBrowserSupportsSidePanel.ts
+++ b/ui/hooks/useBrowserSupportsSidePanel.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook to check if the browser actually supports sidepanel.
+ * Some browsers like Arc have the sidePanel API but it doesn't work properly.
+ * This hook verifies by querying for sidepanel contexts.
+ *
+ * @returns boolean | null - true if supported, false if not, null while checking
+ */
+export const useBrowserSupportsSidePanel = (): boolean | null => {
+  const [isSupported, setIsSupported] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkSupport = async () => {
+      try {
+        // Check if chrome.runtime.getContexts exists
+        if (!chrome?.runtime?.getContexts) {
+          setIsSupported(false);
+          return;
+        }
+
+        // Try to query for sidepanel contexts
+        // On browsers that don't properly support sidepanel, this may fail or return unexpected results
+        await chrome.runtime.getContexts({
+          contextTypes: ['SIDE_PANEL' as chrome.runtime.ContextType],
+        });
+
+        // If we get here without error, the API works
+        setIsSupported(true);
+      } catch (error) {
+        console.log('Browser does not support sidepanel:', error);
+        setIsSupported(false);
+      }
+    };
+
+    checkSupport();
+  }, []);
+
+  return isSupported;
+};
+

--- a/ui/hooks/useBrowserSupportsSidePanel.ts
+++ b/ui/hooks/useBrowserSupportsSidePanel.ts
@@ -38,4 +38,3 @@ export const useBrowserSupportsSidePanel = (): boolean | null => {
 
   return isSupported;
 };
-

--- a/ui/hooks/useSidePanelEnabled.ts
+++ b/ui/hooks/useSidePanelEnabled.ts
@@ -1,9 +1,12 @@
+import { getIsSidePanelFeatureEnabled } from '../../shared/modules/environment';
+
 /**
  * Custom hook to check if sidepanel feature is enabled.
- * Checks the build-time environment flag.
+ * Checks the build-time environment flag and browser compatibility.
+ * Returns false for Firefox (no sidePanel API) and Arc browser (doesn't support sidepanel properly).
  *
  * @returns boolean - True if sidepanel feature is enabled, false otherwise
  */
 export const useSidePanelEnabled = (): boolean => {
-  return process.env.IS_SIDEPANEL?.toString() === 'true';
+  return getIsSidePanelFeatureEnabled();
 };


### PR DESCRIPTION
This PR is to remove sidepanel support for arc browser

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38757?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: removed sidepanel for arc

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a fresh build in arc browser
2. Open wallet should open extension in full page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables side panel on Arc via environment detection, adds a runtime support hook, and hardens the global menu toggle flow to verify side panel availability before switching.
> 
> - **Side panel support gating**
>   - Add `getIsSidePanelFeatureEnabled` in `shared/modules/environment.ts` to gate side panel by build flag, API presence, and Arc detection via `--arc-palette-title`.
>   - Refactor `useSidePanelEnabled` to use `getIsSidePanelFeatureEnabled`.
> - **Runtime support check**
>   - Introduce `useBrowserSupportsSidePanel` hook that probes `chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] })` to confirm real support.
> - **Global menu behavior** (`ui/components/multichain/global-menu/global-menu.tsx`)
>   - Use `useBrowserSupportsSidePanel` to conditionally show the side panel toggle.
>   - Rework `toggleDefaultView` logic:
>     - When in side panel, switch to popup and close the side panel.
>     - From popup, verify `browser.sidePanel.open` exists, attempt open, then confirm side panel context before setting `useSidePanelAsDefault` and closing popup; otherwise no-op.
>   - Update labels/conditions to avoid offering side panel where unsupported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b44f6927b789ac28d96c479be2d784713445e70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->