### PR TITLE
refactor(confirmations): replace inline naming-convention disables with file-level disables

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -1,3 +1,4 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Provider } from '@metamask/network-controller';
 import {
@@ -56,8 +57,6 @@ const METHOD_NAME_MOCK = 'testMethod1';
 const METHOD_NAME_2_MOCK = 'testMethod2';
 
 const providerResultStub = {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   eth_getCode: '0x123',
 };
 const { provider } = createTestProviderTools({
@@ -69,11 +68,7 @@ const { provider } = createTestProviderTools({
 jest.mock('../snap-keyring/metrics', () => {
   return {
     getSnapAndHardwareInfoForMetrics: jest.fn().mockResolvedValue({
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       account_snap_type: 'snaptype',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       account_snap_version: 'snapversion',
     }),
   };
@@ -162,8 +157,6 @@ describe('Transaction metrics', () => {
     mockTransactionMetaWithBlockaid = {
       ...JSON.parse(JSON.stringify(mockTransactionMeta)),
       securityAlertResponse: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         result_type: BlockaidResultType.Malicious,
         reason: BlockaidReason.maliciousDomain,
         providerRequestsCount: {
@@ -174,114 +167,46 @@ describe('Transaction metrics', () => {
     };
 
     expectedProperties = {
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       account_snap_type: 'snaptype',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       account_snap_version: 'snapversion',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       account_type: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       address_alert_response: 'not_applicable',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       api_method: MESSAGE_TYPE.ETH_SEND_TRANSACTION,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       asset_type: AssetType.native,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       chain_id: mockChainId,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       device_model: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       eip_1559_version: '0',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       eip7702_upgrade_transaction: false,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_edit_attempted: 'none',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_estimation_failed: false,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_fee_selected: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_insufficient_native_asset: true,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_paid_with: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_payment_tokens_available: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       is_smart_transaction: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_edit_type: 'none',
       network: mockNetworkId,
       referrer: ORIGIN_METAMASK,
       source: MetaMetricsTransactionEventSource.User,
       status: 'unapproved',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       token_standard: TokenStandard.none,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_speed_up: false,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_type: TransactionType.simpleSend,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       ui_customizations: null,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_advanced_view: undefined,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_contract_method: [],
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_internal_id: '1',
     };
 
     expectedSensitiveProperties = {
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       default_estimate: MetaMetricsEventTransactionEstimateType.DefaultEstimate,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       default_gas: '0.000031501',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       default_gas_price: '2',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       first_seen: 1624408066355,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_limit: '0x7b0d',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       gas_price: '2',
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_contract_address: [],
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       transaction_replaced: undefined,
     };
 
@@ -485,20 +410,10 @@ describe('Transaction metrics', () => {
         {
           properties: {
             ...expectedProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ui_customizations: ['flagged_as_malicious'],
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_reason: BlockaidReason.maliciousDomain,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_response: 'Malicious',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_call_count: 5,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_getCode_count: 3,
           },
           sensitiveProperties: expectedSensitiveProperties,
@@ -635,20 +550,10 @@ describe('Transaction metrics', () => {
         {
           properties: {
             ...expectedProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ui_customizations: ['flagged_as_malicious'],
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_reason: BlockaidReason.maliciousDomain,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_response: 'Malicious',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_call_count: 5,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_getCode_count: 3,
           },
           sensitiveProperties: {
@@ -780,11 +685,7 @@ describe('Transaction metrics', () => {
           properties: expectedProperties,
           sensitiveProperties: {
             ...expectedSensitiveProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             completion_time: expect.any(String),
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             gas_used: '0.000000291',
             status: METRICS_STATUS_FAILED,
           },
@@ -848,29 +749,15 @@ describe('Transaction metrics', () => {
         {
           properties: {
             ...expectedProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ui_customizations: ['flagged_as_malicious'],
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_reason: BlockaidReason.maliciousDomain,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_response: 'Malicious',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_call_count: 5,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_getCode_count: 3,
           },
           sensitiveProperties: {
             ...expectedSensitiveProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             completion_time: expect.any(String),
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             gas_used: '0.000000291',
             status: METRICS_STATUS_FAILED,
           },
@@ -897,37 +784,19 @@ describe('Transaction metrics', () => {
       const properties = {
         ...expectedProperties,
         status: TransactionStatus.confirmed,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         transaction_type: TransactionType.contractInteraction,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_type: AssetType.unknown,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         ui_customizations: null,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         is_smart_transaction: undefined,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         transaction_advanced_view: undefined,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         rpc_domain: 'private',
       };
       const sensitiveProperties = {
         ...expectedSensitiveProperties,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         transaction_contract_address: [
           '0x1678a085c290ebd122dc42cba69373b5953b831d',
         ],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         completion_time: expect.any(String),
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         gas_used: '0.000000291',
         status: METRICS_STATUS_FAILED,
       };
@@ -1018,14 +887,8 @@ describe('Transaction metrics', () => {
           properties: expectedProperties,
           sensitiveProperties: {
             ...expectedSensitiveProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             completion_time: expect.any(String),
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             completion_time_onchain: '0.88',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             gas_used: '0.000000291',
             status: METRICS_STATUS_FAILED,
           },
@@ -1094,8 +957,6 @@ describe('Transaction metrics', () => {
           sensitiveProperties: {
             ...expectedSensitiveProperties,
             dropped: true,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             transaction_replaced: 'other',
           },
         },
@@ -1151,27 +1012,15 @@ describe('Transaction metrics', () => {
         {
           properties: {
             ...expectedProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ui_customizations: ['flagged_as_malicious'],
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_reason: BlockaidReason.maliciousDomain,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_response: 'Malicious',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_call_count: 5,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_getCode_count: 3,
           },
           sensitiveProperties: {
             ...expectedSensitiveProperties,
             dropped: true,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             transaction_replaced: 'other',
           },
         },
@@ -1286,20 +1135,10 @@ describe('Transaction metrics', () => {
         {
           properties: {
             ...expectedProperties,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ui_customizations: ['flagged_as_malicious'],
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_reason: BlockaidReason.maliciousDomain,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             security_alert_response: 'Malicious',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_call_count: 5,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             ppom_eth_getCode_count: 3,
           },
           sensitiveProperties: expectedSensitiveProperties,
@@ -1334,8 +1173,6 @@ describe('Transaction metrics', () => {
       expect(mockTransactionMetricsRequest.createEventFragment).toBeCalledWith(
         expect.objectContaining({
           properties: expect.objectContaining({
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             eip7702_upgrade_rejection: true,
           }),
         }),
@@ -1613,8 +1450,6 @@ describe('Transaction metrics', () => {
 
       expect(properties).toStrictEqual(
         expect.objectContaining({
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           account_type: 'error',
         }),
       );

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -1,8 +1,8 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import React from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { hexStripZeros } from '@ethersproject/bytes';
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 import _ from 'lodash';
 import { Hex, isHexString } from '@metamask/utils';
 
@@ -128,8 +128,6 @@ export const TransactionData = ({
   );
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function Container({
   children,
   isLoading,
@@ -164,8 +162,6 @@ export function Container({
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function RawDataRow({ transactionData }: { transactionData: string }) {
   const t = useI18nContext();
   return (
@@ -178,8 +174,6 @@ function RawDataRow({ transactionData }: { transactionData: string }) {
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function FunctionContainer({
   method,
   source,
@@ -237,8 +231,6 @@ function FunctionContainer({
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function ParamValue({
   param,
   source,
@@ -275,8 +267,6 @@ function ParamValue({
   return <ConfirmInfoRowText text={valueString} />;
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function ParamRow({
   param,
   index,
@@ -315,8 +305,6 @@ function ParamRow({
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function UniswapPath({
   pathPools,
   chainId,

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.test.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import { useContext, useEffect, useState } from 'react';
 import {
   SimulationData,
@@ -169,8 +171,6 @@ describe('useSimulationMetrics', () => {
       expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
         expect.objectContaining({
           properties: expect.objectContaining({
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             simulation_latency: LOADING_TIME_MOCK,
           }),
         }),
@@ -207,8 +207,6 @@ describe('useSimulationMetrics', () => {
             },
             expect.objectContaining({
               properties: expect.objectContaining({
-                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                // eslint-disable-next-line @typescript-eslint/naming-convention
                 simulation_response: simulationResponse,
               }),
             }),
@@ -544,20 +542,10 @@ describe('useSimulationMetrics', () => {
         category: MetaMetricsEventCategory.Transactions,
         event: MetaMetricsEventName.SimulationIncompleteAssetDisplayed,
         properties: {
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_address: ADDRESS_MOCK,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_petname: PetnameType.Unknown,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_symbol: undefined,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_type: AssetType.ERC20,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           fiat_conversion_available: FiatType.Available,
           location: 'confirmation',
         },
@@ -583,20 +571,10 @@ describe('useSimulationMetrics', () => {
         category: MetaMetricsEventCategory.Transactions,
         event: MetaMetricsEventName.SimulationIncompleteAssetDisplayed,
         properties: {
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_address: ADDRESS_MOCK,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_petname: PetnameType.Saved,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_symbol: SYMBOL_MOCK,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           asset_type: AssetType.ERC20,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           fiat_conversion_available: FiatType.NotAvailable,
           location: 'confirmation',
         },

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import {
   SimulationData,
   SimulationErrorCode,
@@ -104,11 +106,7 @@ export function useSimulationMetrics({
   const simulationLatency = loadingTime;
 
   const properties = {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     simulation_response: simulationResponse,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     simulation_latency: simulationLatency,
     ...getProperties(
       receivingAssets,
@@ -176,20 +174,10 @@ function useIncompleteAssetEvent(
       event: MetaMetricsEventName.SimulationIncompleteAssetDisplayed,
       category: MetaMetricsEventCategory.Transactions,
       properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_address: change.asset.address,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_petname: getPetnameType(change, displayName),
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_symbol: displayName?.contractDisplayName,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_type: getAssetType(change.asset.standard),
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         fiat_conversion_available: change.fiatAmount
           ? FiatType.Available
           : FiatType.NotAvailable,
@@ -229,8 +217,6 @@ function getProperties(
   const totalValue = totalFiat ? Math.abs(totalFiat) : undefined;
 
   return getPrefixProperties(
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     { petname, quantity, type, value, total_value: totalValue },
     prefix,
   );
@@ -310,8 +296,6 @@ function getSimulationResponseType(
   return SimulationResponseType.Changes;
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function unique<T>(list: T[]): T[] {
   return Array.from(new Set(list));
 }

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import { TransactionType } from '@metamask/transaction-controller';
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import {
@@ -170,11 +172,8 @@ describe('useShieldCoverageAlert', () => {
     expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result: 'covered',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_reason: 'shieldCoverageAlertCovered',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result_response_latency_ms: 150,
         },
       }),
@@ -188,11 +187,8 @@ describe('useShieldCoverageAlert', () => {
     expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result: 'not_covered_malicious',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_reason: 'shieldCoverageAlertMessagePotentialRisks',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result_response_latency_ms: 'N/A',
         },
       }),
@@ -206,11 +202,8 @@ describe('useShieldCoverageAlert', () => {
     expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result: 'not_covered',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_reason: 'shieldCoverageAlertMessagePotentialRisks',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result_response_latency_ms: 'N/A',
         },
       }),
@@ -224,11 +217,8 @@ describe('useShieldCoverageAlert', () => {
     expect(updateTransactionEventFragmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result: 'loading',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_reason: 'shieldCoverageAlertMessagePotentialRisks',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result_response_latency_ms: 'N/A',
         },
       }),
@@ -243,11 +233,8 @@ describe('useShieldCoverageAlert', () => {
     expect(updateSignatureEventFragmentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result: 'covered',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_reason: 'shieldCoverageAlertCovered',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           shield_result_response_latency_ms: 200,
         },
       }),

--- a/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.test.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { act } from '@testing-library/react-hooks';
 
@@ -61,32 +63,16 @@ const STATE_MOCK = getMockConfirmStateForTransaction(
 );
 
 const EXPECTED_PROPERTIES_BASE = {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_action_clicked: [],
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_key_clicked: [],
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_resolved: [],
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_resolved_count: 0,
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_triggered: [
     ALERT_NAME_METRICS_MOCK,
     ALERTS_NAME_METRICS[AlertsName.Blockaid],
   ],
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_triggered_count: 2,
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_visualized: [],
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_visualized_count: 0,
 };
 
@@ -129,11 +115,7 @@ describe('useConfirmationAlertMetrics', () => {
       alertKey: AlertsName.GasFeeLow,
       action: 'trackAlertRender',
       expectedProperties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_visualized: [ALERT_NAME_METRICS_MOCK],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_visualized_count: 1,
       },
     },
@@ -143,8 +125,6 @@ describe('useConfirmationAlertMetrics', () => {
       alertKey: AlertsName.GasFeeLow,
       action: 'trackInlineAlertClicked',
       expectedProperties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_key_clicked: [ALERT_NAME_METRICS_MOCK],
       },
     },
@@ -154,8 +134,6 @@ describe('useConfirmationAlertMetrics', () => {
       alertKey: AlertsName.GasFeeLow,
       action: 'trackAlertActionClicked',
       expectedProperties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_action_clicked: [ALERT_NAME_METRICS_MOCK],
       },
     },
@@ -165,11 +143,7 @@ describe('useConfirmationAlertMetrics', () => {
       alertKey: UUID_ALERT_KEY_MOCK,
       action: 'trackAlertRender',
       expectedProperties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_visualized: [ALERTS_NAME_METRICS[AlertsName.Blockaid]],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         alert_visualized_count: 1,
       },
     },

--- a/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertMetrics.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { validate as isUuid } from 'uuid';
 
@@ -10,17 +12,9 @@ import { useSignatureEventFragment } from './useSignatureEventFragment';
 import { useTransactionEventFragment } from './useTransactionEventFragment';
 
 export type AlertMetricsProperties = {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_visualized: string[];
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_visualized_count: number;
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_key_clicked: string[];
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   alert_action_clicked: string[];
 };
 
@@ -36,8 +30,6 @@ export const ALERTS_NAME_METRICS: Record<AlertsName | string, string> = {
   [AlertsName.Blockaid]: 'blockaid',
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function uniqueFreshArrayPush<T>(array: T[], value: T): T[] {
   return [...new Set([...array, value])];
 }
@@ -60,19 +52,11 @@ export function useConfirmationAlertMetrics() {
   const alertsProperties = useMemo(() => {
     return alerts.length > 0
       ? {
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           alert_triggered_count: alerts.length,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           alert_triggered: getAlertNames(alerts),
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           alert_resolved_count: alerts.filter((alert) =>
             isAlertConfirmed(alert.key),
           ).length,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           alert_resolved: getAlertNames(
             alerts.filter((alert) => isAlertConfirmed(alert.key)),
           ),
@@ -85,17 +69,9 @@ export function useConfirmationAlertMetrics() {
 
   const [metricsProperties, setMetricsProperties] =
     useState<AlertMetricsProperties>({
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       alert_visualized: [],
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       alert_visualized_count: 0,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       alert_key_clicked: [],
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       alert_action_clicked: [],
     });
 

--- a/ui/pages/confirmations/hooks/useDecodedSignatureMetrics.test.ts
+++ b/ui/pages/confirmations/hooks/useDecodedSignatureMetrics.test.ts
@@ -1,3 +1,5 @@
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+/* eslint-disable @typescript-eslint/naming-convention */
 import {
   DecodingData,
   DecodingDataChangeType,
@@ -76,8 +78,6 @@ describe('useDecodedSignatureMetrics', () => {
     expect(mockUpdateSignatureEventFragment).toHaveBeenCalledTimes(1);
     expect(mockUpdateSignatureEventFragment).toHaveBeenLastCalledWith({
       properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_response: 'decoding_in_progress',
       },
     });
@@ -104,17 +104,9 @@ describe('useDecodedSignatureMetrics', () => {
     expect(mockUpdateSignatureEventFragment).toHaveBeenCalledTimes(1);
     expect(mockUpdateSignatureEventFragment).toHaveBeenLastCalledWith({
       properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_change_types: [],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_response: 'NO_CHANGE',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_description: null,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_latency: 0,
       },
     });
@@ -142,17 +134,9 @@ describe('useDecodedSignatureMetrics', () => {
     expect(mockUpdateSignatureEventFragment).toHaveBeenCalledTimes(1);
     expect(mockUpdateSignatureEventFragment).toHaveBeenLastCalledWith({
       properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_change_types: ['APPROVE'],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_response: 'CHANGE',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_description: null,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_latency: 0,
       },
     });
@@ -186,17 +170,9 @@ describe('useDecodedSignatureMetrics', () => {
     expect(mockUpdateSignatureEventFragment).toHaveBeenCalledTimes(1);
     expect(mockUpdateSignatureEventFragment).toHaveBeenLastCalledWith({
       properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_change_types: [],
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_response: 'SOME_ERROR',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_description: 'some message',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         decoding_latency: 0,
       },
     });


### PR DESCRIPTION
## **Description**

This PR addresses the new ESLint rule `@typescript-eslint/naming-convention` that was introduced in PR #32106 to prevent snake_case naming.

Instead of having many individual `// eslint-disable-next-line @typescript-eslint/naming-convention` comments scattered throughout files (primarily metrics-related files that use snake_case for analytics properties), this change consolidates them into a single file-level `/* eslint-disable @typescript-eslint/naming-convention */` directive for files with more than 5 occurrences.

**Changes:**
- Files with >5 inline disable comments now use a file-level disable with a TODO comment linking to issue #31860
- Files with ≤5 occurrences remain unchanged (keeping their individual inline disables)
- Reduces code noise while maintaining the same ESLint behavior

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39079?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4992

## **Manual testing steps**

1. Run `yarn lint` to verify ESLint passes
2. Verify the modified files still have proper snake_case naming allowed where needed

## **Screenshots/Recordings**

Not applicable - code cleanup only.

### **Before**

Files had many repeated inline disable comments:
```typescript
// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
// eslint-disable-next-line @typescript-eslint/naming-convention
account_snap_type: 'snaptype',
// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
// eslint-disable-next-line @typescript-eslint/naming-convention
account_snap_version: 'snapversion',
```

### **After**

Single file-level disable at the top:
```typescript
// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
/* eslint-disable @typescript-eslint/naming-convention */
import { ... } from '...';
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines lint suppression for snake_case analytics fields without changing runtime behavior.
> 
> - Adds `/* eslint-disable @typescript-eslint/naming-convention */` (with issue TODO) at top of files with many occurrences; removes per-line disables in `transaction-data.tsx`, simulation and alert metrics hooks/tests, and transaction metrics tests
> - No logic changes; only comment/lint directive consolidation to reduce noise
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 658372d3249d905e3342c16c0c6acafa95f4820f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->