### PR TITLE
fix: Return token exchange rate for specific chain instead of the current chain

### DIFF
--- a/test/integration/confirmations/signatures/permit.test.tsx
+++ b/test/integration/confirmations/signatures/permit.test.tsx
@@ -212,7 +212,7 @@ describe('Permit Confirmation', () => {
     // Get the pending permit ID to override chainId on the message
     const pendingPermitId = Object.keys(
       mockedMetaMaskState.unapprovedTypedMessages,
-    )[0];
+    )[0] as keyof typeof mockedMetaMaskState.unapprovedTypedMessages;
 
     await act(async () => {
       await integrationTestRender({
@@ -222,7 +222,7 @@ describe('Permit Confirmation', () => {
           unapprovedTypedMessages: {
             [pendingPermitId]: {
               ...mockedMetaMaskState.unapprovedTypedMessages[pendingPermitId],
-              chainId: '0x1',
+              chainId: '0x1' as const,
             },
           },
           selectedNetworkClientId: 'testNetworkConfigurationId',

--- a/test/integration/confirmations/signatures/permit.test.tsx
+++ b/test/integration/confirmations/signatures/permit.test.tsx
@@ -209,10 +209,22 @@ describe('Permit Confirmation', () => {
       'Permit',
     );
 
+    // Get the pending permit ID to override chainId on the message
+    const pendingPermitId = Object.keys(
+      mockedMetaMaskState.unapprovedTypedMessages,
+    )[0];
+
     await act(async () => {
       await integrationTestRender({
         preloadedState: {
           ...mockedMetaMaskState,
+          // Override the chainId on the message to mainnet to match the nock mock
+          unapprovedTypedMessages: {
+            [pendingPermitId]: {
+              ...mockedMetaMaskState.unapprovedTypedMessages[pendingPermitId],
+              chainId: '0x1',
+            },
+          },
           selectedNetworkClientId: 'testNetworkConfigurationId',
           providerConfig: {
             type: 'rpc',

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
+import { Hex } from '@metamask/utils';
 import mockState from '../../../../../test/data/mock-state.json';
 import configureStore from '../../../../store/store';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
@@ -10,6 +11,7 @@ import useTokenExchangeRate from './useTokenExchangeRate';
 const renderUseTokenExchangeRate = (
   tokenAddress?: string,
   metaMaskState?: Record<string, unknown>,
+  overrideChainId?: Hex,
 ) => {
   const state = {
     ...mockState,
@@ -19,11 +21,17 @@ const renderUseTokenExchangeRate = (
         ETH: {
           conversionRate: 11.1,
         },
+        POL: {
+          conversionRate: 0.25,
+        },
       },
       marketData: {
         '0x5': {
           '0xdAC17F958D2ee523a2206206994597C13D831ec7': { price: 0.5 },
           '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e': { price: 3.304588 },
+        },
+        '0x89': {
+          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': { price: 1.0 },
         },
       },
       ...metaMaskState,
@@ -36,7 +44,9 @@ const renderUseTokenExchangeRate = (
     <Provider store={configureStore(state)}>{children}</Provider>
   );
 
-  return renderHook(() => useTokenExchangeRate(tokenAddress), { wrapper });
+  return renderHook(() => useTokenExchangeRate(tokenAddress, overrideChainId), {
+    wrapper,
+  });
 };
 
 jest.mock('../../../../helpers/utils/util', () => ({
@@ -127,5 +137,83 @@ describe('useProcessNewDecimalValue', () => {
     } = renderUseTokenExchangeRate(undefined, { currencyRates: {} });
 
     expect(exchangeRate?.value).toBe(undefined);
+  });
+
+  describe('with overrideChainId', () => {
+    it('ERC-20: returns price from override chain market data', () => {
+      // Current chain is 0x5 (Goerli), but we request price for token on 0x89 (Polygon)
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(
+        '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        undefined,
+        '0x89',
+      );
+
+      // price (1.0) * POL conversion rate (0.25) = 0.25
+      expect(String(exchangeRate?.value)).toEqual('0.25');
+    });
+
+    it('ERC-20: fetches from API when token not in override chain market data', () => {
+      // Token exists on 0x5 but not on 0x89
+      renderUseTokenExchangeRate(
+        '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        undefined,
+        '0x89',
+      );
+
+      // Should trigger API fetch since token not in 0x89 market data
+      expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
+        'POL',
+        ['0xdAC17F958D2ee523a2206206994597C13D831ec7'],
+        '0x89',
+      );
+    });
+
+    it('native: returns conversion rate for override chain', () => {
+      // Current chain is 0x5 (ETH), but we request native rate for 0x89 (POL)
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(undefined, undefined, '0x89');
+
+      expect(String(exchangeRate?.value)).toEqual('0.25');
+    });
+
+    it('native: returns undefined when override chain has no conversion rate', () => {
+      const {
+        result: { current: exchangeRate },
+      } = renderUseTokenExchangeRate(
+        undefined,
+        {
+          currencyRates: {
+            ETH: { conversionRate: 11.1 },
+            // POL not included
+          },
+        },
+        '0x89',
+      );
+
+      expect(exchangeRate?.value).toBe(undefined);
+    });
+
+    it('ERC-20: fetches from API with override chainId when not in state', async () => {
+      (fetchTokenExchangeRates as jest.Mock).mockReturnValue(
+        Promise.resolve({
+          '0x0000000000000000000000000000000000000002': 2.0,
+        }),
+      );
+
+      renderUseTokenExchangeRate(
+        '0x0000000000000000000000000000000000000002',
+        undefined,
+        '0x89',
+      );
+
+      expect(fetchTokenExchangeRates).toHaveBeenCalledWith(
+        'POL',
+        ['0x0000000000000000000000000000000000000002'],
+        '0x89',
+      );
+    });
   });
 });

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
 import {
@@ -46,7 +46,7 @@ export default function useTokenExchangeRate(
   const crossChainTokenExchangeRates: Record<
     Hex,
     Record<string, number>
-  > = useSelector(getCrossChainTokenExchangeRates);
+  > = useSelector(getCrossChainTokenExchangeRates, shallowEqual);
 
   const [exchangeRates, setExchangeRates] = useState<
     Record<string, ExchangeRate>

--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useState } from 'react';
 import { toChecksumAddress } from 'ethereumjs-util';
-import { shallowEqual, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
 import { getCurrentChainId } from '../../../../../shared/modules/selectors/networks';
-import { getTokenExchangeRates } from '../../../../selectors';
-import { Numeric } from '../../../../../shared/modules/Numeric';
 import {
-  getConversionRate,
-  getNativeCurrency,
-} from '../../../../ducks/metamask/metamask';
+  getCrossChainTokenExchangeRates,
+  selectConversionRateByChainId,
+  selectNetworkConfigurationByChainId,
+} from '../../../../selectors';
+import { Numeric } from '../../../../../shared/modules/Numeric';
 import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 
 type ExchangeRate = number | typeof LOADING | typeof FAILED | undefined;
@@ -19,23 +20,33 @@ const FAILED = 'failed';
  * A hook that returns the exchange rate of the given token –– assumes native if no token address is passed.
  *
  * @param uncheckedTokenAddress - the address of the token. If not provided, the function will return the native exchange rate.
+ * @param overrideChainId - optional chainId to use instead of the currently selected chain. Useful when displaying values for a transaction on a different chain.
  * @returns the exchange rate of the token
  */
 export default function useTokenExchangeRate(
   uncheckedTokenAddress?: string,
+  overrideChainId?: Hex,
 ): Numeric | undefined {
   const tokenAddress = uncheckedTokenAddress
     ? toChecksumAddress(uncheckedTokenAddress)
     : undefined;
-  const nativeCurrency = useSelector(getNativeCurrency);
-  const chainId = useSelector(getCurrentChainId);
 
-  const selectedNativeConversionRate = useSelector(getConversionRate);
+  const currentChainId = useSelector(getCurrentChainId);
+  const chainId = overrideChainId ?? currentChainId;
 
-  const contractExchangeRates: Record<string, number> = useSelector(
-    getTokenExchangeRates,
-    shallowEqual,
+  const networkConfig = useSelector((state) =>
+    selectNetworkConfigurationByChainId(state, chainId),
   );
+  const nativeCurrency = networkConfig?.nativeCurrency;
+
+  const selectedNativeConversionRate = useSelector((state) =>
+    selectConversionRateByChainId(state, chainId),
+  );
+
+  const crossChainTokenExchangeRates: Record<
+    Hex,
+    Record<string, number>
+  > = useSelector(getCrossChainTokenExchangeRates);
 
   const [exchangeRates, setExchangeRates] = useState<
     Record<string, ExchangeRate>
@@ -62,6 +73,7 @@ export default function useTokenExchangeRate(
       return undefined;
     }
 
+    const contractExchangeRates = crossChainTokenExchangeRates[chainId] ?? {};
     const contractExchangeRate =
       contractExchangeRates[tokenAddress] || exchangeRates[tokenAddress];
 
@@ -97,6 +109,6 @@ export default function useTokenExchangeRate(
     nativeCurrency,
     tokenAddress,
     selectedNativeConversionRate,
-    contractExchangeRates,
+    crossChainTokenExchangeRates,
   ]);
 }

--- a/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/use-token-values.ts
@@ -1,6 +1,7 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
 import { calcTokenAmount } from '../../../../../../../shared/lib/transactions-controller-utils';
 import useTokenExchangeRate from '../../../../../../components/app/currency-input/hooks/useTokenExchangeRate';
 import { getIntlLocale } from '../../../../../../ducks/locale/locale';
@@ -12,7 +13,10 @@ import { useTokenTransactionData } from './useTokenTransactionData';
 export const useTokenValues = (transactionMeta: TransactionMeta) => {
   const locale = useSelector(getIntlLocale);
   const parsedTransactionData = useTokenTransactionData();
-  const exchangeRate = useTokenExchangeRate(transactionMeta?.txParams?.to);
+  const exchangeRate = useTokenExchangeRate(
+    transactionMeta?.txParams?.to,
+    transactionMeta?.chainId as Hex,
+  );
   const fiatFormatter = useFiatFormatter();
 
   const { decimals } = useAssetDetails(

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
@@ -80,7 +80,7 @@ const PermitSimulationValueDisplay: React.FC<
 }) => {
   const t = useI18nContext();
 
-  const exchangeRate = useTokenExchangeRate(tokenContract);
+  const exchangeRate = useTokenExchangeRate(tokenContract, chainId);
 
   const tokenDetails = useGetTokenStandardAndDetails(tokenContract);
   useTrackERC20WithoutDecimalInformation(


### PR DESCRIPTION
## **Description**
Returns token exchange rate for specific chain instead of the current chain.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38902?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix: Show fiat value for some tokens in Confirmations

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6458

## **Manual testing steps**

1. Click on Send
2. Try to send something on Linea or Arbitrum
3. On the Confirmation page you will see a fiat value under the token value

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="362" height="168" alt="image" src="https://github.com/user-attachments/assets/bd9c6dd2-79ac-442e-ad1f-741dace382df" />


### **After**

<img width="375" height="258" alt="image" src="https://github.com/user-attachments/assets/0f2f75c2-42b8-4c37-97ab-fcd205d7fdb2" />

<img width="377" height="260" alt="image" src="https://github.com/user-attachments/assets/a4e8efb0-5914-46c5-9957-c8ab6e432e21" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return token exchange rates for a specified chain (via overrideChainId) and update confirmations to pass chainId, with tests covering cross-chain behavior.
> 
> - **Hooks**:
>   - Update `useTokenExchangeRate` to accept `overrideChainId`, derive native rate and market data per chain via `selectConversionRateByChainId`, `selectNetworkConfigurationByChainId`, and `getCrossChainTokenExchangeRates`.
>   - Add per-chain caching key (`chainId-tokenAddress`) and fetch rates with `chainId` to prevent cross-chain contamination.
> - **Confirmations UI**:
>   - Pass `transactionMeta.chainId`/`chainId` to `useTokenExchangeRate` in `use-token-values.ts` and typed sign permit value display.
> - **Tests**:
>   - Expand `useTokenExchangeRate.test.tsx` with override chain scenarios (native and ERC-20), API fetch assertions including `chainId`, and per-chain cache validation.
>   - Adjust permit integration test to set typed message `chainId` to match mocked mainnet price API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2961932ae2d035dedcb531daf371f3a278a38f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->