### PR TITLE
fix: type-4 nonce calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/streams": "^0.4.0",
     "@metamask/subscription-controller": "^5.3.1",
-    "@metamask/transaction-controller": "^62.3.1",
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.6.0-preview-d2037635",
     "@metamask/transaction-pay-controller": "^10.2.0",
     "@metamask/tron-wallet-snap": "^1.16.0",
     "@metamask/user-operation-controller": "^40.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8650,6 +8650,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@62.6.0-preview-d2037635":
+  version: 62.6.0-preview-d2037635
+  resolution: "@metamask-previews/transaction-controller@npm:62.6.0-preview-d2037635"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^35.0.0"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^27.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^3.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.8.1"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/a8f6d5795100dfdbf827290de8259d966ea59788a74b58279e97708c24280a46634d558cab6582388b4d2202526b7e7cf1ba07235bac4203e2419fa96d51176b
+  languageName: node
+  linkType: hard
+
 "@metamask/transaction-controller@npm:^61.0.0":
   version: 61.2.0
   resolution: "@metamask/transaction-controller@npm:61.2.0"
@@ -32976,7 +33014,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.0"
     "@metamask/test-dapp-solana": "npm:^0.3.1"
     "@metamask/test-snaps": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^62.3.1"
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.6.0-preview-d2037635"
     "@metamask/transaction-pay-controller": "npm:^10.2.0"
     "@metamask/tron-wallet-snap": "npm:^1.16.0"
     "@metamask/user-operation-controller": "npm:^40.0.0"


### PR DESCRIPTION
## **Description**

Bump `@metamask/transaction-controller` to correctly calculate nonces with pending type-4 transactions. 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#23881](https://github.com/MetaMask/metamask-mobile/issues/23881)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `@metamask/transaction-controller` to preview release `62.6.0-preview-d2037635`.
> 
> - **Dependencies**:
>   - Switch `@metamask/transaction-controller` to preview release `62.6.0-preview-d2037635` via npm alias in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d95886ad30cdc36859715fe68f27c4834da83e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->