### PR TITLE
chore: Apply `react-hooks/exhaustive-deps` checks to `useAsync` custom hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -299,6 +299,12 @@ module.exports = {
         'react/no-deprecated': 'error',
         'react/default-props-match-prop-types': 'error',
         'react/jsx-no-duplicate-props': 'error',
+        'react-hooks/exhaustive-deps': [
+          'warn',
+          {
+            additionalHooks: 'useAsync(Callback|Result|ResultOrThrow)',
+          },
+        ],
       },
       settings: {
         react: {
@@ -342,6 +348,12 @@ module.exports = {
         'react/no-children-prop': 'off',
         'react/jsx-key': 'warn', // TODO - increase this into 'error' level
         'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': [
+          'warn',
+          {
+            additionalHooks: 'useAsync(Callback|Result|ResultOrThrow)',
+          },
+        ],
       },
       settings: {
         react: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`react-hooks` ESLint checks are essential to enforce the [rules of hooks](https://react.dev/reference/rules/rules-of-hooks), which is in turn necessary for React Compiler optimizations to be applied. 

The `useAsync(Callback|Result|ResultOrThrow)` custom hooks are used widely in performance-heavy flows (36 results across 25 files), but lack `exhaustive-deps` checks, leading to silent errors from stale closure, and/or incomplete or blocked optimizations, which will only get worse over time with code drift. 

This commit fixes this issue by ensuring that these custom hooks are subject to lint checks for exhaustive dependency enumeration. This comes at the cost of increased warnings in CI, but in this case we should prioritize preventing silent failure cases.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38768?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

- Closes https://github.com/MetaMask/MetaMask-planning/issues/6455

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d33b1c507e18f0939b58d81125721f27fd534aea. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->