### PR TITLE
chore: cp-13.13.1 Extend post-update auto restart to all Extension versions running on Chromium versions affected by broken MV3 update bug

### DIFF
--- a/app/scripts/on-update.ts
+++ b/app/scripts/on-update.ts
@@ -1,5 +1,4 @@
 import log from 'loglevel';
-import { RemoteFeatureFlagController } from '@metamask/remote-feature-flag-controller';
 import { PLATFORM_FIREFOX } from '../../shared/constants/app';
 import { getPlatform } from './lib/util';
 import type MetaMaskController from './metamask-controller';
@@ -11,8 +10,6 @@ import { AppStateController } from './controllers/app-state-controller';
  *
  * @param controller - The MetaMask controller instance.
  * @param controller.store - The MetaMask store.
- * @param controller.remoteFeatureFlagController - The remote feature flag
- * controller.
  * @param controller.appStateController - The app state controller.
  * @param platform - The ExtensionPlatform API.
  * @param previousVersion - The previous version string.
@@ -24,7 +21,6 @@ export function onUpdate(
   // include the actual controllers as properties.
   controller: {
     store: MetaMaskController['store'];
-    remoteFeatureFlagController: RemoteFeatureFlagController;
     appStateController: AppStateController;
   },
   platform: ExtensionPlatform,
@@ -67,21 +63,15 @@ export function onUpdate(
     // loop! This is overkill, as `onUpdate` is already only called when
     // `previousVersion !== platform.getVersion()`, but better safe than better
     // safe than better safe than... rebooting forever. :-)
-    const { remoteFeatureFlagController } = controller;
-    const shouldReload = remoteFeatureFlagController.state.remoteFeatureFlags
-      .extensionPlatformAutoReloadAfterUpdate as boolean | undefined;
-    log.info(`[onUpdate]: Should reload: ${shouldReload}`);
-    if (shouldReload === true) {
-      log.info(
-        `[onUpdate]: Requesting "safe reload" after update to ${platform.getVersion()}`,
-      );
-      // use `setImmediate` to be absolutely sure the reload happens after
-      // other "update" events triggered by the `setLastUpdatedFromVersion`
-      // and `setLastUpdatedAt` calls above have been processed by storage.
-      // I think there _is_ still a risk of a race condition here, mostly
-      // due to the complexity of state storage's locks, debounce, and async
-      // nature.
-      setImmediate(requestSafeReload);
-    }
+    log.info(
+      `[onUpdate]: Requesting "safe reload" after update to ${platform.getVersion()}`,
+    );
+    // use `setImmediate` to be absolutely sure the reload happens after
+    // other "update" events triggered by the `setLastUpdatedFromVersion`
+    // and `setLastUpdatedAt` calls above have been processed by storage.
+    // I think there _is_ still a risk of a race condition here, mostly
+    // due to the complexity of state storage's locks, debounce, and async
+    // nature.
+    setImmediate(requestSafeReload);
   }
 }

--- a/app/scripts/on-update.ts
+++ b/app/scripts/on-update.ts
@@ -1,7 +1,7 @@
 import log from 'loglevel';
 import Bowser from 'bowser';
 import { PLATFORM_FIREFOX } from '../../shared/constants/app';
-import { getIsBrowserMV3StableUpdatesSupported } from '../../shared/modules/browser-runtime.utils';
+import { getIsChromiumBrowserMV3StableUpdatesSupported } from '../../shared/modules/browser-runtime.utils';
 import { getPlatform } from './lib/util';
 import type MetaMaskController from './metamask-controller';
 import type ExtensionPlatform from './platforms/extension';
