### PR TITLE
test: Prevent double `FixtureExtensionStore` initialization

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -114,7 +114,7 @@ const inTest = process.env.IN_TEST;
 const useFixtureStore =
   inTest && getManifestFlags().testing?.forceExtensionStore !== true;
 const localStore = useFixtureStore
-  ? new FixtureExtensionStore()
+  ? new FixtureExtensionStore({ initialize: true })
   : new ExtensionStore();
 const persistenceManager = new PersistenceManager({ localStore });
 

--- a/app/scripts/lib/stores/fixture-extension-store.test.ts
+++ b/app/scripts/lib/stores/fixture-extension-store.test.ts
@@ -64,9 +64,24 @@ describe('FixtureExtensionStore', () => {
   });
 
   describe('constructor', () => {
+    it('skips initialization if initialize is not true', async () => {
+      const interceptor =
+        mockFixtureServerInterceptor().replyWithError('error!');
+      const logDebugSpy = jest
+        .spyOn(log, 'debug')
+        .mockImplementation(() => undefined);
+      const store = new FixtureExtensionStore();
+
+      const result = await store.get();
+
+      expect(result).toBe(null);
+      expect(logDebugSpy).not.toHaveBeenCalled();
+      expect(interceptor.isDone()).toBe(false);
+    });
+
     it('loads state from the network if fetch is successful and response is ok', async () => {
       setMockFixtureServerReply(MOCK_STATE);
-      const store = new FixtureExtensionStore();
+      const store = new FixtureExtensionStore({ initialize: true });
 
       const result = await store.get();
 
@@ -78,7 +93,7 @@ describe('FixtureExtensionStore', () => {
         .spyOn(log, 'debug')
         .mockImplementation(() => undefined);
       mockFixtureServerInterceptor().reply(400);
-      const store = new FixtureExtensionStore();
+      const store = new FixtureExtensionStore({ initialize: true });
 
       const result = await store.get();
 
@@ -93,7 +108,7 @@ describe('FixtureExtensionStore', () => {
       const logDebugSpy = jest
         .spyOn(log, 'debug')
         .mockImplementation(() => undefined);
-      const store = new FixtureExtensionStore();
+      const store = new FixtureExtensionStore({ initialize: true });
 
       const result = await store.get();
 
@@ -107,7 +122,7 @@ describe('FixtureExtensionStore', () => {
   describe('get', () => {
     it('returns fixture state after waiting for init', async () => {
       setMockFixtureServerReply(MOCK_STATE);
-      const store = new FixtureExtensionStore();
+      const store = new FixtureExtensionStore({ initialize: true });
 
       const result = await store.get();
 
@@ -117,7 +132,7 @@ describe('FixtureExtensionStore', () => {
 
   describe('set', () => {
     it('sets the state', async () => {
-      const store = new FixtureExtensionStore();
+      const store = new FixtureExtensionStore({ initialize: true });
 
       await store.set({
         data: { appState: { test: true } },

--- a/app/scripts/lib/stores/fixture-extension-store.ts
+++ b/app/scripts/lib/stores/fixture-extension-store.ts
@@ -17,9 +17,23 @@ export class FixtureExtensionStore extends ExtensionStore {
 
   #initializing?: Promise<void>;
 
-  constructor() {
+  /**
+   * Construct a FixtureExtensionStore.
+   *
+   * If the `initialize` argument is `false`, the store is assumed to be initialized already.
+   *
+   * @param args - Arguments
+   * @param args.initialize - Whether to initialize the store by reading and setting fixtures.
+   */
+  constructor({ initialize = false }: { initialize?: boolean } = {}) {
     super();
-    this.#initializing = this.#init();
+
+    if (initialize) {
+      this.#initializing = this.#init();
+    } else {
+      this.#initializing = Promise.resolve();
+      this.#initialized = true;
+    }
   }
 
   async #init() {


### PR DESCRIPTION
## **Description**

The `FixtureExtensionStore` gets initialized both in the background and in each UI instance. Each time it reads the fixture state from disk and writes it to `storage.local`.

The store has been updated to optionally skip initialization. It no longer initializes by default, you need to opt-in to that step. It will now only initialize in the background process.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38875?quickstart=1)

## **Changelog**

CHANGELOG entry: null

This only impacts E2E tests, no user-facing changes.

## **Related issues**

Helps unblock https://github.com/MetaMask/metamask-extension/pull/38784

This problem was introduced recently in https://github.com/MetaMask/metamask-extension/pull/38093 (we didn't realize this was being initialized in multiple processes)

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `FixtureExtensionStore` initialization opt-in, initializing only in background while updating constructor, background usage, and tests.
> 
> - **Stores**:
>   - `FixtureExtensionStore`: add optional `{ initialize }` constructor arg (default `false`); when `true` perform network init, otherwise skip; ensure `get`/`set` wait for init; update init logging.
> - **Background**:
>   - Instantiate `FixtureExtensionStore` with `{ initialize: true }` when test fixture store is used in `app/scripts/background.js`.
> - **Tests**:
>   - Add test asserting initialization is skipped by default.
>   - Update tests to pass `{ initialize: true }` where initialization is required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce53c01f39ce69a384ad39eeecdb89e730995f25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->