### PR TITLE
refactor: remove use of legacy state field `provider`

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -188,7 +188,6 @@ const CrossChainSwapTxDetails = () => {
     }) =>
       getNativeTokenInfo(
         state.metamask.networkConfigurationsByChainId,
-        state.metamask.provider,
         srcChainTxMeta?.chainId ?? '',
       ),
   ) as { decimals: number; symbol: string };

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -180,17 +180,12 @@ const CrossChainSwapTxDetails = () => {
     getIsDelayed(bridgeStatus, bridgeHistoryItem);
 
   // TODO set for gasless swaps
-  const gasCurrency = useSelector(
-    (state: {
-      metamask: MetaMaskReduxState['metamask'] & {
-        provider: Record<string, unknown>;
-      };
-    }) =>
-      getNativeTokenInfo(
-        state.metamask.networkConfigurationsByChainId,
-        srcChainTxMeta?.chainId ?? '',
-      ),
-  ) as { decimals: number; symbol: string };
+  const gasCurrency = useSelector((state: MetaMaskReduxState) =>
+    getNativeTokenInfo(
+      state.metamask.networkConfigurationsByChainId,
+      srcChainTxMeta?.chainId ?? '',
+    ),
+  );
 
   const srcNetworkIconName = (
     <Box display={Display.Flex} gap={1} alignItems={AlignItems.center}>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -58,7 +58,6 @@ export const NativeTokenPeriodicDetails: React.FC<{
     }) =>
       getNativeTokenInfo(
         state.metamask.networkConfigurationsByChainId,
-        state.metamask.provider,
         chainId,
       ) as NativeTokenInfo,
   );

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -19,12 +19,6 @@ import { formatPeriodDuration } from './typed-sign-permission-util';
 import { DateAndTimeRow } from './date-and-time-row';
 import { NativeAmountRow } from './native-amount-row';
 
-type NativeTokenInfo = {
-  symbol: string;
-  decimals: number;
-  name: string;
-};
-
 /**
  * Component for displaying native token periodic permission details.
  * Shows period amount, duration, start date, and expiration date for native token periodic permissions.
@@ -50,16 +44,8 @@ export const NativeTokenPeriodicDetails: React.FC<{
 
   const { startTime, periodAmount, periodDuration } = permission.data;
 
-  const { symbol, decimals } = useSelector(
-    (state: {
-      metamask: MetaMaskReduxState['metamask'] & {
-        provider: Record<string, unknown>;
-      };
-    }) =>
-      getNativeTokenInfo(
-        state.metamask.networkConfigurationsByChainId,
-        chainId,
-      ) as NativeTokenInfo,
+  const { symbol, decimals } = useSelector((state: MetaMaskReduxState) =>
+    getNativeTokenInfo(state.metamask.networkConfigurationsByChainId, chainId),
   );
 
   const tokenImageUrl = CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId];

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -16,12 +16,6 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { NativeAmountRow } from './native-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
 
-type NativeTokenInfo = {
-  symbol: string;
-  decimals: number;
-  name: string;
-};
-
 /**
  * Component for displaying native token stream permission details.
  * Shows initial allowance, max allowance, stream start date, expiration date, stream rate, and daily available amount.
@@ -50,16 +44,8 @@ export const NativeTokenStreamDetails: React.FC<{
   // DAY is in milliseconds, so we divide by 1000 to get seconds
   const amountPerDay = new BigNumber(amountPerSecond).mul(DAY / 1000);
 
-  const { symbol, decimals } = useSelector(
-    (state: {
-      metamask: MetaMaskReduxState['metamask'] & {
-        provider: Record<string, unknown>;
-      };
-    }) =>
-      getNativeTokenInfo(
-        state.metamask.networkConfigurationsByChainId,
-        chainId,
-      ) as NativeTokenInfo,
+  const { symbol, decimals } = useSelector((state: MetaMaskReduxState) =>
+    getNativeTokenInfo(state.metamask.networkConfigurationsByChainId, chainId),
   );
 
   const tokenImageUrl = CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId];

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -58,7 +58,6 @@ export const NativeTokenStreamDetails: React.FC<{
     }) =>
       getNativeTokenInfo(
         state.metamask.networkConfigurationsByChainId,
-        state.metamask.provider,
         chainId,
       ) as NativeTokenInfo,
   );

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -822,7 +822,6 @@ export function getSelectedAccountTokensAcrossChains(state) {
     if (nativeBalance) {
       const nativeTokenInfo = getNativeTokenInfo(
         state.metamask.networkConfigurationsByChainId,
-        state.metamask.provider,
         chainId,
       );
       tokensByChain[chainId].push({
@@ -873,7 +872,6 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
   [
     (state) => state.metamask.allTokens,
     (state) => state.metamask.networkConfigurationsByChainId,
-    (state) => state.metamask.provider,
     (state, accountAddress) =>
       getNativeTokenCachedBalanceByChainIdSelector(state, accountAddress),
     (_state, accountAddress) => accountAddress,
@@ -881,7 +879,6 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
   (
     allTokens,
     networkConfigurationsByChainId,
-    provider,
     nativeTokenBalancesByChainId,
     selectedAddress,
   ) => {
@@ -908,7 +905,6 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
       if (nativeBalance) {
         const nativeTokenInfo = getNativeTokenInfo(
           networkConfigurationsByChainId,
-          provider,
           chainId,
         );
         tokensByChain[chainId].push({
@@ -930,15 +926,10 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
  * without hardcoding any values.
  *
  * @param {object} networkConfigurationsByChainId - Network configurations by chain ID
- * @param {object} provider - Provider
  * @param {string} chainId - Chain ID
  * @returns {object} Native token information
  */
