### PR TITLE
fix(snaps): Prevent scroll reset on interface update

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/box.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/box.ts
@@ -54,26 +54,33 @@ function generateAlignItems(
   }
 }
 
-export const box: UIComponentFactory<BoxElement> = ({
-  element,
-  ...params
-}) => ({
-  element: 'Box',
-  children: getJsxChildren(element).map((children) =>
-    mapToTemplate({ ...params, element: children as JSXElement }),
-  ) as NonEmptyArray<UIComponent>,
-  props: {
-    display: Display.Flex,
-    flexDirection:
-      element.props.direction === 'horizontal'
-        ? FlexDirection.Row
-        : FlexDirection.Column,
-    justifyContent: generateJustifyContent(element.props.alignment),
-    alignItems: generateAlignItems(
-      element.props.crossAlignment,
-      element.props.center,
-    ),
-    className: 'snap-ui-renderer__panel',
-    color: TextColor.textDefault,
-  },
-});
+export const box: UIComponentFactory<BoxElement> = ({ element, ...params }) => {
+  const scrollBehavior = params.isScrollableContainer
+    ? {
+        ref: params.scrollableContainerRef,
+        onScroll: params.setScroll,
+      }
+    : {};
+
+  return {
+    element: 'Box',
+    children: getJsxChildren(element).map((children) =>
+      mapToTemplate({ ...params, element: children as JSXElement }),
+    ) as NonEmptyArray<UIComponent>,
+    props: {
+      display: Display.Flex,
+      flexDirection:
+        element.props.direction === 'horizontal'
+          ? FlexDirection.Row
+          : FlexDirection.Column,
+      justifyContent: generateJustifyContent(element.props.alignment),
+      alignItems: generateAlignItems(
+        element.props.crossAlignment,
+        element.props.center,
+      ),
+      ...scrollBehavior,
+      className: 'snap-ui-renderer__panel',
+      color: TextColor.textDefault,
+    },
+  };
+};

