### PR TITLE
fix: cp-13.13.0 not execute QuotedSwapTransactionData if quoted swap is not selected

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
@@ -21,6 +21,7 @@ import {
   updateCustomNonce,
 } from '../../../../../../../store/actions';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { useDappSwapContext } from '../../../../../context/dapp-swap';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { isSignatureTransactionType } from '../../../../../utils';
 import { NestedTransactionData } from '../../batch/nested-transaction-data/nested-transaction-data';
@@ -93,6 +94,7 @@ export const AdvancedDetails = ({
 }: {
   overrideVisibility?: boolean;
 }) => {
+  const { isQuotedSwapDisplayedInInfo } = useDappSwapContext();
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
@@ -106,7 +108,7 @@ export const AdvancedDetails = ({
       <NonceDetails />
       <TransactionData />
       <NestedTransactionData />
-      <QuotedSwapTransactionData />
+      {isQuotedSwapDisplayedInInfo && <QuotedSwapTransactionData />}
     </>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix error from QuotedSwapTransactionData when swap is rendered.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38811

## **Manual testing steps**

1. Submit uniswap transaction
2. Open advance view
3. No error should be thrown

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render `QuotedSwapTransactionData` only when `isQuotedSwapDisplayedInInfo` from dapp-swap context is true, preventing errors when a quoted swap isn't selected.
> 
> - **Confirmations UI**
>   - Use `useDappSwapContext` to access `isQuotedSwapDisplayedInInfo` in `AdvancedDetails`.
>   - Conditionally render `QuotedSwapTransactionData` based on this flag instead of always rendering it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ea8b139269f2ffcea433c251ed5e4e1c61f76f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->