### PR TITLE
chore: add erc20 token revocation to permissions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -610,6 +610,9 @@
   "allTimeLow": {
     "message": "All-time low"
   },
+  "allTokens": {
+    "message": "All tokens"
+  },
   "allowAddRpc": {
     "message": "Add RPC"
   },
@@ -5625,6 +5628,9 @@
   },
   "revokeSimulationDetailsDesc": {
     "message": "You're removing someone's permission to spend tokens from your account."
+  },
+  "revokeTokenApprovals": {
+    "message": "Revoke token approvals"
   },
   "reward": {
     "message": "Reward"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -610,6 +610,9 @@
   "allTimeLow": {
     "message": "All-time low"
   },
+  "allTokens": {
+    "message": "All tokens"
+  },
   "allowAddRpc": {
     "message": "Add RPC"
   },
@@ -5625,6 +5628,9 @@
   },
   "revokeSimulationDetailsDesc": {
     "message": "You're removing someone's permission to spend tokens from your account."
+  },
+  "revokeTokenApprovals": {
+    "message": "Revoke token approvals"
   },
   "reward": {
     "message": "Reward"

--- a/builds.yml
+++ b/builds.yml
@@ -146,7 +146,7 @@ buildTypes:
       - APPLE_FLASK_CLIENT_ID
       - GOOGLE_CLIENT_ID_REF: GOOGLE_FLASK_CLIENT_ID
       - APPLE_CLIENT_ID_REF: APPLE_FLASK_CLIENT_ID
-      - GATOR_ENABLED_PERMISSION_TYPES: 'native-token-stream,native-token-periodic,erc20-token-stream,erc20-token-periodic'
+      - GATOR_ENABLED_PERMISSION_TYPES: 'native-token-stream,native-token-periodic,erc20-token-stream,erc20-token-periodic,erc20-token-revocation'
       - GATOR_PERMISSIONS_REVOCATION_ENABLED: true
 
     isPrerelease: true

--- a/shared/lib/gator-permissions/gator-permissions-utils.test.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.test.ts
@@ -420,6 +420,19 @@ describe('gator-permissions-utils', () => {
       });
     });
 
