### PR TITLE
fix: Fix transaction re-simulation on sidepanel

### DIFF
--- a/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
+++ b/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { TransactionType } from '@metamask/transaction-controller';
+
+import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
+// eslint-disable-next-line import/no-restricted-paths
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { setTransactionActive } from '../../../store/actions';
 import { useWindowFocus } from '../../../hooks/useWindowFocus';
 import { useConfirmContext } from '../context/confirm';
@@ -24,6 +28,7 @@ export const useTransactionFocusEffect = () => {
   const [focusedConfirmationId, setFocusedConfirmationId] = useState<
     string | null
   >(null);
+  const isSidepanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
 
   const setTransactionFocus = useCallback(
     async (transactionId: string, isFocused: boolean) => {
@@ -45,8 +50,11 @@ export const useTransactionFocusEffect = () => {
       return;
     }
 
-    if (isWindowFocused && focusedConfirmationId !== id) {
-      // If the window is focused and the focused confirmation is not the current one,
+    // Sidepanel is always considered focused since it's always visible alongside the dapp
+    const isFocused = isWindowFocused || isSidepanel;
+
+    if (isFocused && focusedConfirmationId !== id) {
+      // If the window is focused (or sidepanel) and the focused confirmation is not the current one,
       // we need to unfocus the previous focused confirmation and focus the current one
       if (focusedConfirmationId) {
         setTransactionFocus(focusedConfirmationId, false);
@@ -54,11 +62,18 @@ export const useTransactionFocusEffect = () => {
       // Set the focused confirmation to the current one
       setFocusedConfirmationId(id);
       setTransactionFocus(id, true);
-    } else if (!isWindowFocused && focusedConfirmationId) {
-      // If the window is not focused and there is a focused confirmation,
+    } else if (!isFocused && focusedConfirmationId) {
+      // If the window is not focused (and not sidepanel) and there is a focused confirmation,
       // we need to unfocus the focused confirmation
       setTransactionFocus(focusedConfirmationId, false);
       setFocusedConfirmationId(null);
     }
-  }, [focusedConfirmationId, id, isWindowFocused, setTransactionFocus, type]);
+  }, [
+    focusedConfirmationId,
+    id,
+    isSidepanel,
+    isWindowFocused,
+    setTransactionFocus,
+    type,
+  ]);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In transaction confirmations we have a re-simulate feature that protects user's transaction from front running. In UI logic we are only re-simulating every 3 seconds if user focused on the window.

In side panel mode extension always open alongside with dApp, hence we want to keep re-simulate.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38890?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix transaction re-simulation on side panel mode

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38889

## **Manual testing steps**

1. Open extension as side panel
2. Start dapp transaction (See sentinel requests in network tab)
3. Focus dapp alongside with sidepanel
4. See network requests to sentinel NOT stopped

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates transaction focus logic to consider sidepanel always focused and adds tests covering sidepanel behavior.
> 
> - **Confirmations UI** (`ui/pages/confirmations/hooks/useTransactionFocusEffect.ts`):
>   - Add environment detection via `getEnvironmentType` and `ENVIRONMENT_TYPE_SIDEPANEL`.
>   - Treat sidepanel as always focused (`isFocused = isWindowFocused || isSidepanel`) and adjust focus/unfocus logic accordingly.
>   - Update effect dependencies to include `isSidepanel`.
> - **Tests** (`ui/pages/confirmations/hooks/useTransactionFocusEffect.test.ts`):
>   - Mock `getEnvironmentType` and default to `ENVIRONMENT_TYPE_POPUP`.
>   - Add sidepanel test cases to ensure focus when window not focused, persistence on blur, and correct switching between confirmations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62a1364860f77e0427e30b3ea66b9c4ff05a7560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->