### PR TITLE
fix: Show correct spending cap

### DIFF
--- a/test/integration/confirmations/signatures/permit.test.tsx
+++ b/test/integration/confirmations/signatures/permit.test.tsx
@@ -36,6 +36,7 @@ describe('Permit Confirmation', () => {
     mockedBackgroundConnection.submitRequestToBackground.mockImplementation(
       createMockImplementation({
         getTokenStandardAndDetails: { decimals: '2', standard: 'ERC20' },
+        getTokenStandardAndDetailsByChain: { decimals: '2', standard: 'ERC20' },
       }),
     );
   });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/permit-simulation/permit-simulation.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/permit-simulation/permit-simulation.test.tsx
@@ -16,6 +16,9 @@ jest.mock('../../../../../../../../store/actions', () => {
     getTokenStandardAndDetails: jest
       .fn()
       .mockResolvedValue({ decimals: 2, standard: 'ERC20' }),
+    getTokenStandardAndDetailsByChain: jest
+      .fn()
+      .mockResolvedValue({ decimals: 2, standard: 'ERC20' }),
   };
 });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/typed-sign-v4-simulation.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/typed-sign-v4-simulation.test.tsx
@@ -21,6 +21,9 @@ jest.mock('../../../../../../../store/actions', () => {
     getTokenStandardAndDetails: jest
       .fn()
       .mockResolvedValue({ decimals: 2, standard: 'ERC20' }),
+    getTokenStandardAndDetailsByChain: jest
+      .fn()
+      .mockResolvedValue({ decimals: 2, standard: 'ERC20' }),
     updateEventFragment: jest.fn(),
   };
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
@@ -12,6 +12,9 @@ jest.mock('../../../../../../../../store/actions', () => {
     getTokenStandardAndDetails: jest
       .fn()
       .mockResolvedValue({ decimals: 4, standard: 'ERC20' }),
+    getTokenStandardAndDetailsByChain: jest
+      .fn()
+      .mockResolvedValue({ decimals: 4, standard: 'ERC20' }),
   };
 });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx
@@ -82,7 +82,7 @@ const PermitSimulationValueDisplay: React.FC<
 
   const exchangeRate = useTokenExchangeRate(tokenContract, chainId);
 