+    it('should return correct metadata for erc20-token-revocation', () => {
+      const result = getGatorPermissionDisplayMetadata(
+        'erc20-token-revocation',
+        {},
+      );
+
+      expect(result).toStrictEqual({
+        displayNameKey: 'revokeTokenApprovals',
+        amount: '',
+        frequencyKey: '',
+      });
+    });
+
     it('should return default metadata for unknown permission type', () => {
       const result = getGatorPermissionDisplayMetadata('unknown-type', {});
 

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -450,6 +450,14 @@ export function getGatorPermissionDisplayMetadata(
     };
   }
 
+  if (permissionType === 'erc20-token-revocation') {
+    return {
+      displayNameKey: 'revokeTokenApprovals',
+      amount: '',
+      frequencyKey: '',
+    };
+  }
+
   return {
     displayNameKey: 'permission',
     amount: '',

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -2310,7 +2310,7 @@
     "accountsAssets": {},
     "assetsMetadata": {},
     "allIgnoredAssets": {},
-    "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
+    "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"erc20-token-revocation\":{},\"other\":{}}",
     "isGatorPermissionsEnabled": false,
     "isFetchingGatorPermissions": false,
     "isUpdatingGatorPermissions": false,

--- a/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
+++ b/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
@@ -101,6 +101,14 @@ export const PermissionItem: React.FC<PermissionItemProps> = ({
 
   // Only memoize the formatted description since it depends on multiple values
   const formattedDescription = useMemo(() => {
+    // For erc20-token-revocation, only show account info (no amount/frequency data)
+    if (permission.permissionType === 'erc20-token-revocation') {
+      if (signerAddress) {
+        return accountName || shortenAddress(signerAddress);
+      }
+      return '';
+    }
+
     let description = formatAmountDescription(
       amount,
       tokenInfo.symbol,
@@ -123,6 +131,7 @@ export const PermissionItem: React.FC<PermissionItemProps> = ({
     signerAddress,
     accountName,
     formatAmountDescription,
+    permission.permissionType,
   ]);
 
   return (

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
@@ -385,6 +385,181 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
 </div>
 `;
 
+exports[`Permission List Item render ERC20 token permissions renders erc20 token revocation permission correctly without frequency row 1`] = `
+<div>
+  <div
+    class="box box--margin-4 box--padding-4 box--gap-1 box--flex-direction-row box--background-color-background-default box--rounded-md box--border-style-solid box--border-color-border-muted box--border-width-1"
+    data-testid="review-gator-permission-item"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="flex flex-row gap-2 justify-between"
+        style="flex: 1; align-self: center;"
+      >
+        <p
+          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-left truncate"
+        >
+          localhost:8000
+        </p>
+        <button
+          class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+          role="button"
+          style="background-color: transparent; padding: 0px;"
+        >
+          <p
+            class="text-error-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+          >
+            Revoke
+          </p>
+        </button>
+      </div>
+    </div>
+    <div
+      class="bg-default"
+    >
+      <div
+        class="flex flex-row gap-4 justify-between mt-2"
+        style="flex: 1; align-self: center;"
+      >
+        <p
+          class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-left"
+        >
+          Revoke token approvals
+        </p>
+        <div
+          class="flex flex-row gap-2 items-center justify-end"
+          style="flex: 1; align-self: center;"
+        >
+          <div
+            class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
+            style="height: 16px; width: 100px;"
+          >
+            <p
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-right"
+              data-testid="review-gator-permission-amount-label"
+            >
+              All tokens
+            </p>
+          </div>
+        </div>
+      </div>
+      
+      <div
+        class="flex flex-row gap-4 justify-between mt-2"
+        style="flex: 1; align-self: center;"
+      >
+        <p
+          class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-left"
+        >
+          Account
+        </p>
+        <div
+          class="flex flex-row gap-2 items-center justify-end"
+          style="flex: 1; align-self: center;"
+        >
+          <div
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          >
+            <div
+              class="flex [&>div]:!rounded-none"
+            >
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(251, 24, 39);"
+              >
+                <svg
+                  height="32"
+                  width="32"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#1864F2"
+                    height="32"
+                    transform="translate(9.96703630109566 2.15221170843441) rotate(42.9 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#C81420"
+                    height="32"
+                    transform="translate(-5.34718879899408 14.69096052287909) rotate(270.0 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#F97D01"
+                    height="32"
+                    transform="translate(28.51282382181125 4.72720698958831) rotate(127.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <p
+            class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+            data-testid="review-gator-permission-account-name"
+          >
+            Test Gator Account
+          </p>
+          <button
+            aria-label="copy-button"
+            class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+            style="cursor: pointer; position: static;"
+          >
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/copy.svg');"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class=""
+    >
+      <div
+        class="flex flex-row gap-2 justify-between mt-2"
+        style="flex: 1; align-self: center;"
+      >
+        <div
+          class="flex flex-row gap-2 justify-between"
+          style="flex: 1; align-self: center; cursor: pointer;"
+        >
+          <p
+            class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+          >
+            Show Details
+          </p>
+          <button
+            aria-label="expand"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            color="text-icon-muted"
+          >
+            <svg
+              class="inline-block w-4 h-4 text-inherit"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m2 7.887 1.775-1.775L12 14.337l8.225-8.225L22 7.887l-10 10z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Permission List Item render ERC20 token permissions renders erc20 token stream permission correctly 1`] = `
 <div>
   <div

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
@@ -594,6 +594,84 @@ describe('Permission List Item', () => {
         const expandedSkeletons = container.querySelectorAll('.mm-skeleton');
         expect(expandedSkeletons.length).toBeGreaterThan(skeletons.length);
       });
+
+      it('renders erc20 token revocation permission correctly without frequency row', () => {
+        const mockErc20TokenRevocationPermission: StoredGatorPermissionSanitized<
+          Signer,
+          {
+            type: 'erc20-token-revocation';
+            isAdjustmentAllowed: boolean;
+            data: Record<string, unknown>;
+            rules?: {
+              type: string;
+              isAdjustmentAllowed: boolean;
+              data: { timestamp: number };
+            }[];
+          }
+        > = {
+          permissionResponse: {
+            chainId: '0x1',
+            address: mockAccountAddress,
+            permission: {
+              type: 'erc20-token-revocation',
+              isAdjustmentAllowed: false,
+              data: {
+                justification: 'Revoke all token approvals',
+              },
+              rules: [
+                {
+                  type: 'expiry',
+                  isAdjustmentAllowed: false,
+                  data: { timestamp: 1736358176 }, // January 8, 2025
+                },
+              ],
+            },
+            context: '0x00000000',
+            signerMeta: {
+              delegationManager: '0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3',
+            },
+          },
+          siteOrigin: 'http://localhost:8000',
+        };
+
+        const { container, getByTestId, queryByTestId } = renderWithProvider(
+          <ReviewGatorPermissionItem
+            networkName={mockNetworkName}
+            gatorPermission={mockErc20TokenRevocationPermission}
+            onRevokeClick={() => mockOnClick()}
+          />,
+          store,
+        );
+
+        expect(container).toMatchSnapshot();
+
+        expect(getByTestId('review-gator-permission-item')).toBeInTheDocument();
+
+        // Verify the amount label shows "All tokens" (the value for revocation)
+        const amountLabel = getByTestId('review-gator-permission-amount-label');
+        expect(amountLabel).toHaveTextContent('All tokens');
+
+        // Verify frequency row is NOT rendered for revocation permission
+        expect(
+          queryByTestId('review-gator-permission-frequency-label'),
+        ).not.toBeInTheDocument();
+
+        // Expand to see more details
+        const expandButton = container.querySelector('[aria-label="expand"]');
+        if (expandButton) {
+          fireEvent.click(expandButton);
+        }
+
+        // Verify expiration date is rendered
+        const expirationDate = getByTestId(
+          'review-gator-permission-expiration-date',
+        );
+        expect(expirationDate).toBeInTheDocument();
+
+        // Verify network name is rendered
+        const networkName = getByTestId('review-gator-permission-network-name');
+        expect(networkName).toHaveTextContent(mockNetworkName);
+      });
     });
   });
 });

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -346,6 +346,40 @@ export const ReviewGatorPermissionItem = ({
   );
 
   /**
+   * Returns the token revocation permission details
+   *
+   * @returns The permission details for erc20-token-revocation
+   */
+  const getTokenRevocationPermissionDetails =
+    useCallback((): PermissionDetails => {
+      return {
+        amountLabel: {
+          translationKey: 'revokeTokenApprovals',
+          value: t('allTokens'),
+          testId: 'review-gator-permission-amount-label',
+        },
+        frequencyLabel: {
+          translationKey: '',
+          valueTranslationKey: '',
+          testId: 'review-gator-permission-frequency-label',
+        },
+        expandedDetails: {
+          expirationDate: {
+            translationKey: 'gatorPermissionsExpirationDate',
+            value: getExpirationDate(
+              (
+                permissionResponse.permission as unknown as {
+                  rules: GatorPermissionRule[];
+                }
+              ).rules,
+            ),
+            testId: 'review-gator-permission-expiration-date',
+          },
+        },
+      };
+    }, [t, getExpirationDate, permissionResponse.permission]);
+
+  /**
    * Returns the permission details
    *
    * @returns The permission details
@@ -362,6 +396,8 @@ export const ReviewGatorPermissionItem = ({
         return getTokenPeriodicPermissionDetails(
           permissionResponse.permission as Erc20TokenPeriodicPermission,
         );
+      case 'erc20-token-revocation':
+        return getTokenRevocationPermissionDetails();
       default:
         throw new Error(`Invalid permission type: ${permissionType}`);
     }
@@ -370,6 +406,7 @@ export const ReviewGatorPermissionItem = ({
     getTokenStreamPermissionDetails,
     permissionResponse.permission,
     getTokenPeriodicPermissionDetails,
+    getTokenRevocationPermissionDetails,
   ]);
 
   return (
@@ -426,11 +463,13 @@ export const ReviewGatorPermissionItem = ({
           testId={permissionDetails.amountLabel.testId}
           isLoading={loading}
         />
-        <PermissionDetailRow
-          label={t(permissionDetails.frequencyLabel.translationKey)}
-          value={t(permissionDetails.frequencyLabel.valueTranslationKey)}
-          testId={permissionDetails.frequencyLabel.testId}
-        />
+        {permissionDetails.frequencyLabel.translationKey && (
+          <PermissionDetailRow
+            label={t(permissionDetails.frequencyLabel.translationKey)}
+            value={t(permissionDetails.frequencyLabel.valueTranslationKey)}
+            testId={permissionDetails.frequencyLabel.testId}
+          />
+        )}
         {/* Account row - custom layout with avatar and copy icon */}
         <Box
           flexDirection={BoxFlexDirection.Row}

--- a/ui/components/multichain/pages/gator-permissions/gator-permissions-page.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/gator-permissions-page.test.tsx
@@ -37,6 +37,7 @@ mockState.metamask.gatorPermissionsMapSerialized = JSON.stringify({
   'native-token-stream': {},
   'erc20-token-stream': {},
   'erc20-token-periodic': {},
+  'erc20-token-revocation': {},
   other: {},
 });
 mockState.metamask.isGatorPermissionsEnabled = true;

--- a/ui/selectors/gator-permissions/gator-permissions.ts
+++ b/ui/selectors/gator-permissions/gator-permissions.ts
@@ -63,6 +63,7 @@ const TOKEN_TRANSFER_PERMISSION_TYPES: SupportedGatorPermissionType[] = [
   'erc20-token-stream',
   'native-token-periodic',
   'erc20-token-periodic',
+  'erc20-token-revocation',
 ];
 
 const getMetamask = (state: AppState) => state.metamask;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds support for the `erc20-token-revocation` permission type to the Gator permissions system.

**Why:**
- Enable users to grant delegated permissions for revoking ERC20 token approvals through the Gator system.

**What's included:**
- Added `erc20-token-revocation` to enabled permission types in Flask builds
- Added new translation keys (`allTokens`, `revokeTokenApprovals`)
- Updated `getGatorPermissionDisplayMetadata` to handle revocation permissions
- Added revocation-specific display logic in `ReviewGatorPermissionItem` (shows "All tokens" instead of amount, hides frequency row)
- Updated `PermissionItem` to display only account info for revocation permissions
- Added `erc20-token-revocation` to `TOKEN_TRANSFER_PERMISSION_TYPES` selector
- Added comprehensive test coverage for the new permission type

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38888?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for `erc20-token-revocation` permission

## **Related issues**

Fixes:

## **Manual testing steps**

1. Approve a erc20 token revocation permission
2. Check it in all permissions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/bb96bd88-cb4b-4f0f-a2fb-870f14b31235


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for `erc20-token-revocation` across utils, UI, selectors, Flask build config, locales, and tests.
> 
> - **Gator Permissions (core/utils)**:
>   - Handle `erc20-token-revocation` in `getGatorPermissionDisplayMetadata` (no amount/frequency).
> - **UI**:
>   - `ui/components/.../review-gator-permission-item.tsx`: Display revocation as "All tokens", hide frequency row, include expiration in details; conditional rendering of frequency row.
>   - `ui/components/.../disconnect-permissions-modal/permission-item.tsx`: For revocation, show only account info in description.
> - **Selectors**:
>   - Add `erc20-token-revocation` to `TOKEN_TRANSFER_PERMISSION_TYPES` in `ui/selectors/gator-permissions`.
> - **Builds**:
>   - `builds.yml` (Flask): Enable `erc20-token-revocation` in `GATOR_ENABLED_PERMISSION_TYPES`.
> - **Locales**:
>   - Add `allTokens` and `revokeTokenApprovals` to `app/_locales/en/messages.json` and `en_GB/messages.json`.
> - **Tests & Fixtures**:
>   - Add tests and snapshots for revocation display and behavior; update mock state to include `erc20-token-revocation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87899fc7143340a20acc35a740815674c33a0968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->