### PR TITLE
fix: chart history date label when older than current year

### DIFF
--- a/ui/pages/asset/components/chart/asset-chart-price.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-price.tsx
@@ -8,7 +8,7 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { Box, Text } from '../../../../components/component-library';
-import { loadingOpacity, getShortDateFormatter } from '../../util';
+import { loadingOpacity, getDynamicShortDate } from '../../util';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { Skeleton } from '../../../../components/component-library/skeleton';
 import { TokenCellPercentChange } from '../../../../components/app/assets/token-cell/cells';
@@ -135,7 +135,7 @@ const AssetChartPrice = forwardRef(
               color={TextColor.textAlternative}
               marginLeft={2}
             >
-              {getShortDateFormatter().format(date)}
+              {getDynamicShortDate(date)}
             </Text>
           </Box>
         )}

--- a/ui/pages/asset/util.ts
+++ b/ui/pages/asset/util.ts
@@ -21,6 +21,23 @@ export const getShortDateFormatterV2 = () =>
   });
 
 /**
+ * Returns a dynamically formatted date string.
+ * If the date is in the same year as the current date, it omits the year.
+ * Otherwise, it includes the year.
+ *
+ * @param date - The date to format, either as a Date object or timestamp.
+ * @returns A formatted date string.
+ */
+export const getDynamicShortDate = (date: Date | number) => {
+  const currentDate = new Date(date);
+  const now = new Date();
+  const isSameYear = currentDate.getFullYear() === now.getFullYear();
+  return isSameYear
+    ? getShortDateFormatter().format(date)
+    : getShortDateFormatterV2().format(date);
+};
+
+/**
  * Returns the number of decimals the fiat price should be formatted to.
  * This tells `currency-formatter` to render prices < 1 cent like $0.00001234
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Dynamically format asset chart dates to omit the year for current year dates and include it for past/future years to improve readability.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38853?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: chart history date label when older than current year

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38736 https://consensyssoftware.atlassian.net/browse/ASSETS-2116

## **Manual testing steps**

See issue comment

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/83ad9a83ccc9422cb24086452034ba6f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<a href="https://cursor.com/background-agent?bcId=bc-3dbc29e7-618a-45c6-9e0e-38596f63fb80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3dbc29e7-618a-45c6-9e0e-38596f63fb80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a dynamic short date for chart labels (time for current year, year for other years) and add unit tests.
> 
> - **UI**:
>   - Update `ui/pages/asset/components/chart/asset-chart-price.tsx` to use `getDynamicShortDate(date)` for the hovered date label.
> - **Utils**:
>   - Add `getDynamicShortDate(date)` in `ui/pages/asset/util.ts` to switch between `getShortDateFormatter` and `getShortDateFormatterV2` based on year.
> - **Tests**:
>   - Add tests in `ui/pages/asset/util.test.ts` covering multiple current/past/future year and timestamp scenarios for `getDynamicShortDate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b363c9e1778a2e6a736fd183a19cfae4e19f46b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->