@@ -54,7 +54,7 @@ export function onUpdate(
 
   if (
     !isFirefox &&
-    !getIsBrowserMV3StableUpdatesSupported(
+    !getIsChromiumBrowserMV3StableUpdatesSupported(
       Bowser.getParser(globalThis.navigator.userAgent),
     )
   ) {

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -81,13 +81,13 @@ export function getIsBrowserPrerenderBroken(
 }
 
 /**
- * Returns true if the browser is no longer affected by a bug that causes MV3 updates to break service workers,
- * and Extension updates are stable.
+ * Returns true if the Chromium-based browser is no longer affected by a bug
+ * that causes MV3 updates to break service workers, and Extension updates are stable.
  *
  * @param {import('bowser').Parser} bowser - optional Bowser Parser instance to check against
  * @returns {boolean} Whether the browser is no longer affected by the MV3 update bug.
  */
-export function getIsBrowserMV3StableUpdatesSupported(
+export function getIsChromiumBrowserMV3StableUpdatesSupported(
   bowser = Bowser.getParser(window.navigator.userAgent),
 ) {
   return (

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -7,7 +7,7 @@ import browser from 'webextension-polyfill';
 import log from 'loglevel';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
-  FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS,
+  FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
@@ -90,7 +90,10 @@ export function getIsBrowserPrerenderBroken(
 export function getIsBrowserMV3StableUpdatesSupported(
   bowser = Bowser.getParser(window.navigator.userAgent),
 ) {
-  return bowser.satisfies(FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS) ?? false;
+  return (
+    bowser.satisfies(FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS) ??
+    false
+  );
 }
 
 /**

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -7,6 +7,7 @@ import browser from 'webextension-polyfill';
 import log from 'loglevel';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
+  FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
@@ -78,6 +79,20 @@ export function getIsBrowserPrerenderBroken(
     false
   );
 }
+
+/**
+ * Returns true if the browser is no longer affected by a bug that causes MV3 updates to break service workers,
+ * and Extension updates are stable.
+ *
+ * @param {import('bowser').Parser} bowser - optional Bowser Parser instance to check against
+ * @returns {boolean} Whether the browser is no longer affected by the MV3 update bug.
+ */
+export function getIsBrowserMV3StableUpdatesSupported(
+  bowser = Bowser.getParser(window.navigator.userAgent),
+) {
+  return bowser.satisfies(FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS) ?? false;
+}
+
 /**
  * Returns the name of the browser
  *

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -81,5 +81,5 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
 export const FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS = {
   // https://chromiumdash.appspot.com/commit/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5
   chrome: '>=143.0.7465.0',
-  edge: '>=143.0.7465.0',
+  edge: '>=143',
 };

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -70,3 +70,26 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
   chrome: '>=121',
   edge: '>=121',
 };
+
+/**
+ * Specifies the browser and their versions on a specific OS where
+ * MV3 updates are stable and don't break service workers.
+ *
+ * @see {@link https://chromium.googlesource.com/chromium/src/+/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5}
+ * @see {@link https://chromium.googlesource.com/chromium/src/+/a5d13d7b91139dfac4721708937f75094d3c24e3}
+ */
+export const FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS = {
+  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Windows
+  windows: {
+    chrome: '>=143',
+    edge: '>=143',
+  },
+  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Mac
+  macos: {
+    chrome: '>=143',
+    edge: '>=143',
+  },
+  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Linux
+  chrome: '>=143',
+  edge: '>=143',
+};

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -72,13 +72,13 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
 };
 
 /**
- * Specifies the browser and their versions where
+ * Specifies the Chromium-based browser and their versions where
  * MV3 updates are stable and don't break service workers.
  *
  * @see {@link https://chromium.googlesource.com/chromium/src/+/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5}
  * @see {@link https://chromium.googlesource.com/chromium/src/+/a5d13d7b91139dfac4721708937f75094d3c24e3}
  */
-export const FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS = {
+export const FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS = {
   // https://chromiumdash.appspot.com/commit/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5
   chrome: '>=143.0.7465.0',
   edge: '>=143',

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -72,24 +72,14 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
 };
 
 /**
- * Specifies the browser and their versions on a specific OS where
+ * Specifies the browser and their versions where
  * MV3 updates are stable and don't break service workers.
  *
  * @see {@link https://chromium.googlesource.com/chromium/src/+/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5}
  * @see {@link https://chromium.googlesource.com/chromium/src/+/a5d13d7b91139dfac4721708937f75094d3c24e3}
  */
 export const FIXED_MV3_STABLE_UPDATES_BROWSER_VERSIONS = {
-  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Windows
-  windows: {
-    chrome: '>=143',
-    edge: '>=143',
-  },
-  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Mac
-  macos: {
-    chrome: '>=143',
-    edge: '>=143',
-  },
-  // https://chromiumdash.appspot.com/commits?commit=4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5&platform=Linux
-  chrome: '>=143',
-  edge: '>=143',
+  // https://chromiumdash.appspot.com/commit/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5
+  chrome: '>=143.0.7465.0',
+  edge: '>=143.0.7465.0',
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes feature flag: `extensionPlatformAutoReloadAfterUpdate`. 

This applies the auto-restart workaround introduced in https://github.com/MetaMask/metamask-extension/pull/37552 to all Extension versions (previously only v13.11 and newer were supported). This unblocks the update prompt flow that was previously unusable due to the Chromium bug that the workaround addresses.

In this commit, the workaround is also gated to apply only to `<143` Chromium versions affected by the [bug it addresses](https://issues.chromium.org/issues/40805401). It doesn't run in newer versions where it's not needed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38867?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Extension will automatically restart after updating in Chromium browsers older than v143 that are affected by a bug causing broken MV3 updates.

## **Related issues**

- Closes https://github.com/MetaMask/MetaMask-planning/issues/6487

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-restarts the extension after updates on Chromium browsers <143 using a Bowser-based check, removing the feature-flag gate and adding shared version-gating utilities/constants.
> 
> - **Update handling (`app/scripts/on-update.ts`)**
>   - Remove `RemoteFeatureFlagController` dependency and feature-flag check for post-update reload.
>   - Add Bowser-based gate via `getIsChromiumBrowserMV3StableUpdatesSupported` and trigger safe reload on non-Firefox Chromium browsers below the fixed versions.
> - **Shared utilities**
>   - Add `getIsChromiumBrowserMV3StableUpdatesSupported` in `shared/modules/browser-runtime.utils.js`.
>   - Introduce and export `FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS` in `ui/helpers/constants/common.ts`, and import it in `browser-runtime.utils.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54771886f3ad60b97650d67582b5429ec030c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->