### PR TITLE
fix: send amount validation of small numbers for non-evm chains using snap

### DIFF
--- a/ui/pages/confirmations/hooks/send/useAmountValidation.ts
+++ b/ui/pages/confirmations/hooks/send/useAmountValidation.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Numeric } from '../../../../../shared/modules/Numeric';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
+  addLeadingZeroIfNeeded,
   fromTokenMinUnitsNumeric,
   isValidPositiveNumericString,
 } from '../../utils/send';
@@ -43,7 +44,7 @@ export const useAmountValidation = () => {
 
     try {
       const result = (await validateAmountWithSnap(
-        value || '0',
+        addLeadingZeroIfNeeded(value) || '0',
       )) as SnapOnAmountInputResult;
 
       if (result.errors?.length > 0) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix validation of send amount for solana chain for fractional value without leading 0.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38825

## **Manual testing steps**

1. Start solana send with amount .01
2. It should be possible to trigger this send

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes non-EVM send amounts by adding a leading zero before snap validation to support inputs like .01.
> 
> - **Validation**:
>   - In `ui/pages/confirmations/hooks/send/useAmountValidation.ts`, non-EVM amount validation now passes `addLeadingZeroIfNeeded(value)` to `validateAmountWithSnap` to correctly handle fractional inputs without a leading zero (e.g., `.01`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aba81449081cedeea2aa95d707136064e88f22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->