### PR TITLE
fix: first time interaction alert for token transfers

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -378,7 +378,7 @@ describe('useFirstTimeInteractionAlert', () => {
 
     // Verify useTrustSignal was called with the actual recipient, not contract address
     expect(mockUseTrustSignal).toHaveBeenCalledWith(
-      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'i')),
+      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'iu')),
       expect.anything(),
       expect.anything(),
     );
@@ -430,7 +430,7 @@ describe('useFirstTimeInteractionAlert', () => {
 
     // Verify useTrustSignal was called with the actual recipient, not contract address
     expect(mockUseTrustSignal).toHaveBeenCalledWith(
-      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'i')),
+      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'iu')),
       expect.anything(),
       expect.anything(),
     );

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.test.ts
@@ -269,6 +269,7 @@ describe('useFirstTimeInteractionAlert', () => {
 
     expect(alerts).toEqual([]);
   });
+
   it('does not return alert when trust signal is still loading', () => {
     mockUseTrustSignal.mockReturnValue({
       state: TrustSignalDisplayState.Loading,
@@ -338,5 +339,100 @@ describe('useFirstTimeInteractionAlert', () => {
     });
 
     expect(alerts).toEqual([]);
+  });
+
+  it('checks trust signal for decoded token transfer recipient instead of contract address', () => {
+    // Mock trust signal to return Verified only for the actual recipient
+    mockUseTrustSignal.mockImplementation((address) => {
+      // Return Verified only for the actual token recipient
+      if (address.toLowerCase() === ACCOUNT_ADDRESS_2_MOCK.toLowerCase()) {
+        return {
+          state: TrustSignalDisplayState.Verified,
+          label: null,
+        };
+      }
+      // Return Unknown for the contract address
+      return {
+        state: TrustSignalDisplayState.Unknown,
+        label: null,
+      };
+    });
+
+    const firstTimeConfirmation = {
+      ...TRANSACTION_META_MOCK,
+      isFirstTimeInteraction: true,
+      type: TransactionType.tokenMethodTransfer,
+      txParams: {
+        ...TRANSACTION_META_MOCK.txParams,
+        to: CONTRACT_ADDRESS_MOCK, // Token contract, NOT the recipient
+        data: genUnapprovedTokenTransferConfirmation().txParams.data, // Contains actual recipient
+      },
+    };
+
+    const alerts = runHook({
+      currentConfirmation: firstTimeConfirmation,
+    });
+
+    // Trust signal is checked for decoded recipient (verified), so no alert shown
+    expect(alerts).toEqual([]);
+
+    // Verify useTrustSignal was called with the actual recipient, not contract address
+    expect(mockUseTrustSignal).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'i')),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('returns alert when decoded token transfer recipient is not verified', () => {
+    // Mock trust signal to return Unknown for the actual recipient
+    mockUseTrustSignal.mockImplementation((address) => {
+      if (address.toLowerCase() === ACCOUNT_ADDRESS_2_MOCK.toLowerCase()) {
+        return {
+          state: TrustSignalDisplayState.Unknown,
+          label: null,
+        };
+      }
+      return {
+        state: TrustSignalDisplayState.Unknown,
+        label: null,
+      };
+    });
+
+    const firstTimeConfirmation = {
+      ...TRANSACTION_META_MOCK,
+      isFirstTimeInteraction: true,
+      type: TransactionType.tokenMethodTransfer,
+      txParams: {
+        ...TRANSACTION_META_MOCK.txParams,
+        to: CONTRACT_ADDRESS_MOCK, // Token contract, NOT the recipient
+        data: genUnapprovedTokenTransferConfirmation().txParams.data, // Contains actual recipient
+      },
+    };
+
+    const alerts = runHook({
+      currentConfirmation: firstTimeConfirmation,
+    });
+
+    // Trust signal is checked for decoded recipient (not verified), so alert is shown
+    expect(alerts).toEqual([
+      {
+        actions: [],
+        field: RowAlertKey.InteractingWith,
+        isBlocking: false,
+        key: 'firstTimeInteractionTitle',
+        message:
+          "You're interacting with this address for the first time. Make sure that it's correct before you continue.",
+        reason: '1st interaction',
+        severity: Severity.Warning,
+      },
+    ]);
+
+    // Verify useTrustSignal was called with the actual recipient, not contract address
+    expect(mockUseTrustSignal).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp(ACCOUNT_ADDRESS_2_MOCK, 'i')),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useFirstTimeInteractionAlert.ts
@@ -26,7 +26,7 @@ export function useFirstTimeInteractionAlert(): Alert[] {
   const to = useTransferRecipient();
   const { isFirstTimeInteraction, chainId, txParams } =
     currentConfirmation ?? {};
-  const recipient = (txParams?.to ?? '0x') as Hex;
+  const recipient = (to ?? txParams?.to ?? '0x') as Hex;
 
   const isInternalAccount = internalAccounts.some(
     (account) => account.address?.toLowerCase() === to?.toLowerCase(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

First time alert is not working for token transfer.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**
NA

## **Manual testing steps**

1. Submit a token transfer to a recipient for first time
2. Ensure that first time interaction warning is displayed

## **Screenshots/Recordings**
<img width="826" height="754" alt="Screenshot 2026-01-09 at 4 04 07 PM" src="https://github.com/user-attachments/assets/74009baf-c45e-4913-bcd7-f6cd2ab3e827" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures first-time interaction alerts evaluate the actual token transfer recipient rather than the token contract.
> 
> - In `useFirstTimeInteractionAlert`, derive `recipient` from `useTransferRecipient()` (fallback to `txParams.to`) so trust signals validate the decoded token transfer recipient; continue to suppress alerts for internal accounts, verified addresses, first-party contracts, or while trust signal is loading.
> - Expand tests to cover loading state and token transfer scenarios, verifying `useTrustSignal` is called with the decoded recipient and that alerts show only when the recipient is unverified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1fa9776d3fd0a464a512cce592380b197b18dad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->