### PR TITLE
fix: add resolutions for "which" npm package

### DIFF
--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1909,7 +1909,6 @@
         "chokidar>anymatch": true,
         "chokidar>braces": true,
         "chokidar>fsevents": true,
-        "tsx>fsevents": true,
         "eslint>glob-parent": true,
         "chokidar>is-binary-path": true,
         "del>is-glob": true,
@@ -3498,13 +3497,6 @@
       "packages": {
         "gulp-watch>chokidar>fsevents>node-pre-gyp": true
       }
-    },
-    "tsx>fsevents": {
-      "globals": {
-        "console.assert": true,
-        "process.platform": true
-      },
-      "native": true
     },
     "string.prototype.matchall>es-abstract>function.prototype.name": {
       "globals": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1909,6 +1909,7 @@
         "chokidar>anymatch": true,
         "chokidar>braces": true,
         "chokidar>fsevents": true,
+        "tsx>fsevents": true,
         "eslint>glob-parent": true,
         "chokidar>is-binary-path": true,
         "del>is-glob": true,
@@ -3498,6 +3499,13 @@
         "gulp-watch>chokidar>fsevents>node-pre-gyp": true
       }
     },
+    "tsx>fsevents": {
+      "globals": {
+        "console.assert": true,
+        "process.platform": true
+      },
+      "native": true
+    },
     "string.prototype.matchall>es-abstract>function.prototype.name": {
       "globals": {
         "document": true
@@ -3682,7 +3690,7 @@
       },
       "packages": {
         "stylelint>global-modules>global-prefix>ini": true,
-        "stylelint>global-modules>global-prefix>which": true
+        "@sentry/cli>which": true
       }
     },
     "eslint-plugin-react>es-iterator-helpers>globalthis": {
@@ -4293,12 +4301,14 @@
     },
     "@sentry/cli>which>isexe": {
       "builtin": {
-        "fs": true
+        "fs.statSync": true,
+        "fs/promises.stat": true
       },
       "globals": {
-        "TESTING_WINDOWS": true,
         "process.env.PATHEXT": true,
+        "process.env._ISEXE_TEST_PLATFORM_": true,
         "process.getgid": true,
+        "process.getgroups": true,
         "process.getuid": true,
         "process.platform": true
       }
@@ -8720,13 +8730,15 @@
         "webpack-dev-server>sockjs>websocket-driver>websocket-extensions": true
       }
     },
-    "stylelint>global-modules>global-prefix>which": {
+    "@sentry/cli>which": {
       "builtin": {
-        "path.join": true
+        "path.delimiter": true,
+        "path.join": true,
+        "path.posix.sep": true,
+        "path.sep": true
       },
       "globals": {
         "process.cwd": true,
-        "process.env.OSTYPE": true,
         "process.env.PATH": true,
         "process.env.PATHEXT": true,
         "process.platform": true

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -3682,7 +3682,7 @@
       },
       "packages": {
         "stylelint>global-modules>global-prefix>ini": true,
-        "@sentry/cli>which": true
+        "@lavamoat/allow-scripts>@npmcli/run-script>which": true
       }
     },
     "eslint-plugin-react>es-iterator-helpers>globalthis": {
@@ -4291,7 +4291,7 @@
         "process": true
       }
     },
