### PR TITLE
release: Revert "release: 13.13.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.13.1]
-
-### Fixed
-
-- Extension will automatically restart after updating in Chromium browsers older than v143 that are affected by a bug causing broken MV3 updates (#38867)
-
 ## [13.13.0]
 
 ### Added
@@ -1465,8 +1459,7 @@ authorized by the user.` error until the user fully revoked dapp
 - This changelog was split off with 12.22.0
 - All older changes can be found in [docs/CHANGELOG_older.md](https://github.com/MetaMask/metamask-extension/blob/main/docs/CHANGELOG_older.md)
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.13.1...HEAD
-[13.13.1]: https://github.com/MetaMask/metamask-extension/compare/v13.13.0...v13.13.1
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v13.13.0...HEAD
 [13.13.0]: https://github.com/MetaMask/metamask-extension/compare/v13.12.2...v13.13.0
 [13.12.2]: https://github.com/MetaMask/metamask-extension/compare/v13.12.1...v13.12.2
 [13.12.1]: https://github.com/MetaMask/metamask-extension/compare/v13.12.0...v13.12.1

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -81,7 +81,6 @@ export const SENTRY_BACKGROUND_STATE = {
     showNetworkBanner: true,
     showAccountBanner: true,
     showTestnetMessageInDropdown: true,
-    sidePanelGasPollTokens: true,
     surveyLinkLastClickedOrClosed: true,
     snapsInstallPrivacyWarningShown: true,
     termsOfUseLastAgreed: true,

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -311,13 +311,11 @@ describe('AppStateController', () => {
         controller.addPollingToken('token1', 'popupGasPollTokens');
         controller.addPollingToken('token2', 'notificationGasPollTokens');
         controller.addPollingToken('token3', 'fullScreenGasPollTokens');
-        controller.addPollingToken('token4', 'sidePanelGasPollTokens');
         controller.clearPollingTokens();
 
         expect(controller.state.popupGasPollTokens).toStrictEqual([]);
         expect(controller.state.notificationGasPollTokens).toStrictEqual([]);
         expect(controller.state.fullScreenGasPollTokens).toStrictEqual([]);
-        expect(controller.state.sidePanelGasPollTokens).toStrictEqual([]);
       });
     });
   });
@@ -808,7 +806,6 @@ describe('AppStateController', () => {
               "showPermissionsTour": true,
               "showShieldEntryModalOnce": null,
               "showTestnetMessageInDropdown": true,
-              "sidePanelGasPollTokens": [],
               "signatureSecurityAlertResponses": {},
               "slides": [],
               "snapsInstallPrivacyWarningShown": false,
@@ -901,7 +898,6 @@ describe('AppStateController', () => {
               "showPermissionsTour": true,
               "showShieldEntryModalOnce": null,
               "showTestnetMessageInDropdown": true,
-              "sidePanelGasPollTokens": [],
               "signatureSecurityAlertResponses": {},
               "slides": [],
               "snapsInstallPrivacyWarningShown": false,
@@ -1073,7 +1069,6 @@ describe('AppStateController', () => {
               "showNetworkBanner": true,
               "showPermissionsTour": true,
               "showShieldEntryModalOnce": null,
-              "sidePanelGasPollTokens": [],
               "signatureSecurityAlertResponses": {},
               "slides": [],
               "snapsInstallPrivacyWarningShown": false,

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -126,7 +126,6 @@ export type AppStateControllerState = {
   onboardingDate: number | null;
   outdatedBrowserWarningLastShown: number | null;
   popupGasPollTokens: string[];
-  sidePanelGasPollTokens: string[];
   productTour?: string;
   recoveryPhraseReminderHasBeenShown: boolean;
   recoveryPhraseReminderLastShown: number;
@@ -253,8 +252,7 @@ export type AppStateControllerMessenger = Messenger<
 type PollingTokenType =
   | 'popupGasPollTokens'
   | 'notificationGasPollTokens'
-  | 'fullScreenGasPollTokens'
-  | 'sidePanelGasPollTokens';
+  | 'fullScreenGasPollTokens';
 
 type AppStateControllerInitState = Partial<
   Omit<
@@ -302,7 +300,6 @@ const getDefaultAppStateControllerState = (): AppStateControllerState => ({
   onboardingDate: null,
   outdatedBrowserWarningLastShown: null,
   popupGasPollTokens: [],
-  sidePanelGasPollTokens: [],
   productTour: 'accountIcon',
   recoveryPhraseReminderHasBeenShown: false,
   recoveryPhraseReminderLastShown: new Date().getTime(),
@@ -532,12 +529,6 @@ const controllerMetadata: StateMetadata<AppStateControllerState> = {
     usedInUi: true,
   },
   popupGasPollTokens: {
-    includeInStateLogs: true,
-    persist: false,
-    includeInDebugSnapshot: true,
-    usedInUi: true,
-  },
-  sidePanelGasPollTokens: {
     includeInStateLogs: true,
     persist: false,
     includeInDebugSnapshot: true,
@@ -1225,7 +1216,6 @@ export class AppStateController extends BaseController<
       'popupGasPollTokens',
       'notificationGasPollTokens',
       'fullScreenGasPollTokens',
-      'sidePanelGasPollTokens',
     ];
 
     return validTokenTypes.includes(pollingTokenType);
@@ -1239,7 +1229,6 @@ export class AppStateController extends BaseController<
       state.popupGasPollTokens = [];
       state.notificationGasPollTokens = [];
       state.fullScreenGasPollTokens = [];
-      state.sidePanelGasPollTokens = [];
     });
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5309,12 +5309,7 @@ export default class MetamaskController extends EventEmitter {
 
     // TODO: Move this logic to the SnapKeyring directly.
     // Forward selected accounts to the Snap keyring, so each Snaps can fetch those accounts.
-    // It is not necessary to await this since it is just expected for the snap to receive
-    // the information without blocking the login flow. Despite not awaiting for
-    // forwardSelectedAccountGroupToSnapKeyring to be completed, we still want to await for
-    // getSnapKeyring to ensure the Snap keyring is available.
-    // eslint-disable-next-line no-void
-    void this.forwardSelectedAccountGroupToSnapKeyring(
+    await this.forwardSelectedAccountGroupToSnapKeyring(
       await this.getSnapKeyring(),
       this.accountTreeController.getSelectedAccountGroup(),
     );

--- a/app/scripts/on-update.ts
+++ b/app/scripts/on-update.ts
@@ -1,7 +1,6 @@
 import log from 'loglevel';
-import Bowser from 'bowser';
+import { RemoteFeatureFlagController } from '@metamask/remote-feature-flag-controller';
 import { PLATFORM_FIREFOX } from '../../shared/constants/app';
-import { getIsChromiumBrowserMV3StableUpdatesSupported } from '../../shared/modules/browser-runtime.utils';
 import { getPlatform } from './lib/util';
 import type MetaMaskController from './metamask-controller';
 import type ExtensionPlatform from './platforms/extension';
@@ -12,6 +11,8 @@ import { AppStateController } from './controllers/app-state-controller';
  *
  * @param controller - The MetaMask controller instance.
  * @param controller.store - The MetaMask store.
+ * @param controller.remoteFeatureFlagController - The remote feature flag
+ * controller.
  * @param controller.appStateController - The app state controller.
  * @param platform - The ExtensionPlatform API.
  * @param previousVersion - The previous version string.
@@ -23,6 +24,7 @@ export function onUpdate(
   // include the actual controllers as properties.
   controller: {
     store: MetaMaskController['store'];
+    remoteFeatureFlagController: RemoteFeatureFlagController;
     appStateController: AppStateController;
   },
   platform: ExtensionPlatform,
@@ -52,32 +54,34 @@ export function onUpdate(
   appStateController.setLastUpdatedAt(lastUpdatedAt);
   appStateController.setLastUpdatedFromVersion(previousVersion);
 
-  if (
-    !isFirefox &&
-    !getIsChromiumBrowserMV3StableUpdatesSupported(
-      Bowser.getParser(globalThis.navigator.userAgent),
-    )
-  ) {
+  if (!isFirefox) {
     // Work around Chromium bug https://issues.chromium.org/issues/40805401
-    // by doing a safe reload after an update. We have gated this workaround behind
-    // a Chromium version check for `<143`, to prevent it from running on
-    // newer versions that are no longer affected by the bug. Once the affected
-    // Chromium versions are no longer supported, we should remove this.
+    // by doing a safe reload after an update. We'll be able to gate this
+    // behind a Chromium version check once we know the chromium version #
+    // that fixes this bug, ETA: December 2025 (likely in `143.0.7465.0`).
+    // Once we no longer support the affected Chromium versions, we should
+    // remove this workaround.
     // We only want to do the safe reload when the version actually changed,
     // just as a safe guard, as Chrome fires this event each time we call
     // `runtime.reload` -- as we really don't want to send Chrome into a restart
     // loop! This is overkill, as `onUpdate` is already only called when
     // `previousVersion !== platform.getVersion()`, but better safe than better
-    // safe than better safe than better safe than... rebooting forever. :-)
-    log.info(
-      `[onUpdate]: Requesting "safe reload" after update to ${platform.getVersion()}`,
-    );
-    // use `setImmediate` to be absolutely sure the reload happens after
-    // other "update" events triggered by the `setLastUpdatedFromVersion`
-    // and `setLastUpdatedAt` calls above have been processed by storage.
-    // I think there _is_ still a risk of a race condition here, mostly
-    // due to the complexity of state storage's locks, debounce, and async
-    // nature.
-    setImmediate(requestSafeReload);
+    // safe than better safe than... rebooting forever. :-)
+    const { remoteFeatureFlagController } = controller;
+    const shouldReload = remoteFeatureFlagController.state.remoteFeatureFlags
+      .extensionPlatformAutoReloadAfterUpdate as boolean | undefined;
+    log.info(`[onUpdate]: Should reload: ${shouldReload}`);
+    if (shouldReload === true) {
+      log.info(
+        `[onUpdate]: Requesting "safe reload" after update to ${platform.getVersion()}`,
+      );
+      // use `setImmediate` to be absolutely sure the reload happens after
+      // other "update" events triggered by the `setLastUpdatedFromVersion`
+      // and `setLastUpdatedAt` calls above have been processed by storage.
+      // I think there _is_ still a risk of a race condition here, mostly
+      // due to the complexity of state storage's locks, debounce, and async
+      // nature.
+      setImmediate(requestSafeReload);
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.13.1",
+  "version": "13.13.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -88,7 +88,6 @@ export const POLLING_TOKEN_ENVIRONMENT_TYPES = {
   [ENVIRONMENT_TYPE_POPUP]: 'popupGasPollTokens',
   [ENVIRONMENT_TYPE_NOTIFICATION]: 'notificationGasPollTokens',
   [ENVIRONMENT_TYPE_FULLSCREEN]: 'fullScreenGasPollTokens',
-  [ENVIRONMENT_TYPE_SIDEPANEL]: 'sidePanelGasPollTokens',
   [ENVIRONMENT_TYPE_BACKGROUND]: 'none',
 } as const;
 

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -7,7 +7,6 @@ import browser from 'webextension-polyfill';
 import log from 'loglevel';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
-  FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
@@ -79,23 +78,6 @@ export function getIsBrowserPrerenderBroken(
     false
   );
 }
-
-/**
- * Returns true if the Chromium-based browser is no longer affected by a bug
- * that causes MV3 updates to break service workers, and Extension updates are stable.
- *
- * @param {import('bowser').Parser} bowser - optional Bowser Parser instance to check against
- * @returns {boolean} Whether the browser is no longer affected by the MV3 update bug.
- */
-export function getIsChromiumBrowserMV3StableUpdatesSupported(
-  bowser = Bowser.getParser(window.navigator.userAgent),
-) {
-  return (
-    bowser.satisfies(FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS) ??
-    false
-  );
-}
-
 /**
  * Returns the name of the browser
  *

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -149,7 +149,6 @@ export type ControllerStatePropertiesEnumerated = {
   enforcedSimulationsSlippageForTransactions: AppStateControllerState['enforcedSimulationsSlippageForTransactions'];
   networkConnectionBanner: AppStateControllerState['networkConnectionBanner'];
   isWalletResetInProgress: AppStateControllerState['isWalletResetInProgress'];
-  sidePanelGasPollTokens: AppStateControllerState['sidePanelGasPollTokens'];
   quoteRequest: BridgeControllerState['quoteRequest'];
   quotes: BridgeControllerState['quotes'];
   quotesInitialLoadTime: BridgeControllerState['quotesInitialLoadTime'];

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -54,7 +54,6 @@
     "pendingShieldCohortTxType": null,
     "pna25Acknowledged": "boolean",
     "popupGasPollTokens": "object",
-    "sidePanelGasPollTokens": [],
     "productTour": "accountIcon",
     "recoveryPhraseReminderHasBeenShown": true,
     "recoveryPhraseReminderLastShown": "number",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -157,7 +157,6 @@
     "onboardingDate": null,
     "outdatedBrowserWarningLastShown": "object",
     "popupGasPollTokens": "object",
-    "sidePanelGasPollTokens": [],
     "productTour": "accountIcon",
     "recoveryPhraseReminderHasBeenShown": true,
     "recoveryPhraseReminderLastShown": "number",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -813,7 +813,6 @@
     "showPermissionsTour": "boolean",
     "showShieldEntryModalOnce": "boolean",
     "showTestnetMessageInDropdown": "boolean",
-    "sidePanelGasPollTokens": [],
     "signatureRequests": {},
     "signatureSecurityAlertResponses": {},
     "syncQueue": {

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -70,16 +70,3 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
   chrome: '>=121',
   edge: '>=121',
 };
-
-/**
- * Specifies the Chromium-based browser and their versions where
- * MV3 updates are stable and don't break service workers.
- *
- * @see {@link https://chromium.googlesource.com/chromium/src/+/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5}
- * @see {@link https://chromium.googlesource.com/chromium/src/+/a5d13d7b91139dfac4721708937f75094d3c24e3}
- */
-export const FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS = {
-  // https://chromiumdash.appspot.com/commit/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5
-  chrome: '>=143.0.7465.0',
-  edge: '>=143',
-};


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#38869 due to a publishing error. We will re-attempt this release shortly, after updating the publishing workflow to fix the error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts 13.13.1, gates Chromium post-update safe-reload behind a remote feature flag, removes sidepanel polling token support, and awaits Snap keyring forwarding.
> 
> - **Release/Changelog**
>   - Revert to `v13.13.0` (`package.json`, `CHANGELOG.md`), remove `13.13.1` entry and fix compare links.
> - **Update handling**
>   - Non-Firefox post-update safe-reload now controlled by `RemoteFeatureFlagController` (`on-update.ts`).
>   - Remove Bowser version gate and related utility/constant (`shared/modules/browser-runtime.utils.js`, `ui/helpers/constants/common.ts`).
> - **App State / Polling Tokens**
>   - Remove `sidePanelGasPollTokens` support across state, metadata, validation, and environment mapping (`app-state-controller.ts`, tests, `shared/constants/app.ts`, `shared/types/background.ts`).
> - **Controller behavior**
>   - Await forwarding of selected account group to Snap keyring (`metamask-controller.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 282067d55690293df7f0fda6955c9351b3aa4a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->