### PR TITLE
fix: dapp swap UI logic should not be executed if flag is not enabled

### DIFF
--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.test.tsx
@@ -193,6 +193,15 @@ describe('<DappSwapComparisonBanner />', () => {
     });
   });
 
+  it('does not render component if dappSwapUi is not enabled', () => {
+    mockGetRemoteFeatureFlags.mockReturnValue({
+      dappSwapMetrics: { enabled: true },
+      dappSwapUi: { enabled: false, threshold: 0.01 },
+    });
+    const { container } = render();
+    expect(container.firstChild).toBeNull();
+  });
+
   it('call function to update quote swap clicks on Market rate button', () => {
     const mockSetQuotedSwapDisplayedInInfo = jest.fn();
     jest.spyOn(DappSwapContext, 'useDappSwapContext').mockReturnValue({

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -75,7 +75,11 @@ const SwapTabs = React.memo(
   },
 );
 
-const DappSwapComparisonInner = () => {
+const DappSwapComparisonInner = ({
+  dappSwapComparisonInfoResult,
+}: {
+  dappSwapComparisonInfoResult: ReturnType<typeof useDappSwapComparisonInfo>;
+}) => {
   const t = useI18nContext();
   const {
     fiatRates,
@@ -85,7 +89,7 @@ const DappSwapComparisonInner = () => {
     sourceTokenAmount,
     tokenAmountDifference,
     tokenDetails,
-  } = useDappSwapComparisonInfo();
+  } = dappSwapComparisonInfoResult;
   const { captureDappSwapComparisonDisplayProperties } =
     useDappSwapComparisonMetrics();
   const { dappSwapUi, dappSwapQa } = useSelector(getRemoteFeatureFlags) as {
@@ -246,7 +250,7 @@ const DappSwapComparisonInner = () => {
 };
 
 const DappSwapComparisonWrapper = () => {
-  useDappSwapComparisonInfo();
+  const dappSwapComparisonInfoResult = useDappSwapComparisonInfo();
   const { dappSwapUi } = useSelector(getRemoteFeatureFlags) as {
     dappSwapUi: DappSwapUiFlag;
   };
@@ -255,7 +259,11 @@ const DappSwapComparisonWrapper = () => {
     return null;
   }
 
-  return <DappSwapComparisonInner />;
+  return (
+    <DappSwapComparisonInner
+      dappSwapComparisonInfoResult={dappSwapComparisonInfoResult}
+    />
+  );
 };
 
 export const DappSwapComparisonBanner = () => {

--- a/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
+++ b/ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx
@@ -140,7 +140,8 @@ const DappSwapComparisonInner = () => {
 
   const swapComparisonDisplayed =
     dappSwapUi?.enabled &&
-    (selectedQuoteValueDifference >= dappSwapUi?.threshold ||
+    ((selectedQuoteValueDifference &&
+      selectedQuoteValueDifference >= dappSwapUi?.threshold) ||
       (dappSwapQa?.enabled && selectedQuote));
 
   useEffect(() => {
@@ -244,6 +245,19 @@ const DappSwapComparisonInner = () => {
   );
 };
 
+const DappSwapComparisonWrapper = () => {
+  useDappSwapComparisonInfo();
+  const { dappSwapUi } = useSelector(getRemoteFeatureFlags) as {
+    dappSwapUi: DappSwapUiFlag;
+  };
+
+  if (!dappSwapUi?.enabled) {
+    return null;
+  }
+
+  return <DappSwapComparisonInner />;
+};
+
 export const DappSwapComparisonBanner = () => {
   const { isSwapToBeCompared } = useDappSwapCheck();
 
@@ -251,5 +265,5 @@ export const DappSwapComparisonBanner = () => {
     return null;
   }
 
-  return <DappSwapComparisonInner />;
+  return <DappSwapComparisonWrapper />;
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.tsx
@@ -32,21 +32,23 @@ export const QuotedSwapTransactionData = () => {
 
   return (
     <Box>
-      <ConfirmInfoSection>
-        <ConfirmInfoExpandableRow
-          label={approvalLabel}
-          content={
-            <TransactionData
-              data={(approval as TxData)?.data as Hex}
-              to={(approval as TxData)?.to as Hex}
-              noPadding
-              nestedTransactionIndex={1}
-            />
-          }
-        >
-          <ConfirmInfoRowText text="" />
-        </ConfirmInfoExpandableRow>
-      </ConfirmInfoSection>
+      {approval && (
+        <ConfirmInfoSection>
+          <ConfirmInfoExpandableRow
+            label={approvalLabel}
+            content={
+              <TransactionData
+                data={(approval as TxData)?.data as Hex}
+                to={(approval as TxData)?.to as Hex}
+                noPadding
+                nestedTransactionIndex={1}
+              />
+            }
+          >
+            <ConfirmInfoRowText text="" />
+          </ConfirmInfoExpandableRow>
+        </ConfirmInfoSection>
+      )}
       <ConfirmInfoSection>
         <ConfirmInfoExpandableRow
           label={tradeLabel}

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -248,7 +248,6 @@ function ParamValue({
   source?: DecodedTransactionDataSource;
   chainId: string;
 }) {
-  console.log('----------------------- param 0', param);
   const { name, type, value } = param;
 
   if (type === 'address') {
@@ -294,7 +293,6 @@ function ParamRow({
   const tooltip = `${type}${description ? ` - ${description}` : ''}`;
   const dataTestId = `advanced-details-data-param-${index}`;
 
-  console.log('----------------------- param 0', param.children);
   const childRows = param.children?.map((childParam, childIndex) => (
     <ParamRow
       key={childIndex}

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -4,7 +4,7 @@ import { hexStripZeros } from '@ethersproject/bytes';
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import _ from 'lodash';
-import { Hex } from '@metamask/utils';
+import { Hex, isHexString } from '@metamask/utils';
 
 import { APPROVAL_METHOD_NAMES } from '../../../../../../../../shared/constants/transaction';
 import { useDecodedTransactionData } from '../../hooks/useDecodedTransactionData';
@@ -248,6 +248,7 @@ function ParamValue({
   source?: DecodedTransactionDataSource;
   chainId: string;
 }) {
+  console.log('----------------------- param 0', param);
   const { name, type, value } = param;
 
   if (type === 'address') {
@@ -264,7 +265,11 @@ function ParamValue({
     valueString = renderShortTokenId(valueString, 5);
   }
 
-  if (!Array.isArray(value) && valueString.startsWith('0x')) {
+  if (
+    !Array.isArray(value) &&
+    valueString.startsWith('0x') &&
+    isHexString(valueString)
+  ) {
     valueString = hexStripZeros(valueString);
   }
 
@@ -289,6 +294,7 @@ function ParamRow({
   const tooltip = `${type}${description ? ` - ${description}` : ''}`;
   const dataTestId = `advanced-details-data-param-${index}`;
 
+  console.log('----------------------- param 0', param.children);
   const childRows = param.children?.map((childParam, childIndex) => (
     <ParamRow
       key={childIndex}

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { TokenStandAndDetails } from '../../../../../store/actions';
+import { getRemoteFeatureFlags } from '../../../../../selectors/remote-feature-flags';
 import * as Utils from '../../../../../helpers/utils/util';
 import * as TokenUtils from '../../../utils/token';
 import { Confirmation } from '../../../types/confirm';
@@ -29,6 +30,8 @@ jest.mock('../../../../../store/controller-actions/bridge-controller', () => ({
   fetchQuotes: jest.fn(),
 }));
 
+jest.mock('../../../../../selectors/remote-feature-flags');
+
 const mockUseDappSwapComparisonLatencyMetricsResponse = {
   requestDetectionLatency: '1200',
   updateRequestDetectionLatency: jest.fn(),
@@ -39,6 +42,8 @@ jest.mock('./useDappSwapComparisonLatencyMetrics', () => ({
   useDappSwapComparisonLatencyMetrics: () =>
     mockUseDappSwapComparisonLatencyMetricsResponse,
 }));
+
+const mockGetRemoteFeatureFlags = jest.mocked(getRemoteFeatureFlags);
 
 async function runHook(args: Record<string, unknown> = {}) {
   const response = renderHookWithConfirmContextProvider(
@@ -71,6 +76,13 @@ async function runHook(args: Record<string, unknown> = {}) {
 }
 
 describe('useDappSwapComparisonInfo', () => {
+  beforeEach(() => {
+    mockGetRemoteFeatureFlags.mockReturnValue({
+      dappSwapQa: { enabled: true },
+      dappSwapUi: { enabled: true, threshold: 0.01 },
+    });
+  });
+
   it('initially call updateTransactionEventFragment with loading', async () => {
     await runHook();
     expect(mockUpdateTransactionEventFragment).toHaveBeenNthCalledWith(
@@ -184,5 +196,43 @@ describe('useDappSwapComparisonInfo', () => {
       '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': 0.999804,
       '0xfdcc3dd6671eab0709a4c0f3f53de9a333d80798': 1,
     });
+  });
+
+  it('return quote calculation values as zero if dappSwapUi is not enabled', async () => {
+    mockGetRemoteFeatureFlags.mockReturnValue({
+      dappSwapQa: { enabled: true },
+      dappSwapUi: { enabled: false, threshold: 0.01 },
+    });
+    jest.spyOn(Utils, 'fetchTokenExchangeRates').mockResolvedValue({
+      '0x0000000000000000000000000000000000000000': 4052.27,
+      '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': 0.999804,
+      '0xfdcc3dd6671eab0709a4c0f3f53de9a333d80798': 1,
+    });
+    jest.spyOn(TokenUtils, 'fetchAllTokenDetails').mockResolvedValue({
+      '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': {
+        symbol: 'USDC',
+        decimals: '6',
+      } as TokenStandAndDetails,
+      '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9': {
+        symbol: 'USDT',
+        decimals: '6',
+      } as TokenStandAndDetails,
+    });
+
+    const {
+      selectedQuote,
+      selectedQuoteValueDifference,
+      tokenAmountDifference,
+    } = await runHook({
+      swapInfo: {
+        srcTokenAddress: '0xfdcc3dd6671eab0709a4c0f3f53de9a333d80798',
+        destTokenAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        srcTokenAmount: '0x0de0b6b3a7640000',
+        destTokenAmountMin: '0x0',
+      },
+    });
+    expect(selectedQuote).toEqual(mockBridgeQuotes[3]);
+    expect(selectedQuoteValueDifference).toBe(0);
+    expect(tokenAmountDifference).toBe(0);
   });
 });

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapComparisonInfo.ts
@@ -31,9 +31,11 @@ const getGasFromQuote = (quote: QuoteResponse) => {
 };
 
 export function useDappSwapComparisonInfo() {
-  const { dappSwapQa } = useSelector(getRemoteFeatureFlags) as {
+  const { dappSwapUi, dappSwapQa } = useSelector(getRemoteFeatureFlags) as {
+    dappSwapUi: { enabled: boolean };
     dappSwapQa: { enabled: boolean };
   };
+
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const {
     quotes,
@@ -237,7 +239,13 @@ export function useDappSwapComparisonInfo() {
   const { selectedQuoteValueDifference = 0, tokenAmountDifference = 0 } =
     useMemo(() => {
       try {
-        if (!selectedQuote || !swapInfo || !simulationData || !tokenDetails) {
+        if (
+          !selectedQuote ||
+          !swapInfo ||
+          !simulationData ||
+          !tokenDetails ||
+          !dappSwapUi?.enabled
+        ) {
           return {};
         }
 
@@ -301,9 +309,11 @@ export function useDappSwapComparisonInfo() {
       simulationData,
       swapInfo,
       tokenDetails,
+      dappSwapUi.enabled,
     ]);
 
   return {
+    dappSwapUi,
     fiatRates,
     minDestTokenAmountInUSD: getDestinationTokenUSDValue(
       selectedQuote?.quote?.minDestTokenAmount ?? '0',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The PR addresses:
- dapp swap UI logic should be executed only if flag is enabled
- test-dapp batch swap throws error in advance view, the PR addresses that also

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6486

## **Manual testing steps**

1. Submit batch swap from test-dapp
2. Open advance section
3. It should not throw error

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates Dapp Swap comparison UI and value calculations behind `dappSwapUi` flag, fixes batch swap advanced view crashes, and adds safety checks in transaction decoding with corresponding tests.
> 
> - **Confirmations UI**
>   - **Dapp Swap Comparison Banner**:
>     - Wraps rendering in `DappSwapComparisonWrapper` that returns `null` when `dappSwapUi.enabled` is false.
>     - Passes `useDappSwapComparisonInfo` result into `DappSwapComparisonInner` via props.
>     - Safeguards `swapComparisonDisplayed` to handle missing `selectedQuoteValueDifference`.
> - **Transaction Info Rendering**
>   - `quoted-transaction-data`: Only renders approval section when `approval` exists to avoid batch swap errors.
>   - `transaction-data`: Uses `isHexString` before `hexStripZeros` to safely format hex parameter values.
> - **Hook: `useDappSwapComparisonInfo`**
>   - Reads `dappSwapUi` from feature flags and returns it.
>   - Skips value difference calculations when `dappSwapUi.enabled` is false.
>   - Updates memo deps accordingly.
> - **Tests**
>   - Adds test ensuring banner does not render when `dappSwapUi` is disabled.
>   - Adds test asserting quote calculation values are zero when `dappSwapUi` is disabled.
>   - Adjusts existing tests to align with new gating and props flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f5793dcbb9f9b1366fd2c68c1c2c9bf24299ae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->