### PR TITLE
feat: hardware wallet state manager

### DIFF
--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
@@ -148,6 +148,17 @@ describe('HardwareWalletStateManager', () => {
       );
     });
 
+    it('initializes previousWalletTypeRef to null', () => {
+      const store = mockStore(createMockState(KeyringTypes.ledger));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      // previousWalletTypeRef should start as null since there's no previous value
+      expect(result.current.refs.previousWalletTypeRef.current).toBe(null);
+    });
+
     it('returns null walletType for unknown keyring types', () => {
       const store = mockStore(createMockState('unknown-keyring'));
 

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { useHardwareWalletStateManager } from './HardwareWalletStateManager';
+import { HardwareWalletType, HardwareConnectionPermissionState } from './types';
+
+const mockStore = configureStore([]);
+
+const createMockState = (
+  keyringType: string | null = null,
+  address = '0x123',
+) => ({
+  metamask: {
+    internalAccounts: {
+      accounts: {
+        'account-1': {
+          id: 'account-1',
+          address,
+          metadata: {
+            keyring: {
+              type: keyringType,
+            },
+          },
+        },
+      },
+      selectedAccount: 'account-1',
+    },
+  },
+});
+
+const createWrapper =
+  (store: ReturnType<typeof mockStore>) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+describe('HardwareWalletStateManager', () => {
+  describe('useHardwareWalletStateManager', () => {
+    it('initializes with correct default state for non-hardware wallet account', () => {
+      const store = mockStore(createMockState(KeyringTypes.hd));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.state).toEqual({
+        deviceId: null,
+        hardwareConnectionPermissionState:
+          HardwareConnectionPermissionState.Unknown,
+        currentAppName: null,
+        connectionState: {
+          status: 'disconnected',
+        },
+        walletType: null,
+        isHardwareWalletAccount: false,
+        accountAddress: '0x123',
+      });
+    });
+
+    it('initializes with correct state for Ledger account', () => {
+      const store = mockStore(createMockState(KeyringTypes.ledger));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.state.walletType).toBe(HardwareWalletType.Ledger);
+      expect(result.current.state.isHardwareWalletAccount).toBe(true);
+    });
+
+    it('initializes with correct state for Trezor account', () => {
+      const store = mockStore(createMockState(KeyringTypes.trezor));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.state.walletType).toBe(HardwareWalletType.Trezor);
+      expect(result.current.state.isHardwareWalletAccount).toBe(true);
+    });
+
+    it('provides state setters', () => {
+      const store = mockStore(createMockState(KeyringTypes.hd));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(typeof result.current.setters.setDeviceId).toBe('function');
+      expect(
+        typeof result.current.setters.setHardwareConnectionPermissionState,
+      ).toBe('function');
+      expect(typeof result.current.setters.setCurrentAppName).toBe('function');
+      expect(typeof result.current.setters.setConnectionState).toBe('function');
+    });
+
+    it('provides all required refs', () => {
+      const store = mockStore(createMockState(KeyringTypes.hd));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      const { refs } = result.current;
+
+      expect(refs.adapterRef).toEqual({ current: null });
+      expect(refs.abortControllerRef).toEqual({ current: null });
+      expect(refs.isConnectingRef).toEqual({ current: false });
+      expect(refs.hasAutoConnectedRef).toEqual({ current: false });
+      expect(refs.lastConnectedAccountRef).toEqual({ current: null });
+      expect(refs.currentConnectionIdRef).toEqual({ current: null });
+      expect(refs.connectRef).toEqual({ current: null });
+      expect(refs.deviceIdRef).toEqual({ current: null });
+      expect(refs.walletTypeRef).toEqual({ current: null });
+      expect(refs.previousWalletTypeRef).toEqual({ current: null });
+    });
+
+    it('syncs deviceId with deviceIdRef', () => {
+      const store = mockStore(createMockState(KeyringTypes.ledger));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      // Initially null
+      expect(result.current.refs.deviceIdRef.current).toBe(null);
+
+      // Update deviceId
+      act(() => {
+        result.current.setters.setDeviceId('test-device-123');
+      });
+
+      // Ref should be updated
+      expect(result.current.refs.deviceIdRef.current).toBe('test-device-123');
+    });
+
+    it('syncs walletType with walletTypeRef', () => {
+      const store = mockStore(createMockState(KeyringTypes.ledger));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.refs.walletTypeRef.current).toBe(
+        HardwareWalletType.Ledger,
+      );
+    });
+
+    it('returns null walletType for unknown keyring types', () => {
+      const store = mockStore(createMockState('unknown-keyring'));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.state.walletType).toBe(null);
+      expect(result.current.state.isHardwareWalletAccount).toBe(false);
+    });
+
+    it('handles account with no keyring type', () => {
+      const store = mockStore(createMockState(null));
+
+      const { result } = renderHook(() => useHardwareWalletStateManager(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(result.current.state.walletType).toBe(null);
+      expect(result.current.state.isHardwareWalletAccount).toBe(false);
+    });
+  });
+});

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.test.tsx
@@ -49,7 +49,6 @@ describe('HardwareWalletStateManager', () => {
         deviceId: null,
         hardwareConnectionPermissionState:
           HardwareConnectionPermissionState.Unknown,
-        currentAppName: null,
         connectionState: {
           status: 'disconnected',
         },
@@ -92,7 +91,6 @@ describe('HardwareWalletStateManager', () => {
       expect(
         typeof result.current.setters.setHardwareConnectionPermissionState,
       ).toBe('function');
-      expect(typeof result.current.setters.setCurrentAppName).toBe('function');
       expect(typeof result.current.setters.setConnectionState).toBe('function');
     });
 

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -1,0 +1,181 @@
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import {
+  HardwareConnectionPermissionState,
+  HardwareWalletType,
+  type HardwareWalletAdapter,
+  type HardwareWalletConnectionState,
+} from './types';
+import { ConnectionState } from './connectionState';
+import { getMaybeSelectedInternalAccount } from '../../selectors';
+
+/**
+ * State and refs managed by the hardware wallet context
+ */
+export type HardwareWalletState = {
+  // Basic state
+  deviceId: string | null;
+  hardwareConnectionPermissionState: HardwareConnectionPermissionState;
+  currentAppName: string | null;
+  connectionState: HardwareWalletConnectionState;
+
+  // Derived state
+  walletType: HardwareWalletType | null;
+  isHardwareWalletAccount: boolean;
+  accountAddress: string | null;
+};
+
+/**
+ * Refs used for managing async operations and state
+ */
+export type HardwareWalletRefs = {
+  adapterRef: React.MutableRefObject<HardwareWalletAdapter | null>;
+  abortControllerRef: React.MutableRefObject<AbortController | null>;
+  isConnectingRef: React.MutableRefObject<boolean>;
+  hasAutoConnectedRef: React.MutableRefObject<boolean>;
+  lastConnectedAccountRef: React.MutableRefObject<string | null>;
+  currentConnectionIdRef: React.MutableRefObject<number | null>;
+  connectRef: React.MutableRefObject<(() => Promise<void>) | null>;
+  deviceIdRef: React.MutableRefObject<string | null>;
+  walletTypeRef: React.MutableRefObject<HardwareWalletType | null>;
+  previousWalletTypeRef: React.MutableRefObject<HardwareWalletType | null>;
+};
+
+/**
+ * Hook that manages all hardware wallet state and refs
+ */
+export const useHardwareWalletStateManager = () => {
+  const accountInfo = useSelector(selectAccountHardwareInfo, shallowEqual);
+
+  const walletType = useMemo(
+    () => keyringTypeToHardwareWalletType(accountInfo.keyringType),
+    [accountInfo.keyringType],
+  );
+
+  const isHardwareWalletAccount = useMemo(
+    () => walletType !== null,
+    [walletType],
+  );
+
+  const accountAddress = accountInfo.address;
+
+  // State declarations
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const [
+    hardwareConnectionPermissionState,
+    setHardwareConnectionPermissionState,
+  ] = useState<HardwareConnectionPermissionState>(
+    HardwareConnectionPermissionState.Unknown,
+  );
+  const [currentAppName, setCurrentAppName] = useState<string | null>(null);
+  const [connectionState, setConnectionState] =
+    useState<HardwareWalletConnectionState>(ConnectionState.disconnected());
+
+  // Ref declarations
+  const adapterRef = useRef<HardwareWalletAdapter | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isConnectingRef = useRef(false);
+  const hasAutoConnectedRef = useRef(false);
+  const lastConnectedAccountRef = useRef<string | null>(null);
+  const currentConnectionIdRef = useRef<number | null>(null);
+  const connectRef = useRef<(() => Promise<void>) | null>(null);
+  const deviceIdRef = useRef<string | null>(null);
+  const walletTypeRef = useRef<HardwareWalletType | null>(null);
+  const previousWalletTypeRef = useRef<HardwareWalletType | null>(null);
+
+  // Sync deviceId with deviceIdRef
+  useEffect(() => {
+    deviceIdRef.current = deviceId;
+  }, [deviceId]);
+
+  // Sync walletType with walletTypeRef
+  useEffect(() => {
+    walletTypeRef.current = walletType;
+  }, [walletType]);
+
+  const state: HardwareWalletState = {
+    deviceId,
+    hardwareConnectionPermissionState,
+    currentAppName,
+    connectionState,
+    walletType,
+    isHardwareWalletAccount,
+    accountAddress,
+  };
+
+  const refs = useMemo<HardwareWalletRefs>(
+    () => ({
+      adapterRef,
+      abortControllerRef,
+      isConnectingRef,
+      hasAutoConnectedRef,
+      lastConnectedAccountRef,
+      currentConnectionIdRef,
+      connectRef,
+      deviceIdRef,
+      walletTypeRef,
+      previousWalletTypeRef,
+    }),
+    [],
+  );
+
+  const setters = useMemo(
+    () => ({
+      setDeviceId,
+      setHardwareConnectionPermissionState,
+      setCurrentAppName,
+      setConnectionState,
+    }),
+    [
+      setDeviceId,
+      setHardwareConnectionPermissionState,
+      setCurrentAppName,
+      setConnectionState,
+    ],
+  );
+
+  return {
+    state,
+    refs,
+    setters,
+  };
+};
+
+/**
+ * Selector that extracts only the account data we need for hardware wallet detection.
+ * This prevents re-renders when other account properties change.
+ *
+ * @param state - Redux state object
+ * @returns Account hardware info with keyring type and address
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function selectAccountHardwareInfo(state: any) {
+  const account = getMaybeSelectedInternalAccount(state);
+  return {
+    keyringType: account?.metadata?.keyring?.type ?? null,
+    address: account?.address ?? null,
+  };
+}
+
+/**
+ * Utility function to convert keyring type to hardware wallet type
+ *
+ * @param keyringType
+ */
+function keyringTypeToHardwareWalletType(
+  keyringType?: string | null,
+): HardwareWalletType | null {
+  if (!keyringType) {
+    return null;
+  }
+
+  switch (keyringType) {
+    case KeyringTypes.ledger:
+      return HardwareWalletType.Ledger;
+    case KeyringTypes.trezor:
+      return HardwareWalletType.Trezor;
+    default:
+      return null;
+  }
+}

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -94,6 +94,7 @@ export const useHardwareWalletStateManager = () => {
 
   // Sync walletType with walletTypeRef
   useEffect(() => {
+    // Keep the previous reference so we know when to reset event subscriptions (e.g Trezor -> Ledger).
     previousWalletTypeRef.current = walletTypeRef.current;
     walletTypeRef.current = walletType;
   }, [walletType]);

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -91,6 +91,7 @@ export const useHardwareWalletStateManager = () => {
 
   // Sync walletType with walletTypeRef
   useEffect(() => {
+    previousWalletTypeRef.current = walletTypeRef.current;
     walletTypeRef.current = walletType;
   }, [walletType]);
 

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -20,7 +20,6 @@ export type HardwareWalletState = {
   // Basic state
   deviceId: string | null;
   hardwareConnectionPermissionState: HardwareConnectionPermissionState;
-  currentAppName: string | null;
   connectionState: HardwareWalletConnectionState;
 
   // Derived state
@@ -71,7 +70,6 @@ export const useHardwareWalletStateManager = () => {
   ] = useState<HardwareConnectionPermissionState>(
     HardwareConnectionPermissionState.Unknown,
   );
-  const [currentAppName, setCurrentAppName] = useState<string | null>(null);
   const [connectionState, setConnectionState] =
     useState<HardwareWalletConnectionState>(ConnectionState.disconnected());
 
@@ -102,7 +100,6 @@ export const useHardwareWalletStateManager = () => {
   const state: HardwareWalletState = {
     deviceId,
     hardwareConnectionPermissionState,
-    currentAppName,
     connectionState,
     walletType,
     isHardwareWalletAccount,
@@ -129,15 +126,9 @@ export const useHardwareWalletStateManager = () => {
     () => ({
       setDeviceId,
       setHardwareConnectionPermissionState,
-      setCurrentAppName,
       setConnectionState,
     }),
-    [
-      setDeviceId,
-      setHardwareConnectionPermissionState,
-      setCurrentAppName,
-      setConnectionState,
-    ],
+    [setDeviceId, setHardwareConnectionPermissionState, setConnectionState],
   );
 
   return {

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -48,7 +48,7 @@ export type HardwareWalletRefs = {
  * Hook that manages all hardware wallet state and refs
  */
 export const useHardwareWalletStateManager = () => {
-  const accountInfo = useSelector(selectAccountHardwareInfo, shallowEqual);
+  const accountInfo = useSelector(getAccountHardwareInfo, shallowEqual);
 
   const walletType = useMemo(
     () => keyringTypeToHardwareWalletType(accountInfo.keyringType),
@@ -145,7 +145,7 @@ export const useHardwareWalletStateManager = () => {
  * @param state - Redux state object
  * @returns Account hardware info with keyring type and address
  */
-function selectAccountHardwareInfo(state: AccountsState) {
+function getAccountHardwareInfo(state: AccountsState) {
   const account = getMaybeSelectedInternalAccount(state);
   return {
     keyringType: account?.metadata?.keyring?.type ?? null,

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { getMaybeSelectedInternalAccount } from '../../selectors';
 import {
   HardwareConnectionPermissionState,
   HardwareWalletType,
@@ -8,7 +9,6 @@ import {
   type HardwareWalletConnectionState,
 } from './types';
 import { ConnectionState } from './connectionState';
-import { getMaybeSelectedInternalAccount } from '../../selectors';
 
 /**
  * State and refs managed by the hardware wallet context
@@ -175,6 +175,12 @@ function keyringTypeToHardwareWalletType(
       return HardwareWalletType.Ledger;
     case KeyringTypes.trezor:
       return HardwareWalletType.Trezor;
+    case KeyringTypes.oneKey:
+      return HardwareWalletType.OneKey;
+    case KeyringTypes.lattice:
+      return HardwareWalletType.Lattice;
+    case KeyringTypes.qr:
+      return HardwareWalletType.Qr;
     default:
       return null;
   }

--- a/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletStateManager.tsx
@@ -1,7 +1,10 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import { getMaybeSelectedInternalAccount } from '../../selectors';
+import {
+  AccountsState,
+  getMaybeSelectedInternalAccount,
+} from '../../selectors';
 import {
   HardwareConnectionPermissionState,
   HardwareWalletType,
@@ -150,8 +153,7 @@ export const useHardwareWalletStateManager = () => {
  * @param state - Redux state object
  * @returns Account hardware info with keyring type and address
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function selectAccountHardwareInfo(state: any) {
+function selectAccountHardwareInfo(state: AccountsState) {
   const account = getMaybeSelectedInternalAccount(state);
   return {
     keyringType: account?.metadata?.keyring?.type ?? null,

--- a/ui/contexts/hardware-wallets/connectionState.ts
+++ b/ui/contexts/hardware-wallets/connectionState.ts
@@ -1,0 +1,42 @@
+import { ConnectionStatus, type HardwareWalletConnectionState } from './types';
+
+/**
+ * Factory functions for creating connection state objects
+ * These ensure type-safe state transitions
+ */
+export const ConnectionState = {
+  disconnected: (): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.Disconnected,
+  }),
+
+  connecting: (): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.Connecting,
+  }),
+
+  connected: (): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.Connected,
+  }),
+
+  ready: (): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.Ready,
+  }),
+
+  awaitingConfirmation: (): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.AwaitingConfirmation,
+  }),
+
+  awaitingApp: (
+    reason: string,
+    appName?: string,
+  ): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.AwaitingApp,
+    reason,
+    appName,
+  }),
+
+  error: (reason: string, error: Error): HardwareWalletConnectionState => ({
+    status: ConnectionStatus.ErrorState,
+    reason,
+    error,
+  }),
+};

--- a/ui/contexts/hardware-wallets/types.ts
+++ b/ui/contexts/hardware-wallets/types.ts
@@ -86,16 +86,14 @@ export type HardwareWalletAdapter = {
   isConnected(): boolean;
   destroy(): void;
 
-  // Optional methods
-  getCurrentAppName?(): Promise<string>;
   /**
-   * Verify the device is ready for operations
+   * Ensure the device is ready for operations
    * (e.g., Ledger requires the Ethereum app to be open)
    *
    * @returns true if ready
    * @throws {HardwareWalletError} if device is not ready (locked, wrong app, etc.)
    */
-  verifyDeviceReady?(deviceId: string): Promise<boolean>;
+  ensureDeviceReady?(deviceId: string): Promise<boolean>;
 };
 
 /**
@@ -121,7 +119,6 @@ export type HardwareWalletContextType = {
   hardwareConnectionPermissionState: HardwareConnectionPermissionState;
   isWebHidAvailable: boolean;
   isWebUsbAvailable: boolean;
-  currentAppName: string | null;
 
   // Actions
   connect: (type: HardwareWalletType, deviceId: string) => Promise<void>;

--- a/ui/contexts/hardware-wallets/types.ts
+++ b/ui/contexts/hardware-wallets/types.ts
@@ -1,5 +1,5 @@
 /**
- * Enum for hardware wallet types
+ * Hardware wallet types normalized for the hardware wallet context
  */
 export enum HardwareWalletType {
   Ledger = 'ledger',
@@ -10,7 +10,7 @@ export enum HardwareWalletType {
 }
 
 /**
- * Enum for connection status
+ * Hardware wallet connection status
  */
 export enum ConnectionStatus {
   Disconnected = 'disconnected',
@@ -23,7 +23,7 @@ export enum ConnectionStatus {
 }
 
 /**
- * Enum for WebHID/WebUSB permission state
+ * Hardware wallet connection permission state
  */
 export enum HardwareConnectionPermissionState {
   Unknown = 'unknown',
@@ -33,7 +33,7 @@ export enum HardwareConnectionPermissionState {
 }
 
 /**
- * Enum for device events
+ * Hardware wallet device events
  */
 export enum DeviceEvent {
   Disconnected = 'disconnected',
@@ -45,7 +45,7 @@ export enum DeviceEvent {
 }
 
 /**
- * Connection state type (discriminated union)
+ * Hardware wallet connection State
  */
 export type HardwareWalletConnectionState =
   | { status: ConnectionStatus.Disconnected }
@@ -87,7 +87,6 @@ export type HardwareWalletAdapter = {
   destroy(): void;
 
   // Optional methods
-  setPendingOperation?(pending: boolean): void;
   getCurrentAppName?(): Promise<string>;
   /**
    * Verify the device is ready for operations

--- a/ui/contexts/hardware-wallets/types.ts
+++ b/ui/contexts/hardware-wallets/types.ts
@@ -1,0 +1,139 @@
+/**
+ * Enum for hardware wallet types
+ */
+export enum HardwareWalletType {
+  Ledger = 'ledger',
+  Trezor = 'trezor',
+  OneKey = 'oneKey',
+  Lattice = 'lattice',
+  Qr = 'qr',
+}
+
+/**
+ * Enum for connection status
+ */
+export enum ConnectionStatus {
+  Disconnected = 'disconnected',
+  Connecting = 'connecting',
+  Connected = 'connected',
+  Ready = 'ready',
+  AwaitingConfirmation = 'awaiting_confirmation',
+  AwaitingApp = 'awaiting_app',
+  ErrorState = 'error',
+}
+
+/**
+ * Enum for WebHID/WebUSB permission state
+ */
+export enum HardwareConnectionPermissionState {
+  Unknown = 'unknown',
+  Granted = 'granted',
+  Prompt = 'prompt',
+  Denied = 'denied',
+}
+
+/**
+ * Enum for device events
+ */
+export enum DeviceEvent {
+  Disconnected = 'disconnected',
+  DeviceLocked = 'device_locked',
+  AppNotOpen = 'app_not_open',
+  AppChanged = 'app_changed',
+  ConnectionFailed = 'connection_failed',
+  OperationTimeout = 'operation_timeout',
+}
+
+/**
+ * Connection state type (discriminated union)
+ */
+export type HardwareWalletConnectionState =
+  | { status: ConnectionStatus.Disconnected }
+  | { status: ConnectionStatus.Connecting }
+  | { status: ConnectionStatus.Connected }
+  | { status: ConnectionStatus.Ready }
+  | { status: ConnectionStatus.AwaitingConfirmation }
+  | { status: ConnectionStatus.AwaitingApp; reason: string; appName?: string }
+  | { status: ConnectionStatus.ErrorState; reason: string; error: Error };
+
+/**
+ * Device event payload
+ */
+export type DeviceEventPayload = {
+  event: DeviceEvent;
+  error?: Error;
+  currentAppName?: string;
+  previousAppName?: string;
+  deviceName?: string;
+};
+
+/**
+ * Unsubscribe function type
+ */
+export type Unsubscribe = () => void;
+
+/**
+ * Adapter interface
+ *
+ * Note: This adapter manages connection state only.
+ * Actual signing operations flow through the existing MetaMask infrastructure
+ * (TransactionController, SignatureController, etc.) which already use the
+ * KeyringController's hardware wallet keyrings.
+ */
+export type HardwareWalletAdapter = {
+  connect(deviceId: string): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+  destroy(): void;
+
+  // Optional methods
+  setPendingOperation?(pending: boolean): void;
+  getCurrentAppName?(): Promise<string>;
+  /**
+   * Verify the device is ready for operations
+   * (e.g., Ledger requires the Ethereum app to be open)
+   *
+   * @returns true if ready
+   * @throws {HardwareWalletError} if device is not ready (locked, wrong app, etc.)
+   */
+  verifyDeviceReady?(deviceId: string): Promise<boolean>;
+};
+
+/**
+ * Adapter options (callbacks)
+ */
+export type HardwareWalletAdapterOptions = {
+  onDisconnect: (error?: unknown) => void;
+  onAwaitingConfirmation: () => void;
+  onDeviceLocked: () => void;
+  onAppNotOpen: () => void;
+  onDeviceEvent: (payload: DeviceEventPayload) => void;
+};
+
+/**
+ * Context type
+ */
+export type HardwareWalletContextType = {
+  // State
+  isHardwareWalletAccount: boolean;
+  walletType: HardwareWalletType | null;
+  connectionState: HardwareWalletConnectionState;
+  deviceId: string | null;
+  hardwareConnectionPermissionState: HardwareConnectionPermissionState;
+  isWebHidAvailable: boolean;
+  isWebUsbAvailable: boolean;
+  currentAppName: string | null;
+
+  // Actions
+  connect: (type: HardwareWalletType, deviceId: string) => Promise<void>;
+  disconnect: () => Promise<void>;
+  clearError: () => void;
+  retry: () => Promise<void>;
+  checkHardwareWalletPermission: (
+    walletType: HardwareWalletType,
+  ) => Promise<HardwareConnectionPermissionState>;
+  requestHardwareWalletPermission: (
+    walletType: HardwareWalletType,
+  ) => Promise<boolean>;
+  ensureDeviceReady: () => Promise<boolean>;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is the first of 8 prs to introduce hardware wallet state management system for handling hardware wallet connections in MetaMask. It manages the connection lifecycle, permission handling, error states, and provides a clean interface for UI components to interact with hardware wallets.

This PR adds a new state manager that will be responsible for providing the hardware device state.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39158?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/MUL-1299?atlOrigin=eyJpIjoiZWZlYjE4M2NiOWVmNDk0N2I3MzA4MzMzZTg2M2U1YzYiLCJwIjoiaiJ9
 
## **Manual testing steps**

Not testable, this pr only introduces 

## **Screenshots/Recordings**

N/a. Not testable because it is not wired up. 

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes the foundation for hardware wallet state management.
> 
> - Adds `useHardwareWalletStateManager` hook to derive `walletType` from keyring, expose `state` (`deviceId`, `hardwareConnectionPermissionState`, `connectionState`, `isHardwareWalletAccount`, `accountAddress`), stable `refs` (e.g., `deviceIdRef`, `walletTypeRef`, `previousWalletTypeRef`), and `setters`.
> - Introduces `ConnectionState` factory for typed connection statuses (`disconnected`, `connecting`, `connected`, `ready`, `awaitingConfirmation`, `awaitingApp`, `error`).
> - Defines enums/types/interfaces in `types.ts` (wallet types, connection states, permission states, device events, `HardwareWalletAdapter` and options, context shape).
> - Adds unit tests covering initialization for various keyring types, presence of refs and setters, ref syncing, and handling of unknown/missing keyring types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fff66574a7645f892be3a747294af554e31fa4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->