### PR TITLE
fix: vault recovery split state cp-13.14.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -893,6 +893,17 @@ export async function loadStateFromPersistence(backup) {
     // migrations will behave correctly.
     if (hasProperty(backup, 'meta') && isObject(backup.meta)) {
       preMigrationVersionedData.meta = backup.meta;
+      // old versions of meta used "data" as the storage kind, without
+      // explicitly setting the "storageKind" to data. If it is missing, we just
+      // always default to "data" ("data" was the default before "split"
+      // existed).
+      // We need to set it properly here so that the persistence manager uses
+      // the correct storage kind when restoring from the `backup`.
+      if (backup.meta.storageKind === "split" || backup.meta.storageKind === "data") {
+        persistenceManager.storageKind = backup.meta.storageKind;
+      } else {
+        persistenceManager.storageKind = "data";
+      }
     }
     // sanity check on the meta property
     if (typeof preMigrationVersionedData.meta.version !== 'number') {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -899,10 +899,13 @@ export async function loadStateFromPersistence(backup) {
       // existed).
       // We need to set it properly here so that the persistence manager uses
       // the correct storage kind when restoring from the `backup`.
-      if (backup.meta.storageKind === "split" || backup.meta.storageKind === "data") {
+      if (
+        backup.meta.storageKind === 'split' ||
+        backup.meta.storageKind === 'data'
+      ) {
         persistenceManager.storageKind = backup.meta.storageKind;
       } else {
-        persistenceManager.storageKind = "data";
+        persistenceManager.storageKind = 'data';
       }
     }
     // sanity check on the meta property


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Vault Recovery was not working for meta values using the "split" `storageKind`.

Automated tests not added because the test suite for this is disabled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39141?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #39120

## **Manual testing steps**

1. See https://github.com/MetaMask/metamask-extension/issues/39120
<!--
## **Screenshots/Recordings**


### **Before**


### **After**

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures vault recovery restores using the correct persistence storage mode.
> 
> - In `loadStateFromPersistence` (`app/scripts/background.js`), when a `backup` is present, set `persistenceManager.storageKind` from `backup.meta.storageKind` if it is `'split'` or `'data'`, otherwise default to `'data'`, so split-state backups are handled properly and legacy backups remain compatible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4da8c8ae80e2d6aef200ea76b65161b0e41c218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->