### PR TITLE
ci: Use PAT for creating GitHub release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,9 @@ jobs:
   publish-release:
     name: Publish release
     runs-on: ubuntu-latest
+    # Grant access to `stable` branch environment secrets
+    # This will only work on `stable` branch
+    environment: stable
     timeout-minutes: 30
     env:
       # Publishing tokens
@@ -104,6 +107,8 @@ jobs:
 
       - name: Create GitHub release
         run: .github/scripts/release-create-gh-release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.EXTENSION_PUBLISH_TOKEN }}
 
       - name: Push Firefox bundle script
         run: .github/scripts/push-firefox-bundle-script.sh


### PR DESCRIPTION
## **Description**

The release workflow has been updated to use a PAT for the publishing step. The GITHUB_TOKEN we were using previously no longer works for releases that are missing changes to workflows present on `main`, as explained in this blog post: https://github.blog/changelog/2023-11-02-github-actions-enforcing-workflow-scope-when-creating-a-release/

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38922?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update release workflow to use the stable environment and a PAT for creating GitHub releases.
> 
> - **CI/Release workflow (`.github/workflows/publish-release.yml`)**:
>   - Set job `environment` to `stable` to access branch environment secrets.
>   - `Create GitHub release` step now uses `GITHUB_TOKEN` from `secrets.EXTENSION_PUBLISH_TOKEN` (PAT).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2b65e66ff9843ed7ec2c3218d66630c0689d8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->