### PR TITLE
perf: memoize getNumberOfAllUnapprovedTransactionsAndMessages selector

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -136,7 +136,6 @@ import { MULTICHAIN_NETWORK_TO_ASSET_TYPES } from '../../shared/constants/multic
 import { hasTransactionData } from '../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
-import { createShallowEqualSelector } from '../../shared/modules/selectors/selector-creators';
 import { isSnapIgnoredInProd } from '../helpers/utils/snaps';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
 import {
@@ -2473,32 +2472,27 @@ export function getShowRecoveryPhraseReminder(state) {
  * @param state - Redux state object.
  * @returns Number of unapproved transactions
  */
-export const getNumberOfAllUnapprovedTransactionsAndMessages =
-  createShallowEqualSelector(
-    [
-      getUnapprovedTransactions,
-      (state) => state.metamask.unapprovedDecryptMsgs,
-      (state) => state.metamask.unapprovedPersonalMsgs,
-      (state) => state.metamask.unapprovedEncryptionPublicKeyMsgs,
-      (state) => state.metamask.unapprovedTypedMessages,
-    ],
-    (
-      unapprovedTxs,
-      unapprovedDecryptMsgs,
-      unapprovedPersonalMsgs,
-      unapprovedEncryptionPublicKeyMsgs,
-      unapprovedTypedMessages,
-    ) => {
-      const allUnapprovedMessages = {
-        ...unapprovedTxs,
-        ...unapprovedDecryptMsgs,
-        ...unapprovedPersonalMsgs,
-        ...unapprovedEncryptionPublicKeyMsgs,
-        ...unapprovedTypedMessages,
-      };
-      return Object.keys(allUnapprovedMessages).length;
-    },
-  );
+export const getNumberOfAllUnapprovedTransactionsAndMessages = createSelector(
+  [
+    getUnapprovedTransactions,
+    (state) => state.metamask.unapprovedDecryptMsgs,
+    (state) => state.metamask.unapprovedPersonalMsgs,
+    (state) => state.metamask.unapprovedEncryptionPublicKeyMsgs,
+    (state) => state.metamask.unapprovedTypedMessages,
+  ],
+  (
+    unapprovedTxs,
+    unapprovedDecryptMsgs,
+    unapprovedPersonalMsgs,
+    unapprovedEncryptionPublicKeyMsgs,
+    unapprovedTypedMessages,
+  ) =>
+    Object.keys(unapprovedTxs ?? {}).length +
+    Object.keys(unapprovedDecryptMsgs ?? {}).length +
+    Object.keys(unapprovedPersonalMsgs ?? {}).length +
+    Object.keys(unapprovedEncryptionPublicKeyMsgs ?? {}).length +
+    Object.keys(unapprovedTypedMessages ?? {}).length,
+);
 
 export const getCurrentNetwork = createDeepEqualSelector(
   getNetworkConfigurationsByChainId,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -136,6 +136,7 @@ import { MULTICHAIN_NETWORK_TO_ASSET_TYPES } from '../../shared/constants/multic
 import { hasTransactionData } from '../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { createDeepEqualSelector } from '../../shared/modules/selectors/util';
+import { createShallowEqualSelector } from '../../shared/modules/selectors/selector-creators';
 import { isSnapIgnoredInProd } from '../helpers/utils/snaps';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
 import {
@@ -2473,7 +2474,7 @@ export function getShowRecoveryPhraseReminder(state) {
  * @returns Number of unapproved transactions
  */
 export const getNumberOfAllUnapprovedTransactionsAndMessages =
-  createDeepEqualSelector(
+  createShallowEqualSelector(
     [
       getUnapprovedTransactions,
       (state) => state.metamask.unapprovedDecryptMsgs,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2472,19 +2472,32 @@ export function getShowRecoveryPhraseReminder(state) {
  * @param state - Redux state object.
  * @returns Number of unapproved transactions
  */
-export function getNumberOfAllUnapprovedTransactionsAndMessages(state) {
-  const unapprovedTxs = getUnapprovedTransactions(state);
-
-  const allUnapprovedMessages = {
-    ...unapprovedTxs,
-    ...state.metamask.unapprovedDecryptMsgs,
-    ...state.metamask.unapprovedPersonalMsgs,
-    ...state.metamask.unapprovedEncryptionPublicKeyMsgs,
-    ...state.metamask.unapprovedTypedMessages,
-  };
-  const numUnapprovedMessages = Object.keys(allUnapprovedMessages).length;
-  return numUnapprovedMessages;
-}
+export const getNumberOfAllUnapprovedTransactionsAndMessages =
+  createDeepEqualSelector(
+    [
+      getUnapprovedTransactions,
+      (state) => state.metamask.unapprovedDecryptMsgs,
+      (state) => state.metamask.unapprovedPersonalMsgs,
+      (state) => state.metamask.unapprovedEncryptionPublicKeyMsgs,
+      (state) => state.metamask.unapprovedTypedMessages,
+    ],
+    (
+      unapprovedTxs,
+      unapprovedDecryptMsgs,
+      unapprovedPersonalMsgs,
+      unapprovedEncryptionPublicKeyMsgs,
+      unapprovedTypedMessages,
+    ) => {
+      const allUnapprovedMessages = {
+        ...unapprovedTxs,
+        ...unapprovedDecryptMsgs,
+        ...unapprovedPersonalMsgs,
+        ...unapprovedEncryptionPublicKeyMsgs,
+        ...unapprovedTypedMessages,
+      };
+      return Object.keys(allUnapprovedMessages).length;
+    },
+  );
 
 export const getCurrentNetwork = createDeepEqualSelector(
   getNetworkConfigurationsByChainId,


### PR DESCRIPTION
## **Description**

The `getNumberOfAllUnapprovedTransactionsAndMessages` selector was unmemoized and created new objects via spread operators on every state change, causing unnecessary recomputations in a critical hot path (app header badge count).

This PR implements several optimizations:

1. **Memoization**: Converts to a memoized selector using reselect's `createSelector`
2. **Reference equality**: Uses standard `createSelector` since Redux/Immer provides stable input references
3. **Direct count summation**: Sums `Object.keys().length` directly instead of spreading objects into a merged object, which:
   - Reduces memory allocation from O(N) to O(1)
   - Eliminates potential ID collision bugs (if tx/message IDs overlapped, spread would overwrite and undercount)
   - Only allocates arrays when inputs actually change (memoization prevents recomputation on stable refs)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39041?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6380

## **Manual testing steps**

1. Open MetaMask extension
2. Navigate to a dapp and initiate a transaction
3. Verify the badge count in the header updates correctly
4. Verify no regression in badge count functionality

## **Screenshots/Recordings**

Not applicable - internal performance optimization with no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes a hot-path selector used for the header badge count.
> 
> - Converts `getNumberOfAllUnapprovedTransactionsAndMessages` to a memoized `createSelector`
> - Avoids object spreads by summing `Object.keys(...).length` across sources with nullish guards
> - Reduces unnecessary recomputation and memory allocation; removes risk of ID collisions from object merging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a406e7d692de288e4439312cc2c061d68f8a7d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->