### PR TITLE
fix: fix benchmark powerUserHome tests

### DIFF
--- a/test/e2e/benchmarks/benchmark.ts
+++ b/test/e2e/benchmarks/benchmark.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { capitalize } from 'lodash';
 import get from 'lodash/get';
+import { Mockttp } from 'mockttp';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 import { generateWalletState } from '../../../app/scripts/fixtures/generate-wallet-state';
@@ -16,6 +17,7 @@ import { unlockWallet, withFixtures } from '../helpers';
 import AccountListPage from '../page-objects/pages/account-list-page';
 import HeaderNavbar from '../page-objects/pages/header-navbar';
 import { PAGES } from '../webdriver/driver';
+import { mockNotificationServices } from '../tests/notifications/mocks';
 import {
   BenchmarkArguments,
   BenchmarkResults,
@@ -82,6 +84,9 @@ async function measurePagePowerUser(
       },
       useMockingPassThrough: true,
       disableServerMochaToBackground: true,
+      testSpecificMock: async (server: Mockttp) => {
+        await mockNotificationServices(server);
+      },
     },
     async ({ driver, getNetworkReport, clearNetworkReport }) => {
       await unlockWallet(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Add notification servicemocks to the `powerUserHome` benchmark to prevent "Unable to enable notifications" errors, which is caused by the power user fixture's unread notifications triggering authentication with unmocked external APIs.
eg: https://github.com/MetaMask/metamask-extension/actions/runs/20750379743/job/59579140493?pr=38614

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39058?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds notification service mocking to stabilize `powerUser` page-load benchmarks.
> 
> - Imports `Mockttp` and `mockNotificationServices`, and wires a `testSpecificMock` in `withFixtures` for `measurePagePowerUser`
> - Ensures notification requests are intercepted during benchmarks by invoking `mockNotificationServices(server)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04c9b5c67189e926033116fa8b8bcf68792e66be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->