### PR TITLE
Temporary check never executed tests

### DIFF
--- a/.github/scripts/extract-failed-tests.ts
+++ b/.github/scripts/extract-failed-tests.ts
@@ -1,0 +1,70 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { normalizeTestPath, XML } from './shared/utils';
+
+/**
+ * Extracts the paths of failed test files from XML test results.
+ * Used to identify which tests to re-run when a CI job is retried.
+ *
+ * @param resultsDir - Directory containing XML test result files
+ * @returns Array of normalized test file paths that had failures
+ */
+export async function extractFailedTestPaths(
+  resultsDir: string,
+): Promise<string[]> {
+  if (!existsSync(resultsDir)) {
+    console.log(`Results directory does not exist: ${resultsDir}`);
+    return [];
+  }
+
+  const failedTests: string[] = [];
+  const files = readdirSync(resultsDir).filter((f) => f.endsWith('.xml'));
+
+  if (files.length === 0) {
+    console.log(`No XML files found in: ${resultsDir}`);
+    return [];
+  }
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(path.join(resultsDir, file), 'utf-8');
+      const result = await XML.parse(content);
+
+      for (const suite of result.testsuites?.testsuite || []) {
+        const failures = parseInt(suite.$.failures || '0', 10);
+        const errors = parseInt(suite.$.errors || '0', 10);
+
+        if ((failures > 0 || errors > 0) && suite.$.file) {
+          const testPath = normalizeTestPath(suite.$.file);
+          failedTests.push(testPath);
+        }
+      }
+    } catch (error) {
+      console.warn(`Failed to parse XML file ${file}:`, error);
+    }
+  }
+
+  // Remove duplicates and return
+  const uniqueFailedTests = [...new Set(failedTests)];
+  console.log(`Found ${uniqueFailedTests.length} failed test files`);
+
+  return uniqueFailedTests;
+}
+
+/**
+ * CLI entry point for testing the script directly
+ */
+if (require.main === module) {
+  const resultsDir =
+    process.argv[2] || 'previous-test-results/test/test-results/e2e';
+
+  extractFailedTestPaths(resultsDir)
+    .then((failedTests) => {
+      console.log('Failed tests:', failedTests);
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+      process.exit(1);
+    });
+}
+

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -76,6 +76,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       TEST_SUITE_NAME: ${{ inputs.test-suite-name }}
       IS_SIDEPANEL: true
+      RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -133,12 +134,24 @@ jobs:
           name: test-runs-for-splitting
           path: test/test-results/
 
+      # On re-run (run_attempt > 1), download previous test results to identify failed tests
+      - name: Download previous test results (on re-run)
+        if: ${{ github.run_attempt > 1 }}
+        id: download-previous-results
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.JOB_NAME }}
+          path: ./previous-test-results/
+
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: ${{ inputs.test-command }} --retries 1
         env:
           # The properties are picked up by mocha-junit-reporter and added to the XML test results
           PROPERTIES: 'JOB_NAME:${{ env.JOB_NAME }},RUN_ID:${{ env.RUN_ID }},PR_NUMBER:${{ env.PR_NUMBER }}'
+          # On re-run, pass the path to previous results to run only failed tests
+          PREVIOUS_RESULTS_PATH: ${{ steps.download-previous-results.outcome == 'success' && './previous-test-results/test/test-results/e2e' || '' }}
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -177,6 +177,10 @@ async function withFixtures(options, testSuite) {
     extendedTimeoutMultiplier = 1,
   } = options;
 
+  if (process.env.RUN_ATTEMPT === '1') {
+    throw new Error('forced failure');
+  }
+
   // Normalize localNodeOptions
   const localNodeOptsNormalized = normalizeLocalNodeOptions(localNodeOptions);
 


### PR DESCRIPTION
Temporary branch to test never executed tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds XML parsing and workflow wiring to rerun only failed or never-executed E2E tests on re-runs, with support to skip chunks that already passed.
> 
> - **CI/Workflow (`.github/workflows/run-e2e.yml`)**:
>   - Add `RUN_ATTEMPT` env and download previous job’s artifacts on re-run.
>   - Pass `PREVIOUS_RESULTS_PATH` to tests when prior results exist.
> - **E2E Runner (`test/e2e/run-all.ts`)**:
>   - Import and use new results extractor to rerun only `failed` + `never executed` tests within the current chunk.
>   - Log run attempt; skip running when nothing to rerun.
> - **Results Extraction (`.github/scripts/extract-failed-tests.ts`)**:
>   - New script to parse JUnit XML and return `failedTests` and `executedTests` (with CLI entry point).
> - **Helpers (`test/e2e/helpers.js`)**:
>   - Throw error when `RUN_ATTEMPT === '1'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 036f1449c755cf111d4edacbb02b8009ce4f223d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->