### PR TITLE
feat: prevent start adornment from shrinking on small screens

### DIFF
--- a/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
+++ b/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
@@ -12,45 +12,49 @@ exports[`Toast should render Toast component 1`] = `
         class="mm-box mm-box--display-flex mm-box--gap-3"
       >
         <div
-          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          class="mm-box flex-shrink-0"
         >
           <div
-            class="flex [&>div]:!rounded-none"
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
           >
             <div
-              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 165, 242);"
+              class="flex [&>div]:!rounded-none"
             >
-              <svg
-                height="32"
-                width="32"
-                x="0"
-                y="0"
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 165, 242);"
               >
-                <rect
-                  fill="#018E8C"
+                <svg
                   height="32"
-                  transform="translate(6.42726344433259 -1.72032957977240) rotate(470.8 16.00000000000000 16.00000000000000)"
                   width="32"
                   x="0"
                   y="0"
-                />
-                <rect
-                  fill="#F93301"
-                  height="32"
-                  transform="translate(1.15641197664763 16.12885374650032) rotate(198.5 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-                <rect
-                  fill="#FA6800"
-                  height="32"
-                  transform="translate(22.34808017126402 5.11536968457706) rotate(148.9 16.00000000000000 16.00000000000000)"
-                  width="32"
-                  x="0"
-                  y="0"
-                />
-              </svg>
+                >
+                  <rect
+                    fill="#018E8C"
+                    height="32"
+                    transform="translate(6.42726344433259 -1.72032957977240) rotate(470.8 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#F93301"
+                    height="32"
+                    transform="translate(1.15641197664763 16.12885374650032) rotate(198.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#FA6800"
+                    height="32"
+                    transform="translate(22.34808017126402 5.11536968457706) rotate(148.9 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+              </div>
             </div>
           </div>
         </div>

--- a/ui/components/multichain/toast/toast.tsx
+++ b/ui/components/multichain/toast/toast.tsx
@@ -102,7 +102,9 @@ export const Toast = ({
         data-testid={dataTestId}
         {...contentProps}
       >
-        {startAdornment}
+        {startAdornment && (
+          <Box className="flex-shrink-0">{startAdornment}</Box>
+        )}
         <Box>
           <Text
             className="toast-text"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Prevent start adornment from shrinking on small screens

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38929?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Prevent start adornment from shrinking on small screens

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="353" height="190" alt="Screenshot 2025-12-17 at 5 21 19 PM" src="https://github.com/user-attachments/assets/7109b467-fc56-42e3-9707-095f950750cf" />


<!-- [screenshots/recordings] -->

### **After**
<img width="354" height="221" alt="Screenshot 2025-12-17 at 5 19 20 PM" src="https://github.com/user-attachments/assets/ed1ed701-c268-484d-9a6c-a9684326d56d" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps `startAdornment` in a non-shrinking container in `Toast`, updating the snapshot accordingly.
> 
> - **UI**
>   - `ui/components/multichain/toast/toast.tsx`: Wraps `startAdornment` in a `Box` with `flex-shrink-0` to prevent shrinking; renders only when present.
> - **Tests**
>   - `ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap`: Updated snapshot to reflect non-shrinking start adornment container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be37ecaffbcf7e099887796743b169ed53b0ab19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->