### PR TITLE
fix: View on block explorer copy address success state

### DIFF
--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -22,10 +22,13 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
-  BoxBackgroundColor,
   AvatarNetwork,
   FontWeight,
 } from '@metamask/design-system-react';
+import {
+  BackgroundColor,
+  TextColor as DesignSystemTextColor,
+} from '../../../helpers/constants/design-system';
 import {
   Modal,
   ModalOverlay,
@@ -242,9 +245,12 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
                 size={ButtonSize.Lg}
                 isFullWidth
                 onClick={handleCopyClick}
-                className={
+                style={
                   addressCopied
-                    ? `${BoxBackgroundColor.SuccessMuted} ${TextColor.SuccessDefault}`
+                    ? {
+                        backgroundColor: `var(--color-${BackgroundColor.successMuted})`,
+                        color: `var(--color-${DesignSystemTextColor.successDefault})`,
+                      }
                     : undefined
                 }
                 data-testid="address-qr-code-modal-copy-button"

--- a/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
+++ b/ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useRef,
+  useEffect,
+} from 'react';
 import qrCode from 'qrcode-generator';
 import { CaipChainId } from '@metamask/utils';
 import {
@@ -8,12 +15,14 @@ import {
   TextColor,
   Button,
   IconName,
+  IconColor,
   ButtonVariant,
   ButtonSize,
   Box,
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
+  BoxBackgroundColor,
   AvatarNetwork,
   FontWeight,
 } from '@metamask/design-system-react';
@@ -64,8 +73,20 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
   networkImageSrc,
 }) => {
   const t = useI18nContext();
-  const [copied, handleCopy] = useCopyToClipboard();
+  const [, handleCopy] = useCopyToClipboard();
   const trackEvent = useContext(MetaMetricsContext);
+
+  const [addressCopied, setAddressCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  // Cleanup timeout when component unmounts
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   // Address segmentation for display
   const addressStart = address.substring(0, PREFIX_LEN);
@@ -90,6 +111,16 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
   // Handle copy address
   const handleCopyClick = useCallback(() => {
     handleCopy(address);
+    setAddressCopied(true);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setAddressCopied(false);
+      timeoutRef.current = null;
+    }, 1000);
   }, [address, handleCopy]);
 
   // Get block explorer info from network configuration
@@ -200,12 +231,25 @@ export const AddressQRCodeModal: React.FC<AddressQRCodeModalProps> = ({
               </Text>
               <Button
                 variant={ButtonVariant.Tertiary}
-                endIconName={copied ? IconName.CopySuccess : IconName.Copy}
+                endIconName={
+                  addressCopied ? IconName.CopySuccess : IconName.Copy
+                }
+                endIconProps={{
+                  color: addressCopied
+                    ? IconColor.SuccessDefault
+                    : IconColor.IconDefault,
+                }}
                 size={ButtonSize.Lg}
                 isFullWidth
                 onClick={handleCopyClick}
+                className={
+                  addressCopied
+                    ? `${BoxBackgroundColor.SuccessMuted} ${TextColor.SuccessDefault}`
+                    : undefined
+                }
+                data-testid="address-qr-code-modal-copy-button"
               >
-                {t('copyAddressShort')}
+                {addressCopied ? t('addressCopied') : t('copyAddressShort')}
               </Button>
             </Box>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. What is the reason for the change?
- To have a consistent experience across our screens
- To give the user feedback about their actions
3. What is the improvement/solution?
- apply success styling to the button when the user clicks on the copy address button.
    - The text should become green
    - The background colour should become a muted green
    - the copy icon should change from copy to copy success


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38919?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show success state when copying address from the view on block explorer modal

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1343

## **Manual testing steps**

1. import/create a wallet
2. click on receive from the home page
3. you should be taken to the address list
4. click on the block explorer icon
5. a modal with your address should appear
6. click on the copy address button
7. the button should change colours and indicate that the address was copied
8. verify that the address was copied
9. The styling should match what happens when you click on the copy icon in the address list row as well as the hoverable address list on the home screen

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/20b642c6-f902-4874-980b-837beb019b40



### **After**


https://github.com/user-attachments/assets/51717d45-936e-4de9-9c5e-c4f909011a49



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds transient success feedback (icon, colors, text) with a 1s timeout when copying the address in the Address QR Code modal.
> 
> - **UI — `ui/components/multichain-accounts/address-qr-code-modal/address-qr-code-modal.tsx`**:
>   - **Copy success feedback**: Button now shows success icon, green text, and muted green background; label switches to `t('addressCopied')`.
>   - **State handling**: Introduces `useState`, `useRef`, and `useEffect` to manage a 1s success state with cleanup.
>   - **Copy handler**: Updates `handleCopyClick` to trigger success state; removes reliance on hook-returned `copied` value.
>   - **Design system**: Uses `IconColor.SuccessDefault`, `BackgroundColor.successMuted`, and `TextColor.successDefault` for styling.
>   - **Testing**: Adds `data-testid="address-qr-code-modal-copy-button"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e3a9b95075ec2c99a45f2c2b2a8312b7e1b1f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->