### PR TITLE
ci(INFRA-3170): Block merge button for stable to main PRs

### DIFF
--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -2,7 +2,7 @@ name: Block stable-main to main PRs
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
     branches:
       - main
 

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -1,0 +1,28 @@
+name: Block stable-main to main PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    name: Block stable-main-X.Y.Z to main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          TARGET_BRANCH="${{ github.base_ref }}"
+          
+          echo "Source branch: $SOURCE_BRANCH"
+          echo "Target branch: $TARGET_BRANCH"
+          
+          # Check if source branch matches stable-main-X.Y.Z pattern
+          if [[ "$TARGET_BRANCH" == "main" && "$SOURCE_BRANCH" =~ ^stable-main-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ ERROR: PRs from stable-main-X.Y.Z branches to main are not allowed to be manually merged!"
+            echo "Source branch '$SOURCE_BRANCH' matches the blocked pattern 'stable-main-X.Y.Z'"
+            exit 1
+          fi
+          
+          echo "✅ Branch check passed"

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check exact branch pattern
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref }}
+          TARGET_BRANCH: ${{ github.base_ref }}
         run: |
-          SOURCE_BRANCH="${{ github.head_ref }}"
-          TARGET_BRANCH="${{ github.base_ref }}"
-          
           # Check if source branch matches exact pattern: stable-main-X.Y.Z
           if [[ "$TARGET_BRANCH" == "main" && "$SOURCE_BRANCH" =~ ^stable-main-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "❌ ERROR: Manual merge from stable-main-X.Y.Z branches to main are not allowed!"

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -8,20 +8,21 @@ on:
 jobs:
   check-branch:
     name: Block stable-main-X.Y.Z to main
+    # Pre-filter: only spin up runner for branches starting with 'stable-main-'
+    # This saves runner time for most PRs while still doing exact regex check below
+    if: startsWith(github.head_ref, 'stable-main-')
     runs-on: ubuntu-latest
     steps:
-      - name: Check source branch
+      - name: Check exact branch pattern
         run: |
           SOURCE_BRANCH="${{ github.head_ref }}"
           TARGET_BRANCH="${{ github.base_ref }}"
           
-          echo "Source branch: $SOURCE_BRANCH"
-          echo "Target branch: $TARGET_BRANCH"
-          
-          # Check if source branch matches stable-main-X.Y.Z pattern
+          # Check if source branch matches exact pattern: stable-main-X.Y.Z
           if [[ "$TARGET_BRANCH" == "main" && "$SOURCE_BRANCH" =~ ^stable-main-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ ERROR: PRs from stable-main-X.Y.Z branches to main are not allowed to be manually merged!"
-            echo "Source branch '$SOURCE_BRANCH' matches the blocked pattern 'stable-main-X.Y.Z'"
+            echo "❌ ERROR: Manual merge from stable-main-X.Y.Z branches to main are not allowed!"
+            echo "Source branch '$SOURCE_BRANCH' matches the blocked pattern."
+            echo "These branches should only be merged via automated workflows, comment 'Merge my PR' to merge."
             exit 1
           fi
           

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -25,5 +25,5 @@ jobs:
             echo "These branches should only be merged via automated workflows, comment 'Merge my PR' to merge."
             exit 1
           fi
-          
+
           echo "✅ Branch check passed"

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -2,6 +2,7 @@ name: Block stable-main to main PRs
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
     branches:
       - main
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Task: https://consensyssoftware.atlassian.net/browse/INFRA-3170
Block merge button for stable-main-X.Y.Z -> main PRs, so "Merge my PR" workflow is used instead for stable sync PRs.
Required github rule example: https://github.com/consensys-test/metamask-mobile-test-workflow/settings/rules/11670449
Tested here: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/177, https://github.com/consensys-test/metamask-mobile-test-workflow/pull/179, https://github.com/consensys-test/metamask-mobile-test-workflow/pull/180


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39135?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions check to block manual merges from `stable-main-X.Y.Z` branches into `main`, enforcing use of the automated merge workflow.
> 
> - New workflow `block-stable-main-to-main.yml` runs on PRs to `main`
> - Pre-filters branches with `startsWith('stable-main-')` to reduce runner usage
> - Fails PRs when source matches `stable-main-[0-9]+\.[0-9]+\.[0-9]+` and target is `main`, with guidance to use "Merge my PR"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e79c55b78080342d5a685e0160b85ff60d5cfc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->