### PR TITLE
refactor: Improve JsonRpcEngineV2 boundaries provider engines

### DIFF
--- a/app/scripts/lib/createMetamaskMiddleware.ts
+++ b/app/scripts/lib/createMetamaskMiddleware.ts
@@ -1,9 +1,5 @@
 import { createWalletMiddleware } from '@metamask/eth-json-rpc-middleware';
-import {
-  asLegacyMiddleware,
-  createScaffoldMiddleware,
-  JsonRpcEngineV2,
-} from '@metamask/json-rpc-engine/v2';
+import { createScaffoldMiddleware } from '@metamask/json-rpc-engine/v2';
 
 import {
   createPendingNonceMiddleware,
@@ -32,28 +28,25 @@ export default function createMetamaskMiddleware({
   getPendingTransactionByHash,
   processRequestExecutionPermissions,
 }: Options) {
-  const engine = JsonRpcEngineV2.create({
-    middleware: [
-      /* eslint-disable @typescript-eslint/naming-convention */
-      createScaffoldMiddleware({
-        eth_syncing: false,
-        web3_clientVersion: `MetaMask/v${version}`,
-      }),
-      /* eslint-enable @typescript-eslint/naming-convention */
-      createWalletMiddleware({
-        getAccounts,
-        processTransaction,
-        processTypedMessage,
-        processTypedMessageV3,
-        processTypedMessageV4,
-        processPersonalMessage,
-        processDecryptMessage,
-        processEncryptionPublicKey,
-        processRequestExecutionPermissions,
-      }),
-      createPendingNonceMiddleware({ getPendingNonce }),
-      createPendingTxMiddleware({ getPendingTransactionByHash }),
-    ],
-  });
-  return asLegacyMiddleware(engine);
+  return [
+    /* eslint-disable @typescript-eslint/naming-convention */
+    createScaffoldMiddleware({
+      eth_syncing: false,
+      web3_clientVersion: `MetaMask/v${version}`,
+    }),
+    /* eslint-enable @typescript-eslint/naming-convention */
+    createWalletMiddleware({
+      getAccounts,
+      processTransaction,
+      processTypedMessage,
+      processTypedMessageV3,
+      processTypedMessageV4,
+      processPersonalMessage,
+      processDecryptMessage,
+      processEncryptionPublicKey,
+      processRequestExecutionPermissions,
+    }),
+    createPendingNonceMiddleware({ getPendingNonce }),
+    createPendingTxMiddleware({ getPendingTransactionByHash }),
+  ];
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Creates clean boundaries at the end of both provider engine middleware (EIP-1193 and CAIP) for the use of `JsonRpcEngineV2`, setting the stage for continued middleware migration.

The order that some middleware functions are added to the respective provider engine is changed. This change in order, and all other changes in this PR, should be non-behavioral.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38951?quickstart=1)

## **Changelog**

N/A

## **Manual testing steps**

1. Make sure that both EIP-1193 and CAIP APIs continue to function as normal

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors EIP-1193 and CAIP providers to end with a JsonRpcEngineV2 boundary using V2 wallet/provider middleware, and updates createMetamaskMiddleware to return a V2 middleware array.
> 
> - **Provider engines (EIP-1193 & CAIP)**:
>   - Terminate pipelines with `JsonRpcEngineV2` wrapped by `asLegacyMiddleware`.
>   - Inject `...metamaskMiddlewareV2` (new V2 middleware array) plus `providerAsMiddlewareV2` (or a V2 async provider handler for CAIP).
>   - Reorder middleware so `filterMiddleware` and `subscriptionManager.middleware` precede the V2 boundary.
> - **createMetamaskMiddleware**:
>   - Now returns an array of V2 middleware (`createScaffoldMiddleware`, `createWalletMiddleware`, pending nonce/tx) instead of constructing a legacy engine.
> - **Imports/Adapters**:
>   - Switch to `providerAsMiddlewareV2`; add `JsonRpcEngineV2`/`asLegacyMiddleware` usage; remove legacy engine wrapping from `createMetamaskMiddleware`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10ef3bbd0fe3315f031fcb2c2642d307331ed3b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->