### PR TITLE
feat: enable sidepanel on Opera

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -70,5 +70,18 @@
     "notifications",
     "identity"
   ],
-  "short_name": "__MSG_appName__"
+  "short_name": "__MSG_appName__",
+  "sidebar_action": {
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "19": "images/icon-19.png",
+      "32": "images/icon-32.png",
+      "38": "images/icon-38.png",
+      "64": "images/icon-64.png",
+      "128": "images/icon-128.png",
+      "512": "images/icon-512.png"
+    },
+    "default_title": "__MSG_appName__",
+    "default_panel": "sidepanel.html"
+  }
 }

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -93,5 +93,18 @@
   "sandbox": {
     "pages": ["snaps/index.html"]
   },
-  "short_name": "__MSG_appName__"
+  "short_name": "__MSG_appName__",
+  "sidebar_action": {
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "19": "images/icon-19.png",
+      "32": "images/icon-32.png",
+      "38": "images/icon-38.png",
+      "64": "images/icon-64.png",
+      "128": "images/icon-128.png",
+      "512": "images/icon-512.png"
+    },
+    "default_title": "__MSG_appName__",
+    "default_panel": "sidepanel.html"
+  }
 }


### PR DESCRIPTION
## **Description**

This simple manifest change seems to work, but I don't know everything to test.

Based on documentation here: https://help.opera.com/en/extensions/sidebar-action-manual/

Our buttons to open the sidepanel don't work, but Opera's sidepanel button works.

## **Changelog**

CHANGELOG entry: Enable sidepanel on Opera

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->