-  const tokenDetails = useGetTokenStandardAndDetails(tokenContract);
+  const tokenDetails = useGetTokenStandardAndDetails(tokenContract, chainId);
   useTrackERC20WithoutDecimalInformation(
     chainId,
     tokenContract,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -31,7 +31,7 @@ const useTokenContract = () => {
   const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
 
   if (!currentConfirmation?.msgParams) {
-    return {};
+    return { chainId: '' };
   }
 
   const {
@@ -42,24 +42,26 @@ const useTokenContract = () => {
   const isPermit = isPermitSignatureRequest(currentConfirmation);
   const isOrder = isOrderSignatureRequest(currentConfirmation);
   const tokenContract = isPermit || isOrder ? verifyingContract : undefined;
+  const chainId = currentConfirmation.chainId as string;
 
-  return { tokenContract, verifyingContract, spender, isPermit };
+  return { tokenContract, verifyingContract, spender, isPermit, chainId };
 };
 
 const TypedSignInfo: React.FC = () => {
   const t = useI18nContext();
   const isSimulationSupported = useTypesSignSimulationEnabledInfo();
   const isBIP44 = useIsBIP44();
-  const { tokenContract, verifyingContract, spender, isPermit } =
+  const { tokenContract, verifyingContract, spender, isPermit, chainId } =
     useTokenContract();
-  const { decimalsNumber } = useGetTokenStandardAndDetails(tokenContract);
+  const { decimalsNumber } = useGetTokenStandardAndDetails(
+    tokenContract,
+    chainId,
+  );
 
   const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
   if (!currentConfirmation?.msgParams) {
     return null;
   }
-
-  const chainId = currentConfirmation.chainId as string;
 
   const toolTipMessage = isSnapId(currentConfirmation.msgParams.origin)
     ? t('requestFromInfoSnap')

--- a/ui/pages/confirmations/components/confirm/row/dataTree.tsx
+++ b/ui/pages/confirmations/components/confirm/row/dataTree.tsx
@@ -105,7 +105,10 @@ export const DataTree = ({
   chainId: string;
 }) => {
   const tokenContract = getTokenContractInDataTree(data);
-  const { decimalsNumber } = useGetTokenStandardAndDetails(tokenContract);
+  const { decimalsNumber } = useGetTokenStandardAndDetails(
+    tokenContract,
+    chainId,
+  );
   const tokenDecimals =
     typeof decimalsNumber === 'number' ? decimalsNumber : tokenDecimalsProp;
 

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -2193,7 +2193,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                         <div
                           aria-describedby="tippy-tooltip-3"
                           class=""
-                          data-original-title="30"
+                          data-original-title="3,000"
                           data-tooltipped=""
                           style="display: inline;"
                           tabindex="0"
@@ -2203,7 +2203,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                             data-testid="simulation-token-value"
                             style="padding-top: 1px; padding-bottom: 1px;"
                           >
-                            30
+                            3,000
                           </p>
                         </div>
                       </div>

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -2193,7 +2193,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                         <div
                           aria-describedby="tippy-tooltip-3"
                           class=""
-                          data-original-title="3,000"
+                          data-original-title="30"
                           data-tooltipped=""
                           style="display: inline;"
                           tabindex="0"
@@ -2203,7 +2203,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                             data-testid="simulation-token-value"
                             style="padding-top: 1px; padding-bottom: 1px;"
                           >
-                            3,000
+                            30
                           </p>
                         </div>
                       </div>

--- a/ui/pages/confirmations/confirm/confirm.test.tsx
+++ b/ui/pages/confirmations/confirm/confirm.test.tsx
@@ -94,6 +94,10 @@ describe('Confirm', () => {
       decimals: '2',
       standard: 'ERC20',
     });
+    jest.spyOn(actions, 'getTokenStandardAndDetailsByChain').mockResolvedValue({
+      decimals: '2',
+      standard: 'ERC20',
+    });
 
     const mockStore = configureMockStore(middleware)(mockStateTypedSign);
     let container;
@@ -135,6 +139,10 @@ describe('Confirm', () => {
     );
 
     jest.spyOn(actions, 'getTokenStandardAndDetails').mockResolvedValue({
+      decimals: '2',
+      standard: 'ERC20',
+    });
+    jest.spyOn(actions, 'getTokenStandardAndDetailsByChain').mockResolvedValue({
       decimals: '2',
       standard: 'ERC20',
     });
@@ -181,6 +189,10 @@ describe('Confirm', () => {
       decimals: '2',
       standard: 'ERC20',
     });
+    jest.spyOn(actions, 'getTokenStandardAndDetailsByChain').mockResolvedValue({
+      decimals: '2',
+      standard: 'ERC20',
+    });
 
     await act(async () => {
       const { container } = await renderWithConfirmContextProvider(
@@ -202,6 +214,10 @@ describe('Confirm', () => {
     const mockStore = configureMockStore(middleware)(mockStateTypedSign);
 
     jest.spyOn(actions, 'getTokenStandardAndDetails').mockResolvedValue({
+      decimals: '2',
+      standard: 'ERC20',
+    });
+    jest.spyOn(actions, 'getTokenStandardAndDetailsByChain').mockResolvedValue({
       decimals: '2',
       standard: 'ERC20',
     });

--- a/ui/pages/confirmations/hooks/useGetTokenStandardAndDetails.ts
+++ b/ui/pages/confirmations/hooks/useGetTokenStandardAndDetails.ts
@@ -7,17 +7,20 @@ import {
   ERC20_DEFAULT_DECIMALS,
   parseTokenDetailDecimals,
   memoizedGetTokenStandardAndDetails,
+  memoizedGetTokenStandardAndDetailsByChain,
   TokenDetailsERC20,
 } from '../utils/token';
 
 /**
  * Returns token details for a given token contract
  *
- * @param tokenAddress
- * @returns
+ * @param tokenAddress - The token contract address
+ * @param chainId - Optional chain ID. When provided, uses chain-aware lookup
+ * @returns Token details including decimalsNumber
  */
 export const useGetTokenStandardAndDetails = (
   tokenAddress?: Hex | string | undefined,
+  chainId?: Hex | string | undefined,
 ) => {
   const { value: details } =
     useAsyncResult<TokenDetailsERC20 | null>(async () => {
@@ -25,10 +28,18 @@ export const useGetTokenStandardAndDetails = (
         return Promise.resolve(null);
       }
 
+      // Use chain-aware lookup when chainId is provided (memoized for performance)
+      if (chainId) {
+        return (await memoizedGetTokenStandardAndDetailsByChain(
+          tokenAddress,
+          chainId,
+        )) as TokenDetailsERC20;
+      }
+
       return (await memoizedGetTokenStandardAndDetails(
         tokenAddress,
       )) as TokenDetailsERC20;
-    }, [tokenAddress]);
+    }, [tokenAddress, chainId]);
 
   return useMemo(() => {
     if (!details) {

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -72,6 +72,30 @@ export const memoizedGetTokenStandardAndDetails = memoize(
   },
 );
 
+export const memoizedGetTokenStandardAndDetailsByChain = memoize(
+  async (
+    tokenAddress?: Hex | string,
+    chainId?: Hex | string,
+  ): Promise<TokenDetails | Record<string, never>> => {
+    try {
+      if (!tokenAddress) {
+        return {};
+      }
+
+      return (await getTokenStandardAndDetailsByChain(
+        tokenAddress,
+        undefined,
+        undefined,
+        chainId,
+      )) as TokenDetails;
+    } catch {
+      return {};
+    }
+  },
+  // Custom resolver to use both tokenAddress and chainId as cache key
+  (tokenAddress, chainId) => `${tokenAddress}-${chainId}`,
+);
+
 /**
  * Fetches the decimals for the given token address.
  *


### PR DESCRIPTION
## **Description**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39098?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show correct spending cap

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38862

## **Manual testing steps**

1. In the extension make sure to select "All popular networks"
2. Go to https://www.monadfastbridge.com/
3. Enter an amount and press accept (e.g. 1 USDC)
4. It opens MetaMask and the Spending cap will show correct amount

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="426" height="125" alt="image" src="https://github.com/user-attachments/assets/a6df0f94-0af5-406c-bca7-239383c0b3ac" />

### **After**
<img width="317" height="365" alt="image" src="https://github.com/user-attachments/assets/d0065ee9-be4d-434d-b24a-51687d74f0d4" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures spending caps and token amounts use the correct ERC20 decimals for the active network.
> 
> - Adds `memoizedGetTokenStandardAndDetailsByChain` and updates `useGetTokenStandardAndDetails` to accept `chainId` and prefer chain-aware lookups
> - Propagates `chainId` through typed-sign flows and uses `useGetTokenStandardAndDetails(tokenContract, chainId)` in `TypedSignInfo`, `value-display`, and `DataTree`
> - Updates permit/typed-sign simulations to use chain-aware token details; passes `chainId` to rate/amount displays
> - Expands unit tests and integration tests to mock `getTokenStandardAndDetailsByChain`, add memoization tests, and update snapshots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c53416f551b355e9204c6cf1e3293b14bf2b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->