### PR TITLE
fix: Do not throw an error when switching between queued dapp transactions

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/advanced-details.tsx
@@ -21,7 +21,6 @@ import {
   updateCustomNonce,
 } from '../../../../../../../store/actions';
 import { useConfirmContext } from '../../../../../context/confirm';
-import { useDappSwapContext } from '../../../../../context/dapp-swap';
 import { selectConfirmationAdvancedDetailsOpen } from '../../../../../selectors/preferences';
 import { isSignatureTransactionType } from '../../../../../utils';
 import { NestedTransactionData } from '../../batch/nested-transaction-data/nested-transaction-data';
@@ -94,7 +93,6 @@ export const AdvancedDetails = ({
 }: {
   overrideVisibility?: boolean;
 }) => {
-  const { isQuotedSwapDisplayedInInfo } = useDappSwapContext();
   const showAdvancedDetails = useSelector(
     selectConfirmationAdvancedDetailsOpen,
   );
@@ -108,7 +106,7 @@ export const AdvancedDetails = ({
       <NonceDetails />
       <TransactionData />
       <NestedTransactionData />
-      {isQuotedSwapDisplayedInInfo && <QuotedSwapTransactionData />}
+      <QuotedSwapTransactionData />
     </>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.test.tsx
@@ -64,4 +64,51 @@ describe('QuotedSwapTransactionData', () => {
     expect(queryByText('Approve')).not.toBeInTheDocument();
     expect(queryByText('Swap')).not.toBeInTheDocument();
   });
+
+  it('does not render if selectedQuote is undefined', () => {
+    jest.spyOn(DappSwapContextModule, 'useDappSwapContext').mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+      selectedQuote: undefined,
+    } as unknown as ReturnType<
+      typeof DappSwapContextModule.useDappSwapContext
+    >);
+
+    const { queryByText } = render();
+
+    expect(queryByText('Transaction 1')).not.toBeInTheDocument();
+    expect(queryByText('Transaction 2')).not.toBeInTheDocument();
+  });
+
+  it('handles transition from defined to undefined selectedQuote without error', () => {
+    const mockUseDappSwapContext = jest.spyOn(
+      DappSwapContextModule,
+      'useDappSwapContext',
+    );
+
+    // First render with valid quote
+    mockUseDappSwapContext.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+      selectedQuote: mockBridgeQuotes[0],
+    } as unknown as ReturnType<
+      typeof DappSwapContextModule.useDappSwapContext
+    >);
+
+    const { queryByText, rerender } = render();
+    expect(queryByText('Transaction 1')).toBeInTheDocument();
+
+    // Simulate switching confirmations - selectedQuote becomes undefined
+    mockUseDappSwapContext.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+      selectedQuote: undefined,
+    } as unknown as ReturnType<
+      typeof DappSwapContextModule.useDappSwapContext
+    >);
+
+    // Re-render should not throw React hooks error
+    expect(() => {
+      rerender(<QuotedSwapTransactionData />);
+    }).not.toThrow();
+
+    expect(queryByText('Transaction 1')).not.toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/quote-transaction-data/quoted-transaction-data.tsx
@@ -87,5 +87,10 @@ export const QuotedSwapTransactionData = () => {
     return null;
   }
 
-  return <QuotedSwapTransactionDataContent selectedQuote={selectedQuote} />;
+  return (
+    <QuotedSwapTransactionDataContent
+      key={selectedQuote.quote.requestId}
+      selectedQuote={selectedQuote}
+    />
+  );
 };

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.test.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.test.tsx
@@ -96,7 +96,7 @@ describe('NestedTransactionTag', () => {
     ]);
 
     // First render with batch transactions
