### PR TITLE
chore: onboarding miscellaneous improvements/fixes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1227,6 +1227,9 @@
   "chainListReturnedDifferentTickerSymbol": {
     "message": "This token symbol doesn't match the network name or chain ID entered. Many popular tokens use similar symbols, which scammers can use to trick you into sending them a more valuable token in return. Verify everything before you continue."
   },
+  "changePasswordDetailsSocial": {
+    "message": "Losing this password means losing wallet access on all devices."
+  },
   "changePasswordLoading": {
     "message": "Changing password..."
   },
@@ -1751,7 +1754,7 @@
     "message": "Unlocks MetaMask on this device only."
   },
   "createPasswordDetailsSocial": {
-    "message": "Losing this password means losing wallet access on all devices."
+    "message": "Losing this password means losing wallet access on all devices, "
   },
   "createPasswordDetailsSocialReset": {
     "message": "MetaMask can't reset it."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1751,7 +1751,7 @@
     "message": "Unlocks MetaMask on this device only."
   },
   "createPasswordDetailsSocial": {
-    "message": "Losing this password means losing wallet access on all devices, "
+    "message": "Losing this password means losing wallet access on all devices."
   },
   "createPasswordDetailsSocialReset": {
     "message": "MetaMask can't reset it."
@@ -4530,7 +4530,7 @@
     "message": "By continuing, I agree to MetaMask’s $1 and $2"
   },
   "onboardingLoginFooterPrivacyNotice": {
-    "message": "Privacy notice."
+    "message": "Privacy notice"
   },
   "onboardingLoginFooterTermsOfUse": {
     "message": "Terms of Use"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1227,6 +1227,9 @@
   "chainListReturnedDifferentTickerSymbol": {
     "message": "This token symbol doesn't match the network name or chain ID entered. Many popular tokens use similar symbols, which scammers can use to trick you into sending them a more valuable token in return. Verify everything before you continue."
   },
+  "changePasswordDetailsSocial": {
+    "message": "Losing this password means losing wallet access on all devices."
+  },
   "changePasswordLoading": {
     "message": "Changing password..."
   },
@@ -1751,7 +1754,7 @@
     "message": "Unlocks MetaMask on this device only."
   },
   "createPasswordDetailsSocial": {
-    "message": "Losing this password means losing wallet access on all devices."
+    "message": "Losing this password means losing wallet access on all devices, "
   },
   "createPasswordDetailsSocialReset": {
     "message": "MetaMask can't reset it."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1751,7 +1751,7 @@
     "message": "Unlocks MetaMask on this device only."
   },
   "createPasswordDetailsSocial": {
-    "message": "Losing this password means losing wallet access on all devices, "
+    "message": "Losing this password means losing wallet access on all devices."
   },
   "createPasswordDetailsSocialReset": {
     "message": "MetaMask can't reset it."
@@ -4530,7 +4530,7 @@
     "message": "By continuing, I agree to MetaMask’s $1 and $2"
   },
   "onboardingLoginFooterPrivacyNotice": {
-    "message": "Privacy notice."
+    "message": "Privacy notice"
   },
   "onboardingLoginFooterTermsOfUse": {
     "message": "Terms of Use"

--- a/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
+++ b/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Location as RouterLocation } from 'react-router-dom';
 import classnames from 'classnames';
