### PR TITLE
feat: remove copy button from tx details item sender and recipient addresses

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -131,7 +131,6 @@ export default class TransactionBreakdown extends PureComponent {
               <TransactionBreakdownRow title="Gas Paid By">
                 <RecipientWithAddress
                   checksummedRecipientAddress={gasPaidByAddress}
-                  addressOnly
                 />
               </TransactionBreakdownRow>
             )}

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -45,7 +45,6 @@ export default class TransactionListItemDetails extends PureComponent {
     title: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     recipientAddress: PropTypes.string,
-    recipientName: PropTypes.string,
     senderAddress: PropTypes.string.isRequired,
     tryReverseResolveAddress: PropTypes.func.isRequired,
     senderNickname: PropTypes.string.isRequired,
@@ -154,7 +153,6 @@ export default class TransactionListItemDetails extends PureComponent {
       showSpeedUp,
       // showRetry,
       recipientAddress,
-      recipientName,
       senderAddress,
       isEarliestNonce,
       senderNickname,
@@ -255,20 +253,9 @@ export default class TransactionListItemDetails extends PureComponent {
                 variant={DEFAULT_VARIANT}
                 addressOnly
                 recipientAddress={recipientAddress}
-                recipientName={recipientName}
                 senderName={senderNickname}
                 senderAddress={senderAddress}
                 chainId={chainId}
-                onRecipientClick={() => {
-                  this.context.trackEvent({
-                    category: MetaMetricsEventCategory.Navigation,
-                    event: 'Copied "To" Address',
-                    properties: {
-                      action: 'Activity Log',
-                      legacy_event: true,
-                    },
-                  });
-                }}
               />
             </div>
             <div className="transaction-list-item-details__cards-container">

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -269,16 +269,6 @@ export default class TransactionListItemDetails extends PureComponent {
                     },
                   });
                 }}
-                onSenderClick={() => {
-                  this.context.trackEvent({
-                    category: MetaMetricsEventCategory.Navigation,
-                    event: 'Copied "From" Address',
-                    properties: {
-                      action: 'Activity Log',
-                      legacy_event: true,
-                    },
-                  });
-                }}
               />
             </div>
             <div className="transaction-list-item-details__cards-container">

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -14,10 +14,9 @@ import { tryReverseResolveAddress } from '../../../store/actions';
 import TransactionListItemDetails from './transaction-list-item-details.component';
 
 const mapStateToProps = (state, ownProps) => {
-  const { recipientAddress, senderAddress } = ownProps;
+  const { senderAddress } = ownProps;
   const addressBook = getAddressBook(state);
   const accounts = getInternalAccounts(state);
-  const recipientName = getAccountName(accounts, recipientAddress);
   const senderAccountName = getAccountName(accounts, senderAddress);
 
   const getNickName = (address) => {
@@ -37,7 +36,6 @@ const mapStateToProps = (state, ownProps) => {
     senderNickname: senderAccountName || getNickName(senderAddress),
     isCustomNetwork,
     blockExplorerLinkText: getBlockExplorerLinkText(state),
-    recipientName,
   };
 };
 

--- a/ui/components/ui/sender-to-recipient/index.scss
+++ b/ui/components/ui/sender-to-recipient/index.scss
@@ -33,10 +33,6 @@
 
         &--recipient {
           border-left: 1px solid var(--color-border-muted);
-
-          &-with-address {
-            cursor: pointer;
-          }
         }
       }
 

--- a/ui/components/ui/sender-to-recipient/index.scss
+++ b/ui/components/ui/sender-to-recipient/index.scss
@@ -31,10 +31,6 @@
         text-overflow: ellipsis;
         border-bottom: 1px solid var(--color-border-muted);
 
