### PR TITLE
fix(e2e): check for nullish value in `checkHasAccountSyncingSyncedAtLeastOnce`

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -408,11 +408,19 @@ class HomePage {
    */
   async checkHasAccountSyncingSyncedAtLeastOnce(): Promise<void> {
     console.log('Check if account syncing has synced at least once');
-    await this.driver.wait(async () => {
-      const uiState = await getCleanAppState(this.driver);
-      // Check for nullish, as the state we might seems to be `null` sometimes.
-      return uiState?.metamask.hasAccountTreeSyncingSyncedAtLeastOnce === true;
-    }, 30000); // Syncing can take some time so adding a longer timeout to reduce flakes
+    await this.driver.waitUntil(
+      async () => {
+        const uiState = await getCleanAppState(this.driver);
+        // Check for nullish, as the state we might seems to be `null` sometimes.
+        return (
+          uiState?.metamask.hasAccountTreeSyncingSyncedAtLeastOnce === true
+        );
+      },
+      {
+        interval: 1000,
+        timeout: 30000, // Syncing can take some time so adding a longer timeout to reduce flakes
+      },
+    );
   }
 
   async checkIfSendButtonIsClickable(): Promise<boolean> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -410,7 +410,8 @@ class HomePage {
     console.log('Check if account syncing has synced at least once');
     await this.driver.wait(async () => {
       const uiState = await getCleanAppState(this.driver);
-      return uiState.metamask.hasAccountTreeSyncingSyncedAtLeastOnce === true;
+      // Check for nullish, as the state we might seems to be `null` sometimes.
+      return uiState?.metamask.hasAccountTreeSyncingSyncedAtLeastOnce === true;
     }, 30000); // Syncing can take some time so adding a longer timeout to reduce flakes
   }
 

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -413,7 +413,7 @@ class HomePage {
         const uiState = await getCleanAppState(this.driver);
         // Check for nullish, as the state we might seems to be `null` sometimes.
         return (
-          uiState?.metamask.hasAccountTreeSyncingSyncedAtLeastOnce === true
+          uiState?.metamask?.hasAccountTreeSyncingSyncedAtLeastOnce === true
         );
       },
       {


### PR DESCRIPTION
## **Description**

Should fix this kind of issue:

```console
Failure on testcase: 'Account syncing - Accounts with Balances gracefully handles adding accounts with balances and synced accounts', for more information see the artifacts tab in CI

TypeError: Cannot read properties of null (reading 'metamask')
```

I assume the state can be "nullish", thus using `?.` should fix `checkHasAccountSyncingSyncedAtLeastOnce` calls.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38774?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the e2e account syncing check more robust by using waitUntil with polling and null-safe state access.
> 
> - **E2E tests**
>   - **`test/e2e/page-objects/pages/home/homepage.ts`**
>     - Update `checkHasAccountSyncingSyncedAtLeastOnce`:
>       - Use `driver.waitUntil` with `{ interval: 1000, timeout: 30000 }`.
>       - Null-safe access to Redux state via `uiState?.metamask?.hasAccountTreeSyncingSyncedAtLeastOnce`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218825df67ab7386600968b7ce49fafbf7ec4a8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->