### PR TITLE
fix: updated clear metametrics data modal

### DIFF
--- a/ui/components/app/clear-metametrics-data/clear-metametrics-data.test.tsx
+++ b/ui/components/app/clear-metametrics-data/clear-metametrics-data.test.tsx
@@ -44,8 +44,8 @@ describe('ClearMetaMetricsData', () => {
   it('should call createMetaMetricsDataDeletionTask when Clear button is clicked', () => {
     const store = configureStore({});
     const { getByText } = renderWithProvider(<ClearMetaMetricsData />, store);
-    expect(getByText('Clear')).toBeEnabled();
-    fireEvent.click(getByText('Clear'));
+    expect(getByText('Delete')).toBeEnabled();
+    fireEvent.click(getByText('Delete'));
     expect(Actions.createMetaMetricsDataDeletionTask).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/components/app/clear-metametrics-data/clear-metametrics-data.tsx
+++ b/ui/components/app/clear-metametrics-data/clear-metametrics-data.tsx
@@ -75,6 +75,7 @@ export default function ClearMetaMetricsData() {
     <Modal isOpen onClose={closeModal}>
       <ModalOverlay />
       <ModalContent
+        alignItems={AlignItems.center}
         modalDialogProps={{
           display: Display.Flex,
           flexDirection: FlexDirection.Column,
@@ -124,7 +125,7 @@ export default function ClearMetaMetricsData() {
               onClick={deleteMetaMetricsData}
               danger
             >
-              {t('clear')}
+              {t('delete')}
             </Button>
           </Box>
         </ModalFooter>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR, I have updated the Clear MetaMetrics data modal, where we changed the `Clear` CTA to `Delete`, and the modal is centre-aligned.

Jira Link: 
- https://consensyssoftware.atlassian.net/browse/SL-398
- https://consensyssoftware.atlassian.net/browse/SL-405


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38955?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update CTA text on Clear Metametrics Data Modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to extension.
2. Create a wallet using social login
3. After completion, the user will be redirected to `Completion Page` 
4. Then click on `Manage default settings` > `Security & Privacy` > click on `Delete MetaMetrics data`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1728" height="1035" alt="Screenshot 2025-12-18 at 11 31 46 AM" src="https://github.com/user-attachments/assets/d274fff1-8bb9-4b45-971c-977f3efaa029" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Center-aligns the MetaMetrics data deletion modal and changes the primary action from Clear to Delete; updates related tests.
> 
> - **UI**:
>   - Center-aligns `ModalContent` in `ui/components/app/clear-metametrics-data/clear-metametrics-data.tsx`.
>   - Renames primary CTA from `t('clear')` to `t('delete')` (label now “Delete”).
> - **Tests**:
>   - Update assertions and clicks to use "Delete" instead of "Clear" in `clear-metametrics-data.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a6f796d4fab1a6a81b6991d8c2f9672c2874450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->