### PR TITLE
test: fix flaky test Phishing Detection Via Iframe should display the MetaMask Phishing Detection page in an iframe and take the user to the blocked page if they continue

### DIFF
--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -10,9 +10,7 @@ class PhishingWarningPage {
 
   private readonly iframeSelector = 'iframe';
 
-  private readonly openWarningInNewTabLink = {
-    text: 'Open this warning in a new tab',
-  };
+  private readonly openWarningInNewTabLink = '#open-self-in-new-tab';
 
   private readonly phishingWarningPageTitle = {
     text: 'This website might be harmful',
@@ -56,6 +54,7 @@ class PhishingWarningPage {
       this.iframeSelector,
     )) as WebElement;
     await this.driver.switchToFrame(iframe as unknown as string);
+    await this.checkPageIsLoaded();
     await this.driver.clickElement(this.openWarningInNewTabLink);
   }
 

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -154,6 +154,10 @@ describe('Phishing Detection', function (this: Suite) {
           await driver.openNewPage(DAPP_WITH_IFRAMED_PAGE_ON_BLOCKLIST);
           const phishingWarningPage = new PhishingWarningPage(driver);
           await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
+          await new HomePage(driver).checkPageIsLoaded();
 
           await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
           await phishingWarningPage.checkPageIsLoaded();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

There is a race condition where we get this error on firefox: `NoSuchWindowError: Browsing context has been discarded`

The problem is that after we click "Open warning in a new tab," it automatically opens a new window. However, when we try to retrieve the window handle before fully switching to the new page, Firefox throws the error `browsing context has been discarded`, because the window we were trying to access has changed.
After several attempts, I found that we can force a switch to the homepage after clicking the button, since we know the homepage exists and is fully loaded. Then, we can switch to the new page. This gives time for the window handles to become stable, and this solution resolves the flakiness.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/38982?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Test should pass and be stable

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch phishing warning link to a CSS selector with a load check, and update the iframe test to handle the extension full-screen window before proceeding.
> 
> - **E2E Page Object (`test/e2e/page-objects/pages/phishing-warning-page.ts`)**:
>   - Change `openWarningInNewTabLink` from text lookup to CSS selector `#open-self-in-new-tab`.
>   - In `clickOpenWarningInNewTabLinkOnIframe`, add `checkPageIsLoaded()` before clicking.
> - **E2E Test (`test/e2e/tests/phishing-controller/phishing-detection.spec.ts`)**:
>   - After opening the warning in a new tab (iframe scenario), switch to `WINDOW_TITLES.ExtensionInFullScreenView` and verify `HomePage` is loaded, then return to the phishing warning window and continue flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fdacdc40e54223e4b0189036191238b8e605535. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->