-export function getNativeTokenInfo(
-  networkConfigurationsByChainId,
-  provider,
-  chainId,
-) {
+export function getNativeTokenInfo(networkConfigurationsByChainId, chainId) {
   const networkConfig = networkConfigurationsByChainId?.[chainId];
 
   // Fill native token info by network config (if a user has a network added)
@@ -946,19 +937,6 @@ export function getNativeTokenInfo(
     const symbol = networkConfig.nativeCurrency || AssetType.native;
     const decimals = 18;
     const name = networkConfig.name || 'Native Token';
-
-    return {
-      symbol,
-      decimals,
-      name,
-    };
-  }
-
-  // Fill native token info by DApp provider
-  if (provider?.chainId === chainId) {
-    const symbol = provider.ticker || AssetType.native;
-    const decimals = provider.nativeCurrency?.decimals || 18;
-    const name = provider.nickname || 'Native Token';
 
     return {
       symbol,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -927,7 +927,7 @@ export const getTokensAcrossChainsByAccountAddressSelector = createSelector(
  *
  * @param {object} networkConfigurationsByChainId - Network configurations by chain ID
  * @param {string} chainId - Chain ID
- * @returns {object} Native token information
+ * @returns {{ symbol: string, decimals: number, name: string }} Native token information
  */
 export function getNativeTokenInfo(networkConfigurationsByChainId, chainId) {
   const networkConfig = networkConfigurationsByChainId?.[chainId];

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -2783,7 +2783,6 @@ describe('getNativeTokenInfo', () => {
     const state = {
       metamask: {
         networkConfigurationsByChainId: {},
-        provider: {},
       },
     };
 
@@ -2799,7 +2798,6 @@ describe('getNativeTokenInfo', () => {
 
     const result = selectors.getNativeTokenInfo(
       mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
       '0x1337',
     );
     expect(result).toStrictEqual({
@@ -2818,49 +2816,6 @@ describe('getNativeTokenInfo', () => {
 
     const result = selectors.getNativeTokenInfo(
       mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
-      '0x1337',
-    );
-    expect(result).toStrictEqual({
-      symbol: 'NATIVE',
-      decimals: 18,
-      name: 'Native Token',
-    });
-  });
-
-  it('provides native token from DApp provider', () => {
-    const mocks = arrange();
-    mocks.state.metamask.provider = {
-      chainId: '0x1337',
-      ticker: 'HELLO',
-      nativeCurrency: { decimals: 18 },
-      nickname: 'MyToken',
-    };
-
-    const result = selectors.getNativeTokenInfo(
-      mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
-      '0x1337',
-    );
-    expect(result).toStrictEqual({
-      symbol: 'HELLO',
-      decimals: 18,
-      name: 'MyToken',
-    });
-  });
-
-  it('provides native token from DApp provider but with fallbacks for missing fields', () => {
-    const mocks = arrange();
-    mocks.state.metamask.provider = {
-      chainId: '0x1337',
-      ticker: undefined,
-      nativeCurrency: undefined,
-      nickname: undefined,
-    };
-
-    const result = selectors.getNativeTokenInfo(
-      mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
       '0x1337',
     );
     expect(result).toStrictEqual({
@@ -2875,7 +2830,6 @@ describe('getNativeTokenInfo', () => {
 
     const result = selectors.getNativeTokenInfo(
       mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
       '0x89',
     );
     expect(result).toStrictEqual({
@@ -2889,7 +2843,6 @@ describe('getNativeTokenInfo', () => {
     const mocks = arrange();
     const result = selectors.getNativeTokenInfo(
       mocks.state.metamask.networkConfigurationsByChainId,
-      mocks.state.metamask.provider,
       '0xFakeToken',
     );
     expect(result).toStrictEqual({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38961?quickstart=1)

It's been recently raised during a refactor that piece of state does not seem to exist. After doing some testing and digging, that seems to be the case.

https://github.com/MetaMask/metamask-extension/pull/38891#discussion_r2623240408

The code related to it is therefore being removed, which will have no impact in the application.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates `provider`-based logic from `getNativeTokenInfo`, updates all callers to the new signature, and adjusts tests accordingly.
> 
> - **Selectors**:
>   - Simplify `getNativeTokenInfo(networkConfigurationsByChainId, chainId)`; remove `provider` param and provider-based fallback.
>   - Update selectors using native token info (e.g., token aggregation across chains) to call the new signature.
>   - Improve JSDoc return type for `getNativeTokenInfo`.
> - **UI Components**:
>   - Update `transaction-details.tsx`, `native-token-periodic-details.tsx`, and `native-token-stream-details.tsx` to use the new `getNativeTokenInfo` signature.
> - **Tests**:
>   - Remove `provider` references and provider-fallback cases.
>   - Adjust tests to validate network-config and hardcoded fallbacks only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c003df4e83ddbb61f719b2907f90612e79aa2d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->