### PR TITLE
fix: Make `getTransactions` use `createSelector` instead of` createDeepEqualSelector`

### DIFF
--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -41,7 +41,7 @@ const allowedSwapsSmartTransactionStatusesForActivityList = [
   SmartTransactionStatuses.CANCELLED,
 ];
 
-export const getTransactions = createDeepEqualSelector(
+export const getTransactions = createSelector(
   (state) => state.metamask?.transactions,
   (transactions) => {
     if (!transactions?.length) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38798?quickstart=1)

After discussion on the previous PR [here](https://github.com/MetaMask/metamask-extension/pull/38776/changes#r2611287906), it appears that we can directly use `createSelector` instead of `createDeepEqualSelector` because as core benefit of `Immer` it only applies the reference change when the actual data changes. 

Tests are done in the same way with previous PR - cache hit rates are expected with usage of `createSelector`. 

More discussions [here](https://github.com/MetaMask/metamask-extension/pull/38676) for further clarification

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6340
Related discussion: https://github.com/MetaMask/metamask-extension/pull/38776/changes#r2611287906

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Tests are done while UI have an active transaction confirmation (so "computes" are expected because of gas updates)
<img width="587" height="119" alt="Screenshot 2025-12-12 at 11 23 54" src="https://github.com/user-attachments/assets/14011471-7e23-4de7-b89e-9b760dbd7f3d" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `createDeepEqualSelector` with `createSelector` for `getTransactions` in `ui/selectors/transactions.js`, keeping the ascending time sort unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5b5c5ec6c8968699a69b22648e3e1941a6bda8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->