### PR TITLE
chore: update gas fees sponsored tooltip message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7634,7 +7634,7 @@
     "message": "Paid by MetaMask"
   },
   "swapGasFeesSponsoredExplanation": {
-    "message": "This network fee is paid by MetaMask, so you can swap without $1 in your account."
+    "message": "This network fee is paid by MetaMask, so you can transact without $1 in your account."
   },
   "swapGasFeesSummary": {
     "message": "Gas fees are paid to crypto miners who process transactions on the $1 network. MetaMask does not profit from gas fees.",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7634,7 +7634,7 @@
     "message": "Paid by MetaMask"
   },
   "swapGasFeesSponsoredExplanation": {
-    "message": "This network fee is paid by MetaMask, so you can swap without $1 in your account."
+    "message": "This network fee is paid by MetaMask, so you can transact without $1 in your account."
   },
   "swapGasFeesSummary": {
     "message": "Gas fees are paid to crypto miners who process transactions on the $1 network. MetaMask does not profit from gas fees.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enhances the gas fee sponsorship user experience by updating the tooltip message of "network fee" when the transaction is gas fees sponsored.

### Problem
The tooltip message of "network fee" when the transaction is gas fees sponsored is not enough explicit for send transactions.

### Solution
Implement a workaround that updates the tooltip message for gas fees sponsored.

## **Changelog**

CHANGELOG entry: fixed gas fees sponsored tooltip message

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Go to the send page.
2. Send token to an address on a chain eligible of gas fees sponsored.
3. The "network fee" tooltip message should be explicit.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="400" height="596" alt="ext send msg" src="https://github.com/user-attachments/assets/cac1c17d-0453-46b2-8106-89884fe1e15a" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates localization copy for the sponsored gas fee tooltip to use broader "transact" wording.
> 
> - Changes `swapGasFeesSponsoredExplanation` message from "swap without $1" to "transact without $1" in `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e97230bbab3971846d1f1ec137941507c73aeff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->