### PR TITLE
fix: show notice that the account isn't connected when switching accounts - in side panel view

### DIFF
--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -133,7 +133,7 @@ export function selectShowConnectAccountToast(
     connectedAccounts.length > 0 &&
     !isInternalAccountInPermittedAccountIds(account, connectedAccounts);
 
-  return showConnectAccountToast;
+  return Boolean(showConnectAccountToast);
 }
 
 // If there is more than one connected account to activeTabOrigin,
@@ -167,7 +167,7 @@ export function selectShowConnectAccountGroupToast(
     connectedAccounts.length > 0 &&
     !isConnected;
 
-  return showConnectAccountToast;
+  return Boolean(showConnectAccountToast);
 }
 
 /**

--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -116,6 +116,7 @@ export function selectShowConnectAccountToast(
   account: InternalAccount,
 ): boolean {
   const allowShowAccountSetting = getAlertEnabledness(state).unconnectedAccount;
+  const activeTabOrigin = getOriginOfCurrentTab(state);
   const connectedAccounts = getAllPermittedAccountsForCurrentTab(state);
 
   // We only support connection with EVM or Solana accounts
@@ -127,7 +128,7 @@ export function selectShowConnectAccountToast(
   const showConnectAccountToast =
     allowShowAccountSetting &&
     account &&
-    state.activeTab.origin &&
+    activeTabOrigin &&
     isConnectableAccount &&
     connectedAccounts.length > 0 &&
     !isInternalAccountInPermittedAccountIds(account, connectedAccounts);
@@ -162,7 +163,7 @@ export function selectShowConnectAccountGroupToast(
     allowShowAccountSetting &&
     accountGroup &&
     isAccountSupported &&
-    state.activeTab.origin &&
+    activeTabOrigin &&
     connectedAccounts.length > 0 &&
     !isConnected;
 


### PR DESCRIPTION
This PR ensures that not connected notification show up for sidepanel. Issue here was that the selector
`selectShowConnectAccountToast` used `state.activeTab.origin` directly instead of `getOriginOfCurrentTab(state)`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: #38804 

## **Manual testing steps**

1. Fresh install
2. Do not open pop-up view only side panel view
3. Connect to a dapp with account 1
4. Switch accounts and see the notification appear for not connected account

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
NA

### **After**
![Screenshot 2026-01-07 at 12 17 40 PM](https://github.com/user-attachments/assets/11b04a5b-abd8-4c9a-ba1d-8b96d896a0e2)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes connect-account toast logic for side panel contexts.
> 
> - Use `getOriginOfCurrentTab` instead of `state.activeTab.origin` in `selectShowConnectAccountToast` and `selectShowConnectAccountGroupToast` to correctly resolve origin in side panel
> - Explicitly coerce selector results to booleans with `Boolean(...)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 528b78fa710e8a0f923fc618b78648c9192fedab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->