### PR TITLE
fix: render the account name instead of the address for the transaction details

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -42,11 +42,8 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
-import {
-  getAccountByAddress,
-  getURLHostName,
-  shortenAddress,
-} from '../../../helpers/utils/util';
+import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
+import { getAccountName } from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
@@ -120,8 +117,8 @@ export function MultichainTransactionDetailsModal({
     if (!address) {
       return null;
     }
-    const account = getAccountByAddress(internalAccounts, address);
-    const displayName = account?.metadata?.name || shortenAddress(address);
+    const accountName = getAccountName(internalAccounts, address);
+    const displayName = accountName || shortenAddress(address);
 
     return (
       <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
@@ -141,8 +141,9 @@ describe('TransactionListItemDetails for swaps', () => {
     });
 
     expect(queryByText('View on block explorer')).toBeInTheDocument();
+    // Sender shows account name ("Test Account") since it matches an internal account
     expect(queryByTestId('sender-to-recipient')).toHaveTextContent(
-      '0x0DCD5...3E7bc0x00000...00000',
+      'Test Account0x00000...00000',
     );
     const expectedRows = [
       'Nonce1',

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   const addressBook = getAddressBook(state);
   const accounts = getInternalAccounts(state);
   const recipientName = getAccountName(accounts, recipientAddress);
+  const senderAccountName = getAccountName(accounts, senderAddress);
 
   const getNickName = (address) => {
     const entry = addressBook.find((contact) => {
@@ -33,7 +34,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     rpcPrefs,
     networkConfiguration,
-    senderNickname: getNickName(senderAddress),
+    senderNickname: senderAccountName || getNickName(senderAddress),
     isCustomNetwork,
     blockExplorerLinkText: getBlockExplorerLinkText(state),
     recipientName,


### PR DESCRIPTION
This PR ensures that if account name is there then show account name , otherwise falls back to shortened address.


## **Description**

Before: Always showed shortenAddress(address)
After: Shows account name if found, otherwise falls back to shortened address

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38959?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: #38860 

## **Manual testing steps**

1. Perform a transaction and confirm
2. Click tx on the Activity list
3. See From field displays the the account name


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display internal account names for sender/addresses in transaction details, falling back to shortened addresses; update container logic and tests accordingly.
> 
> - **UI**
>   - `multichain-transaction-details-modal.tsx`: Resolve display name via `getAccountName(getInternalAccounts, address)` and use it instead of `shortenAddress` (fallback retained). Adds selector usage for internal accounts.
>   - `transaction-list-item-details.container.js`: Prefer internal `senderAccountName` over address book nickname for `senderNickname`.
> - **Tests**
>   - `transaction-list-item-details.component.test.js`: Update expectation to show sender account name ("Test Account") instead of shortened address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af47abdbdc9e3c8c00279ba66490127a342ab6bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->