### PR TITLE
feat: disabled 'Open Wallet' button when sidepanel is open cp-13.13.0

### DIFF
--- a/shared/types/sidepanel.ts
+++ b/shared/types/sidepanel.ts
@@ -2,5 +2,9 @@
 export type BrowserWithSidePanel = typeof browser & {
   sidePanel?: {
     open: (options: { windowId?: number }) => Promise<void>;
+    onClosed: {
+      addListener: (callback: (args: unknown) => void) => void;
+      removeListener: (callback: (args: unknown) => void) => void;
+    };
   };
 };

--- a/shared/types/sidepanel.ts
+++ b/shared/types/sidepanel.ts
@@ -2,6 +2,7 @@
 export type BrowserWithSidePanel = typeof browser & {
   sidePanel?: {
     open: (options: { windowId?: number }) => Promise<void>;
+    // REFERENCE: {@link https://developer.chrome.com/docs/extensions/reference/api/sidePanel#event-onClosed}
     onClosed: {
       addListener: (callback: (args: unknown) => void) => void;
       removeListener: (callback: (args: unknown) => void) => void;

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useContext } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import browser from 'webextension-polyfill';
@@ -79,6 +85,31 @@ export default function CreationSuccessful() {
   const isFromReminder = searchParams.get('isFromReminder');
   const isFromSettingsSecurity = searchParams.get('isFromSettingsSecurity');
   const isFromSettingsSRPBackup = isWalletReady && isFromReminder;
+
+  const [isSidePanelOpen, setIsSidePanelOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const browserWithSidePanel = browser as BrowserWithSidePanel;
+    const handleSidePanelClosed = (_args: unknown) => {
+      setIsSidePanelOpen(false);
+    };
+
+    if (isSidePanelEnabled) {
+      if (browserWithSidePanel?.sidePanel?.onClosed?.addListener) {
+        browserWithSidePanel.sidePanel.onClosed.addListener(
+          handleSidePanelClosed,
+        );
+      }
+    }
+
+    return () => {
+      if (browserWithSidePanel?.sidePanel?.onClosed?.removeListener) {
+        browserWithSidePanel.sidePanel.onClosed.removeListener(
+          handleSidePanelClosed,
+        );
+      }
+    };
+  }, [isSidePanelEnabled]);
 
   const renderDetails1 = useMemo(() => {
     if (isFromReminder) {
@@ -178,6 +209,7 @@ export default function CreationSuccessful() {
             await dispatch(setUseSidePanelAsDefault(true));
             // Use the sidepanel-specific action - no navigation needed, sidepanel is already open
             await dispatch(setCompletedOnboardingWithSidepanel());
+            setIsSidePanelOpen(true);
             return;
           }
         }
@@ -216,6 +248,7 @@ export default function CreationSuccessful() {
           size={ButtonSize.Lg}
           width={BlockSize.Full}
           onClick={onDone}
+          disabled={isSidePanelEnabled && isSidePanelOpen}
         >
           {isSidePanelEnabled ? t('openWallet') : t('done')}
         </Button>

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -101,6 +101,10 @@ export default function CreationSuccessful() {
         browserWithSidePanel.sidePanel.onClosed.addListener(
           handleSidePanelClosed,
         );
+      } else {
+        console.warn('`sidePanel.onClosed` event is not available');
+        // If the event is not available, we set the state to false to prevent the button from being disabled
+        setIsSidePanelOpen(false);
       }
     }
 

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -95,6 +95,8 @@ export default function CreationSuccessful() {
     };
 
     if (isSidePanelEnabled) {
+      // NOTE: `sidePanel.onClosed` event is only available on later versions of Chrome
+      // REFERENCE: {@link https://developer.chrome.com/docs/extensions/reference/api/sidePanel#event-onClosed}
       if (browserWithSidePanel?.sidePanel?.onClosed?.addListener) {
         browserWithSidePanel.sidePanel.onClosed.addListener(
           handleSidePanelClosed,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the `Open Wallet` button state in the Onboarding Completion page with the Side Panel.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38760?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disabled `Open Wallet` button when Side Panel is opened in Onboarding Complete page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38652

## **Manual testing steps**

1. Start new wallet. 
2. On the onboarding completion page, clicked on the `Open Wallet` button.
3. The side panel should appear and the button should be disabled.
4. When the side panel is closed, the button should be enabled again.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the onboarding "Open Wallet" button while the side panel is open and re-enables it on close, adding type support for sidePanel.onClosed.
> 
> - **UI (onboarding completion)**:
>   - Track side panel state with `isSidePanelOpen` and `useEffect` listener for `sidePanel.onClosed` to re-enable the button when closed.
>   - Set `isSidePanelOpen` to `true` after invoking `sidePanel.open`; disable primary action button via `disabled={isSidePanelEnabled && isSidePanelOpen}`.
>   - Cleanup `onClosed` listener on unmount; fallback with warning if event unsupported.
> - **Types**:
>   - Augment `BrowserWithSidePanel` to include `sidePanel.onClosed.addListener/removeListener`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 911685a9d9a3f7958874b6b2d610c341e829dc08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->