@@ -33,6 +33,10 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 
 type OnboardingAppHeaderProps = {
   isWelcomePage: boolean;
@@ -61,6 +65,12 @@ export default function OnboardingAppHeader({
   const isFromSettingsSecurity = searchParams.get('isFromSettingsSecurity');
   const isFromSettingsSRPBackup = isFromReminder || isFromSettingsSecurity;
 
+  // We don't wanna show the logo and locale dropdown in the sidepanel view
+  const showLogoAndLocaleDropdown = useMemo(() => {
+    const windowType = getEnvironmentType();
+    return windowType !== ENVIRONMENT_TYPE_SIDEPANEL;
+  }, []);
+
   return (
     <Box
       display={Display.Flex}
@@ -72,79 +82,84 @@ export default function OnboardingAppHeader({
         'onboarding-app-header--welcome': isWelcomePage,
       })}
     >
-      <Box
-        display={Display.Flex}
-        width={BlockSize.Full}
-        justifyContent={
-          pathname === ONBOARDING_WELCOME_ROUTE
-            ? JustifyContent.flexEnd
-            : JustifyContent.spaceBetween
-        }
-        className="onboarding-app-header__contents"
-      >
-        {pathname !== ONBOARDING_WELCOME_ROUTE && (
-          <MetaFoxLogo unsetIconHeight isOnboarding />
-        )}
+      {showLogoAndLocaleDropdown ? (
+        <Box
+          display={Display.Flex}
+          width={BlockSize.Full}
+          justifyContent={
+            pathname === ONBOARDING_WELCOME_ROUTE
+              ? JustifyContent.flexEnd
+              : JustifyContent.spaceBetween
+          }
+          className="onboarding-app-header__contents"
+        >
+          {pathname !== ONBOARDING_WELCOME_ROUTE && (
+            <MetaFoxLogo unsetIconHeight isOnboarding />
+          )}
 
-        {pathname === ONBOARDING_COMPLETION_ROUTE &&
-        !isFromSettingsSRPBackup ? (
-          <Box
-            paddingTop={12}
-            className="onboarding-app-header__banner-tip-container"
-          >
-            <BannerTip
-              borderColor={BorderColor.borderMuted}
-              backgroundColor={BackgroundColor.backgroundMuted}
-              title={t('pinMetaMask')}
-              gap={4}
-              titleProps={{
-                color: TextColor.textDefault,
-                variant: TextVariant.bodyMdMedium,
-                paddingRight: 2,
-              }}
-              className="onboarding-app-header__banner-tip"
-              padding={3}
-              alignItems={AlignItems.center}
+          {pathname === ONBOARDING_COMPLETION_ROUTE &&
+          !isFromSettingsSRPBackup ? (
+            <Box
+              paddingTop={12}
+              className="onboarding-app-header__banner-tip-container"
             >
-              <Text
-                variant={TextVariant.bodySm}
+              <BannerTip
+                borderColor={BorderColor.borderMuted}
+                backgroundColor={BackgroundColor.backgroundMuted}
+                title={t('pinMetaMask')}
+                gap={4}
+                titleProps={{
+                  color: TextColor.textDefault,
+                  variant: TextVariant.bodyMdMedium,
+                  paddingRight: 2,
+                }}
+                className="onboarding-app-header__banner-tip"
+                padding={3}
                 alignItems={AlignItems.center}
-                color={TextColor.textAlternative}
-                paddingRight={2}
               >
-                {t('pinMetaMaskDescription', [
-                  <Icon
-                    name={IconName.Extension}
-                    key="extension"
-                    color={IconColor.iconDefault}
-                    size={IconSize.Md}
-                    className="onboarding-app-header__banner-tip-icon"
-                  />,
-                  <Icon
-                    name={IconName.Keep}
-                    key="keep"
-                    color={IconColor.iconDefault}
-                    size={IconSize.Md}
-                    className="onboarding-app-header__banner-tip-icon"
-                  />,
-                ])}
-              </Text>
-            </BannerTip>
-          </Box>
-        ) : (
-          <Dropdown
-            data-testid="select-locale"
-            className={classnames('onboarding-app-header__dropdown', {
-              'onboarding-app-header__dropdown--welcome--login': isWelcomePage,
-            })}
-            options={localeOptions}
-            selectedOption={currentLocale}
-            onChange={async (newLocale) =>
-              dispatch(updateCurrentLocale(newLocale))
-            }
-          />
-        )}
-      </Box>
+                <Text
+                  variant={TextVariant.bodySm}
+                  alignItems={AlignItems.center}
+                  color={TextColor.textAlternative}
+                  paddingRight={2}
+                >
+                  {t('pinMetaMaskDescription', [
+                    <Icon
+                      name={IconName.Extension}
+                      key="extension"
+                      color={IconColor.iconDefault}
+                      size={IconSize.Md}
+                      className="onboarding-app-header__banner-tip-icon"
+                    />,
+                    <Icon
+                      name={IconName.Keep}
+                      key="keep"
+                      color={IconColor.iconDefault}
+                      size={IconSize.Md}
+                      className="onboarding-app-header__banner-tip-icon"
+                    />,
+                  ])}
+                </Text>
+              </BannerTip>
+            </Box>
+          ) : (
+            <Dropdown
+              data-testid="select-locale"
+              className={classnames('onboarding-app-header__dropdown', {
+                'onboarding-app-header__dropdown--welcome--login':
+                  isWelcomePage,
+              })}
+              options={localeOptions}
+              selectedOption={currentLocale}
+              onChange={async (newLocale) =>
+                dispatch(updateCurrentLocale(newLocale))
+              }
+            />
+          )}
+        </Box>
+      ) : (
+        <></>
+      )}
     </Box>
   );
 }

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -141,7 +141,7 @@ exports[`Security Tab should match snapshot 1`] = `
             class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
             data-testid="reveal-seed-words"
           >
-            Back up Secret Recovery Phrase
+            Reveal Secret Recovery Phrase
           </button>
         </div>
       </div>

--- a/ui/pages/settings/security-tab/change-password/change-password.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.tsx
@@ -235,7 +235,7 @@ const ChangePassword = () => {
               as="h2"
             >
               {isSocialLoginFlow
-                ? t('createPasswordDetailsSocial')
+                ? t('changePasswordDetailsSocial')
                 : t('createPasswordDetails')}
             </Text>
             <PasswordForm

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -232,6 +232,8 @@ export default class SecurityTab extends PureComponent {
     const getButtonText = () => {
       if (socialLoginEnabled) {
         return t('securitySrpWalletRecovery');
+      } else if (isSeedPhraseBackedUp) {
+        return t('revealSeedWords');
       }
       return t('revealSecretRecoveryPhrase');
     };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Miscellaneous minor bug/locale fixes wrt the onboarding.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38839?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes minor issues relates to locales
CHANGELOG entry: removed Fox logo and locale dropdown in Onboarding app header (Sidepanel view)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

#### Button label updates (based on SRP Backup status)
<img width="991" height="984" alt="Screenshot 2025-12-13 at 2 38 12 PM" src="https://github.com/user-attachments/assets/00bcc9b3-45c8-4fe8-9c0a-94de74759ec1" />

#### Remove App Logo and Locale Dropdown from Onboarding Header (for SidePanel)
<img width="1596" height="963" alt="Screenshot 2025-12-13 at 2 36 51 PM" src="https://github.com/user-attachments/assets/731bf5f6-3631-4f60-8537-5c819f90fc7f" />

#### Locales updates
<img width="1577" height="964" alt="Screenshot 2025-12-13 at 2 38 36 PM" src="https://github.com/user-attachments/assets/15865863-6ec7-4dd7-b649-19b408e6c5b4" />

<img width="579" height="948" alt="Screenshot 2025-12-13 at 2 48 34 PM" src="https://github.com/user-attachments/assets/5c22a10e-187e-41a6-8412-6f5f12efadbf" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the MetaMask logo and locale dropdown in the onboarding header when in sidepanel, updates the SRP action button to “Reveal Secret Recovery Phrase” when backed up, and adds/uses a social change‑password locale string with minor locale punctuation tweaks.
> 
> - **UI**:
>   - **Onboarding header (`ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx`)**: Hide `MetaFoxLogo` and locale `Dropdown` in sidepanel (`getEnvironmentType` != `ENVIRONMENT_TYPE_SIDEPANEL`).
>   - **Security tab (`ui/pages/settings/security-tab/security-tab.component.js`)**: Change SRP button text to `t('revealSeedWords')` when `isSeedPhraseBackedUp`; fallback remains `t('revealSecretRecoveryPhrase')`.
> - **Settings > Change Password**:
>   - **`change-password.tsx`**: Use new `t('changePasswordDetailsSocial')` for social login flow messaging.
> - **Locales**:
>   - Add `en`/`en_GB` key `changePasswordDetailsSocial`.
>   - Tweak `onboardingLoginFooterPrivacyNotice` message from "Privacy notice." to "Privacy notice".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4618d01005a3eefc809846a8543c4dbb1843514c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->