-    const { getByText, rerender, container } = render({
+    const { getByText, rerender } = render({
       nestedTransactions: [
         BATCH_TRANSACTION_PARAMS_MOCK,
         BATCH_TRANSACTION_PARAMS_MOCK,
@@ -132,7 +132,7 @@ describe('NestedTransactionTag', () => {
       FUNCTION_NAME_MOCK,
     ]);
 
-    const { getByText, container } = render({
+    const { getByText } = render({
       nestedTransactions: [
         BATCH_TRANSACTION_PARAMS_MOCK,
         BATCH_TRANSACTION_PARAMS_MOCK,

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.test.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.test.tsx
@@ -96,7 +96,7 @@ describe('NestedTransactionTag', () => {
     ]);
 
     // First render with batch transactions
-    const { getByText, rerender } = render({
+    const { getByText, unmount } = render({
       nestedTransactions: [
         BATCH_TRANSACTION_PARAMS_MOCK,
         BATCH_TRANSACTION_PARAMS_MOCK,
@@ -104,24 +104,12 @@ describe('NestedTransactionTag', () => {
     });
     expect(getByText('Includes 2 transactions')).toBeInTheDocument();
 
-    // Re-render with no nested transactions (simulating switching to different confirmation)
-    // This should not throw React hooks error
-    const storeWithNoNested = configureStore(
-      getMockConfirmStateForTransaction(
-        genUnapprovedContractInteractionConfirmation({
-          address: ADDRESS_MOCK,
-          nestedTransactions: undefined,
-        }),
-      ),
-    );
+    // Unmount and render with no nested transactions (simulating switching confirmation)
+    unmount();
 
+    // This should not throw React hooks error
     expect(() => {
-      rerender(
-        renderWithConfirmContextProvider(
-          <NestedTransactionTag />,
-          storeWithNoNested,
-        ).container.firstChild as React.ReactElement,
-      );
+      render({ nestedTransactions: undefined });
     }).not.toThrow();
   });
 

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  BatchTransactionParams,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import { useNestedTransactionLabels } from '../../confirm/info/hooks/useNestedTransactionLabels';
@@ -17,26 +20,32 @@ import {
 import Tooltip from '../../../../../components/ui/tooltip';
 import { isBatchTransaction } from '../../../../../../shared/lib/transactions.utils';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function NestedTransactionTag() {
+/**
+ * Inner component that renders the nested transaction tag.
+ * Uses confirmationId as key to force remount when confirmation changes,
+ * ensuring consistent hook calls.
+ *
+ * @param options0
+ * @param options0.nestedTransactions
+ * @param options0.confirmationId
+ */
+const NestedTransactionTagContent = ({
+  nestedTransactions,
+  confirmationId,
+}: {
+  nestedTransactions: BatchTransactionParams[];
+  confirmationId: string | undefined;
+}) => {
   const t = useI18nContext();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
-  const { nestedTransactions } = currentConfirmation ?? {};
-
-  const isBatch = isBatchTransaction(nestedTransactions);
   const functionNames = useNestedTransactionLabels({ nestedTransactions });
 
-  if (!isBatch || nestedTransactions?.length === 1) {
-    return null;
-  }
   const tooltip = t('transactionIncludesTypes', [functionNames.join(', ')]);
 
   return (
-    <Box paddingBottom={4} textAlign={TextAlign.Center}>
+    <Box key={confirmationId} paddingBottom={4} textAlign={TextAlign.Center}>
       <Tooltip title={tooltip} position="bottom">
         <Tag
-          label={t('includesXTransactions', [nestedTransactions?.length])}
+          label={t('includesXTransactions', [nestedTransactions.length])}
           startIconName={IconName.Info}
           paddingLeft={2}
           paddingRight={2}
@@ -47,5 +56,31 @@ export function NestedTransactionTag() {
         />
       </Tooltip>
     </Box>
+  );
+};
+
+/**
+ * Wrapper component that guards against rendering when nested transactions
+ * are not available or invalid. This prevents React hook violations that occur
+ * when switching between confirmations with different numbers of nested transactions.
+ * See: https://github.com/MetaMask/metamask-extension/issues/29191
+ */
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function NestedTransactionTag() {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const { nestedTransactions } = currentConfirmation ?? {};
+
+  const isBatch = isBatchTransaction(nestedTransactions);
+
+  if (!isBatch || !nestedTransactions || nestedTransactions.length <= 1) {
+    return null;
+  }
+
+  return (
+    <NestedTransactionTagContent
+      nestedTransactions={nestedTransactions}
+      confirmationId={currentConfirmation?.id}
+    />
   );
 }

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
@@ -22,19 +22,16 @@ import { isBatchTransaction } from '../../../../../../shared/lib/transactions.ut
 
 /**
  * Inner component that renders the nested transaction tag.
- * Uses confirmationId as key to force remount when confirmation changes,
- * ensuring consistent hook calls.
+ * Must be keyed by confirmationId when rendered to force remount when
+ * confirmation changes, ensuring consistent hook calls in useNestedTransactionLabels.
  *
  * @param options0
  * @param options0.nestedTransactions
- * @param options0.confirmationId
  */
 const NestedTransactionTagContent = ({
   nestedTransactions,
-  confirmationId,
 }: {
   nestedTransactions: BatchTransactionParams[];
-  confirmationId: string | undefined;
 }) => {
   const t = useI18nContext();
   const functionNames = useNestedTransactionLabels({ nestedTransactions });
@@ -42,7 +39,7 @@ const NestedTransactionTagContent = ({
   const tooltip = t('transactionIncludesTypes', [functionNames.join(', ')]);
 
   return (
-    <Box key={confirmationId} paddingBottom={4} textAlign={TextAlign.Center}>
+    <Box paddingBottom={4} textAlign={TextAlign.Center}>
       <Tooltip title={tooltip} position="bottom">
         <Tag
           label={t('includesXTransactions', [nestedTransactions.length])}
@@ -79,8 +76,8 @@ export function NestedTransactionTag() {
 
   return (
     <NestedTransactionTagContent
+      key={currentConfirmation?.id}
       nestedTransactions={nestedTransactions}
-      confirmationId={currentConfirmation?.id}
     />
   );
 }


### PR DESCRIPTION
## **Description**
Do not throw an error when switching between queued dapp transactions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39128?quickstart=1)

## **Changelog**

CHANGELOG entry: Do not throw an error when switching between queued dapp transactions

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/29191

## **Manual testing steps**

1. Connect to dapp 1 (https://www.sushi.com/fantom/swap)
2. Connect to dapp 2 (https://app.uniswap.org/swap)
3. Add a new network from dapp1 and do not submit the transaction
4. Enter details for a swap on dapp 2, submit it
5. Switch between confirmations, it will no longer throw an error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents React hook-order errors when switching between confirmations from different dapps.
> 
> - Split `QuotedSwapTransactionData` into guarded wrapper + `...Content`; render only when `isQuotedSwapDisplayedInInfo` and `selectedQuote` are set, key by `selectedQuote.quote.requestId`, and pass empty arrays to `useNestedTransactionLabels` when `approval`/`trade` are absent
> - Update `AdvancedDetails` to always include `QuotedSwapTransactionData` (internal guard handles visibility)
> - Refactor `NestedTransactionTag` into wrapper + `...Content`; render only for valid batch with `> 1` items and key by `currentConfirmation.id`
> - Add tests covering transitions: defined→undefined quote, approval presence changes, batch→non-batch, and varying nested counts without throwing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2d9bdc5b861464458055aebaf869731a3854aff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->