### PR TITLE
fix: Bump @metamask/smart-transactions-controller to ^21.0.0 cp-13.13.0

### DIFF
--- a/app/scripts/controller-init/messengers/smart-transactions-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/smart-transactions-controller-messenger.ts
@@ -1,6 +1,5 @@
 import { Messenger } from '@metamask/messenger';
 import type {
-  TransactionControllerConfirmExternalTransactionAction,
   TransactionControllerGetNonceLockAction,
   TransactionControllerGetTransactionsAction,
   TransactionControllerUpdateTransactionAction,
@@ -18,8 +17,7 @@ type MessengerActions =
   | NetworkControllerGetStateAction
   | TransactionControllerGetNonceLockAction
   | TransactionControllerGetTransactionsAction
-  | TransactionControllerUpdateTransactionAction
-  | TransactionControllerConfirmExternalTransactionAction;
+  | TransactionControllerUpdateTransactionAction;
 
 type MessengerEvents = NetworkControllerStateChangeEvent;
 
@@ -45,7 +43,6 @@ export function getSmartTransactionsControllerMessenger(
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',
       'TransactionController:getNonceLock',
-      'TransactionController:confirmExternalTransaction',
       'TransactionController:getTransactions',
       'TransactionController:updateTransaction',
     ],

--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -136,7 +136,6 @@ function withRequest<ReturnValue>(
     messenger: smartTransactionsControllerMessenger,
     actions: [
       'TransactionController:getNonceLock',
-      'TransactionController:confirmExternalTransaction',
       'TransactionController:getTransactions',
       'TransactionController:updateTransaction',
     ],

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2054,7 +2054,6 @@
         "@metamask/smart-transactions-controller>@metamask/polling-controller": true,
         "@metamask/transaction-controller": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "fast-json-patch": true,
         "lodash": true
       }
     },

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -2054,7 +2054,6 @@
         "@metamask/smart-transactions-controller>@metamask/polling-controller": true,
         "@metamask/transaction-controller": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "fast-json-patch": true,
         "lodash": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2054,7 +2054,6 @@
         "@metamask/smart-transactions-controller>@metamask/polling-controller": true,
         "@metamask/transaction-controller": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "fast-json-patch": true,
         "lodash": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2054,7 +2054,6 @@
         "@metamask/smart-transactions-controller>@metamask/polling-controller": true,
         "@metamask/transaction-controller": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "fast-json-patch": true,
         "lodash": true
       }
     },

--- a/lavamoat/webpack/mv2/policy.json
+++ b/lavamoat/webpack/mv2/policy.json
@@ -2045,7 +2045,6 @@
         "@metamask/smart-transactions-controller>@metamask/polling-controller": true,
         "@metamask/transaction-controller": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "fast-json-patch": true,
         "lodash": true
       }
     },

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/shield-controller": "^3.1.0",
     "@metamask/signature-controller": "^35.0.0",
-    "@metamask/smart-transactions-controller": "^20.0.0",
+    "@metamask/smart-transactions-controller": "^21.0.0",
     "@metamask/snaps-controllers": "^17.1.1",
     "@metamask/snaps-execution-environments": "^10.3.0",
     "@metamask/snaps-rpc-methods": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8179,9 +8179,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^20.0.0":
-  version: 20.0.0
-  resolution: "@metamask/smart-transactions-controller@npm:20.0.0"
+"@metamask/smart-transactions-controller@npm:^21.0.0":
+  version: 21.0.0
+  resolution: "@metamask/smart-transactions-controller@npm:21.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -8212,7 +8212,7 @@ __metadata:
       optional: true
     "@metamask/remote-feature-flag-controller":
       optional: true
-  checksum: 10/8c3bb501531820c1d2d470d433b8f3a4335e9e45bc87edbc0c6a4c2ebf57bdabf5a1b67b4614fd84bb5c0ac17595690fae473afd5ab169c8b0d8b5a57521c4ef
+  checksum: 10/a0d5c58f3671368a9f6649eef5c0ffe9b82c562662adf0641c898c32299577ead9f40514b2f44e805b8a0641335eaa36f14a3bf33eae037b6f063c338138f360
   languageName: node
   linkType: hard
 
@@ -32958,7 +32958,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/shield-controller": "npm:^3.1.0"
     "@metamask/signature-controller": "npm:^35.0.0"
-    "@metamask/smart-transactions-controller": "npm:^20.0.0"
+    "@metamask/smart-transactions-controller": "npm:^21.0.0"
     "@metamask/snap-account-abstraction-keyring-site": "npm:^1.0.0"
     "@metamask/snap-simple-keyring-site": "npm:^2.0.0"
     "@metamask/snaps-controllers": "npm:^17.1.1"


### PR DESCRIPTION
## **Description**
Changes: https://github.com/MetaMask/smart-transactions-controller/releases/tag/v21.0.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38775?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38764

## **Manual testing steps**

Quickest way is to upgrade or downgrade an EIP-7702 account and use any gas fee token, with STX enabled.

Before this fix only one transaction from a batch would be marked as failed, with this all transactions in a batch are marked as failed. It only started happening after we started returning a txHash asap. Before that all transactions were being marked as failed in the TransactionController.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `@metamask/smart-transactions-controller` to ^21.0.0 and removes `TransactionController:confirmExternalTransaction` usage in the Smart Transactions messenger and tests, with corresponding LavaMoat policy updates.
> 
> - **Dependencies**:
>   - Upgrade `@metamask/smart-transactions-controller` to `^21.0.0` (lockfile updated).
> - **Smart Transactions Messenger**:
>   - Remove `TransactionController:confirmExternalTransaction` from allowed actions/types in `app/scripts/controller-init/messengers/smart-transactions-controller-messenger.ts`.
>   - Update tests in `app/scripts/lib/smart-transaction/smart-transactions.test.ts` to reflect the removed action.
> - **LavaMoat Policies**:
>   - Update policy files to align with the new controller version (e.g., drop `fast-json-patch` allowance under smart-transactions controller).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d85aa637ef0fd8dc048ccb51b0c8ce844275406e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->