### PR TITLE
fix: flaky tests ` Confirmation Redesign Token Send ERC1155...` due to timeout for `checkHasAccountSyncingSyncedAtLeastOnce` function

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -418,7 +418,7 @@ class HomePage {
       },
       {
         interval: 1000,
-        timeout: 30000, // Syncing can take some time so adding a longer timeout to reduce flakes
+        timeout: 40000, // Syncing can take some time so adding a longer timeout to reduce flakes
       },
     );
   }

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -4,6 +4,10 @@ import { Ganache } from '../../../seeder/ganache';
 import { Anvil } from '../../../seeder/anvil';
 import HeaderNavbar from '../header-navbar';
 import { getCleanAppState, regularDelayMs } from '../../../helpers';
+import {
+  BASE_ACCOUNT_SYNC_INTERVAL,
+  BASE_ACCOUNT_SYNC_TIMEOUT,
+} from '../../../tests/identity/account-syncing/helpers';
 
 class HomePage {
   protected driver: Driver;
@@ -417,8 +421,8 @@ class HomePage {
         );
       },
       {
-        interval: 1000,
-        timeout: 40000, // Syncing can take some time so adding a longer timeout to reduce flakes
+        interval: BASE_ACCOUNT_SYNC_INTERVAL,
+        timeout: BASE_ACCOUNT_SYNC_TIMEOUT, // Syncing can take some time so adding a longer timeout to reduce flakes
       },
     );
   }

--- a/test/e2e/tests/identity/account-syncing/helpers.ts
+++ b/test/e2e/tests/identity/account-syncing/helpers.ts
@@ -6,12 +6,14 @@ import {
   UserStorageMockttpControllerEvents,
 } from '../../../helpers/identity/user-storage/userStorageMockttpController';
 
+// Syncing can take some time (specially in Firefox) so adding a longer timeout to reduce flakes
+export const BASE_ACCOUNT_SYNC_TIMEOUT = 45000;
+export const BASE_ACCOUNT_SYNC_INTERVAL = 1000;
+
 export const arrangeTestUtils = (
   driver: Driver,
   userStorageMockttpController: UserStorageMockttpController,
 ) => {
-  const BASE_TIMEOUT = 40000;
-  const BASE_INTERVAL = 1000;
 
   const prepareEventsEmittedCounter = (
     event: AsEnum<typeof UserStorageMockttpControllerEvents>,
@@ -28,8 +30,8 @@ export const arrangeTestUtils = (
         `Waiting for user storage event ${event} to be emitted ${expectedNumber} times`,
       );
       await driver.waitUntil(async () => counter >= expectedNumber, {
-        timeout: BASE_TIMEOUT,
-        interval: BASE_INTERVAL,
+        timeout: BASE_ACCOUNT_SYNC_TIMEOUT,
+        interval: BASE_ACCOUNT_SYNC_INTERVAL,
       });
     };
     return { waitUntilEventsEmittedNumberEquals };
@@ -56,8 +58,8 @@ export const arrangeTestUtils = (
         return currentCount === expectedNumber;
       },
       {
-        timeout: BASE_TIMEOUT,
-        interval: BASE_INTERVAL,
+        timeout: BASE_ACCOUNT_SYNC_TIMEOUT,
+        interval: BASE_ACCOUNT_SYNC_INTERVAL,
       },
     );
   };

--- a/test/e2e/tests/identity/account-syncing/helpers.ts
+++ b/test/e2e/tests/identity/account-syncing/helpers.ts
@@ -14,7 +14,6 @@ export const arrangeTestUtils = (
   driver: Driver,
   userStorageMockttpController: UserStorageMockttpController,
 ) => {
-
   const prepareEventsEmittedCounter = (
     event: AsEnum<typeof UserStorageMockttpControllerEvents>,
   ) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Firefox tends to be slower in certain operations. Multiple account sync fail only on firefox as the 30 seconds default time out. I've found that increasing the timeout fixes the issues.

We implemented the timeout increase in this PR, 
https://github.com/MetaMask/metamask-extension/pull/38813


but there's the `checkHasAccountSyncingSyncedAtLeastOnce` method, which still used 30 seconds. Now it's updated to 45 seconds - to be on the safe side

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38850?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps account syncing waits to 45s and refactors E2E tests to use shared timeout/interval constants.
> 
> - **E2E Tests**:
>   - **Timeout/Interval centralization**: Introduces `BASE_ACCOUNT_SYNC_TIMEOUT = 45000` and `BASE_ACCOUNT_SYNC_INTERVAL = 1000` in `test/e2e/tests/identity/account-syncing/helpers.ts`.
>   - **Home page syncing check**: `HomePage.checkHasAccountSyncingSyncedAtLeastOnce` now uses `BASE_ACCOUNT_SYNC_*` instead of hardcoded `interval`/`timeout`.
>   - **Account syncing helpers**: Applies `BASE_ACCOUNT_SYNC_*` to `waitUntilEventsEmittedNumberEquals` and `waitUntilSyncedAccountsNumberEquals` to replace previous hardcoded values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5ae99906d50d03c1c4733bccd21bccca71178ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->