### PR TITLE
feat(STX-331): extract refresh STX liveness from swaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/shield-controller": "^4.0.0",
     "@metamask/signature-controller": "^38.0.0",
-    "@metamask/smart-transactions-controller": "^21.0.0",
+    "@metamask/smart-transactions-controller": "^21.1.0",
     "@metamask/snaps-controllers": "^17.2.0",
     "@metamask/snaps-execution-environments": "^10.3.0",
     "@metamask/snaps-rpc-methods": "^14.1.1",

--- a/shared/modules/selectors/index.test.ts
+++ b/shared/modules/selectors/index.test.ts
@@ -59,6 +59,12 @@ describe('Selectors', () => {
         },
         smartTransactionsState: {
           liveness: true,
+          livenessByChainId: {
+            [CHAIN_IDS.MAINNET]: true,
+            [CHAIN_IDS.BSC]: true,
+            [CHAIN_IDS.SEPOLIA]: true,
+            [CHAIN_IDS.LINEA_MAINNET]: true,
+          },
         },
         ...mockNetworkState({
           id: 'network-configuration-id-1',
@@ -195,10 +201,22 @@ describe('Selectors', () => {
     );
 
     jestIt(
-      'returns false if feature flag is enabled, not a HW, STX liveness is false and is Ethereum network',
+      'returns false if feature flag is enabled, not a HW, STX liveness is false for chain',
       () => {
         const state = createSwapsMockStore();
-        state.metamask.smartTransactionsState.liveness = false;
+        state.metamask.smartTransactionsState.livenessByChainId[
+          CHAIN_IDS.MAINNET
+        ] = false;
+        expect(getSmartTransactionsEnabled(state)).toBe(false);
+      },
+    );
+
+    jestIt(
+      'returns false if feature flag is enabled, not a HW, STX liveness is not set for chain',
+      () => {
+        const state = createSwapsMockStore();
+        // @ts-expect-error Testing undefined liveness for chain
+        state.metamask.smartTransactionsState.livenessByChainId = {};
         expect(getSmartTransactionsEnabled(state)).toBe(false);
       },
     );

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -51,6 +51,7 @@ export type SmartTransactionsMetaMaskState = {
     };
     smartTransactionsState: {
       liveness: boolean;
+      livenessByChainId: Record<string, boolean>;
     };
   };
 };
@@ -176,6 +177,7 @@ export const getSmartTransactionsEnabled = (
   state: SmartTransactionsState,
   chainId?: string,
 ): boolean => {
+  const effectiveChainId = chainId ?? getCurrentChainId(state);
   const supportedAccount = accountSupportsSmartTx(state);
   // @ts-expect-error Smart transaction selector types does not match controller state
   const featureFlagsByChainId = getFeatureFlagsByChainId(state, chainId);
@@ -183,7 +185,9 @@ export const getSmartTransactionsEnabled = (
   const smartTransactionsFeatureFlagEnabled =
     featureFlagsByChainId?.smartTransactions?.extensionActive;
   const smartTransactionsLiveness =
-    state.metamask.smartTransactionsState?.liveness;
+    state.metamask.smartTransactionsState?.livenessByChainId?.[
+      effectiveChainId
+    ];
   return Boolean(
     getChainSupportsSmartTransactions(state, chainId) &&
       getIsAllowedRpcUrlForSmartTransactions(state, chainId) &&

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -840,6 +840,10 @@
   "smartTransactionsState": {
     "fees": {},
     "liveness": true,
+    "livenessByChainId": {
+      "0x1": true,
+      "0xaa36a7": true
+    },
     "smartTransactions": {
       "0x1": [],
       "0xaa36a7": []

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -661,6 +661,12 @@ export const createSwapsMockStore = () => {
         userOptIn: true,
         userOptInV2: true,
         liveness: true,
+        livenessByChainId: {
+          [CHAIN_IDS.MAINNET]: true,
+          [CHAIN_IDS.BSC]: true,
+          [CHAIN_IDS.SEPOLIA]: true,
+          [CHAIN_IDS.LINEA_MAINNET]: true,
+        },
         fees: createGetSmartTransactionFeesApiResponse(),
         smartTransactions: {
           [CHAIN_IDS.MAINNET]: [

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -1913,6 +1913,9 @@ describe('Bridge selectors', () => {
           },
           smartTransactionsState: {
             liveness: true,
+            livenessByChainId: {
+              '0x1': true,
+            },
           },
           swapsState: {
             swapsFeatureFlags: {
@@ -1950,6 +1953,9 @@ describe('Bridge selectors', () => {
           },
           smartTransactionsState: {
             liveness: true,
+            livenessByChainId: {
+              '0x1': true,
+            },
           },
           swapsState: {
             swapsFeatureFlags: {

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -22,7 +22,6 @@ import {
   setSwapsFeatureFlags,
   setSelectedQuoteAggId,
   setSwapsTxGasLimit,
-  fetchSmartTransactionsLiveness,
   signAndSendSmartTransaction,
   updateSmartTransaction,
   setSmartTransactionsRefreshInterval,
@@ -599,11 +598,6 @@ export const fetchSwapsLivenessAndFeatureFlags = () => {
       await dispatch(setSwapsFeatureFlags(swapsFeatureFlags));
       if (ALLOWED_SMART_TRANSACTIONS_CHAIN_IDS.includes(chainId)) {
         await dispatch(setCurrentSmartTransactionsError(undefined));
-        await dispatch(
-          fetchSmartTransactionsLiveness({
-            networkClientId: getSelectedNetworkClientId(state),
-          }),
-        );
         const transactions = await getTransactions({
           searchCriteria: {
             chainId,

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -15,7 +15,6 @@ const middleware = [thunk];
 jest.mock('../../store/actions.ts', () => ({
   setSwapsLiveness: jest.fn(),
   setSwapsFeatureFlags: jest.fn(),
-  fetchSmartTransactionsLiveness: jest.fn(),
   getTransactions: jest.fn(() => {
     return [];
   }),
@@ -85,7 +84,7 @@ describe('Ducks - Swaps', () => {
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
-      expect(mockDispatch).toHaveBeenCalledTimes(5);
+      expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
       expect(setSwapsFeatureFlags).toHaveBeenCalledWith(featureFlagsResponse);
       expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
@@ -106,7 +105,7 @@ describe('Ducks - Swaps', () => {
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
-      expect(mockDispatch).toHaveBeenCalledTimes(5);
+      expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
       expect(setSwapsFeatureFlags).toHaveBeenCalledWith(featureFlagsResponse);
       expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
@@ -128,7 +127,7 @@ describe('Ducks - Swaps', () => {
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
-      expect(mockDispatch).toHaveBeenCalledTimes(5);
+      expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
       expect(setSwapsFeatureFlags).toHaveBeenCalledWith(featureFlagsResponse);
       expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
@@ -174,7 +173,7 @@ describe('Ducks - Swaps', () => {
         createGetState(),
       );
       expect(featureFlagApiNock2.isDone()).toBe(false); // Second API call wasn't made, cache was used instead.
-      expect(mockDispatch).toHaveBeenCalledTimes(10);
+      expect(mockDispatch).toHaveBeenCalledTimes(8);
       expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
       expect(setSwapsFeatureFlags).toHaveBeenCalledWith(featureFlagsResponse);
       expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);

--- a/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.test.ts
+++ b/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as reactRedux from 'react-redux';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { useRefreshSmartTransactionsLiveness } from './useRefreshSmartTransactionsLiveness';
+
+const mockInnerFn = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../store/actions', () => ({
+  fetchSmartTransactionsLiveness: jest.fn(() => mockInnerFn),
+}));
+
+const mockFetchSmartTransactionsLiveness = jest.requireMock(
+  '../../../store/actions',
+).fetchSmartTransactionsLiveness;
+
+describe('useRefreshSmartTransactionsLiveness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (reactRedux.useSelector as jest.Mock).mockReturnValue(true); // opted in by default
+  });
+
+  it('does not fetch when chainId is null', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness(null));
+    expect(mockFetchSmartTransactionsLiveness).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when chainId is undefined', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness(undefined));
+    expect(mockFetchSmartTransactionsLiveness).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch for non-EVM chains', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness('solana:mainnet'));
+    expect(mockFetchSmartTransactionsLiveness).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch for unsupported EVM chains', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness('0x999'));
+    expect(mockFetchSmartTransactionsLiveness).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when user has not opted in', () => {
+    (reactRedux.useSelector as jest.Mock).mockReturnValue(false);
+    renderHook(() => useRefreshSmartTransactionsLiveness(CHAIN_IDS.MAINNET));
+    expect(mockFetchSmartTransactionsLiveness).not.toHaveBeenCalled();
+  });
+
+  it('fetches smart transactions liveness for mainnet', () => {
+    renderHook(() => useRefreshSmartTransactionsLiveness(CHAIN_IDS.MAINNET));
+    expect(mockFetchSmartTransactionsLiveness).toHaveBeenCalledTimes(1);
+    expect(mockFetchSmartTransactionsLiveness).toHaveBeenCalledWith({
+      chainId: CHAIN_IDS.MAINNET,
+    });
+    expect(mockInnerFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when chainId changes to another supported chain', () => {
+    const { rerender } = renderHook<{ chainId: string }, void>(
+      ({ chainId }) => useRefreshSmartTransactionsLiveness(chainId),
+      { initialProps: { chainId: CHAIN_IDS.MAINNET } },
+    );
+
+    expect(mockFetchSmartTransactionsLiveness).toHaveBeenCalledTimes(1);
+    expect(mockInnerFn).toHaveBeenCalledTimes(1);
+
+    // BSC is in both production and development allowed lists
+    rerender({ chainId: CHAIN_IDS.BSC });
+    expect(mockFetchSmartTransactionsLiveness).toHaveBeenCalledTimes(2);
+    expect(mockInnerFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.ts
+++ b/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { getAllowedSmartTransactionsChainIds } from '../../../../shared/constants/smartTransactions';
+import { getSmartTransactionsPreferenceEnabled } from '../../../../shared/modules/selectors';
+import { fetchSmartTransactionsLiveness } from '../../../store/actions';
+import { isNonEvmChain } from '../../../ducks/bridge/utils';
+
+/**
+ * Hook that fetches smart transactions liveness for a given chain.
+ * Ensures fresh liveness data is fetched when entering the page
+ * and when the chain changes.
+ *
+ * @param chainId - The chain ID to check for STX support (string or null/undefined).
+ */
+export function useRefreshSmartTransactionsLiveness(
+  chainId: string | null | undefined,
+): void {
+  const smartTransactionsOptInStatus = useSelector(
+    getSmartTransactionsPreferenceEnabled,
+  );
+
+  useEffect(() => {
+    if (!chainId || !smartTransactionsOptInStatus) {
+      return;
+    }
+
+    if (isNonEvmChain(chainId)) {
+      return;
+    }
+
+    // TODO: will be replaced with feature flags once we have them.
+    const allowedChainId = getAllowedSmartTransactionsChainIds().find(
+      (id) => id === chainId,
+    );
+
+    if (allowedChainId) {
+      fetchSmartTransactionsLiveness({ chainId: allowedChainId })();
+    }
+  }, [chainId, smartTransactionsOptInStatus]);
+}

--- a/ui/pages/bridge/index.tsx
+++ b/ui/pages/bridge/index.tsx
@@ -44,6 +44,7 @@ import PrepareBridgePage from './prepare/prepare-bridge-page';
 import AwaitingSignaturesCancelButton from './awaiting-signatures/awaiting-signatures-cancel-button';
 import AwaitingSignatures from './awaiting-signatures/awaiting-signatures';
 import { BridgeTransactionSettingsModal } from './prepare/bridge-transaction-settings-modal';
+import { useRefreshSmartTransactionsLiveness } from './hooks/useRefreshSmartTransactionsLiveness';
 
 const CrossChainSwap = () => {
   const t = useContext(I18nContext);
@@ -69,6 +70,9 @@ const CrossChainSwap = () => {
 
   // Get chain information to determine if we need gas estimates
   const fromChain = useSelector(getFromChain);
+
+  // Refresh smart transactions liveness for the source chain
+  useRefreshSmartTransactionsLiveness(fromChain?.chainId);
 
   // Only fetch gas estimates if the source chain is EVM (not Solana, Bitcoin, or Tron)
   const shouldFetchGasEstimates =

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6790,13 +6790,16 @@ export function cancelSmartTransaction(
 // TODO: Not a thunk but rather a wrapper around a background call
 export function fetchSmartTransactionsLiveness({
   networkClientId,
+  chainId,
 }: {
+  /** @deprecated Use `chainId` instead. */
   networkClientId?: string;
+  chainId?: string;
 } = {}) {
   return async () => {
     try {
       await submitRequestToBackground('fetchSmartTransactionsLiveness', [
-        { networkClientId },
+        { networkClientId, chainId },
       ]);
     } catch (err) {
       logErrorWithMessage(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8155,9 +8155,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^21.0.0":
-  version: 21.0.0
-  resolution: "@metamask/smart-transactions-controller@npm:21.0.0"
+"@metamask/smart-transactions-controller@npm:^21.1.0":
+  version: 21.1.0
+  resolution: "@metamask/smart-transactions-controller@npm:21.1.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -8188,7 +8188,7 @@ __metadata:
       optional: true
     "@metamask/remote-feature-flag-controller":
       optional: true
-  checksum: 10/a0d5c58f3671368a9f6649eef5c0ffe9b82c562662adf0641c898c32299577ead9f40514b2f44e805b8a0641335eaa36f14a3bf33eae037b6f063c338138f360
+  checksum: 10/85d51b140fd535cf129eed062d687f66d308a11315f433f60bf8484a447a00419af3939f6bf59d43bc3b8b9f0a8ee91a480937e1caef40984bde829cbce2d6eb
   languageName: node
   linkType: hard
 
@@ -32909,7 +32909,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/shield-controller": "npm:^4.0.0"
     "@metamask/signature-controller": "npm:^38.0.0"
-    "@metamask/smart-transactions-controller": "npm:^21.0.0"
+    "@metamask/smart-transactions-controller": "npm:^21.1.0"
     "@metamask/snap-account-abstraction-keyring-site": "npm:^1.0.0"
     "@metamask/snap-simple-keyring-site": "npm:^2.0.0"
     "@metamask/snaps-controllers": "npm:^17.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Separate smart transaction liveness refresh from swap flags. This is part of the migration of STX flags away from swaps.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38877?quickstart=1)

## **Changelog**

CHANGELOG entry: Added network specific smart transactions liveness check before submitting bridge quotes.

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates Smart Transactions (STX) liveness from swaps and makes it chain-specific.
> 
> - Replace global `smartTransactionsState.liveness` with `livenessByChainId`; update `getSmartTransactionsEnabled` to use effective chain ID
> - New `useRefreshSmartTransactionsLiveness` hook; invoked by `ui/pages/bridge/index.tsx` to fetch liveness for allowed EVM chains on load/chain change
> - Update `useSmartTransactionFeatureFlags` to gate by allowed chain IDs and call `fetchSmartTransactionsLiveness({ chainId })`
> - `fetchSmartTransactionsLiveness` now accepts `chainId` (deprecates `networkClientId`) and forwards both to background
> - Remove liveness fetch from swaps feature-flag flow; adjust related tests/dispatch counts
> - Add `livenessByChainId` to test fixtures and integration init state; update selector tests accordingly
> - Bump `@metamask/smart-transactions-controller` to `^21.1.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 444d0e7021e6de72f620519a1b7e89a630889cac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->