### PR TITLE
chore: update network fee tooltip for gas fees sponsored case

### DIFF
--- a/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
@@ -277,18 +277,6 @@ exports[`MultichainBridgeQuoteCard should render gas sponsored text when gasSpon
         >
           Paid by MetaMask
         </p>
-        <div
-          class="mm-box"
-        >
-          <div
-            class="mm-box mm-box--display-flex"
-          >
-            <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-icon-alternative"
-              style="mask-image: url('./images/icons/info.svg');"
-            />
-          </div>
-        </div>
       </div>
     </div>
     <div

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -319,13 +319,6 @@ export const MultichainBridgeQuoteCard = ({
                 >
                   {t('swapGasFeesSponsored')}
                 </Text>
-                <Tooltip
-                  title={t('swapGasFeesSponsored')}
-                  position={PopoverPosition.TopStart}
-                  offset={[-16, 16]}
-                >
-                  {t('swapGasFeesSponsoredExplanation', [nativeTokenSymbol])}
-                </Tooltip>
               </Row>
             )}
             {!shouldShowGasSponsored && activeQuote.quote.gasIncluded && (

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -306,7 +306,9 @@ export const MultichainBridgeQuoteCard = ({
                 position={PopoverPosition.TopStart}
                 offset={[-16, 16]}
               >
-                {t('networkFeeExplanation')}
+                {shouldShowGasSponsored
+                  ? t('swapGasFeesSponsoredExplanation', [nativeTokenSymbol])
+                  : t('networkFeeExplanation')}
               </Tooltip>
             </Row>
             {shouldShowGasSponsored && (

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -24,6 +24,7 @@ import { useDappSwapContext } from '../../../../../context/dapp-swap';
 import { useIsGaslessSupported } from '../../../../../hooks/gas/useIsGaslessSupported';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { useBalanceChanges } from '../../../../simulation-details/useBalanceChanges';
+import { useTransactionNativeTicker } from '../../../../../hooks/transactions/useTransactionNativeTicker';
 import { useSelectedGasFeeToken } from '../../hooks/useGasFeeToken';
 import { EditGasIconButton } from '../edit-gas-icon/edit-gas-icon-button';
 import { SelectedGasFeeToken } from '../selected-gas-fee-token';
@@ -56,11 +57,7 @@ export const EditGasFeesRow = ({
   const fiatValue = gasFeeToken ? gasFeeToken.amountFiat : fiatFee;
   const tokenValue = gasFeeToken ? gasFeeToken.amountFormatted : nativeFee;
   const metamaskFeeFiat = gasFeeToken?.metamaskFeeFiat;
-
-  const tooltip =
-    gasFeeToken?.metaMaskFee && gasFeeToken.metaMaskFee !== '0x0'
-      ? t('confirmGasFeeTokenTooltip', [metamaskFeeFiat])
-      : t('estimatedFeeTooltip');
+  const nativeTokenSymbol = useTransactionNativeTicker() ?? '';
 
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const isLoadingGasUsed = !simulationData || balanceChangesResult.pending;
@@ -69,6 +66,12 @@ export const EditGasFeesRow = ({
   // by the user and 7702 is not supported in the chain.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
+
+  const tooltip = isGasFeeSponsored
+    ? t('swapGasFeesSponsoredExplanation', [nativeTokenSymbol])
+    : gasFeeToken?.metaMaskFee && gasFeeToken.metaMaskFee !== '0x0'
+      ? t('confirmGasFeeTokenTooltip', [metamaskFeeFiat])
+      : t('estimatedFeeTooltip');
 
   const isGasFeeEditable =
     !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -67,11 +67,12 @@ export const EditGasFeesRow = ({
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
 
-  const tooltip = isGasFeeSponsored
-    ? t('swapGasFeesSponsoredExplanation', [nativeTokenSymbol])
-    : gasFeeToken?.metaMaskFee && gasFeeToken.metaMaskFee !== '0x0'
-      ? t('confirmGasFeeTokenTooltip', [metamaskFeeFiat])
-      : t('estimatedFeeTooltip');
+  let tooltip = t('estimatedFeeTooltip');
+  if (isGasFeeSponsored) {
+    tooltip = t('swapGasFeesSponsoredExplanation', [nativeTokenSymbol]);
+  } else if (gasFeeToken?.metaMaskFee && gasFeeToken.metaMaskFee !== '0x0') {
+    tooltip = t('confirmGasFeeTokenTooltip', [metamaskFeeFiat]);
+  }
 
   const isGasFeeEditable =
     !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enhances the gas fee sponsorship user experience by updating the tooltip logo and content next to "network fee" to align with the other tooltip logo in the swap quote card.

### Problem
There was a different tooltip logo for gas fees sponsored swaps in the swap quote card.
The send transaction modal is missing the gas fees sponsored content network fee tooltip.

### Solution
Implement a UI-level workaround that updates the tooltip logo next to "network fee" in the swap quote card.
Add the the gas fees sponsored content network fee tooltip for send transaction.

## **Changelog**

CHANGELOG entry: updated network fee tooltip for gas fees sponsored case

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Go to the swap page.
2. Request a same chain swap quote on a chain eligible of gas fees sponsored.
3. The quote response for network fees should display the correct tooltip logo.
4. The send transaction network fee tooltip should display the specific text for gas fees sponsored case.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="400" height="600" alt="ext before" src="https://github.com/user-attachments/assets/8e65304f-8a83-4131-b3fa-a601d4064456" />


### **After**

<!-- [screenshots/recordings] -->
<img width="401" height="603" alt="ext after" src="https://github.com/user-attachments/assets/e0c7d946-f98f-4304-b4f2-39aa5a4c6bda" />
<img width="399" height="602" alt="ext send" src="https://github.com/user-attachments/assets/d05e9a5e-e4ab-44cd-a7c6-62e865abfe5d" />



## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns network fee tooltip messaging for gas-sponsored scenarios across bridge quotes and send confirmations.
> 
> - In `multichain-bridge-quote-card.tsx`, `Tooltip` under `networkFee` now shows `swapGasFeesSponsoredExplanation` with `nativeTokenSymbol` when sponsorship applies; removed the extra info icon/tooltip from the `Paid by MetaMask` row
> - In `edit-gas-fees-row.tsx`, added `useTransactionNativeTicker` and updated `tooltip` logic to prefer sponsored explanation, else MetaMask fee tooltip, else estimated fee; retains non-editable state when sponsored
> - Snapshots updated to reflect removed icon and adjusted tooltip behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d03e063491fff197f382edf472a8fcf6371892e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->