### PR TITLE
test: fix flaky test Sending with max amount gas modal changes handles market value changes

### DIFF
--- a/test/e2e/page-objects/flows/transaction.ts
+++ b/test/e2e/page-objects/flows/transaction.ts
@@ -32,6 +32,7 @@ export const createInternalTransactionWithMaxAmount = async (
   await sendToPage.checkPageIsLoaded();
   await sendToPage.fillRecipient('0x2f318C334780961FB129D2a6c30D0763d9a5C970');
   await sendToPage.clickMaxAmountButton();
+  await sendToPage.checkAccountValueAndSuffix('$42,499.08');
   await sendToPage.goToNextScreen();
 };
 

--- a/test/e2e/page-objects/pages/confirmations/redesign/gas-fee-modal.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/gas-fee-modal.ts
@@ -18,6 +18,8 @@ export default class GasFeeModal {
   private readonly cancelButton: RawLocator =
     '[data-testid="gas-fee-modal-cancel-button"]';
 
+  private readonly editGasFeeModalTitle = { text: 'Edit gas fee', tag: 'h4' };
+
   private readonly estimatesModal: RawLocator =
     '[data-testid="gas-fee-estimates-modal"]';
 
@@ -105,6 +107,22 @@ export default class GasFeeModal {
       css: selector,
       text: expectedValue,
     });
+  }
+
+  async checkPageIsLoaded(): Promise<void> {
+    try {
+      await this.driver.waitForMultipleSelectors([
+        this.editGasFeeModalTitle,
+        this.gasOptionLow,
+        this.gasOptionMedium,
+        this.gasOptionHigh,
+        this.gasOptionAdvanced,
+      ]);
+    } catch (e) {
+      console.log('Timeout while waiting for gas fee modal to be loaded', e);
+      throw e;
+    }
+    console.log('Gas fee modal is loaded');
   }
 
   /**

--- a/test/e2e/page-objects/pages/confirmations/redesign/gas-fee-modal.ts
+++ b/test/e2e/page-objects/pages/confirmations/redesign/gas-fee-modal.ts
@@ -202,6 +202,7 @@ export default class GasFeeModal {
    */
   async selectLowGasFee(): Promise<void> {
     console.log('Selecting low gas fee option');
+    await this.driver.waitForElementToStopMoving(this.gasOptionLow);
     await this.driver.clickElementAndWaitToDisappear(this.gasOptionLow);
   }
 

--- a/test/e2e/tests/transaction/send-max.spec.ts
+++ b/test/e2e/tests/transaction/send-max.spec.ts
@@ -143,6 +143,7 @@ describe('Sending with max amount', function () {
 
           // update estimates to low
           await sendTokenConfirmPage.clickEditGasFeeIcon();
+          await gasFeeModal.checkPageIsLoaded();
           await gasFeeModal.selectLowGasFee();
 
           // has correct updated value on the confirm screen the transaction


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The gas modal takes time to display on Firefox. Race condition occurs when the modal is not fully loaded, so clicking low gas at that point has no effect.
The fix is to wait until the modal is fully loaded and ensure the low gas button is stable (not moving) before clicking on it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38963?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Test should pass and be stable

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the gas fee modal flow by waiting for full load and element stability, and adds an account value check when sending max amount.
> 
> - **E2E Page Objects**:
>   - `pages/confirmations/redesign/gas-fee-modal.ts`:
>     - Add `editGasFeeModalTitle` locator and `checkPageIsLoaded()` to wait for modal readiness (title + gas options).
>     - In `selectLowGasFee()`, wait for the low option to stop moving before clicking.
> - **E2E Flows**:
>   - `flows/transaction.ts`: After `clickMaxAmountButton()`, assert account value with `checkAccountValueAndSuffix('$42,499.08')`.
> - **E2E Tests**:
>   - `tests/transaction/send-max.spec.ts`:
>     - In "handles market value changes - low", call `gasFeeModal.checkPageIsLoaded()` before selecting low gas fee.
>     - Keep existing assertions for updated gas fee and fiat values after selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5bd230d8b8ea62ab27e9edfa20e61fdf2e9373. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->