### PR TITLE
fix: fix network switch from dapp permission popover

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -357,12 +357,13 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
           dispatch(showPermittedNetworkToast());
         }
 
-        dispatch(
-          setNetworkClientIdForDomain(selectedTabOrigin, finalNetworkClientId),
+        await setNetworkClientIdForDomain(
+          selectedTabOrigin,
+          finalNetworkClientId,
         );
       }
 
-      dispatch(setActiveNetwork(finalNetworkClientId));
+      await dispatch(setActiveNetwork(finalNetworkClientId));
       dispatch(updateCustomNonce(''));
       dispatch(setNextNonce(''));
       dispatch(detectNfts(allChainIds));


### PR DESCRIPTION


## **Description**

When clicking on an EVM network from the dapp connected site popover (the network button shown when a dapp is connected), the network would not switch on the home page. However, selecting a non-EVM network from the same menu would correctly switch the network.

Looking at the code, the intention was clearly for EVM networks to switch when selected - the `handleEvmNetworkChange` function calls `setActiveNetwork(finalNetworkClientId)` which should update the globally selected network. However, this was silently failing.

Non-EVM networks worked correctly because handleNonEvmNetworkChange does not have the dapp-specific code block that calls setNetworkClientIdForDomain. It simply calls setActiveNetwork(chainId) directly without going through the problematic code path


## **Changelog**

CHANGELOG entry: Fixing a bug to allow switching evm networks on main page when selected from dapp connected site popover.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
