### PR TITLE
fix(snaps): Check for updates only for non-preinstalled snaps

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1618,6 +1618,20 @@ const selectSnapId = (_state, snapId) => snapId;
  */
 export const selectInstalledSnaps = (state) => state.metamask.snaps;
 
+/**
+ * Input selector for retrieving all installed non-preinstalled Snaps.
+ *
+ * @param state - Redux state object.
+ * @returns Object - Installed non-preinstalled Snaps.
+ */
+export const selectInstalledNonPreinstalledSnaps = createSelector(
+  [selectInstalledSnaps],
+  (installedSnaps) =>
+    Object.fromEntries(
+      Object.entries(installedSnaps).filter(([, snap]) => !snap.preinstalled),
+    ),
+);
+
 export const selectIsNetworkMenuOpen = (state) =>
   state.appState.isNetworkMenuOpen;
 
@@ -1662,7 +1676,7 @@ export const getSnapLatestVersion = createSelector(
  * @returns Map Snap IDs mapped to a boolean value (true if update is available, false otherwise).
  */
 export const getAllSnapAvailableUpdates = createSelector(
-  [selectInstalledSnaps, rawStateSelector],
+  [selectInstalledNonPreinstalledSnaps, rawStateSelector],
   (installedSnaps, state) => {
     const snapMap = new Map();
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1622,14 +1622,12 @@ export const selectInstalledSnaps = (state) => state.metamask.snaps;
  * Input selector for retrieving all installed non-preinstalled Snaps.
  *
  * @param state - Redux state object.
- * @returns Object - Installed non-preinstalled Snaps.
+ * @returns Array - Installed non-preinstalled Snaps.
  */
 export const selectInstalledNonPreinstalledSnaps = createSelector(
   [selectInstalledSnaps],
   (installedSnaps) =>
-    Object.fromEntries(
-      Object.entries(installedSnaps).filter(([, snap]) => !snap.preinstalled),
-    ),
+    Object.values(installedSnaps).filter((snap) => !snap.preinstalled),
 );
 
 export const selectIsNetworkMenuOpen = (state) =>
@@ -1680,14 +1678,12 @@ export const getAllSnapAvailableUpdates = createSelector(
   (installedSnaps, state) => {
     const snapMap = new Map();
 
-    Object.keys(installedSnaps).forEach((snapId) => {
-      const latestVersion = getSnapLatestVersion(state, snapId);
+    installedSnaps.forEach((snap) => {
+      const latestVersion = getSnapLatestVersion(state, snap.id);
 
       snapMap.set(
-        snapId,
-        latestVersion
-          ? semver.gt(latestVersion, installedSnaps[snapId].version)
-          : false,
+        snap.id,
+        latestVersion ? semver.gt(latestVersion, snap.version) : false,
       );
     });
 


### PR DESCRIPTION
## **Description**

This PR updates the selector that selects the snap update map to only account for non-preinstalled snaps.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39037?quickstart=1)

## **Changelog**

CHANGELOG entry: Snap update dot doesn't take preinstalled snaps into account.

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures update availability is computed only for user-installed snaps.
> 
> - Adds `selectInstalledNonPreinstalledSnaps` to filter out preinstalled snaps
> - Updates `getAllSnapAvailableUpdates` to use the new selector and iterate snaps by `{ id, version }`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b9768407e047a10c5e3cec1cc92f1604dfc33c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->