### PR TITLE
feat(smart account): use auto-upgrade for gasIncluded7702 swaps

### DIFF
--- a/ui/pages/bridge/hooks/useGasIncluded7702.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.ts
@@ -2,13 +2,10 @@ import {
   formatChainIdToHex,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
-import { Hex } from '@metamask/utils';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import { isRelaySupported } from '../../../store/actions';
-import { isAtomicBatchSupported } from '../../../store/controller-actions/transaction-controller';
-import { getUseSmartAccount } from '../../confirmations/selectors/preferences';
 
 type Chain = {
   chainId: string;
@@ -47,15 +44,12 @@ export function useGasIncluded7702({
     getIsSmartTransaction(state as never, fromChain?.chainId),
   );
 
-  const smartAccountOptedIn = useSelector(getUseSmartAccount);
-
   useEffect(() => {
     let isCancelled = false;
 
     const checkGasIncluded7702Support = async () => {
       if (
         (isSendBundleSupportedForChain && isSmartTransaction) ||
-        !smartAccountOptedIn ||
         !isSwap ||
         !selectedAccount?.address ||
         !fromChain?.chainId
@@ -73,25 +67,7 @@ export function useGasIncluded7702({
 
       try {
         const chainIdInHex = formatChainIdToHex(fromChain.chainId);
-        const atomicBatchResult = await isAtomicBatchSupported({
-          address: selectedAccount.address as Hex,
-          chainIds: [chainIdInHex],
-        });
-
-        if (isCancelled) {
-          return;
-        }
-
-        const atomicBatchChainSupport = atomicBatchResult?.find(
-          (result) =>
-            result.chainId.toLowerCase() === fromChain.chainId.toLowerCase(),
-        );
-
-        const relaySupportsChain = await isRelaySupported(chainIdInHex);
-
-        const is7702Supported = Boolean(
-          atomicBatchChainSupport?.isSupported && relaySupportsChain,
-        );
+        const is7702Supported = await isRelaySupported(chainIdInHex);
 
         if (!isCancelled) {
           setIsGasIncluded7702Supported(is7702Supported);
@@ -110,7 +86,6 @@ export function useGasIncluded7702({
       isCancelled = true;
     };
   }, [
-    smartAccountOptedIn,
     fromChain?.chainId,
     isSendBundleSupportedForChain,
     isSmartTransaction,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use auto-upgrade for gas-included swaps with 7702

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39022?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the check for smart account when assessing support for gas included swaps with 7702

## **Related issues**

Fixes:

## **Manual testing steps**

Given the user does not have a smart account on Base/Arbitrum/Polygon
And no native currency to pay for gas
When the use swaps a non native token
Then the quote has gas included
When the user submits the swaps
Then the swap is successful
And the user account is upgraded to a smart account for this network

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the gas-included 7702 support check to depend only on relay availability.
> 
> - Simplifies `useGasIncluded7702` to call `isRelaySupported(formatChainIdToHex(chainId))` and removes `isAtomicBatchSupported` and smart account opt-in (`getUseSmartAccount`) logic
> - Retains early exits when `isSendBundleSupportedForChain && getIsSmartTransaction(...)`, non-swap, missing account/chain, or non-EVM chain
> - Cleans up unused imports and dependencies in the effect
> - Updates `useGasIncluded7702.test.ts` to drop atomic batch expectations, add/adjust cases for relay-supported/unsupported, error handling, and race-condition scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6666cfd756915dd6f07a2bbee568a8716818781c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->