### PR TITLE
fix: Correct ERC1155 balance parsing from hex to integer

### DIFF
--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { ERC721 } from '@metamask/controller-utils';
+import { ERC721, ERC1155 } from '@metamask/controller-utils';
 
 import {
   Box,
@@ -128,10 +128,27 @@ export const Amount = ({
   ]);
 
   const balanceDisplayValue = useMemo(() => {
-    return fiatMode
-      ? `${getFiatDisplayValue(String(balance))} ${t('available')}`
-      : `${balance} ${asset?.symbol} ${t('available')}`;
-  }, [fiatMode, getFiatDisplayValue, balance, asset?.symbol, t]);
+    if (fiatMode) {
+      return `${getFiatDisplayValue(String(balance))} ${t('available')}`;
+    }
+
+    // For ERC1155 tokens, use name or just show balance without symbol
+    if (asset?.standard === ERC1155) {
+      const displayName = asset?.name ? ` ${asset.name}` : '';
+      return `${balance}${displayName} ${t('available')}`;
+    }
+
+    // For other tokens, use symbol
+    return `${balance} ${asset?.symbol} ${t('available')}`;
+  }, [
+    fiatMode,
+    getFiatDisplayValue,
+    balance,
+    asset?.symbol,
+    asset?.name,
+    asset?.standard,
+    t,
+  ]);
 
   if (asset?.standard === ERC721) {
     return null;

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -135,7 +135,7 @@ export const Amount = ({
     // For ERC1155 tokens, use name or just show balance without symbol
     if (asset?.standard === ERC1155) {
       const displayName = asset?.name ? ` ${asset.name}` : '';
-      return `${balance} ${displayName} ${t('available')}`;
+      return `${balance}${displayName} ${t('available')}`;
     }
 
     // For other tokens, use symbol

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -135,7 +135,7 @@ export const Amount = ({
     // For ERC1155 tokens, use name or just show balance without symbol
     if (asset?.standard === ERC1155) {
       const displayName = asset?.name ? ` ${asset.name}` : '';
-      return `${balance}${displayName} ${t('available')}`;
+      return `${balance} ${displayName} ${t('available')}`;
     }
 
     // For other tokens, use symbol

--- a/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.test.ts
+++ b/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.test.ts
@@ -84,12 +84,12 @@ describe('useERC1155BalanceChecker', () => {
   });
 
   it('converts string balance to number', async () => {
-    mockGetERC1155BalanceOf.mockResolvedValue('123');
+    mockGetERC1155BalanceOf.mockResolvedValue('06'); // 6 in hex
 
     const { result } = renderHook(() => useERC1155BalanceChecker());
     const response = await result.current.fetchBalanceForNft(mockERC1155Asset);
 
-    expect(response?.balance).toBe(123);
+    expect(response?.balance).toBe(6);
     expect(typeof response?.balance).toBe('number');
   });
 

--- a/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
+++ b/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
@@ -24,7 +24,7 @@ export const useERC1155BalanceChecker = () => {
         networkClientId,
       );
 
-      return { nft, balance: Number(balance) };
+      return { nft, balance: parseInt(balance, 16) };
     } catch (error) {
       console.error('Error fetching ERC1155 balance:', error);
       return null;


### PR DESCRIPTION
## **Description**


ERC1155 NFT balances were displaying as "NaN" on the send page instead of the correct numeric values.
It also fixes the name display for ERC1155.

The `getERC1155BalanceOf` API returns balance values as hex strings (e.g., `"3b9aca00"`), but the code was using `Number(balance)` to convert them. JavaScript's `Number()` function cannot parse hex strings, causing `Number("3b9aca00")` to return `NaN`.

**Solution**: Changed `Number(balance)` to `parseInt(balance, 16)` in `useERC1155BalanceChecker.ts` to properly convert hex strings to decimal numbers.

**Example**: 
- Before: `Number("3b9aca00")` → `NaN`
- After: `parseInt("3b9aca00", 16)` → `1000000000`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38916?quickstart=1)

## **Changelog**

CHANGELOG entry: Fix ERC1155 NFT Balance Display showing "NaN"

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37564

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="803" height="1002" alt="Screenshot 2025-12-16 at 22 24 12" src="https://github.com/user-attachments/assets/6544bab2-de03-4c37-aeae-072167263c19" />

### **After**

<!-- [screenshots/recordings] -->

<img width="825" height="1007" alt="Screenshot 2025-12-16 at 22 20 57" src="https://github.com/user-attachments/assets/ec7f17b3-b3c3-4e86-b976-9f4d614baf22" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parse ERC1155 balances from hex to number and update amount display for ERC1155 assets; align tests.
> 
> - **Send flow**:
>   - **ERC1155 balance parsing**: In `useERC1155BalanceChecker.ts`, convert `getERC1155BalanceOf` result using `parseInt(balance, 16)`.
>   - **Amount display (ERC1155)**: In `ui/pages/confirmations/components/send/amount/amount.tsx`, show balance with optional `asset.name` (no symbol) for `ERC1155`; keep fiat mode behavior. Added `ERC1155` import.
> - **Tests**:
>   - Update `useERC1155BalanceChecker.test.ts` to mock hex balances and assert numeric parsing; retain other cases (zero, errors, memoization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 172fcaaa478396a3e8950a7033eb9a07cb97d37a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->