### PR TITLE
fix: cp-13.13.0 advance gas fee editing modal when non-evm chain is selected

### DIFF
--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -96,6 +96,7 @@ const BaseFeeInput = () => {
   const [baseFeeInPrimaryCurrency] = useCurrencyDisplay(
     decGWEIToHexWEI(baseFee * gasLimit),
     { currency, numberOfDecimals },
+    chainId,
   );
 
   const updateBaseFee = useCallback(

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -93,6 +93,7 @@ const PriorityFeeInput = () => {
   const [priorityFeeInPrimaryCurrency] = useCurrencyDisplay(
     decGWEIToHexWEI(priorityFee * gasLimit),
     { currency, numberOfDecimals },
+    chainId,
   );
 
   const updatePriorityFee = (value) => {

--- a/ui/pages/confirmations/hooks/useGasEstimates.js
+++ b/ui/pages/confirmations/hooks/useGasEstimates.js
@@ -100,10 +100,14 @@ export function useGasEstimates({
   // The minimum amount this transaction will cost
   const minimumCostInHexWei = getMinimumGasTotalInHexWei(gasSettings);
 
-  const [estimatedMinimumNative] = useCurrencyDisplay(minimumCostInHexWei, {
-    numberOfDecimals: primaryNumberOfDecimals,
-    currency: primaryCurrency,
-  });
+  const [estimatedMinimumNative] = useCurrencyDisplay(
+    minimumCostInHexWei,
+    {
+      numberOfDecimals: primaryNumberOfDecimals,
+      currency: primaryCurrency,
+    },
+    transaction?.chainId,
+  );
 
   return {
     estimatedMinimumNative,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix issue with error being thrown during advance gas fee editing for transaction on EVM chain if a non-evm network is selected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38761

## **Manual testing steps**

1. Select non-evm network extension
2. Submit evm transaction
3. Go for advance gas editing, it should work as expected

## **Screenshots/Recordings**

Uploading Screen Recording 2025-12-11 at 4.40.37 PM.mov…

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates `chainId` to `useCurrencyDisplay` in advanced gas fee inputs and gas estimates to correctly format costs per network.
> 
> - **Advanced Gas Fee UI**:
>   - `base-fee-input.js`: Pass `chainId` to `useCurrencyDisplay` when computing `baseFeeInPrimaryCurrency`.
>   - `priority-fee-input.js`: Pass `chainId` to `useCurrencyDisplay` for `priorityFeeInPrimaryCurrency`.
> - **Hooks**:
>   - `useGasEstimates.js`: Pass `transaction?.chainId` to `useCurrencyDisplay` for `estimatedMinimumNative`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa154b9c7e55b77b01ebeb01229e12b2ccdde360. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->