### PR TITLE
fix: issue where development gator snaps are blocked from making RPC requests

### DIFF
--- a/app/scripts/lib/rpcBlockingMiddleware.test.ts
+++ b/app/scripts/lib/rpcBlockingMiddleware.test.ts
@@ -21,6 +21,7 @@ describe('createRpcBlockingMiddleware', () => {
 
   it('calls next when not blocked', () => {
     const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [],
       state: { isBlocked: false },
     });
     const req = createRequest();
@@ -36,6 +37,7 @@ describe('createRpcBlockingMiddleware', () => {
   it('ends with an error when blocked and origin is not a preinstalled snap', () => {
     const customMessage = 'Requests are temporarily blocked';
     const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [],
       state: { isBlocked: true },
       errorMessage: customMessage,
     });
@@ -57,6 +59,7 @@ describe('createRpcBlockingMiddleware', () => {
     isSnapPreinstalledMock.mockReturnValue(true);
 
     const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [],
       state: { isBlocked: true },
     });
 
@@ -69,8 +72,26 @@ describe('createRpcBlockingMiddleware', () => {
     expect(end).not.toHaveBeenCalled();
   });
 
+  it('calls next when blocked but origin is in allowedOrigins', () => {
+    const allowedOrigin = 'https://dapp.example';
+    const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [allowedOrigin],
+      state: { isBlocked: true },
+    });
+
+    const req = createRequest(allowedOrigin);
+    const next = jest.fn();
+    const end = jest.fn();
+
+    middleware(req, res, next, end);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(end).not.toHaveBeenCalled();
+  });
+
   it('ends with an error when blocked and origin is missing', () => {
     const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [],
       state: { isBlocked: true },
     });
 
@@ -91,6 +112,7 @@ describe('createRpcBlockingMiddleware', () => {
     const state = { isBlocked: true };
 
     const middleware = createRpcBlockingMiddleware({
+      allowedOrigins: [],
       state,
     });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1181,10 +1181,12 @@ export default class MetamaskController extends EventEmitter {
           {
             snapId: process.env.PERMISSIONS_KERNEL_SNAP_ID,
             handleRequest: this.handleSnapRequest.bind(this),
-            onBeforeRequest: () =>
-              (rpcBlockingMiddlewareState.isBlocked = true),
-            onAfterRequest: () =>
-              (rpcBlockingMiddlewareState.isBlocked = false),
+            onBeforeRequest: () => {
+              rpcBlockingMiddlewareState.isBlocked = true;
+            },
+            onAfterRequest: () => {
+              rpcBlockingMiddlewareState.isBlocked = false;
+            },
           },
           params,
           req,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1068,6 +1068,10 @@ export default class MetamaskController extends EventEmitter {
     const rpcBlockingMiddlewareState = { isBlocked: false };
     const eip7715BlockingMiddleware = createRpcBlockingMiddleware({
       state: rpcBlockingMiddlewareState,
+      allowedOrigins: [
+        process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID,
+        process.env.PERMISSIONS_KERNEL_SNAP_ID,
+      ],
       errorMessage:
         'Cannot process requests while a wallet_requestExecutionPermissions request is in process',
     });


### PR DESCRIPTION
## **Description**

`RPCBlockingMiddleware` blocks all RPC requests expect for if the origin is a preinstalled snap. Unfortunately this breaks development environments where the gator permissions snaps aren't preinstalled. This fixes that issue, by configuring the `RPCBlockingMiddleware` with the gator permissions snaps configured as allowed snaps (requests from these snaps are _always_ allowed, even when serving `wallet_requestExecutionPermissions`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38878?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

No changelog, because the impacted functionality (Advanced Permissions) is not yet released.

## **Related issues**


## **Manual testing steps**

Run gator permissions snaps locally. Run extension configured to use local snaps.

Request `wallet_requestExecutionPermissions`.

Expect request to be served successfully.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `allowedOrigins` allowlist to RPC blocking middleware and configures permissions snaps to bypass blocking; updates tests accordingly.
> 
> - **RPC middleware (`app/scripts/lib/rpcBlockingMiddleware.ts`)**
>   - Add `allowedOrigins: string[]` option and bypass logic when blocked (`origin` in `allowedOrigins` or preinstalled snap).
>   - Update JSDoc and error handling flow accordingly.
> - **Controller integration (`app/scripts/metamask-controller.js`)**
>   - Instantiate blocking middleware with `allowedOrigins` set to `process.env.GATOR_PERMISSIONS_PROVIDER_SNAP_ID` and `process.env.PERMISSIONS_KERNEL_SNAP_ID`.
>   - Minor refactor of request lifecycle hooks to toggle `isBlocked`.
> - **Tests (`app/scripts/lib/rpcBlockingMiddleware.test.ts`)**
>   - Update setups to pass `allowedOrigins`.
>   - Add test asserting allowed origin bypasses blocking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aecad9a9446fff5063ccd87a3b6d828fe42a2283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->