### PR TITLE
fix: show notice that the account isn't connected when switching accounts - in side panel view

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -42,11 +42,8 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
-import {
-  getAccountByAddress,
-  getURLHostName,
-  shortenAddress,
-} from '../../../helpers/utils/util';
+import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
+import { getAccountName } from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
@@ -120,8 +117,8 @@ export function MultichainTransactionDetailsModal({
     if (!address) {
       return null;
     }
-    const account = getAccountByAddress(internalAccounts, address);
-    const displayName = account?.metadata?.name || shortenAddress(address);
+    const accountName = getAccountName(internalAccounts, address);
+    const displayName = accountName || shortenAddress(address);
 
     return (
       <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
@@ -141,8 +141,9 @@ describe('TransactionListItemDetails for swaps', () => {
     });
 
     expect(queryByText('View on block explorer')).toBeInTheDocument();
+    // Sender shows account name ("Test Account") since it matches an internal account
     expect(queryByTestId('sender-to-recipient')).toHaveTextContent(
-      '0x0DCD5...3E7bc0x00000...00000',
+      'Test Account0x00000...00000',
     );
     const expectedRows = [
       'Nonce1',

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   const addressBook = getAddressBook(state);
   const accounts = getInternalAccounts(state);
   const recipientName = getAccountName(accounts, recipientAddress);
+  const senderAccountName = getAccountName(accounts, senderAddress);
 
   const getNickName = (address) => {
     const entry = addressBook.find((contact) => {
@@ -33,7 +34,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     rpcPrefs,
     networkConfiguration,
-    senderNickname: getNickName(senderAddress),
+    senderNickname: senderAccountName || getNickName(senderAddress),
     isCustomNetwork,
     blockExplorerLinkText: getBlockExplorerLinkText(state),
     recipientName,


### PR DESCRIPTION
This PR ensures that not connected notification show up for sidepanel. Issue here was that the selector
`selectShowConnectAccountToast` used `state.activeTab.origin` directly instead of `getOriginOfCurrentTab(state)`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: #38860 

## **Manual testing steps**

1. Fresh install
2. Do not open pop-up view only side panel view
3. Connect to a dapp with account 1
4. Switch accounts and see the notification appear for not connected account

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
NA

### **After**
![Screenshot 2026-01-07 at 12 17 40 PM](https://github.com/user-attachments/assets/11b04a5b-abd8-4c9a-ba1d-8b96d896a0e2)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves address display by preferring internal account names where available.
> 
> - In `multichain-transaction-details-modal`, use `getAccountName(getInternalAccounts, address)` for `displayName`, falling back to `shortenAddress`
> - In `transaction-list-item-details.container`, set `senderNickname` to internal account name before address book nickname
> - Update swap details test to expect sender account name instead of shortened address
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e3c5c2c53ad7acdb2c20accb67f8f277d569050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->