-    "@sentry/cli>which>isexe": {
+    "@lavamoat/allow-scripts>@npmcli/run-script>which>isexe": {
       "builtin": {
         "fs.statSync": true,
         "fs/promises.stat": true
@@ -8722,7 +8722,7 @@
         "webpack-dev-server>sockjs>websocket-driver>websocket-extensions": true
       }
     },
-    "@sentry/cli>which": {
+    "@lavamoat/allow-scripts>@npmcli/run-script>which": {
       "builtin": {
         "path.delimiter": true,
         "path.join": true,
@@ -8736,7 +8736,7 @@
         "process.platform": true
       },
       "packages": {
-        "@sentry/cli>which>isexe": true
+        "@lavamoat/allow-scripts>@npmcli/run-script>which>isexe": true
       }
     },
     "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": {

--- a/package.json
+++ b/package.json
@@ -252,7 +252,12 @@
     "@metamask/bridge-controller@npm:^63.2.0": "patch:@metamask/bridge-controller@npm%3A64.0.0#~/.yarn/patches/@metamask-bridge-controller-npm-64.0.0-956740f7c8.patch",
     "@metamask/assets-controllers@npm:^92.0.0": "patch:@metamask/assets-controllers@npm%3A93.1.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.1.0-0f2b5956ff.patch",
     "@metamask/assets-controllers@npm:^93.0.0": "patch:@metamask/assets-controllers@npm%3A93.1.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.1.0-0f2b5956ff.patch",
-    "@metamask/assets-controllers@npm:^91.0.0": "patch:@metamask/assets-controllers@npm%3A93.1.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.1.0-0f2b5956ff.patch"
+    "@metamask/assets-controllers@npm:^91.0.0": "patch:@metamask/assets-controllers@npm%3A93.1.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.1.0-0f2b5956ff.patch",
+    "which@npm:^1.2.12": "^4.0.0",
+    "which@npm:^1.2.14": "^4.0.0",
+    "which@npm:^1.3.1": "^4.0.0",
+    "which@npm:^2.0.1": "^4.0.0",
+    "which@npm:^2.0.2": "^4.0.0"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/package.json
+++ b/package.json
@@ -255,9 +255,7 @@
     "@metamask/assets-controllers@npm:^91.0.0": "patch:@metamask/assets-controllers@npm%3A93.1.0#~/.yarn/patches/@metamask-assets-controllers-npm-93.1.0-0f2b5956ff.patch",
     "which@npm:^1.2.12": "^4.0.0",
     "which@npm:^1.2.14": "^4.0.0",
-    "which@npm:^1.3.1": "^4.0.0",
-    "which@npm:^2.0.1": "^4.0.0",
-    "which@npm:^2.0.2": "^4.0.0"
+    "which@npm:^1.3.1": "^4.0.0"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.25.9#~/.yarn/patches/@babel-runtime-npm-7.25.9-fe8c62510a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29688,13 +29688,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isexe@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "isexe@npm:2.0.0"
-  checksum: 10/7c9f715c03aff08f35e98b1fadae1b9267b38f0615d501824f9743f3aab99ef10e303ce7db3f186763a0b70a19de5791ebfc854ff884d5a8c4d92211f642ec92
-  languageName: node
-  linkType: hard
-
 "isexe@npm:^3.1.1":
   version: 3.1.1
   resolution: "isexe@npm:3.1.1"
@@ -44668,28 +44661,6 @@ __metadata:
     gopd: "npm:^1.2.0"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
-  languageName: node
-  linkType: hard
-
-"which@npm:^1.2.12, which@npm:^1.2.14, which@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "which@npm:1.3.1"
-  dependencies:
-    isexe: "npm:^2.0.0"
-  bin:
-    which: ./bin/which
-  checksum: 10/549dcf1752f3ee7fbb64f5af2eead4b9a2f482108b7de3e85c781d6c26d8cf6a52d37cfbe0642a155fa6470483fe892661a859c03157f24c669cf115f3bbab5e
-  languageName: node
-  linkType: hard
-
-"which@npm:^2.0.1, which@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "which@npm:2.0.2"
-  dependencies:
-    isexe: "npm:^2.0.0"
-  bin:
-    node-which: ./bin/node-which
-  checksum: 10/4782f8a1d6b8fc12c65e968fea49f59752bf6302dc43036c3bf87da718a80710f61a062516e9764c70008b487929a73546125570acea95c5b5dcc8ac3052c70f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29688,6 +29688,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "isexe@npm:2.0.0"
+  checksum: 10/7c9f715c03aff08f35e98b1fadae1b9267b38f0615d501824f9743f3aab99ef10e303ce7db3f186763a0b70a19de5791ebfc854ff884d5a8c4d92211f642ec92
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^3.1.1":
   version: 3.1.1
   resolution: "isexe@npm:3.1.1"
@@ -44661,6 +44668,17 @@ __metadata:
     gopd: "npm:^1.2.0"
     has-tostringtag: "npm:^1.0.2"
   checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
+  languageName: node
+  linkType: hard
+
+"which@npm:^2.0.1, which@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "which@npm:2.0.2"
+  dependencies:
+    isexe: "npm:^2.0.0"
+  bin:
+    node-which: ./bin/node-which
+  checksum: 10/4782f8a1d6b8fc12c65e968fea49f59752bf6302dc43036c3bf87da718a80710f61a062516e9764c70008b487929a73546125570acea95c5b5dcc8ac3052c70f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Some older versions of `which` are using recursion and that can cause some issues when building with lavamoat.

Newer versions of `which` do not have the same problem, thus I just picked the highest version that was already in-use by other transient deps and that seems to do the trick.

Here's an example of the stacktrace I got before this change:
```console
$ yarn lavamoat:webapp:auto:ci --build-types=experimental
[experimental] [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
[experimental] LavaMoat - Error evaluating module "/Users/ccharly/code/metamask-extension/node_modules/stylelint/node_modules/which/which.js" from package "stylelint>global-modules>global-prefix>which"
[experimental] RangeError: Maximum call stack size exceeded
[experimental]   at Object.eval (eval at makeEvaluate (LavaMoat/node/kernel), <anonymous>:12:36)
[experimental]   at safeEvaluate (LavaMoat/node/kernel:8662:14)
[experimental]   at compartmentEvaluate (LavaMoat/node/kernel:11408:10)
[experimental]   at Compartment.evaluate (LavaMoat/node/kernel:12234:12)
[experimental]   at prepareModuleInitializer (LavaMoat/core/kernel:1509:50)
[experimental]   at internalRequire (LavaMoat/core/kernel:1361:50)
[experimental]   at requireRelative (LavaMoat/core/kernel:1420:27)
[experimental]   at requireRelativeWithContext (LavaMoat/core/kernel:1388:18)
[experimental]   at tryNpmPath (/Users/ccharly/code/metamask-extension/node_modules/stylelint/node_modules/global-prefix/index.js:68:28)
[experimental]   at getPrefix (/Users/ccharly/code/metamask-extension/node_modules/stylelint/node_modules/global-prefix/index.js:34:13)
[experimental] Running task "scripts:dist"...
[experimental] Starting 'scripts:dist'...
[experimental] Starting 'scripts:core:dist:standardEntryPoints'...
[experimental] Starting 'scripts:core:dist:contentscript'...
[experimental] Starting 'scripts:core:dist:disable-console'...
[experimental] Starting 'scripts:core:dist:sentry'...
[experimental] scripts:core:dist:contentscript: Bundle start: "inpage"
[experimental] scripts:core:dist:sentry: Bundle start: "sentry-install"
[experimental] scripts:core:dist:disable-console: Bundle start: "disable-console"
[experimental] scripts:core:dist:standardEntryPoints: Bundle start: "primary"
[experimental] Finished 'scripts:core:dist:disable-console'
[experimental] Finished 'scripts:core:dist:sentry'
[experimental] Finished 'scripts:core:dist:contentscript'
...
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38901?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Force `which` to v4 via resolutions and adjust LavaMoat policy to use the new `@lavamoat/allow-scripts>@npmcli/run-script>which` path and updated `isexe` permissions.
> 
> - **Dependencies**
>   - Add resolutions mapping `which@^1.2.x` (and variants) to `^4.0.0` in `package.json`.
>   - Remove old `which@1.3.1` entry from `yarn.lock`.
> - **LavaMoat Policy** (`lavamoat/build-system/policy.json`)
>   - Replace `stylelint>global-modules>global-prefix>which` and `@sentry/cli>which>isexe` references with `@lavamoat/allow-scripts>@npmcli/run-script>which` and `...>which>isexe`.
>   - Update builtins/globals for `which`/`isexe` (e.g., `path.delimiter`, `path.posix.sep`, `fs.statSync`, `fs/promises.stat`, env vars).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39756035e197ee514cc53bef903e4f7ca10f7357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->