### PR TITLE
fix: network filter when switching to hardware wallet

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -22,6 +22,7 @@ import {
   getTokenNetworkFilter,
   getUseNftDetection,
 } from '../../../../../selectors';
+import { selectAccountSupportsNetworkFilter } from '../../../../../selectors/assets';
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
@@ -77,6 +78,7 @@ import {
   checkAndUpdateAllNftsOwnershipStatus,
   detectNfts,
   detectTokens,
+  setEnabledAllPopularNetworks,
   setTokenNetworkFilter,
   showImportNftsModal,
   showImportTokensModal,
@@ -117,6 +119,9 @@ const AssetListControlBar = ({
   const isLineaMainnet = useSelector(getIsLineaMainnet);
   const allChainIds = useSelector(getAllChainsToPoll);
   const isEvm = useSelector(getMultichainIsEvm);
+  const accountSupportsNetworkFilter = useSelector(
+    selectAccountSupportsNetworkFilter,
+  );
 
   const { collections } = useNftsCollections();
 
@@ -211,6 +216,12 @@ const AssetListControlBar = ({
     dispatch,
     currentNamespaceNetworkCount,
   ]);
+
+  useEffect(() => {
+    if (!accountSupportsNetworkFilter && totalEnabledNetworkCount > 0) {
+      dispatch(setEnabledAllPopularNetworks());
+    }
+  }, [accountSupportsNetworkFilter, totalEnabledNetworkCount, dispatch]);
 
   const windowType = getEnvironmentType();
   const isFullScreen =

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -22,7 +22,7 @@ import {
   getTokenNetworkFilter,
   getUseNftDetection,
 } from '../../../../../selectors';
-import { selectAccountSupportsNetworkFilter } from '../../../../../selectors/assets';
+import { selectAccountSupportsEnabledNetworks } from '../../../../../selectors/assets';
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
@@ -119,8 +119,8 @@ const AssetListControlBar = ({
   const isLineaMainnet = useSelector(getIsLineaMainnet);
   const allChainIds = useSelector(getAllChainsToPoll);
   const isEvm = useSelector(getMultichainIsEvm);
-  const accountSupportsNetworkFilter = useSelector(
-    selectAccountSupportsNetworkFilter,
+  const accountSupportsEnabledNetworks = useSelector(
+    selectAccountSupportsEnabledNetworks,
   );
 
   const { collections } = useNftsCollections();
@@ -218,10 +218,10 @@ const AssetListControlBar = ({
   ]);
 
   useEffect(() => {
-    if (!accountSupportsNetworkFilter && totalEnabledNetworkCount > 0) {
+    if (!accountSupportsEnabledNetworks && totalEnabledNetworkCount > 0) {
       dispatch(setEnabledAllPopularNetworks());
     }
-  }, [accountSupportsNetworkFilter, totalEnabledNetworkCount, dispatch]);
+  }, [accountSupportsEnabledNetworks, totalEnabledNetworkCount, dispatch]);
 
   const windowType = getEnvironmentType();
   const isFullScreen =

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -8,7 +8,7 @@ import {
   calculateBalanceChangeForAccountGroup,
   selectAssetsBySelectedAccountGroup,
 } from '@metamask/assets-controllers';
-import { CaipAssetId } from '@metamask/keyring-api';
+import { CaipAssetId, isEvmAccountType } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
 import {
   CaipAssetType,
@@ -1318,14 +1318,13 @@ export const selectAccountSupportsNetworkFilter = createSelector(
       return true;
     }
 
-    const accountScopes = selectedAccount.scopes || [];
-
-    if (accountScopes.length === 0) {
+    if (isEvmAccountType(selectedAccount.type)) {
       return enabledNetworks.some((chainId) =>
         isEvmChainId(chainId as Hex | CaipChainId),
       );
     }
 
+    const accountScopes = selectedAccount.scopes || [];
     return enabledNetworks.some((chainId) =>
       accountScopes.includes(chainId as CaipChainId),
     );

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1312,13 +1312,23 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
 );
 
 export const selectAccountSupportsNetworkFilter = createSelector(
-  [getAssetsBySelectedAccountGroup, getAllEnabledNetworksForAllNamespaces],
-  (accountGroupAssets, enabledNetworks) => {
-    const accountChainIds = Object.keys(accountGroupAssets ?? {});
-    if (accountChainIds.length === 0) {
+  [getSelectedInternalAccount, getAllEnabledNetworksForAllNamespaces],
+  (selectedAccount, enabledNetworks) => {
+    if (!selectedAccount || enabledNetworks.length === 0) {
       return true;
     }
-    return accountChainIds.some((chainId) => enabledNetworks.includes(chainId));
+
+    const accountScopes = selectedAccount.scopes || [];
+
+    if (accountScopes.length === 0) {
+      return enabledNetworks.some((chainId) =>
+        isEvmChainId(chainId as Hex | CaipChainId),
+      );
+    }
+
+    return enabledNetworks.some((chainId) =>
+      accountScopes.includes(chainId as CaipChainId),
+    );
   },
 );
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -63,7 +63,10 @@ import {
   getTokensAcrossChainsByAccountAddressSelector,
   getEnabledNetworks,
 } from './selectors';
-import { getSelectedMultichainNetworkConfiguration } from './multichain/networks';
+import {
+  getAllEnabledNetworksForAllNamespaces,
+  getSelectedMultichainNetworkConfiguration,
+} from './multichain/networks';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from './multichain-accounts/account-tree';
 
 export type AssetsState = {
@@ -1306,6 +1309,14 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
   getStateForAssetSelector,
   (assetListState: AssetListState) =>
     selectAssetsBySelectedAccountGroup(assetListState),
+);
+
+export const selectAccountSupportsNetworkFilter = createSelector(
+  [getAssetsBySelectedAccountGroup, getAllEnabledNetworksForAllNamespaces],
+  (accountGroupAssets, enabledNetworks) =>
+    Object.keys(accountGroupAssets).some((chainId) =>
+      enabledNetworks.includes(chainId),
+    ),
 );
 
 export const getAssetsBySelectedAccountGroupWithTronResources =

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1311,7 +1311,7 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
     selectAssetsBySelectedAccountGroup(assetListState),
 );
 
-export const selectAccountSupportsNetworkFilter = createSelector(
+export const selectAccountSupportsEnabledNetworks = createSelector(
   [getSelectedInternalAccount, getAllEnabledNetworksForAllNamespaces],
   (selectedAccount, enabledNetworks) => {
     if (!selectedAccount || enabledNetworks.length === 0) {

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1313,10 +1313,13 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
 
 export const selectAccountSupportsNetworkFilter = createSelector(
   [getAssetsBySelectedAccountGroup, getAllEnabledNetworksForAllNamespaces],
-  (accountGroupAssets, enabledNetworks) =>
-    Object.keys(accountGroupAssets).some((chainId) =>
-      enabledNetworks.includes(chainId),
-    ),
+  (accountGroupAssets, enabledNetworks) => {
+    const accountChainIds = Object.keys(accountGroupAssets ?? {});
+    if (accountChainIds.length === 0) {
+      return true;
+    }
+    return accountChainIds.some((chainId) => enabledNetworks.includes(chainId));
+  },
 );
 
 export const getAssetsBySelectedAccountGroupWithTronResources =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If the selected account doesn't support the chosen network, default to the all network list.

Aligns with the current token list behavior.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39080?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: network list when switching to hardware walelt

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37841

## **Manual testing steps**
0. Add a hardware wallet
1. Switch to an EVM account then choose Solana/Bitcoin or a network not supported in the hardware wallet
2. Switch to the hardware wallet


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the asset list network filter stays valid when switching to accounts that don’t support the currently enabled networks.
> 
> - Adds `selectAccountSupportsEnabledNetworks` to detect if the selected account supports any of the enabled networks (EVM via `isEvmAccountType`, non‑EVM via `scopes`).
> - In `asset-list-control-bar.tsx`, uses the selector and dispatches `setEnabledAllPopularNetworks()` in a `useEffect` to reset to popular networks when unsupported; wires necessary imports.
> - Keeps network filter behavior consistent with the token list when switching to hardware wallets or cross‑namespace accounts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a09824cb116a26a5a56389451d4d939a336b60cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->