### PR TITLE
fix(tron): max energy and bandwidth incorrectly set to 1 instead of 0 cp-13.13.2

### DIFF
--- a/ui/pages/asset/hooks/useTronResources.test.ts
+++ b/ui/pages/asset/hooks/useTronResources.test.ts
@@ -107,7 +107,7 @@ describe('useTronResources', () => {
       });
     });
 
-    it('returns zero values with default max of 1 when no balances exist', () => {
+    it('returns zero values with max of 0 when no balances exist', () => {
       const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
       const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
 
@@ -131,14 +131,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -170,14 +170,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 250,
-        max: 1, // Defaults to 1 when max is 0
-        percentage: 25000, // 250 / 1 * 100
+        max: 0, // Actual max is 0 when not provided
+        percentage: 25000, // 250 / 1 * 100 (divisor is Math.max(1, 0) = 1)
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 150,
-        max: 1,
+        max: 0,
         percentage: 15000,
       });
     });
@@ -261,7 +261,7 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 100,
-        max: 1,
+        max: 0,
         percentage: 10000,
       });
 
@@ -269,7 +269,7 @@ describe('useTronResources', () => {
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -292,14 +292,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -320,14 +320,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -386,14 +386,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -414,14 +414,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });
@@ -452,14 +452,14 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
 
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
-        max: 1,
+        max: 0,
         percentage: 0,
       });
     });

--- a/ui/pages/asset/hooks/useTronResources.ts
+++ b/ui/pages/asset/hooks/useTronResources.ts
@@ -36,11 +36,11 @@ export const useTronResources = (
   return useMemo(() => {
     if (!account || !chainId) {
       return {
-        energy: { type: 'energy' as const, current: 0, max: 1, percentage: 0 },
+        energy: { type: 'energy' as const, current: 0, max: 0, percentage: 0 },
         bandwidth: {
           type: 'bandwidth' as const,
           current: 0,
-          max: 1,
+          max: 0,
           percentage: 0,
         },
       };
@@ -87,13 +87,14 @@ export const useTronResources = (
       type: 'energy' | 'bandwidth',
       data: { current: number; max: number },
     ): TronResource => {
-      const totalMax = Math.max(1, data.max);
+      // Use max of 1 only for percentage calculation to avoid division by zero
+      const divisor = Math.max(1, data.max);
 
       return {
         type,
         current: data.current,
-        max: totalMax,
-        percentage: (data.current / totalMax) * 100,
+        max: data.max, // Keep actual max for display (can be 0)
+        percentage: (data.current / divisor) * 100,
       };
     };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix Tron resources calculation and default value.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix Tron resources calculation and defaults**
> 
> - In `useTronResources`, keep the actual `max` value (can be `0`) and compute `percentage` using a safe divisor `Math.max(1, max)` to avoid division by zero
> - Default values when account/chainId or balances are missing now use `max: 0` instead of `1`
> - Updated unit tests in `useTronResources.test.ts` to expect `max: 0` across relevant scenarios and validate percentage behavior when `max` is absent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afc97335690214878e6366d7e259527f8c727ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->