### PR TITLE
feat: add memoization to deprecated assets selector

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -182,8 +182,7 @@ const CrossChainSwapTxDetails = () => {
   // TODO set for gasless swaps
   const gasCurrency = useSelector(
     (state: {
-      metamask: {
-        networkConfigurationsByChainId: Record<string, unknown>;
+      metamask: MetaMaskReduxState['metamask'] & {
         provider: Record<string, unknown>;
       };
     }) =>

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -180,9 +180,18 @@ const CrossChainSwapTxDetails = () => {
     getIsDelayed(bridgeStatus, bridgeHistoryItem);
 
   // TODO set for gasless swaps
-  const gasCurrency = getNativeTokenInfo(
-    rootState as MetaMaskReduxState,
-    srcChainTxMeta?.chainId ?? '',
+  const gasCurrency = useSelector(
+    (state: {
+      metamask: {
+        networkConfigurationsByChainId: Record<string, unknown>;
+        provider: Record<string, unknown>;
+      };
+    }) =>
+      getNativeTokenInfo(
+        state.metamask.networkConfigurationsByChainId,
+        state.metamask.provider,
+        srcChainTxMeta?.chainId ?? '',
+      ),
   ) as { decimals: number; symbol: string };
 
   const srcNetworkIconName = (

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -3,7 +3,7 @@ import { NativeTokenPeriodicPermission } from '@metamask/gator-permissions-contr
 import type { Hex } from '@metamask/utils';
 import React from 'react';
 
-import { DefaultRootState, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   ConfirmInfoRow,
   ConfirmInfoRowDivider,
@@ -47,8 +47,18 @@ export const NativeTokenPeriodicDetails: React.FC<{
 
   const { startTime, periodAmount, periodDuration } = permission.data;
 
-  const { symbol, decimals } = useSelector<DefaultRootState, NativeTokenInfo>(
-    (state) => getNativeTokenInfo(state, chainId) as NativeTokenInfo,
+  const { symbol, decimals } = useSelector(
+    (state: {
+      metamask: {
+        networkConfigurationsByChainId: Record<string, unknown>;
+        provider: Record<string, unknown>;
+      };
+    }) =>
+      getNativeTokenInfo(
+        state.metamask.networkConfigurationsByChainId,
+        state.metamask.provider,
+        chainId,
+      ) as NativeTokenInfo,
   );
 
   const tokenImageUrl = CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId];

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -9,7 +9,10 @@ import {
   ConfirmInfoRowDivider,
 } from '../../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import { getNativeTokenInfo } from '../../../../../../../selectors';
+import {
+  getNativeTokenInfo,
+  MetaMaskReduxState,
+} from '../../../../../../../selectors';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../../../../shared/constants/network';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { formatPeriodDuration } from './typed-sign-permission-util';
@@ -49,8 +52,7 @@ export const NativeTokenPeriodicDetails: React.FC<{
 
   const { symbol, decimals } = useSelector(
     (state: {
-      metamask: {
-        networkConfigurationsByChainId: Record<string, unknown>;
+      metamask: MetaMaskReduxState['metamask'] & {
         provider: Record<string, unknown>;
       };
     }) =>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -7,7 +7,10 @@ import { useSelector } from 'react-redux';
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
 import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
-import { getNativeTokenInfo } from '../../../../../../../selectors';
+import {
+  getNativeTokenInfo,
+  MetaMaskReduxState,
+} from '../../../../../../../selectors';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../../../../shared/constants/network';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { NativeAmountRow } from './native-amount-row';
@@ -49,8 +52,7 @@ export const NativeTokenStreamDetails: React.FC<{
 
   const { symbol, decimals } = useSelector(
     (state: {
-      metamask: {
-        networkConfigurationsByChainId: Record<string, unknown>;
+      metamask: MetaMaskReduxState['metamask'] & {
         provider: Record<string, unknown>;
       };
     }) =>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from 'bignumber.js';
 import { NativeTokenStreamPermission } from '@metamask/gator-permissions-controller';
 import type { Hex } from '@metamask/utils';
 import React from 'react';
-import { DefaultRootState, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
@@ -47,8 +47,18 @@ export const NativeTokenStreamDetails: React.FC<{
   // DAY is in milliseconds, so we divide by 1000 to get seconds
   const amountPerDay = new BigNumber(amountPerSecond).mul(DAY / 1000);
 
-  const { symbol, decimals } = useSelector<DefaultRootState, NativeTokenInfo>(
-    (state) => getNativeTokenInfo(state, chainId) as NativeTokenInfo,
+  const { symbol, decimals } = useSelector(
+    (state: {
+      metamask: {
+        networkConfigurationsByChainId: Record<string, unknown>;
+        provider: Record<string, unknown>;
+      };
+    }) =>
+      getNativeTokenInfo(
+        state.metamask.networkConfigurationsByChainId,
+        state.metamask.provider,
+        chainId,
+      ) as NativeTokenInfo,
   );
 
   const tokenImageUrl = CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId];

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { sumHexes } from '../../../../shared/modules/conversion.utils';
 import {
   getMultichainNetworkConfigurationsByChainId,
-  getNativeTokenCachedBalanceByChainIdByAccountAddress,
+  getNativeTokenCachedBalanceByChainIdSelector,
   selectTransactionFeeById,
 } from '../../../selectors';
 import { useConfirmContext } from '../context/confirm';
@@ -30,10 +30,7 @@ export function useHasInsufficientBalance(): {
     ) ?? [];
 
   const chainBalances = useSelector((state) =>
-    getNativeTokenCachedBalanceByChainIdByAccountAddress(
-      state,
-      fromAddress ?? '',
-    ),
+    getNativeTokenCachedBalanceByChainIdSelector(state, fromAddress ?? ''),
   ) as Record<Hex, Hex>;
 
   const balance = chainBalances?.[chainId as Hex] ?? ZERO_HEX_FALLBACK;

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1302,11 +1302,6 @@ const getStateForAssetSelector = ({ metamask }: any) => {
   } as AssetListState;
 };
 
-// export const getAllAssets = createDeepEqualSelector(
-//   getStateForAssetSelector,
-//   (assetListState: AssetListState) => selectAllAssets(assetListState),
-// );
-
 export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
   getStateForAssetSelector,
   (assetListState: AssetListState) =>

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -159,6 +159,9 @@ export function getHistoricalPrices(state: AssetsRatesState) {
   return state.metamask.historicalPrices;
 }
 
+/**
+ * @deprecated use selectBalanceByAccountGroup instead
+ */
 export const getTokenBalancesEvm = createDeepEqualSelector(
   getTokensAcrossChainsByAccountAddressSelector,
   getNativeTokenCachedBalanceByChainIdSelector,
@@ -263,6 +266,9 @@ export const getTokenBalancesEvm = createDeepEqualSelector(
   },
 );
 
+/**
+ * @deprecated use getAllAssets instead
+ */
 export const getMultiChainAssets = createDeepEqualSelector(
   (_state, selectedAccount) => selectedAccount,
   getMultichainBalances,
@@ -327,6 +333,7 @@ export const getMultiChainAssets = createDeepEqualSelector(
 /**
  * Gets a {@link Token} (EVM or Multichain) owned by the passed account by address and chainId.
  *
+ * @deprecated use getAllAssets instead
  * @param state - Redux state object
  * @param tokenAddress - Token address (Hex for EVM, or CaipAssetType for non-EVM)
  * @param chainId - Chain ID (Hex for EVM, or CaipChainId for non-EVM)
@@ -385,6 +392,9 @@ export const getTokenByAccountAndAddressAndChainId = createDeepEqualSelector(
 
 const zeroBalanceAssetFallback = { amount: 0, unit: '' };
 
+/**
+ * @deprecated use selectBalanceByAccountGroup instead
+ */
 export const getMultichainAggregatedBalance = createDeepEqualSelector(
   (_state, selectedAccount) => selectedAccount,
   getMultichainBalances,
@@ -558,6 +568,7 @@ export const getMultichainNativeAssetType = createDeepEqualSelector(
 /**
  * Gets the balance of the native token of the current network for the selected account.
  *
+ * @deprecated use selectBalanceByAccountGroup instead
  * @param state - Redux state object
  * @param selectedAccount - Selected account
  * @returns Balance of the native token, or fallbacks to { amount: 0, unit: '' } if no native token is found
@@ -1290,6 +1301,11 @@ const getStateForAssetSelector = ({ metamask }: any) => {
     ...multichainState,
   } as AssetListState;
 };
+
+// export const getAllAssets = createDeepEqualSelector(
+//   getStateForAssetSelector,
+//   (assetListState: AssetListState) => selectAllAssets(assetListState),
+// );
 
 export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
   getStateForAssetSelector,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -857,12 +857,11 @@ export const getNativeTokenCachedBalanceByChainIdSelector = createSelector(
   },
 );
 
+// eslint-disable-next-line jsdoc/require-param
 /**
  * Get the tokens across chains for a given account address
  *
  * @deprecated use getAllAssets instead
- * @param {object} state - Redux state
- * @param {string} accountAddress - The address of the account
  */
 export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
   [

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -879,7 +879,6 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
     nativeTokenBalancesByChainId,
     selectedAddress,
   ) => {
-    console.log('DEBUG getTokensAcrossChainsByAccountAddressSelector CALLED');
     const tokensByChain = {};
 
     const chainIds = new Set([

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -857,11 +857,12 @@ export const getNativeTokenCachedBalanceByChainIdSelector = createSelector(
   },
 );
 
-// eslint-disable-next-line jsdoc/require-param
 /**
  * Get the tokens across chains for a given account address
  *
  * @deprecated use getAllAssets instead
+ * @param {object} state - Redux state
+ * @param {string} accountAddress - The address of the account
  */
 export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
   [
@@ -879,6 +880,7 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
     nativeTokenBalancesByChainId,
     selectedAddress,
   ) => {
+    console.log('DEBUG getTokensAcrossChainsByAccountAddressSelector CALLED');
     const tokensByChain = {};
 
     const chainIds = new Set([

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -814,7 +814,11 @@ export function getSelectedAccountTokensAcrossChains(state) {
 
     const nativeBalance = nativeTokenBalancesByChainId[chainId];
     if (nativeBalance) {
-      const nativeTokenInfo = getNativeTokenInfo(state, chainId);
+      const nativeTokenInfo = getNativeTokenInfo(
+        state.metamask.networkConfigurationsByChainId,
+        state.metamask.provider,
+        chainId,
+      );
       tokensByChain[chainId].push({
         ...nativeTokenInfo,
         address: '',
@@ -875,6 +879,7 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
     nativeTokenBalancesByChainId,
     selectedAddress,
   ) => {
+    console.log('DEBUG getTokensAcrossChainsByAccountAddressSelector CALLED');
     const tokensByChain = {};
 
     const chainIds = new Set([

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -772,6 +772,7 @@ export function getSelectedAccountNativeTokenCachedBalanceByChainId(state) {
  * Based on the current account address, query for all tokens across all chain networks on that account,
  * including the native tokens, without hardcoding any native token information.
  *
+ * @deprecated use getAssetsBySelectedAccountGroup instead
  * @param {object} state - Redux state
  * @returns {object} An object mapping chain IDs to arrays of tokens (including native tokens) with balances.
  */
@@ -830,6 +831,7 @@ export function getSelectedAccountTokensAcrossChains(state) {
 /**
  * Get the native token balance for a given account address and chainId
  *
+ * @deprecated use selectBalanceByWallet instead
  * @param {object} state - Redux state
  * @param {string} accountAddress - The address of the account
  * @param {string} chainId - The chainId of the account
@@ -851,62 +853,67 @@ export const getNativeTokenCachedBalanceByChainIdSelector = createSelector(
   },
 );
 
-export const getTokensAcrossChainsByAccountAddressSelector =
-  createDeepEqualSelector(
-    [
-      (state) => state.metamask.allTokens,
-      (state) => state.metamask.networkConfigurationsByChainId,
-      (state) => state.metamask.provider,
-      (state, accountAddress) =>
-        getNativeTokenCachedBalanceByChainIdSelector(state, accountAddress),
-      (_state, accountAddress) => accountAddress,
-    ],
-    (
-      allTokens,
-      networkConfigurationsByChainId,
-      provider,
-      nativeTokenBalancesByChainId,
-      selectedAddress,
-    ) => {
-      const tokensByChain = {};
+// eslint-disable-next-line jsdoc/require-param
+/**
+ * Get the tokens across chains for a given account address
+ *
+ * @deprecated use getAllAssets instead
+ */
+export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
+  [
+    (state) => state.metamask.allTokens,
+    (state) => state.metamask.networkConfigurationsByChainId,
+    (state) => state.metamask.provider,
+    (state, accountAddress) =>
+      getNativeTokenCachedBalanceByChainIdSelector(state, accountAddress),
+    (_state, accountAddress) => accountAddress,
+  ],
+  (
+    allTokens,
+    networkConfigurationsByChainId,
+    provider,
+    nativeTokenBalancesByChainId,
+    selectedAddress,
+  ) => {
+    const tokensByChain = {};
 
-      const chainIds = new Set([
-        ...Object.keys(allTokens || {}),
-        ...Object.keys(nativeTokenBalancesByChainId || {}),
-      ]);
+    const chainIds = new Set([
+      ...Object.keys(allTokens || {}),
+      ...Object.keys(nativeTokenBalancesByChainId || {}),
+    ]);
 
-      chainIds.forEach((chainId) => {
-        if (!tokensByChain[chainId]) {
-          tokensByChain[chainId] = [];
-        }
+    chainIds.forEach((chainId) => {
+      if (!tokensByChain[chainId]) {
+        tokensByChain[chainId] = [];
+      }
 
-        if (allTokens[chainId]?.[selectedAddress]) {
-          allTokens[chainId][selectedAddress].forEach((token) => {
-            const tokenWithChain = { ...token, chainId, isNative: false };
-            tokensByChain[chainId].push(tokenWithChain);
-          });
-        }
+      if (allTokens[chainId]?.[selectedAddress]) {
+        allTokens[chainId][selectedAddress].forEach((token) => {
+          const tokenWithChain = { ...token, chainId, isNative: false };
+          tokensByChain[chainId].push(tokenWithChain);
+        });
+      }
 
-        const nativeBalance = nativeTokenBalancesByChainId[chainId];
-        if (nativeBalance) {
-          const nativeTokenInfo = getNativeTokenInfo(
-            networkConfigurationsByChainId,
-            provider,
-            chainId,
-          );
-          tokensByChain[chainId].push({
-            ...nativeTokenInfo,
-            address: '',
-            balance: nativeBalance,
-            chainId,
-            isNative: true,
-            image: getNativeCurrencyForChain(chainId),
-          });
-        }
-      });
-      return tokensByChain;
-    },
-  );
+      const nativeBalance = nativeTokenBalancesByChainId[chainId];
+      if (nativeBalance) {
+        const nativeTokenInfo = getNativeTokenInfo(
+          networkConfigurationsByChainId,
+          provider,
+          chainId,
+        );
+        tokensByChain[chainId].push({
+          ...nativeTokenInfo,
+          address: '',
+          balance: nativeBalance,
+          chainId,
+          isNative: true,
+          image: getNativeCurrencyForChain(chainId),
+        });
+      }
+    });
+    return tokensByChain;
+  },
+);
 
 /**
  * Retrieves native token information (symbol, decimals, name) for a given chainId from the state,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -880,7 +880,6 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
     nativeTokenBalancesByChainId,
     selectedAddress,
   ) => {
-    console.log('DEBUG getTokensAcrossChainsByAccountAddressSelector CALLED');
     const tokensByChain = {};
 
     const chainIds = new Set([

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -2797,7 +2797,11 @@ describe('getNativeTokenInfo', () => {
       name: 'MyToken',
     };
 
-    const result = selectors.getNativeTokenInfo(mocks.state, '0x1337');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0x1337',
+    );
     expect(result).toStrictEqual({
       symbol: 'HELLO',
       decimals: 18,
@@ -2812,7 +2816,11 @@ describe('getNativeTokenInfo', () => {
       name: undefined,
     };
 
-    const result = selectors.getNativeTokenInfo(mocks.state, '0x1337');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0x1337',
+    );
     expect(result).toStrictEqual({
       symbol: 'NATIVE',
       decimals: 18,
@@ -2829,7 +2837,11 @@ describe('getNativeTokenInfo', () => {
       nickname: 'MyToken',
     };
 
-    const result = selectors.getNativeTokenInfo(mocks.state, '0x1337');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0x1337',
+    );
     expect(result).toStrictEqual({
       symbol: 'HELLO',
       decimals: 18,
@@ -2846,7 +2858,11 @@ describe('getNativeTokenInfo', () => {
       nickname: undefined,
     };
 
-    const result = selectors.getNativeTokenInfo(mocks.state, '0x1337');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0x1337',
+    );
     expect(result).toStrictEqual({
       symbol: 'NATIVE',
       decimals: 18,
@@ -2857,7 +2873,11 @@ describe('getNativeTokenInfo', () => {
   it('provides native token from known list of hardcoded native tokens', () => {
     const mocks = arrange();
 
-    const result = selectors.getNativeTokenInfo(mocks.state, '0x89');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0x89',
+    );
     expect(result).toStrictEqual({
       symbol: 'POL',
       decimals: 18,
@@ -2867,7 +2887,11 @@ describe('getNativeTokenInfo', () => {
 
   it('fallbacks for unknown native token info', () => {
     const mocks = arrange();
-    const result = selectors.getNativeTokenInfo(mocks.state, '0xFakeToken');
+    const result = selectors.getNativeTokenInfo(
+      mocks.state.metamask.networkConfigurationsByChainId,
+      mocks.state.metamask.provider,
+      '0xFakeToken',
+    );
     expect(result).toStrictEqual({
       symbol: 'NATIVE',
       decimals: 18,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38891?quickstart=1)

Added memoization to deprecated pre-bip44 selector to attempt performance improvements.

Also marked old selectors as deprecated so that they are not used in future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2079

## **Manual testing steps**

1. Open Swaps page
2. Open modal with list of assets
3. The result should be the same as before

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decouples `getNativeTokenInfo` from root state and updates consumers, adds memoized cross-chain balance/token selectors, and deprecates several legacy asset selectors.
> 
> - **Selectors**:
>   - Refactor `getNativeTokenInfo(networkConfigurationsByChainId, provider, chainId)`; remove state-bound variant and update all call sites.
>   - Add memoized `getNativeTokenCachedBalanceByChainIdSelector` and `getTokensAcrossChainsByAccountAddressSelector`; remove old by-address helper.
>   - Mark legacy selectors as deprecated: `getTokenBalancesEvm`, `getMultiChainAssets`, `getTokenByAccountAndAddressAndChainId`, `getMultichainAggregatedBalance`, `getSelectedAccountTokensAcrossChains`, `getMultichainNativeTokenBalance`.
> - **Hooks/Components**:
>   - Update `useHasInsufficientBalance` to use `getNativeTokenCachedBalanceByChainIdSelector`.
>   - Update UI components to use `useSelector` with new `getNativeTokenInfo` signature in `bridge/transaction-details` and typed-sign permission details.
> - **Tests**:
>   - Adjust tests to call the new `getNativeTokenInfo` signature and related selector changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98eb8883a57da83ea31ccaa554c10794b3d11826. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->