### PR TITLE
fix: flaky NFT transfer e2e

### DIFF
--- a/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
@@ -8,6 +8,7 @@ import WatchAssetConfirmation from '../../../page-objects/pages/confirmations/le
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
 import TokenTransferTransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/token-transfer-confirmation';
 import TransactionConfirmation from '../../../page-objects/pages/confirmations/redesign/transaction-confirmation';
+import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import HomePage from '../../../page-objects/pages/home/homepage';
 import NFTListPage from '../../../page-objects/pages/home/nft-list';
 import NFTDetailsPage from '../../../page-objects/pages/nft-details-page';
@@ -17,7 +18,6 @@ import ContractAddressRegistry from '../../../seeder/contract-address-registry';
 import { Driver } from '../../../webdriver/driver';
 import { withTransactionEnvelopeTypeFixtures } from '../helpers';
 import { TestSuiteArguments } from './shared';
-import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 
 const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 

--- a/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
@@ -27,7 +27,7 @@ describe('Confirmation Redesign Token Send', function () {
   this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('ERC721', function () {
     describe('Wallet initiated', function () {
-      it.only('Sends a type 0 transaction (Legacy)', async function () {
+      it('Sends a type 0 transaction (Legacy)', async function () {
         await withTransactionEnvelopeTypeFixtures(
           this.test?.fullTitle(),
           TransactionEnvelopeType.legacy,
@@ -47,7 +47,7 @@ describe('Confirmation Redesign Token Send', function () {
         );
       });
 
-      it.only('Sends a type 2 transaction (EIP1559)', async function () {
+      it('Sends a type 2 transaction (EIP1559)', async function () {
         await withTransactionEnvelopeTypeFixtures(
           this.test?.fullTitle(),
           TransactionEnvelopeType.feeMarket,

--- a/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/nft-token-send-redesign.spec.ts
@@ -17,6 +17,7 @@ import ContractAddressRegistry from '../../../seeder/contract-address-registry';
 import { Driver } from '../../../webdriver/driver';
 import { withTransactionEnvelopeTypeFixtures } from '../helpers';
 import { TestSuiteArguments } from './shared';
+import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 
 const { SMART_CONTRACTS } = require('../../../seeder/smart-contracts');
 
@@ -26,7 +27,7 @@ describe('Confirmation Redesign Token Send', function () {
   this.timeout(200000); // This test is very long, so we need an unusually high timeout
   describe('ERC721', function () {
     describe('Wallet initiated', function () {
-      it('Sends a type 0 transaction (Legacy)', async function () {
+      it.only('Sends a type 0 transaction (Legacy)', async function () {
         await withTransactionEnvelopeTypeFixtures(
           this.test?.fullTitle(),
           TransactionEnvelopeType.legacy,
@@ -46,7 +47,7 @@ describe('Confirmation Redesign Token Send', function () {
         );
       });
 
-      it('Sends a type 2 transaction (EIP1559)', async function () {
+      it.only('Sends a type 2 transaction (EIP1559)', async function () {
         await withTransactionEnvelopeTypeFixtures(
           this.test?.fullTitle(),
           TransactionEnvelopeType.feeMarket,
@@ -258,7 +259,12 @@ async function createERC721WalletInitiatedTransactionAndAssertDetails(
 
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
 
-  await new HomePage(driver).goToNftTab();
+  const homePage = new HomePage(driver);
+  await homePage.goToActivityList();
+  const activityList = new ActivityListPage(driver);
+  await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+
+  await homePage.goToNftTab();
   await new NFTListPage(driver).clickNFTIconOnActivityList();
 
   const nftDetailsPage = new NFTDetailsPage(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix flaky NFT transfer e2e

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the ERC721 wallet-initiated NFT send e2e by waiting for on-chain confirmation before proceeding.
> 
> - In `nft-token-send-redesign.spec.ts`, after mint confirmation, navigate to `Activity` and assert a confirmed tx count (`checkConfirmedTxNumberDisplayedInActivity(1)`) using `ActivityListPage` before switching to the NFT tab
> - Adds `ActivityListPage` import and uses a `HomePage` instance (`goToActivityList`, then `goToNftTab`) to reduce flakiness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f931d2d721f61aad1ac84101793e1d87fb13f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->