### PR TITLE
feat: avoid shield details icon from shrinking

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6432,11 +6432,11 @@
     "message": "Priority support"
   },
   "shieldTxDetails3Description": {
-    "message": "Get $1 points/$2.",
+    "message": "Get $1 points/$2",
     "description": "The $1 is the number of points, $2 is the plan interval (month or year)"
   },
   "shieldTxDetails3DescriptionLinkReward": {
-    "message": "Link Rewards"
+    "message": "Link"
   },
   "shieldTxDetails3DescriptionSignUp": {
     "message": "Sign up"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6432,11 +6432,11 @@
     "message": "Priority support"
   },
   "shieldTxDetails3Description": {
-    "message": "Get $1 points/$2.",
+    "message": "Get $1 points/$2",
     "description": "The $1 is the number of points, $2 is the plan interval (month or year)"
   },
   "shieldTxDetails3DescriptionLinkReward": {
-    "message": "Link Rewards"
+    "message": "Link"
   },
   "shieldTxDetails3DescriptionSignUp": {
     "message": "Sign up"

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -630,7 +630,7 @@ const TransactionShield = () => {
                   style={{ flexShrink: 0 }}
                 />
               ) : (
-                <Box>
+                <Box className="flex-shrink-0">
                   <Icon name={detail.icon} size={IconSize.Xl} />
                 </Box>
               )}
@@ -666,7 +666,7 @@ const TransactionShield = () => {
               paddingTop={2}
               paddingBottom={2}
             >
-              <Box>
+              <Box className="flex-shrink-0">
                 <Icon name={IconName.MetamaskFoxOutline} size={IconSize.Xl} />
               </Box>
               <Box

--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -630,7 +630,9 @@ const TransactionShield = () => {
                   style={{ flexShrink: 0 }}
                 />
               ) : (
-                <Icon name={detail.icon} size={IconSize.Xl} />
+                <Box>
+                  <Icon name={detail.icon} size={IconSize.Xl} />
+                </Box>
               )}
               <Box
                 width={BlockSize.Full}
@@ -664,7 +666,9 @@ const TransactionShield = () => {
               paddingTop={2}
               paddingBottom={2}
             >
-              <Icon name={IconName.MetamaskFoxOutline} size={IconSize.Xl} />
+              <Box>
+                <Icon name={IconName.MetamaskFoxOutline} size={IconSize.Xl} />
+              </Box>
               <Box
                 width={BlockSize.Full}
                 display={Display.Flex}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix shield details icon shrinking on very small screen
Update `Link Rewards` to just `Link` since details are in the row already and remove full stop on the description

https://consensyssoftware.atlassian.net/browse/SUBS-879?atlOrigin=eyJpIjoiMTNiMGM4ZDdkNTY2NDI0MGFjMWJkZmMzZGYyNDBmNzQiLCJwIjoiaiJ9

https://consensyssoftware.atlassian.net/browse/SUBS-878?atlOrigin=eyJpIjoiNTQ4YjA3ZmNhM2JiNGQyNjk0MmMwYmQzNzhkOGQxOGQiLCJwIjoiaiJ9
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38797?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix shield details icon shrinking on very small screen

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="313" height="316" alt="Screenshot 2025-12-12 at 3 02 31 PM" src="https://github.com/user-attachments/assets/bb18311b-668e-400d-ad57-adb7486efdf6" />


<!-- [screenshots/recordings] -->

### **After**
<img width="310" height="319" alt="Screenshot 2025-12-12 at 2 57 39 PM" src="https://github.com/user-attachments/assets/dce26491-6b1b-403c-9807-a3159bbb476a" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps shield detail icons in a non-shrinking container to maintain size on small screens, and tweaks locale strings (punctuation and label change from "Link Rewards" to "Link").
> 
> - **UI (Transaction Shield settings)**:
>   - Wrap `Icon` elements in `transaction-shield.tsx` with a `Box` using `flex-shrink-0` to prevent shrinking in detail rows and the rewards row.
> - **Localization**:
>   - Update `shieldTxDetails3Description` in `app/_locales/en*/messages.json` to remove trailing period.
>   - Rename `shieldTxDetails3DescriptionLinkReward` message from `"Link Rewards"` to `"Link"` in `en` and `en_GB`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bed3a2efd06d09d57824b4333065bb23b0df803a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->