--- a/ui/components/app/snaps/snap-ui-renderer/components/box.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/box.ts
@@ -65,7 +65,11 @@ export const box: UIComponentFactory<BoxElement> = ({ element, ...params }) => {
   return {
     element: 'Box',
     children: getJsxChildren(element).map((children) =>
-      mapToTemplate({ ...params, element: children as JSXElement }),
+      mapToTemplate({
+        ...params,
+        isScrollableContainer: false,
+        element: children as JSXElement,
+      }),
     ) as NonEmptyArray<UIComponent>,
     props: {
       display: Display.Flex,

--- a/ui/components/app/snaps/snap-ui-renderer/components/container.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/container.ts
@@ -31,13 +31,13 @@ export const container: UIComponentFactory<ContainerElement> = ({
     ? children
     : [Box({ children: children[0] as JSXElement }), ...children.slice(1)];
 
-  const templateChildren = containerChildren.map((child) =>
+  const templateChildren = containerChildren.map((child, index) =>
     mapToTemplate({
       useFooter,
       onCancel,
       t,
+      isScrollableContainer: index === 0,
       ...params,
-
       element: child as JSXElement,
     }),
   );

--- a/ui/components/app/snaps/snap-ui-renderer/components/container.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/container.ts
@@ -36,8 +36,8 @@ export const container: UIComponentFactory<ContainerElement> = ({
       useFooter,
       onCancel,
       t,
-      isScrollableContainer: index === 0,
       ...params,
+      isScrollableContainer: index === 0,
       element: child as JSXElement,
     }),
   );

--- a/ui/components/app/snaps/snap-ui-renderer/components/types.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/types.ts
@@ -18,6 +18,9 @@ export type UIComponentParams<T extends JSXElement> = {
   t: (key: string) => string;
   contentBackgroundColor: string | undefined;
   componentMap: COMPONENT_MAPPING;
+  isScrollableContainer?: boolean;
+  setScroll: () => void;
+  scrollableContainerRef: React.RefObject<HTMLDivElement>;
 };
 
 export type UIComponent = {

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -71,7 +71,7 @@ const SnapUIRendererComponent = ({
 
   useEffect(() => {
     if (scrollableContainerRef.current) {
-      scrollableContainerRef.current.scrollTo(0, scrollRef.current);
+      scrollableContainerRef.current.scrollTo?.(0, scrollRef.current);
     }
   }, [interfaceState?.content]);
 

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -73,7 +73,7 @@ const SnapUIRendererComponent = ({
     if (scrollableContainerRef.current) {
       scrollableContainerRef.current.scrollTo(0, scrollRef.current);
     }
-  }, [interfaceState.content]);
+  }, [interfaceState?.content]);
 
   /**
    * Sets the scroll position to the current scroll position of the scrollable container.

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useRef } from 'react';
+import React, { memo, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Container } from '@metamask/snaps-sdk/jsx';
@@ -56,6 +56,9 @@ const SnapUIRendererComponent = ({
   // eslint-disable-next-line react-compiler/react-compiler
   'use no memo';
 
+  const scrollableContainerRef = useRef(null);
+  const scrollRef = useRef(null);
+
   const t = useI18nContext();
   const locale = useSelector(getIntlLocale);
 
@@ -65,6 +68,23 @@ const SnapUIRendererComponent = ({
     // We do this to avoid useless re-renders.
     (oldState, newState) => isEqual(oldState.content, newState.content),
   );
+
+  useEffect(() => {
+    if (scrollableContainerRef.current) {
+      scrollableContainerRef.current.scrollTo(0, scrollRef.current);
+    }
+  }, [interfaceState.content]);
+
+  /**
+   * Sets the scroll position to the current scroll position of the scrollable container.
+   * This is used to restore the scroll position when the content changes.
+   */
+  const setScroll = () => {
+    if (scrollableContainerRef.current) {
+      scrollRef.current = scrollableContainerRef.current.scrollTop;
+    }
+  };
+
   const rawContent = interfaceState?.content;
   const content =
     rawContent?.type === 'Container' || !rawContent
@@ -98,6 +118,8 @@ const SnapUIRendererComponent = ({
         t,
         contentBackgroundColor: backgroundColor,
         componentMap: COMPONENT_MAPPING,
+        setScroll,
+        scrollableContainerRef,
       }),
     [content, onCancel, useFooter, promptLegacyProps, t, backgroundColor],
   );

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -28,6 +28,9 @@ export type MapToTemplateParams = {
   t?: (key: string) => string;
   contentBackgroundColor?: string | undefined;
   componentMap: COMPONENT_MAPPING;
+  isScrollableContainer?: boolean;
+  setScroll: () => void;
+  scrollableContainerRef: React.RefObject<HTMLDivElement>;
 };
 
 /**
@@ -115,7 +118,10 @@ export const mapToTemplate = (params: MapToTemplateParams): UIComponent => {
 
 export const mapTextToTemplate = (
   elements: NonEmptyArray<JSXElement | string>,
-  params: Pick<MapToTemplateParams, 'map' | 'componentMap'>,
+  params: Pick<
+    MapToTemplateParams,
+    'map' | 'componentMap' | 'setScroll' | 'scrollableContainerRef'
+  >,
 ): NonEmptyArray<UIComponent | string> =>
   elements.map((element) => {
     // With the introduction of JSX elements here can be strings.


### PR DESCRIPTION
## **Description**

This PR fixes the scroll reset happening on interfaces when it's re-rendered.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39100?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent scroll reset on interface update

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

#### Before Wallet UX changes

https://github.com/user-attachments/assets/92211c75-5009-4989-983a-16aae5a002a9

#### After Wallet UX changes

https://github.com/user-attachments/assets/3763463b-ccb0-4416-9324-6677f2f95b96

### **After**


https://github.com/user-attachments/assets/dfb93091-1859-4a10-bb06-2ca2570c14a4

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves scroll position across Snap UI re-renders by wiring scroll tracking through the renderer and first Box container.
> 
> - In `snap-ui-renderer.js`, add `scrollableContainerRef` and `scrollRef`, restore `scrollTop` on content changes via `useEffect`, and expose `setScroll`
> - In `container.ts`, mark the first child as the scrollable container (`isScrollableContainer: index === 0`)
> - In `box.ts`, when `isScrollableContainer`, attach `ref` and `onScroll` to the rendered `Box`; reset flag for children
> - Extend types and utils (`types.ts`, `utils.ts`) to pass `isScrollableContainer`, `setScroll`, and `scrollableContainerRef` through `mapToTemplate` and `mapTextToTemplate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e515cbca66271bb66704969446857ac0e9c514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->