-        &--sender {
-          cursor: pointer;
-        }
-
         &--recipient {
           border-left: 1px solid var(--color-border-muted);
 

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -1,10 +1,8 @@
 import { NameType } from '@metamask/name-controller';
 import classnames from 'classnames';
-import copyToClipboard from 'copy-to-clipboard';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { AvatarAccountSize, TextVariant } from '@metamask/design-system-react';
-import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -12,7 +10,6 @@ import Name from '../../app/name/name';
 import { Icon, IconName } from '../../component-library';
 import AccountMismatchWarning from '../account-mismatch-warning/account-mismatch-warning.component';
 import { PreferredAvatar } from '../../app/preferred-avatar';
-import Tooltip from '../tooltip';
 import {
   CARDS_VARIANT,
   DEFAULT_VARIANT,
@@ -64,29 +61,9 @@ SenderAddress.propTypes = {
 
 export function RecipientWithAddress({
   checksummedRecipientAddress,
-  onRecipientClick,
-  addressOnly,
-  recipientName,
-  recipientIsOwnedAccount,
   chainId,
   className = '',
 }) {
-  const t = useI18nContext();
-  const [addressCopied, setAddressCopied] = useState(false);
-
-  let tooltipHtml = <p>{t('copiedExclamation')}</p>;
-  if (!addressCopied) {
-    tooltipHtml = addressOnly ? (
-      <p>{t('copyAddress')}</p>
-    ) : (
-      <p>
-        {shortenAddress(checksummedRecipientAddress)}
-        <br />
-        {t('copyAddress')}
-      </p>
-    );
-  }
-
   return (
     <>
       <div
@@ -94,30 +71,13 @@ export function RecipientWithAddress({
           'sender-to-recipient__party sender-to-recipient__party--recipient sender-to-recipient__party--recipient-with-address',
           className,
         )}
-        onClick={() => {
-          if (recipientIsOwnedAccount) {
-            setAddressCopied(true);
-            copyToClipboard(checksummedRecipientAddress, COPY_OPTIONS);
-          } else if (onRecipientClick) {
-            onRecipientClick();
-          }
-        }}
       >
-        <Tooltip
-          position="bottom"
-          disabled={!recipientName}
-          html={tooltipHtml}
-          wrapperClassName="sender-to-recipient__tooltip-wrapper"
-          containerClassName="sender-to-recipient__tooltip-container"
-          onHidden={() => setAddressCopied(false)}
-        >
-          <Name
-            value={checksummedRecipientAddress}
-            type={NameType.ETHEREUM_ADDRESS}
-            variation={chainId}
-            variant={TextVariant.BodyXs}
-          />
-        </Tooltip>
+        <Name
+          value={checksummedRecipientAddress}
+          type={NameType.ETHEREUM_ADDRESS}
+          variation={chainId}
+          variant={TextVariant.BodyXs}
+        />
       </div>
     </>
   );
@@ -125,10 +85,6 @@ export function RecipientWithAddress({
 
 RecipientWithAddress.propTypes = {
   checksummedRecipientAddress: PropTypes.string,
-  recipientName: PropTypes.string,
-  addressOnly: PropTypes.bool,
-  onRecipientClick: PropTypes.func,
-  recipientIsOwnedAccount: PropTypes.bool,
   chainId: PropTypes.string,
   className: PropTypes.string,
 };
@@ -155,12 +111,9 @@ export default function SenderToRecipient({
   senderAddress,
   addressOnly,
   senderName,
-  recipientName,
-  onRecipientClick,
   recipientAddress,
   variant,
   warnUserOnAccountMismatch,
-  recipientIsOwnedAccount,
   chainId,
 }) {
   const t = useI18nContext();
@@ -184,10 +137,6 @@ export default function SenderToRecipient({
         <RecipientWithAddress
           className="justify-end"
           checksummedRecipientAddress={checksummedRecipientAddress}
-          onRecipientClick={onRecipientClick}
-          addressOnly={addressOnly}
-          recipientName={recipientName}
-          recipientIsOwnedAccount={recipientIsOwnedAccount}
           chainId={chainId}
         />
       ) : (
@@ -208,12 +157,9 @@ SenderToRecipient.defaultProps = {
 SenderToRecipient.propTypes = {
   senderName: PropTypes.string,
   senderAddress: PropTypes.string,
-  recipientName: PropTypes.string,
   recipientAddress: PropTypes.string,
   variant: PropTypes.oneOf([DEFAULT_VARIANT, CARDS_VARIANT, FLAT_VARIANT]),
   addressOnly: PropTypes.bool,
-  onRecipientClick: PropTypes.func,
   warnUserOnAccountMismatch: PropTypes.bool,
-  recipientIsOwnedAccount: PropTypes.bool,
   chainId: PropTypes.string,
 };

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -33,9 +33,7 @@ function SenderAddress({
   warnUserOnAccountMismatch,
 }) {
   return (
-    <div
-      className="sender-to-recipient__party sender-to-recipient__party--sender gap-1"
-    >
+    <div className="sender-to-recipient__party sender-to-recipient__party--sender gap-1">
       <PreferredAvatar
         address={toChecksumHexAddress(senderAddress)}
         size={AvatarAccountSize.Sm}

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -29,56 +29,26 @@ function SenderAddress({
   addressOnly,
   checksummedSenderAddress,
   senderName,
-  onSenderClick,
   senderAddress,
   warnUserOnAccountMismatch,
 }) {
-  const t = useI18nContext();
-  const [addressCopied, setAddressCopied] = useState(false);
-  let tooltipHtml = <p>{t('copiedExclamation')}</p>;
-  if (!addressCopied) {
-    tooltipHtml = addressOnly ? (
-      <p>{t('copyAddress')}</p>
-    ) : (
-      <p>
-        {shortenAddress(checksummedSenderAddress)}
-        <br />
-        {t('copyAddress')}
-      </p>
-    );
-  }
   return (
     <div
       className="sender-to-recipient__party sender-to-recipient__party--sender gap-1"
-      onClick={() => {
-        setAddressCopied(true);
-        copyToClipboard(checksummedSenderAddress, COPY_OPTIONS);
-        if (onSenderClick) {
-          onSenderClick();
-        }
-      }}
     >
       <PreferredAvatar
         address={toChecksumHexAddress(senderAddress)}
         size={AvatarAccountSize.Sm}
       />
-      <Tooltip
-        position="bottom"
-        html={tooltipHtml}
-        wrapperClassName="sender-to-recipient__tooltip-wrapper"
-        containerClassName="sender-to-recipient__tooltip-container"
-        onHidden={() => setAddressCopied(false)}
-      >
-        <div className="sender-to-recipient__name text-s-body-xs">
-          {addressOnly ? (
-            <span>
-              {`${senderName || shortenAddress(checksummedSenderAddress)}`}
-            </span>
-          ) : (
-            senderName
-          )}
-        </div>
-      </Tooltip>
+      <div className="sender-to-recipient__name text-s-body-xs">
+        {addressOnly ? (
+          <span>
+            {`${senderName || shortenAddress(checksummedSenderAddress)}`}
+          </span>
+        ) : (
+          senderName
+        )}
+      </div>
       {warnUserOnAccountMismatch && (
         <AccountMismatchWarning address={senderAddress} />
       )}
@@ -91,7 +61,6 @@ SenderAddress.propTypes = {
   checksummedSenderAddress: PropTypes.string,
   addressOnly: PropTypes.bool,
   senderAddress: PropTypes.string,
-  onSenderClick: PropTypes.func,
   warnUserOnAccountMismatch: PropTypes.bool,
 };
 
@@ -190,7 +159,6 @@ export default function SenderToRecipient({
   senderName,
   recipientName,
   onRecipientClick,
-  onSenderClick,
   recipientAddress,
   variant,
   warnUserOnAccountMismatch,
@@ -210,7 +178,6 @@ export default function SenderToRecipient({
         checksummedSenderAddress={checksummedSenderAddress}
         addressOnly={addressOnly}
         senderName={senderName}
-        onSenderClick={onSenderClick}
         senderAddress={senderAddress}
         warnUserOnAccountMismatch={warnUserOnAccountMismatch}
       />
@@ -248,7 +215,6 @@ SenderToRecipient.propTypes = {
   variant: PropTypes.oneOf([DEFAULT_VARIANT, CARDS_VARIANT, FLAT_VARIANT]),
   addressOnly: PropTypes.bool,
   onRecipientClick: PropTypes.func,
-  onSenderClick: PropTypes.func,
   warnUserOnAccountMismatch: PropTypes.bool,
   recipientIsOwnedAccount: PropTypes.bool,
   chainId: PropTypes.string,

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.stories.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.stories.js
@@ -16,9 +16,6 @@ export default {
     senderAddress: {
       control: 'text',
     },
-    recipientName: {
-      control: 'text',
-    },
     recipientEns: {
       control: 'text',
     },
@@ -35,9 +32,6 @@ export default {
     addressOnly: {
       control: 'boolean',
     },
-    onRecipientClick: {
-      action: 'onRecipientClick',
-    },
     warnUserOnAccountMismatch: {
       control: 'boolean',
     },
@@ -45,7 +39,6 @@ export default {
   args: {
     senderName: 'Account 1',
     senderAddress: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
-    recipientName: 'Account 2',
     recipientAddress: '0xb19ac54efa18cc3a14a5b821bfec73d284bf0c5e',
   },
 };

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.stories.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.stories.js
@@ -38,9 +38,6 @@ export default {
     onRecipientClick: {
       action: 'onRecipientClick',
     },
-    onSenderClick: {
-      action: 'onSenderClick',
-    },
     warnUserOnAccountMismatch: {
       control: 'boolean',
     },


### PR DESCRIPTION
## **Description**

This PR removes the copy button and pointer cursor from the sender and recipient address (when owned) in the transaction details view (`SenderToRecipient` component).

**Reason for the change:**
Users are vulnerable to address poisoning attacks when copying addresses from the transaction history. Attackers exploit the common UX pattern of truncated addresses (showing only first/last characters with "...") by:

1. Monitoring the blockchain for victim transactions
3. Creating spoofed wallets with addresses matching the first/last characters of legitimate recipients
5. Sending tiny transactions from the spoofed address to the victim
7. Victims then accidentally copy the attacker's address from their transaction history

**Changes made:**
- Removed `onSenderClick` and `onRecipientClick` callback prop from `SenderToRecipient` component and all its usages
- Removed the `Tooltip` wrapper and copy-to-clipboard functionality from the sender and recipient address (this wasn't working for recipient address in the first place)
- Removed the pointer cursor style for the sender address and the recipient address when owned. When it's not an owned recipient address, it shows the pointer cursor and Petname modal when clicked
- Removed related MetaMetrics event tracking for "Copied 'From' Address" and "Copied 'To' Address" 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39018?quickstart=1)

## **Changelog**

CHANGELOG entry: Removed copy-to-clipboard functionality from sender and recipient address in transaction details

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-853

## **Manual testing steps**

1. Open the MetaMask extension
2. Navigate to the Activity tab
3. Click on any transaction to view details
4. Verify that the sender ("From") address no longer has a pointer cursor
5. Verify that clicking the sender address does not copy it to clipboard or show a tooltip

For owned recipient addresses:
1. Verify that the recipient ("To") address no longer has a pointer cursor
2. Verify that clicking the recipient address does not copy it to clipboard or show a tooltip

For non-owned recipient addresses:
1. Verify that the recipient ("To") address has a pointer cursor and blue hover text
2. Verify that clicking the recipient address opens up the Petnames modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="219" height="117" alt="image" src="https://github.com/user-attachments/assets/ae461def-9454-4bd2-bab6-75598e23bd14" />

<img width="204" height="118" alt="image" src="https://github.com/user-attachments/assets/70ee54e9-37a1-4c29-81b4-d055127ba29b" />


### **After**

<img width="195" height="91" alt="image" src="https://github.com/user-attachments/assets/6eb8ec49-dbd9-4765-b55a-cb307841c0fd" />

Owned recipient address:
<img width="141" height="82" alt="image" src="https://github.com/user-attachments/assets/4ea7ae24-17ec-4cfc-bf46-a124194f2931" />

Not owned recipient address:
<img width="149" height="78" alt="image" src="https://github.com/user-attachments/assets/afd888f6-9905-4318-b257-632720769e24" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes interactive copy behavior from sender/recipient addresses in transaction details and simplifies related props/styles.
> 
> - Strips `copyToClipboard`, `Tooltip`, and click handlers from `sender-to-recipient` (no address copying or tooltips; non-interactive styles) and removes MetaMetrics events for copied addresses
> - Drops `recipientName`, `onRecipientClick`, and `onSenderClick` props and their usage across `transaction-list-item-details.*`, container mapping, and Storybook; updates `RecipientWithAddress` usage in `transaction-breakdown`
> - Updates `index.scss` to remove pointer cursor styles for sender and owned recipient
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 500e57dcc0edb12eab719e915b1a1273763e1938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->