### PR TITLE
feat: fix shield reward signup button showing unexpectedly

### DIFF
--- a/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
+++ b/ui/pages/settings/transaction-shield-tab/transaction-shield.tsx
@@ -212,9 +212,13 @@ const TransactionShield = () => {
     pointsMonthly,
     pointsYearly,
     isRewardsSeason,
-    hasAccountOptedIn: hasOptedIntoRewards,
+    hasAccountOptedIn,
     pending: pendingShieldRewards,
   } = useShieldRewards();
+
+  // Use rewardAccountId from subscription as additional signal for opt-in status
+  const hasOptedIntoRewards =
+    hasAccountOptedIn || Boolean(displayedShieldSubscription?.rewardAccountId);
 
   const isWaitingForSubscriptionCreation =
     shouldWaitForSubscriptionCreation && !currentShieldSubscription;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -847,6 +847,9 @@ export function linkRewardToShieldSubscription(
         subscriptionId,
         rewardPoints,
       ]);
+
+      // refetch the subscriptions
+      await dispatch(getSubscriptions());
     } catch (error) {
       dispatch(displayWarning(error));
       throw error;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Scenario 1**
- User subscribes to rewards 
- Then subscribe to shield
- After shield subscription is completed. Rewards sign up button should not show on Shield Settings page

**Scenario 2**
- User is subscribe to shield
- After subscription flow completes. Rewards Sign up button should show on Shield Settings page
- When user signs up to shield from Shield settings page and complete flow. Sign up button show hide.

https://consensyssoftware.atlassian.net/browse/SUBS-901?atlOrigin=eyJpIjoiNzUxOTEyNzM0NmE3NGRiNGIzZGY4ZjQ3MzFmNGUzOTUiLCJwIjoiaiJ9

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39091?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix shield reward signup button showing unexpectedly

## **Related issues**

Fixes:

## **Manual testing steps**
See description
1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
**Subscribe to Rewards first then subscribe to shield**
<video src="https://github.com/user-attachments/assets/7179d3e7-4380-47b4-952c-2a14f4f565f3">


**Subscribe to Shield first then subscribe to rewards**
<video src="https://github.com/user-attachments/assets/9e3ab733-f327-4904-8aba-700e463d89d5">


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
