### PR TITLE
fix: temporarily skip account syncing E2Es on Firefox

### DIFF
--- a/test/e2e/tests/identity/account-syncing/account-syncing-settings-toggle.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/account-syncing-settings-toggle.spec.ts
@@ -17,7 +17,7 @@ import BackupAndSyncSettings from '../../../page-objects/pages/settings/backup-a
 import SettingsPage from '../../../page-objects/pages/settings/settings-page';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
 import { mockIdentityServices } from '../mocks';
-import { arrangeTestUtils } from './helpers';
+import { arrangeTestUtils, skipOnFirefox } from './helpers';
 
 describe('Account syncing - Settings Toggle', function () {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
@@ -33,6 +33,8 @@ describe('Account syncing - Settings Toggle', function () {
    * Phase 3: Login to a fresh app instance and verify only synced accounts persist
    */
   it('syncs new accounts when account sync is enabled and exclude accounts created when sync is disabled', async function () {
+    skipOnFirefox(this);
+
     const userStorageMockttpController = new UserStorageMockttpController();
 
     const sharedMockSetup = (server: Mockttp) => {

--- a/test/e2e/tests/identity/account-syncing/adding-and-renaming-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/adding-and-renaming-accounts.spec.ts
@@ -17,7 +17,7 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import { completeImportSRPOnboardingFlow } from '../../../page-objects/flows/onboarding.flow';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
 import { mockIdentityServices } from '../mocks';
-import { arrangeTestUtils } from './helpers';
+import { arrangeTestUtils, skipOnFirefox } from './helpers';
 
 describe('Account syncing - Adding and Renaming Accounts', function () {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
@@ -35,6 +35,8 @@ describe('Account syncing - Adding and Renaming Accounts', function () {
    */
 
   it('adds a new account and sync it across multiple phases', async function () {
+    skipOnFirefox(this);
+
     const userStorageMockttpController = new UserStorageMockttpController();
 
     const sharedMockSetup = (server: Mockttp) => {

--- a/test/e2e/tests/identity/account-syncing/balances.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/balances.spec.ts
@@ -13,7 +13,7 @@ import HeaderNavbar from '../../../page-objects/pages/header-navbar';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
 import { mockInfuraAndAccountSync } from '../mocks';
-import { arrangeTestUtils } from './helpers';
+import { arrangeTestUtils, skipOnFirefox } from './helpers';
 
 describe('Account syncing - Accounts with Balances', function () {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
@@ -31,6 +31,8 @@ describe('Account syncing - Accounts with Balances', function () {
    * Phase 2: Complete onboarding flow with balance mocking - should discover additional accounts with balances (3 total: 2 synced + 1 discovered)
    */
   it('gracefully handles adding accounts with balances and synced accounts', async function () {
+    skipOnFirefox(this);
+
     const userStorageMockttpController = new UserStorageMockttpController();
 
     const phase1MockSetup = (server: Mockttp) => {

--- a/test/e2e/tests/identity/account-syncing/helpers.ts
+++ b/test/e2e/tests/identity/account-syncing/helpers.ts
@@ -17,6 +17,7 @@ export const POST_UNLOCK_DELAY = 20000;
 /**
  * Skips the current test if running on Firefox.
  * Account syncing tests are flaky on Firefox due to timing issues.
+ *
  * @param context - The Mocha test context (this)
  */
 export function skipOnFirefox(context: Mocha.Context): void {

--- a/test/e2e/tests/identity/account-syncing/helpers.ts
+++ b/test/e2e/tests/identity/account-syncing/helpers.ts
@@ -1,3 +1,4 @@
+import { Browser } from 'selenium-webdriver';
 import { USER_STORAGE_GROUPS_FEATURE_KEY } from '@metamask/account-tree-controller';
 import { Driver } from '../../../webdriver/driver';
 import {
@@ -12,6 +13,18 @@ export const BASE_ACCOUNT_SYNC_INTERVAL = 1000;
 
 // Extra delay to wait after unlock before checking sync state (helps with Firefox timing issues)
 export const POST_UNLOCK_DELAY = 20000;
+
+/**
+ * Skips the current test if running on Firefox.
+ * Account syncing tests are flaky on Firefox due to timing issues.
+ * @param context - The Mocha test context (this)
+ */
+export function skipOnFirefox(context: Mocha.Context): void {
+  if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
+    console.log('Skipping test on Firefox due to timing issues');
+    context.skip();
+  }
+}
 
 export const arrangeTestUtils = (
   driver: Driver,

--- a/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/imported-accounts.spec.ts
@@ -15,7 +15,7 @@ import AccountListPage from '../../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../../page-objects/pages/header-navbar';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
-import { arrangeTestUtils } from './helpers';
+import { arrangeTestUtils, skipOnFirefox } from './helpers';
 
 describe('Account syncing - Unsupported Account types', function () {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
@@ -34,6 +34,8 @@ describe('Account syncing - Unsupported Account types', function () {
    * Phase 2: Login to a fresh app instance and verify only regular accounts persist (imported accounts are excluded)
    */
   it('does not sync imported accounts and exclude them when logging into a fresh app instance', async function () {
+    skipOnFirefox(this);
+
     const userStorageMockttpController = new UserStorageMockttpController();
 
     const sharedMockSetup = (server: Mockttp) => {

--- a/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
@@ -16,7 +16,7 @@ import AccountListPage from '../../../page-objects/pages/account-list-page';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import { IDENTITY_TEAM_SEED_PHRASE_2 } from '../constants';
 import { mockMultichainAccountsFeatureFlagStateTwo } from '../../multichain-accounts/common';
-import { arrangeTestUtils } from './helpers';
+import { arrangeTestUtils, skipOnFirefox } from './helpers';
 
 describe('Account syncing - Multiple SRPs', function () {
   this.timeout(160000); // This test is very long, so we need an unusually high timeout
@@ -32,6 +32,8 @@ describe('Account syncing - Multiple SRPs', function () {
    * Phase 2: Login to a fresh app instance and verify all accounts from both SRPs persist and are visible after importing the second SRP.
    */
   it('adds accounts across multiple SRPs and sync them', async function () {
+    skipOnFirefox(this);
+
     const userStorageMockttpController = new UserStorageMockttpController();
 
     const sharedMockSetup = (server: Mockttp) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reasons behind this change: https://www.notion.so/consensys/Account-syncing-E2E-flakiness-rundown-2cdfc61a326e80d08a52f40a29262651

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skip account syncing E2E specs on Firefox via a new `skipOnFirefox` helper and updates to affected tests.
> 
> - **E2E Tests (Account Syncing)**:
>   - **Helper**: Add `skipOnFirefox(context)` in `test/e2e/tests/identity/account-syncing/helpers.ts` to skip tests when `SELENIUM_BROWSER` is Firefox.
>   - **Specs Updated**: Import and invoke `skipOnFirefox(this)` at test start in:
>     - `account-syncing-settings-toggle.spec.ts`
>     - `adding-and-renaming-accounts.spec.ts`
>     - `balances.spec.ts`
>     - `imported-accounts.spec.ts`
>     - `multi-srp.spec.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 351d428f5c4c9ad17bf6f1bede5c24b9c7f6bba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->