### PR TITLE
feat: add transaction pay hooks

### DIFF
--- a/app/scripts/controller-init/transaction-pay-controller-init.ts
+++ b/app/scripts/controller-init/transaction-pay-controller-init.ts
@@ -4,7 +4,7 @@ import {
   TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import type { ControllerInitFunction } from './types';
+import type { ControllerInitFunction, ControllerInitResult } from './types';
 import type { TransactionPayControllerInitMessenger } from './messengers';
 
 export const TransactionPayControllerInit: ControllerInitFunction<
@@ -23,8 +23,19 @@ export const TransactionPayControllerInit: ControllerInitFunction<
     state: persistedState.TransactionPayController,
   });
 
-  return { controller };
+  const api = getApi(controller);
+
+  return { controller, api };
 };
+
+function getApi(
+  controller: TransactionPayController,
+): ControllerInitResult<TransactionPayController>['api'] {
+  return {
+    updateTransactionPaymentToken:
+      controller.updatePaymentToken.bind(controller),
+  };
+}
 
 function getStrategy(_transaction: TransactionMeta): TransactionPayStrategy {
   return TransactionPayStrategy.Relay;

--- a/ui/pages/confirmations/hooks/pay/types.ts
+++ b/ui/pages/confirmations/hooks/pay/types.ts
@@ -1,0 +1,16 @@
+import type { Hex } from '@metamask/utils';
+import { Asset } from '../../types/send';
+
+export type TransactionPayAsset = Asset & {
+  disabled?: boolean;
+  disabledMessage?: string;
+  isSelected?: boolean;
+};
+
+export interface SetPayTokenRequest {
+  address: Hex;
+  chainId: Hex;
+}
+
+export const NATIVE_TOKEN_ADDRESS =
+  '0x0000000000000000000000000000000000000000' as Hex;

--- a/ui/pages/confirmations/hooks/pay/types.ts
+++ b/ui/pages/confirmations/hooks/pay/types.ts
@@ -7,10 +7,10 @@ export type TransactionPayAsset = Asset & {
   isSelected?: boolean;
 };
 
-export interface SetPayTokenRequest {
+export type SetPayTokenRequest = {
   address: Hex;
   chainId: Hex;
-}
+};
 
 export const NATIVE_TOKEN_ADDRESS =
   '0x0000000000000000000000000000000000000000' as Hex;

--- a/ui/pages/confirmations/hooks/pay/types.ts
+++ b/ui/pages/confirmations/hooks/pay/types.ts
@@ -11,6 +11,3 @@ export type SetPayTokenRequest = {
   address: Hex;
   chainId: Hex;
 };
-
-export const NATIVE_TOKEN_ADDRESS =
-  '0x0000000000000000000000000000000000000000' as Hex;

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -1,0 +1,232 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import React from 'react';
+import type { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
+import type { Hex } from '@metamask/utils';
+import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { ConfirmContext } from '../../context/confirm';
+import type { TransactionPayAsset, SetPayTokenRequest } from './types';
+
+jest.mock('./useTransactionPayToken');
+jest.mock('./useTransactionPayData');
+jest.mock('./useTransactionPayAvailableTokens');
+jest.mock('../../../../selectors', () => ({
+  getHardwareWalletType: jest.fn(() => null),
+}));
+
+const TOKEN_ADDRESS_1_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const TOKEN_ADDRESS_2_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const TOKEN_ADDRESS_3_MOCK = '0xabc1234567890abcdef1234567890abcdef12345678';
+const PREFERRED_TOKEN_ADDRESS_MOCK =
+  '0x9999999999999999999999999999999999999999';
+const CHAIN_ID_1_MOCK = '0x1';
+const CHAIN_ID_2_MOCK = '0x2';
+const PREFERRED_CHAIN_ID_MOCK = '0x3';
+const TRANSACTION_ID_MOCK = 'transaction-id-mock';
+
+const mockStore = configureStore([]);
+
+const STATE_MOCK = {
+  metamask: {
+    TransactionPayController: {
+      transactionData: {},
+    },
+  },
+};
+
+function renderHookWithProvider({
+  disable = false,
+  preferredToken,
+}: {
+  disable?: boolean;
+  preferredToken?: SetPayTokenRequest;
+} = {}) {
+  const store = mockStore(STATE_MOCK);
+
+  const confirmContextValue = {
+    currentConfirmation: {
+      id: TRANSACTION_ID_MOCK,
+      txParams: { from: '0x123' },
+    },
+    isScrollToBottomCompleted: true,
+    setIsScrollToBottomCompleted: jest.fn(),
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <ConfirmContext.Provider value={confirmContextValue as never}>
+        {children}
+      </ConfirmContext.Provider>
+    </Provider>
+  );
+
+  return renderHook(
+    () => useAutomaticTransactionPayToken({ disable, preferredToken }),
+    { wrapper },
+  );
+}
+
+describe('useAutomaticTransactionPayToken', () => {
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+
+  const setPayTokenMock = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: setPayTokenMock,
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK as Hex,
+        chainId: CHAIN_ID_1_MOCK as Hex,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue([]);
+  });
+
+  it('selects first token', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+      {
+        address: TOKEN_ADDRESS_3_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as TransactionPayAsset[]);
+
+    renderHookWithProvider();
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_2_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
+    });
+  });
+
+  it('selects target token if no tokens with balance', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue(
+      [] as TransactionPayAsset[],
+    );
+
+    renderHookWithProvider();
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_1_MOCK,
+      chainId: CHAIN_ID_1_MOCK,
+    });
+  });
+
+  it('does nothing if no required tokens', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([]);
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+    renderHookWithProvider();
+
+    expect(setPayTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if disabled', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as TransactionPayAsset[]);
+
+    renderHookWithProvider({ disable: true });
+
+    expect(setPayTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('selects preferred payment token when provided with available tokens', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+      {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK,
+        chainId: PREFERRED_CHAIN_ID_MOCK,
+      },
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+    ] as TransactionPayAsset[]);
+
+    renderHookWithProvider({
+      preferredToken: {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK as Hex,
+        chainId: PREFERRED_CHAIN_ID_MOCK as Hex,
+      },
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: PREFERRED_TOKEN_ADDRESS_MOCK,
+      chainId: PREFERRED_CHAIN_ID_MOCK,
+    });
+  });
+
+  it('selects target token when preferred payment token provided but no tokens available', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue(
+      [] as TransactionPayAsset[],
+    );
+
+    renderHookWithProvider({
+      preferredToken: {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK as Hex,
+        chainId: PREFERRED_CHAIN_ID_MOCK as Hex,
+      },
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_1_MOCK,
+      chainId: CHAIN_ID_1_MOCK,
+    });
+  });
+
+  it('selects first available token when preferred token not in available tokens', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      },
+    ] as TransactionPayAsset[]);
+
+    renderHookWithProvider({
+      preferredToken: {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK as Hex,
+        chainId: PREFERRED_CHAIN_ID_MOCK as Hex,
+      },
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_1_MOCK,
+      chainId: CHAIN_ID_1_MOCK,
+    });
+  });
+});

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -4,11 +4,11 @@ import configureStore from 'redux-mock-store';
 import React from 'react';
 import type { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
+import { ConfirmContext } from '../../context/confirm';
 import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import { ConfirmContext } from '../../context/confirm';
 import type { TransactionPayAsset, SetPayTokenRequest } from './types';
 
 jest.mock('./useTransactionPayToken');

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { useConfirmContext } from '../../context/confirm';
+import { getHardwareWalletType } from '../../../../selectors';
+import type { TransactionPayAsset, SetPayTokenRequest } from './types';
+
+export function useAutomaticTransactionPayToken({
+  disable = false,
+  preferredToken,
+}: {
+  disable?: boolean;
+  preferredToken?: SetPayTokenRequest;
+} = {}) {
+  const isUpdated = useRef(false);
+  const { setPayToken } = useTransactionPayToken();
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const tokens = useTransactionPayAvailableTokens();
+
+  const tokensWithBalance = useMemo(
+    () => tokens.filter((t) => !t.disabled),
+    [tokens],
+  );
+
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+
+  const {
+    txParams: { from },
+  } = transactionMeta ?? { txParams: {} };
+
+  const hardwareWalletType = useSelector(getHardwareWalletType);
+  const isHardwareWallet = useMemo(
+    () => Boolean(hardwareWalletType),
+    [hardwareWalletType],
+  );
+
+  const targetToken = useMemo(
+    () => requiredTokens.find((token) => !token.allowUnderMinimum),
+    [requiredTokens],
+  );
+
+  useEffect(() => {
+    if (disable || isUpdated.current) {
+      return;
+    }
+
+    const automaticToken = getBestToken({
+      isHardwareWallet,
+      targetToken,
+      tokens: tokensWithBalance,
+      preferredToken,
+    });
+
+    if (!automaticToken) {
+      return;
+    }
+
+    setPayToken({
+      address: automaticToken.address,
+      chainId: automaticToken.chainId,
+    });
+
+    isUpdated.current = true;
+  }, [
+    disable,
+    isHardwareWallet,
+    preferredToken,
+    requiredTokens,
+    setPayToken,
+    targetToken,
+    tokensWithBalance,
+  ]);
+}
+
+function getBestToken({
+  isHardwareWallet,
+  preferredToken,
+  targetToken,
+  tokens,
+}: {
+  isHardwareWallet: boolean;
+  preferredToken?: SetPayTokenRequest;
+  targetToken?: { address: Hex; chainId: Hex };
+  tokens: TransactionPayAsset[];
+}): { address: Hex; chainId: Hex } | undefined {
+  const targetTokenFallback = targetToken
+    ? {
+        address: targetToken.address,
+        chainId: targetToken.chainId,
+      }
+    : undefined;
+
+  if (isHardwareWallet) {
+    return targetTokenFallback;
+  }
+
+  if (preferredToken) {
+    const preferredTokenAvailable = tokens.some(
+      (token) =>
+        token.address?.toLowerCase() === preferredToken.address.toLowerCase() &&
+        String(token.chainId)?.toLowerCase() ===
+          preferredToken.chainId.toLowerCase(),
+    );
+
+    if (preferredTokenAvailable) {
+      return preferredToken;
+    }
+  }
+
+  if (tokens?.length) {
+    return {
+      address: tokens[0].address as Hex,
+      chainId: tokens[0].chainId as Hex,
+    };
+  }
+
+  return targetTokenFallback;
+}
+

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import { getHardwareWalletType } from '../../../../selectors';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import { useConfirmContext } from '../../context/confirm';
-import { getHardwareWalletType } from '../../../../selectors';
 import type { TransactionPayAsset, SetPayTokenRequest } from './types';
 
 export function useAutomaticTransactionPayToken({
@@ -25,13 +23,6 @@ export function useAutomaticTransactionPayToken({
     () => tokens.filter((t) => !t.disabled),
     [tokens],
   );
-
-  const { currentConfirmation: transactionMeta } =
-    useConfirmContext<TransactionMeta>();
-
-  const {
-    txParams: { from },
-  } = transactionMeta ?? { txParams: {} };
 
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const isHardwareWallet = useMemo(
@@ -121,4 +112,3 @@ function getBestToken({
 
   return targetTokenFallback;
 }
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import * as transactionPayUtils from '../../utils/transaction-pay';
+import { useSendTokens } from '../send/useSendTokens';
+import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from './types';
+import { Asset, AssetStandard } from '../../types/send';
+
+jest.mock('../send/useSendTokens');
+jest.mock('../../utils/transaction-pay', () => ({
+  ...jest.requireActual('../../utils/transaction-pay'),
+  getAvailableTokens: jest.fn(),
+}));
+
+const SEND_TOKEN_MOCK: Asset = {
+  accountType: 'eip155:eoa',
+  address: NATIVE_TOKEN_ADDRESS,
+  balance: '1.23',
+  chainId: '0x123',
+  decimals: 18,
+  name: 'Native Token 1',
+  symbol: 'NTV1',
+  standard: AssetStandard.ERC20,
+  fiat: { balance: 1.23 },
+};
+
+const TOKEN_MOCK: TransactionPayAsset = {
+  ...SEND_TOKEN_MOCK,
+  disabled: false,
+  isSelected: false,
+};
+
+describe('useTransactionPayAvailableTokens', () => {
+  const useSendTokensMock = jest.mocked(useSendTokens);
+  const getAvailableTokensMock = jest.mocked(
+    transactionPayUtils.getAvailableTokens,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useSendTokensMock.mockReturnValue([SEND_TOKEN_MOCK]);
+    getAvailableTokensMock.mockReturnValue([TOKEN_MOCK]);
+  });
+
+  it('returns available tokens', () => {
+    const { result } = renderHook(() => useTransactionPayAvailableTokens());
+
+    expect(result.current).toMatchObject([TOKEN_MOCK]);
+  });
+
+  it('calls getAvailableTokens with tokens from useSendTokens', () => {
+    renderHook(() => useTransactionPayAvailableTokens());
+
+    expect(getAvailableTokensMock).toHaveBeenCalledWith({
+      tokens: expect.arrayContaining([
+        expect.objectContaining({
+          address: NATIVE_TOKEN_ADDRESS,
+          symbol: 'NTV1',
+          chainId: '0x123',
+        }),
+      ]),
+    });
+  });
+
+  it('returns empty array when no tokens available', () => {
+    useSendTokensMock.mockReturnValue([]);
+    getAvailableTokensMock.mockReturnValue([]);
+
+    const { result } = renderHook(() => useTransactionPayAvailableTokens());
+
+    expect(result.current).toEqual([]);
+  });
+});
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
@@ -1,8 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import * as transactionPayUtils from '../../utils/transaction-pay';
 import { useSendTokens } from '../send/useSendTokens';
 import { Asset, AssetStandard } from '../../types/send';
-import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from './types';
+import type { TransactionPayAsset } from './types';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 
 jest.mock('../send/useSendTokens');
@@ -10,6 +11,8 @@ jest.mock('../../utils/transaction-pay', () => ({
   ...jest.requireActual('../../utils/transaction-pay'),
   getAvailableTokens: jest.fn(),
 }));
+
+const NATIVE_TOKEN_ADDRESS = getNativeTokenAddress('0x1');
 
 const SEND_TOKEN_MOCK: Asset = {
   accountType: 'eip155:eoa',

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import * as transactionPayUtils from '../../utils/transaction-pay';
 import { useSendTokens } from '../send/useSendTokens';
-import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from './types';
 import { Asset, AssetStandard } from '../../types/send';
+import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from './types';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 
 jest.mock('../send/useSendTokens');
 jest.mock('../../utils/transaction-pay', () => ({
@@ -70,4 +70,3 @@ describe('useTransactionPayAvailableTokens', () => {
     expect(result.current).toEqual([]);
   });
 });
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { getAvailableTokens } from '../../utils/transaction-pay';
+import { useSendTokens } from '../send/useSendTokens';
+
+export function useTransactionPayAvailableTokens() {
+  const tokens = useSendTokens();
+
+  const availableTokens = useMemo(
+    () =>
+      getAvailableTokens({
+        tokens,
+      }),
+    [tokens],
+  );
+
+  return availableTokens;
+}

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import React from 'react';
+import {
+  TransactionPayStrategy,
+  TransactionPayQuote,
+  TransactionPayTotals,
+  TransactionPayRequiredToken,
+  TransactionPaySourceAmount,
+} from '@metamask/transaction-pay-controller';
+import type { Json } from '@metamask/utils';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
+  useTransactionPaySourceAmounts,
+  useTransactionPayTotals,
+  useTransactionPayIsMaxAmount,
+} from './useTransactionPayData';
+import { ConfirmContext } from '../../context/confirm';
+
+const TRANSACTION_ID_MOCK = 'transaction-id-mock';
+
+const QUOTE_MOCK = {
+  strategy: TransactionPayStrategy.Test,
+} as TransactionPayQuote<Json>;
+
+const REQUIRED_TOKEN_MOCK = {
+  address: '0x123',
+} as unknown as TransactionPayRequiredToken;
+
+const SOURCE_AMOUNT_MOCK = {} as TransactionPaySourceAmount;
+
+const TOTALS_MOCK = {
+  total: { usd: '1000', fiat: '1234' },
+} as unknown as TransactionPayTotals;
+
+const mockStore = configureStore([]);
+
+const STATE_MOCK = {
+  metamask: {
+    TransactionPayController: {
+      transactionData: {
+        [TRANSACTION_ID_MOCK]: {
+          isLoading: true,
+          isMaxAmount: true,
+          quotes: [QUOTE_MOCK],
+          sourceAmounts: [SOURCE_AMOUNT_MOCK],
+          tokens: [REQUIRED_TOKEN_MOCK],
+          totals: TOTALS_MOCK,
+        },
+      },
+    },
+  },
+};
+
+function createWrapper() {
+  const store = mockStore(STATE_MOCK);
+
+  const confirmContextValue = {
+    currentConfirmation: { id: TRANSACTION_ID_MOCK },
+    isScrollToBottomCompleted: true,
+    setIsScrollToBottomCompleted: jest.fn(),
+  };
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <ConfirmContext.Provider value={confirmContextValue as never}>
+        {children}
+      </ConfirmContext.Provider>
+    </Provider>
+  );
+}
+
+describe('useTransactionPayData', () => {
+  describe('useTransactionPayQuotes', () => {
+    it('returns quotes', () => {
+      const { result } = renderHook(() => useTransactionPayQuotes(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toStrictEqual([QUOTE_MOCK]);
+    });
+  });
+
+  describe('useTransactionPayRequiredTokens', () => {
+    it('returns required tokens', () => {
+      const { result } = renderHook(() => useTransactionPayRequiredTokens(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toStrictEqual([REQUIRED_TOKEN_MOCK]);
+    });
+  });
+
+  describe('useTransactionPaySourceAmounts', () => {
+    it('returns source amounts', () => {
+      const { result } = renderHook(() => useTransactionPaySourceAmounts(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toStrictEqual([SOURCE_AMOUNT_MOCK]);
+    });
+  });
+
+  describe('useIsTransactionPayLoading', () => {
+    it('returns loading state', () => {
+      const { result } = renderHook(() => useIsTransactionPayLoading(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('useTransactionPayTotals', () => {
+    it('returns totals', () => {
+      const { result } = renderHook(() => useTransactionPayTotals(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toStrictEqual(TOTALS_MOCK);
+    });
+  });
+
+  describe('useTransactionPayIsMaxAmount', () => {
+    it('returns isMaxAmount', () => {
+      const { result } = renderHook(() => useTransactionPayIsMaxAmount(), {
+        wrapper: createWrapper(),
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+});
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
@@ -10,15 +10,14 @@ import {
   TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
 import type { Json } from '@metamask/utils';
+import { ConfirmContext } from '../../context/confirm';
 import {
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
-  useTransactionPayIsMaxAmount,
 } from './useTransactionPayData';
-import { ConfirmContext } from '../../context/confirm';
 
 const TRANSACTION_ID_MOCK = 'transaction-id-mock';
 
@@ -40,16 +39,13 @@ const mockStore = configureStore([]);
 
 const STATE_MOCK = {
   metamask: {
-    TransactionPayController: {
-      transactionData: {
-        [TRANSACTION_ID_MOCK]: {
-          isLoading: true,
-          isMaxAmount: true,
-          quotes: [QUOTE_MOCK],
-          sourceAmounts: [SOURCE_AMOUNT_MOCK],
-          tokens: [REQUIRED_TOKEN_MOCK],
-          totals: TOTALS_MOCK,
-        },
+    transactionData: {
+      [TRANSACTION_ID_MOCK]: {
+        isLoading: true,
+        quotes: [QUOTE_MOCK],
+        sourceAmounts: [SOURCE_AMOUNT_MOCK],
+        tokens: [REQUIRED_TOKEN_MOCK],
+        totals: TOTALS_MOCK,
       },
     },
   },
@@ -118,14 +114,4 @@ describe('useTransactionPayData', () => {
       expect(result.current).toStrictEqual(TOTALS_MOCK);
     });
   });
-
-  describe('useTransactionPayIsMaxAmount', () => {
-    it('returns isMaxAmount', () => {
-      const { result } = renderHook(() => useTransactionPayIsMaxAmount(), {
-        wrapper: createWrapper(),
-      });
-      expect(result.current).toBe(true);
-    });
-  });
 });
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
@@ -1,0 +1,56 @@
+import { useSelector } from 'react-redux';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
+import {
+  selectIsTransactionPayLoadingByTransactionId,
+  selectTransactionPayIsMaxAmountByTransactionId,
+  selectTransactionPayQuotesByTransactionId,
+  selectTransactionPaySourceAmountsByTransactionId,
+  selectTransactionPayTokensByTransactionId,
+  selectTransactionPayTotalsByTransactionId,
+} from '../../../../selectors/transactionPayController';
+import { useConfirmContext } from '../../context/confirm';
+
+type TransactionPayState = {
+  metamask: {
+    TransactionPayController?: TransactionPayControllerState;
+  };
+};
+
+export function useTransactionPayQuotes() {
+  return useTransactionPayData(selectTransactionPayQuotesByTransactionId);
+}
+
+export function useTransactionPayRequiredTokens() {
+  return useTransactionPayData(selectTransactionPayTokensByTransactionId);
+}
+
+export function useTransactionPaySourceAmounts() {
+  return useTransactionPayData(
+    selectTransactionPaySourceAmountsByTransactionId,
+  );
+}
+
+export function useIsTransactionPayLoading() {
+  return useTransactionPayData(selectIsTransactionPayLoadingByTransactionId);
+}
+
+export function useTransactionPayTotals() {
+  return useTransactionPayData(selectTransactionPayTotalsByTransactionId);
+}
+
+export function useTransactionPayIsMaxAmount() {
+  return useTransactionPayData(selectTransactionPayIsMaxAmountByTransactionId);
+}
+
+function useTransactionPayData<T>(
+  selector: (state: TransactionPayState, transactionId: string) => T,
+) {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const transactionId = currentConfirmation?.id ?? '';
+
+  return useSelector((state: TransactionPayState) =>
+    selector(state, transactionId),
+  );
+}
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
@@ -1,21 +1,14 @@
 import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
 import {
   selectIsTransactionPayLoadingByTransactionId,
-  selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayQuotesByTransactionId,
   selectTransactionPaySourceAmountsByTransactionId,
   selectTransactionPayTokensByTransactionId,
   selectTransactionPayTotalsByTransactionId,
+  TransactionPayState,
 } from '../../../../selectors/transactionPayController';
 import { useConfirmContext } from '../../context/confirm';
-
-type TransactionPayState = {
-  metamask: {
-    TransactionPayController?: TransactionPayControllerState;
-  };
-};
 
 export function useTransactionPayQuotes() {
   return useTransactionPayData(selectTransactionPayQuotesByTransactionId);
@@ -39,12 +32,8 @@ export function useTransactionPayTotals() {
   return useTransactionPayData(selectTransactionPayTotalsByTransactionId);
 }
 
-export function useTransactionPayIsMaxAmount() {
-  return useTransactionPayData(selectTransactionPayIsMaxAmountByTransactionId);
-}
-
-function useTransactionPayData<T>(
-  selector: (state: TransactionPayState, transactionId: string) => T,
+function useTransactionPayData<ReturnType>(
+  selector: (state: TransactionPayState, transactionId: string) => ReturnType,
 ) {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id ?? '';
@@ -53,4 +42,3 @@ function useTransactionPayData<T>(
     selector(state, transactionId),
   );
 }
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
@@ -1,0 +1,204 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import React from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionPayQuote,
+  TransactionPayRequiredToken,
+  TransactionPayStrategy,
+} from '@metamask/transaction-pay-controller';
+import type { Json } from '@metamask/utils';
+import { useTransactionPayMetrics } from './useTransactionPayMetrics';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import {
+  useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
+  useTransactionPayTotals,
+} from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { ConfirmContext } from '../../context/confirm';
+import type { TransactionPayAsset } from './types';
+
+jest.mock('./useTransactionPayToken');
+jest.mock('./useTransactionPayData');
+jest.mock('./useTransactionPayAvailableTokens');
+jest.mock('../../../../store/actions', () => ({
+  updateEventFragment: jest.fn(),
+}));
+
+const TRANSACTION_ID_MOCK = 'transaction-id-mock';
+const CHAIN_ID_MOCK = '0x1';
+const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const TOKEN_AMOUNT_MOCK = '1.23';
+
+const PAY_TOKEN_MOCK = {
+  address: TOKEN_ADDRESS_MOCK,
+  chainId: CHAIN_ID_MOCK,
+  symbol: 'TST',
+};
+
+const QUOTE_MOCK = {
+  dust: {
+    fiat: '0.6',
+    usd: '0.5',
+  },
+  strategy: TransactionPayStrategy.Bridge,
+} as TransactionPayQuote<Json>;
+
+const mockStore = configureStore([]);
+
+function createWrapper(type: TransactionType = TransactionType.perpsDeposit) {
+  const state = {
+    metamask: {
+      TransactionPayController: {
+        transactionData: {},
+      },
+    },
+  };
+
+  const store = mockStore(state);
+
+  const confirmContextValue = {
+    currentConfirmation: {
+      id: TRANSACTION_ID_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      type,
+      txParams: { from: '0x123' },
+    },
+    isScrollToBottomCompleted: true,
+    setIsScrollToBottomCompleted: jest.fn(),
+  };
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <ConfirmContext.Provider value={confirmContextValue as never}>
+        {children}
+      </ConfirmContext.Provider>
+    </Provider>
+  );
+}
+
+describe('useTransactionPayMetrics', () => {
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        amountHuman: TOKEN_AMOUNT_MOCK,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {},
+      {},
+      {},
+      {},
+      {},
+    ] as TransactionPayAsset[]);
+
+    useTransactionPayTotalsMock.mockReturnValue(undefined);
+  });
+
+  it('renders without crashing when no pay token selected', () => {
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('renders with pay token selected', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: jest.fn(),
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('renders with quotes', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: jest.fn(),
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayQuotesMock.mockReturnValue([
+      QUOTE_MOCK,
+      QUOTE_MOCK,
+      QUOTE_MOCK,
+    ]);
+
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('renders with perps deposit type', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: jest.fn(),
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(TransactionType.perpsDeposit),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('renders with predict deposit type', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: jest.fn(),
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(TransactionType.predictDeposit),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it('renders with totals', () => {
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        sourceNetwork: { estimate: { usd: '1.5', fiat: '1.6' } },
+        targetNetwork: { usd: '2.5', fiat: '2.6' },
+        provider: { usd: '0.5', fiat: '0.6' },
+      },
+    } as unknown as ReturnType<typeof useTransactionPayTotals>);
+
+    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
+
+    const { result } = renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+});
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
@@ -34,7 +34,12 @@ const TOKEN_AMOUNT_MOCK = '1.23';
 
 const PAY_TOKEN_MOCK = {
   address: TOKEN_ADDRESS_MOCK,
+  balanceFiat: '100.00',
+  balanceHuman: '50',
+  balanceRaw: '50000000000000000000',
+  balanceUsd: '100.00',
   chainId: CHAIN_ID_MOCK,
+  decimals: 18,
   symbol: 'TST',
 };
 

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
@@ -9,6 +9,7 @@ import {
   TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
 import type { Json } from '@metamask/utils';
+import { ConfirmContext } from '../../context/confirm';
 import { useTransactionPayMetrics } from './useTransactionPayMetrics';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import {
@@ -17,7 +18,6 @@ import {
   useTransactionPayTotals,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import { ConfirmContext } from '../../context/confirm';
 import type { TransactionPayAsset } from './types';
 
 jest.mock('./useTransactionPayToken');
@@ -201,4 +201,3 @@ describe('useTransactionPayMetrics', () => {
     expect(result.error).toBeUndefined();
   });
 });
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -5,13 +5,11 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
 import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 import { useConfirmContext } from '../../context/confirm';
-import {
-  getNativeTokenAddress,
-  hasTransactionType,
-} from '../../utils/transaction-pay';
+import { hasTransactionType } from '../../utils/transaction-pay';
 import { updateEventFragment } from '../../../../store/actions';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import {

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Hex, Json } from '@metamask/utils';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
+import { BigNumber } from 'bignumber.js';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import {
+  useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
+  useTransactionPayTotals,
+} from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { useConfirmContext } from '../../context/confirm';
+import { getNativeTokenAddress, hasTransactionType } from '../../utils/transaction-pay';
+import { updateEventFragment } from '../../../../store/actions';
+import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
+
+export function useTransactionPayMetrics() {
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
+  const { payToken } = useTransactionPayToken();
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const automaticPayToken = useRef<TransactionPaymentToken>();
+  const quotes = useTransactionPayQuotes();
+  const totals = useTransactionPayTotals();
+  const tokens = useTransactionPayAvailableTokens();
+
+  const availableTokens = useMemo(
+    () => tokens.filter((t) => !t.disabled),
+    [tokens],
+  );
+
+  const transactionId = transactionMeta?.id ?? '';
+  const { chainId, type } = transactionMeta ?? {};
+  const primaryRequiredToken = requiredTokens.find((t) => !t.skipIfBalance);
+  const sendingValue = Number(primaryRequiredToken?.amountHuman ?? '0');
+
+  if (!automaticPayToken.current && payToken) {
+    automaticPayToken.current = payToken;
+  }
+
+  const properties: Record<string, Json> = {};
+
+  if (payToken) {
+    properties.mm_pay = true;
+    properties.mm_pay_token_selected = payToken.symbol;
+    properties.mm_pay_chain_selected = payToken.chainId;
+    properties.mm_pay_transaction_step_total = (quotes?.length ?? 0) + 1;
+
+    properties.mm_pay_transaction_step =
+      properties.mm_pay_transaction_step_total;
+
+    properties.mm_pay_token_presented =
+      automaticPayToken.current?.symbol ?? null;
+
+    properties.mm_pay_chain_presented =
+      automaticPayToken.current?.chainId ?? null;
+
+    properties.mm_pay_payment_token_list_size = availableTokens.length;
+  }
+
+  if (payToken && type === TransactionType.perpsDeposit) {
+    properties.mm_pay_use_case = 'perps_deposit';
+    properties.simulation_sending_assets_total_value = sendingValue;
+  }
+
+  if (
+    payToken &&
+    hasTransactionType(transactionMeta, [TransactionType.predictDeposit])
+  ) {
+    properties.mm_pay_use_case = 'predict_deposit';
+    properties.simulation_sending_assets_total_value = sendingValue;
+  }
+
+  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
+
+  const nonGasQuote = quotes?.find(
+    (q) => q.request?.targetTokenAddress !== nativeTokenAddress,
+  );
+
+  if (nonGasQuote) {
+    properties.mm_pay_dust_usd = nonGasQuote.dust.usd;
+  }
+
+  const strategy = quotes?.[0]?.strategy;
+
+  if (strategy === TransactionPayStrategy.Bridge) {
+    properties.mm_pay_strategy = 'mm_swaps_bridge';
+  }
+
+  if (strategy === TransactionPayStrategy.Relay) {
+    properties.mm_pay_strategy = 'relay';
+  }
+
+  if (totals) {
+    properties.mm_pay_network_fee_usd = new BigNumber(
+      totals.fees.sourceNetwork.estimate.usd,
+    )
+      .plus(totals.fees.targetNetwork.usd)
+      .toString(10);
+
+    properties.mm_pay_provider_fee_usd = totals.fees.provider.usd;
+  }
+
+  useEffect(() => {
+    if (transactionId && Object.keys(properties).length > 0) {
+      updateEventFragment(transactionId, { properties });
+    }
+  }, [transactionId, properties]);
+}
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayToken.test.tsx
@@ -3,9 +3,9 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import React from 'react';
 import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
-import { useTransactionPayToken } from './useTransactionPayToken';
 import * as controllerActions from '../../../../store/controller-actions/transaction-pay-controller';
 import { ConfirmContext } from '../../context/confirm';
+import { useTransactionPayToken } from './useTransactionPayToken';
 
 jest.mock(
   '../../../../store/controller-actions/transaction-pay-controller',
@@ -38,13 +38,11 @@ function createMockState({
 } = {}) {
   return {
     metamask: {
-      TransactionPayController: {
-        transactionData: {
-          [TRANSACTION_ID_MOCK]: {
-            isLoading: false,
-            paymentToken: payToken,
-            tokens: [],
-          },
+      transactionData: {
+        [TRANSACTION_ID_MOCK]: {
+          isLoading: false,
+          paymentToken: payToken,
+          tokens: [],
         },
       },
     },
@@ -127,4 +125,3 @@ describe('useTransactionPayToken', () => {
     expect(result.current.isNative).toBe(true);
   });
 });
-

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayToken.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import React from 'react';
+import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import * as controllerActions from '../../../../store/controller-actions/transaction-pay-controller';
+import { ConfirmContext } from '../../context/confirm';
+
+jest.mock(
+  '../../../../store/controller-actions/transaction-pay-controller',
+  () => ({
+    updateTransactionPaymentToken: jest.fn(),
+  }),
+);
+
+const TRANSACTION_ID_MOCK = 'transaction-id-mock';
+const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const CHAIN_ID_MOCK = '0x1';
+
+const PAY_TOKEN_MOCK = {
+  address: TOKEN_ADDRESS_MOCK,
+  balanceHuman: '123.456',
+  balanceFiat: '456.12',
+  balanceUsd: '456.123',
+  balanceRaw: '123456000000000000000',
+  chainId: CHAIN_ID_MOCK,
+  decimals: 4,
+  symbol: 'TST',
+} as TransactionPaymentToken;
+
+const mockStore = configureStore([]);
+
+function createMockState({
+  payToken,
+}: {
+  payToken?: TransactionPaymentToken;
+} = {}) {
+  return {
+    metamask: {
+      TransactionPayController: {
+        transactionData: {
+          [TRANSACTION_ID_MOCK]: {
+            isLoading: false,
+            paymentToken: payToken,
+            tokens: [],
+          },
+        },
+      },
+    },
+  };
+}
+
+function renderHookWithProvider({
+  payToken,
+}: {
+  payToken?: TransactionPaymentToken;
+} = {}) {
+  const state = createMockState({ payToken });
+  const store = mockStore(state);
+
+  const confirmContextValue = {
+    currentConfirmation: { id: TRANSACTION_ID_MOCK },
+    isScrollToBottomCompleted: true,
+    setIsScrollToBottomCompleted: jest.fn(),
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <ConfirmContext.Provider value={confirmContextValue as never}>
+        {children}
+      </ConfirmContext.Provider>
+    </Provider>
+  );
+
+  return renderHook(() => useTransactionPayToken(), { wrapper });
+}
+
+describe('useTransactionPayToken', () => {
+  const updatePaymentTokenMock = jest.mocked(
+    controllerActions.updateTransactionPaymentToken,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns undefined if no state', () => {
+    const { result } = renderHookWithProvider();
+
+    expect(result.current.payToken).toBeUndefined();
+    expect(result.current.isNative).toBeFalsy();
+  });
+
+  it('returns token matching state', () => {
+    const { result } = renderHookWithProvider({
+      payToken: PAY_TOKEN_MOCK,
+    });
+
+    expect(result.current.payToken).toStrictEqual(PAY_TOKEN_MOCK);
+    expect(result.current.isNative).toBe(false);
+  });
+
+  it('sets token in state', () => {
+    const { result } = renderHookWithProvider();
+
+    result.current.setPayToken({
+      address: PAY_TOKEN_MOCK.address,
+      chainId: PAY_TOKEN_MOCK.chainId,
+    });
+
+    expect(updatePaymentTokenMock).toHaveBeenCalledWith({
+      transactionId: TRANSACTION_ID_MOCK,
+      tokenAddress: PAY_TOKEN_MOCK.address,
+      chainId: PAY_TOKEN_MOCK.chainId,
+    });
+  });
+
+  it('returns isNative true when pay token is native address', () => {
+    const { result } = renderHookWithProvider({
+      payToken: {
+        ...PAY_TOKEN_MOCK,
+        address: '0x0000000000000000000000000000000000000000',
+      } as TransactionPaymentToken,
+    });
+
+    expect(result.current.isNative).toBe(true);
+  });
+});
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -3,13 +3,13 @@ import { useCallback } from 'react';
 import type { Hex } from '@metamask/utils';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { useConfirmContext } from '../../context/confirm';
 import {
   selectTransactionPaymentTokenByTransactionId,
   TransactionPayState,
 } from '../../../../selectors/transactionPayController';
 import { updateTransactionPaymentToken } from '../../../../store/controller-actions/transaction-pay-controller';
-import { getNativeTokenAddress } from '../../utils/transaction-pay';
 
 export function useTransactionPayToken(): {
   isNative?: boolean;

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -1,0 +1,56 @@
+import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import type { Hex } from '@metamask/utils';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type {
+  TransactionPaymentToken,
+  TransactionPayControllerState,
+} from '@metamask/transaction-pay-controller';
+import { useConfirmContext } from '../../context/confirm';
+import { selectTransactionPaymentTokenByTransactionId } from '../../../../selectors/transactionPayController';
+import { updateTransactionPaymentToken } from '../../../../store/controller-actions/transaction-pay-controller';
+import { getNativeTokenAddress } from '../../utils/transaction-pay';
+
+type TransactionPayState = {
+  metamask: {
+    TransactionPayController?: TransactionPayControllerState;
+  };
+};
+
+export function useTransactionPayToken(): {
+  isNative?: boolean;
+  payToken: TransactionPaymentToken | undefined;
+  setPayToken: (newPayToken: { address: Hex; chainId: Hex }) => void;
+} {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const transactionId = currentConfirmation?.id ?? '';
+
+  const payToken = useSelector((state: TransactionPayState) =>
+    selectTransactionPaymentTokenByTransactionId(state, transactionId),
+  );
+
+  const isNative =
+    payToken && payToken?.address === getNativeTokenAddress(payToken?.chainId);
+
+  const setPayToken = useCallback(
+    (newPayToken: { address: Hex; chainId: Hex }) => {
+      try {
+        updateTransactionPaymentToken({
+          transactionId: transactionId as string,
+          tokenAddress: newPayToken.address,
+          chainId: newPayToken.chainId,
+        });
+      } catch (e) {
+        console.error('Error updating payment token', e);
+      }
+    },
+    [transactionId],
+  );
+
+  return {
+    isNative,
+    payToken,
+    setPayToken,
+  };
+}
+

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -2,20 +2,14 @@ import { useSelector } from 'react-redux';
 import { useCallback } from 'react';
 import type { Hex } from '@metamask/utils';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import type {
-  TransactionPaymentToken,
-  TransactionPayControllerState,
-} from '@metamask/transaction-pay-controller';
+import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 import { useConfirmContext } from '../../context/confirm';
-import { selectTransactionPaymentTokenByTransactionId } from '../../../../selectors/transactionPayController';
+import {
+  selectTransactionPaymentTokenByTransactionId,
+  TransactionPayState,
+} from '../../../../selectors/transactionPayController';
 import { updateTransactionPaymentToken } from '../../../../store/controller-actions/transaction-pay-controller';
 import { getNativeTokenAddress } from '../../utils/transaction-pay';
-
-type TransactionPayState = {
-  metamask: {
-    TransactionPayController?: TransactionPayControllerState;
-  };
-};
 
 export function useTransactionPayToken(): {
   isNative?: boolean;
@@ -53,4 +47,3 @@ export function useTransactionPayToken(): {
     setPayToken,
   };
 }
-

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -1,0 +1,354 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import type {
+  TransactionPayRequiredToken,
+  TransactionPaymentToken,
+} from '@metamask/transaction-pay-controller';
+import { Asset, AssetStandard } from '../types/send';
+import {
+  hasTransactionType,
+  getTokenTransferData,
+  getTokenAddress,
+  getAvailableTokens,
+} from './transaction-pay';
+
+const CHAIN_ID_MOCK = '0x1' as Hex;
+const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
+const TOKEN_ADDRESS_2_MOCK =
+  '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+const NATIVE_ADDRESS_MOCK = '0x0000000000000000000000000000000000000000' as Hex;
+const TOKEN_TRANSFER_DATA_MOCK =
+  '0xa9059cbb0000000000000000000000001234567890abcdef1234567890abcdef123456780000000000000000000000000000000000000000000000000de0b6b3a7640000' as Hex;
+
+function createMockAsset(overrides: Partial<Asset> = {}): Asset {
+  return {
+    address: TOKEN_ADDRESS_MOCK,
+    balance: '1000000000000000000',
+    chainId: CHAIN_ID_MOCK,
+    standard: AssetStandard.ERC20,
+    accountType: 'eip155:eoa' as Asset['accountType'],
+    symbol: 'TST',
+    decimals: 18,
+    ...overrides,
+  };
+}
+
+function createMockPaymentToken(
+  overrides: Partial<TransactionPaymentToken> = {},
+): TransactionPaymentToken {
+  return {
+    address: TOKEN_ADDRESS_MOCK,
+    balanceFiat: '100.00',
+    balanceHuman: '50',
+    balanceRaw: '50000000000000000000',
+    balanceUsd: '100.00',
+    chainId: CHAIN_ID_MOCK,
+    decimals: 18,
+    symbol: 'TST',
+    ...overrides,
+  };
+}
+
+function createMockRequiredToken(
+  overrides: Partial<TransactionPayRequiredToken> = {},
+): TransactionPayRequiredToken {
+  return {
+    address: TOKEN_ADDRESS_MOCK,
+    allowUnderMinimum: false,
+    amountFiat: '10.00',
+    amountHuman: '5',
+    amountRaw: '5000000000000000000',
+    amountUsd: '10.00',
+    balanceFiat: '100.00',
+    balanceHuman: '50',
+    balanceRaw: '50000000000000000000',
+    balanceUsd: '100.00',
+    chainId: CHAIN_ID_MOCK,
+    decimals: 18,
+    skipIfBalance: false,
+    symbol: 'TST',
+    ...overrides,
+  };
+}
+
+describe('transaction-pay utils', () => {
+  describe('hasTransactionType', () => {
+    it('returns true when transaction type matches', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [TransactionType.simpleSend]),
+      ).toBe(true);
+    });
+
+    it('returns true when transaction type is in the list', () => {
+      const transactionMeta = {
+        type: TransactionType.tokenMethodTransfer,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.simpleSend,
+          TransactionType.tokenMethodTransfer,
+        ]),
+      ).toBe(true);
+    });
+
+    it('returns false when transaction type does not match', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.tokenMethodTransfer,
+        ]),
+      ).toBe(false);
+    });
+
+    it('returns false when transactionMeta is undefined', () => {
+      expect(hasTransactionType(undefined, [TransactionType.simpleSend])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('getTokenTransferData', () => {
+    it('returns token transfer data from txParams when data starts with transfer selector', () => {
+      const transactionMeta = {
+        txParams: {
+          data: TOKEN_TRANSFER_DATA_MOCK,
+          to: TOKEN_ADDRESS_MOCK,
+        },
+      } as TransactionMeta;
+
+      const result = getTokenTransferData(transactionMeta);
+
+      expect(result).toStrictEqual({
+        data: TOKEN_TRANSFER_DATA_MOCK,
+        to: TOKEN_ADDRESS_MOCK,
+        index: undefined,
+      });
+    });
+
+    it('returns undefined when data does not start with transfer selector', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x12345678',
+          to: TOKEN_ADDRESS_MOCK,
+        },
+      } as TransactionMeta;
+
+      expect(getTokenTransferData(transactionMeta)).toBeUndefined();
+    });
+
+    it('returns undefined when to address is missing', () => {
+      const transactionMeta = {
+        txParams: {
+          data: TOKEN_TRANSFER_DATA_MOCK,
+        },
+      } as TransactionMeta;
+
+      expect(getTokenTransferData(transactionMeta)).toBeUndefined();
+    });
+
+    it('returns token transfer data from nested transactions', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x12345678',
+          to: TOKEN_ADDRESS_MOCK,
+        },
+        nestedTransactions: [
+          { data: '0xother', to: TOKEN_ADDRESS_2_MOCK },
+          { data: TOKEN_TRANSFER_DATA_MOCK, to: TOKEN_ADDRESS_MOCK },
+        ],
+      } as unknown as TransactionMeta;
+
+      const result = getTokenTransferData(transactionMeta);
+
+      expect(result).toStrictEqual({
+        data: TOKEN_TRANSFER_DATA_MOCK,
+        to: TOKEN_ADDRESS_MOCK,
+        index: 1,
+      });
+    });
+
+    it('returns undefined when transactionMeta is undefined', () => {
+      expect(getTokenTransferData(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getTokenAddress', () => {
+    it('returns to address from nested transaction when token transfer data exists', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x12345678',
+          to: TOKEN_ADDRESS_2_MOCK,
+        },
+        nestedTransactions: [
+          { data: TOKEN_TRANSFER_DATA_MOCK, to: TOKEN_ADDRESS_MOCK },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getTokenAddress(transactionMeta)).toBe(TOKEN_ADDRESS_MOCK);
+    });
+
+    it('returns to address from txParams when no token transfer data', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x12345678',
+          to: TOKEN_ADDRESS_MOCK,
+        },
+      } as TransactionMeta;
+
+      expect(getTokenAddress(transactionMeta)).toBe(TOKEN_ADDRESS_MOCK);
+    });
+
+    it('returns undefined when transactionMeta is undefined', () => {
+      expect(getTokenAddress(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getAvailableTokens', () => {
+    it('filters out non-ERC20 tokens', () => {
+      const tokens = [
+        createMockAsset({ standard: AssetStandard.Native }),
+        createMockAsset({ standard: AssetStandard.ERC721 }),
+        createMockAsset({
+          standard: AssetStandard.ERC20,
+          address: TOKEN_ADDRESS_MOCK,
+        }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(TOKEN_ADDRESS_MOCK);
+    });
+
+    it('filters out tokens without eip155 account type', () => {
+      const tokens = [
+        createMockAsset({
+          accountType: 'bip122:p2wpkh' as Asset['accountType'],
+        }),
+        createMockAsset({
+          accountType: 'eip155:eoa' as Asset['accountType'],
+          address: TOKEN_ADDRESS_MOCK,
+        }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(TOKEN_ADDRESS_MOCK);
+    });
+
+    it('includes selected pay token even with zero balance', () => {
+      const payToken = createMockPaymentToken({ address: TOKEN_ADDRESS_MOCK });
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK, balance: '0' }),
+      ];
+
+      const result = getAvailableTokens({ payToken, tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].isSelected).toBe(true);
+    });
+
+    it('includes required tokens even with zero balance', () => {
+      const requiredTokens = [
+        createMockRequiredToken({
+          address: TOKEN_ADDRESS_MOCK,
+          skipIfBalance: false,
+        }),
+      ];
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK, balance: '0' }),
+      ];
+
+      const result = getAvailableTokens({ requiredTokens, tokens });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes required tokens with skipIfBalance set to true', () => {
+      const requiredTokens = [
+        createMockRequiredToken({
+          address: TOKEN_ADDRESS_MOCK,
+          skipIfBalance: true,
+        }),
+      ];
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK, balance: '0' }),
+      ];
+
+      const result = getAvailableTokens({ requiredTokens, tokens });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('excludes tokens with zero balance when not selected or required', () => {
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK, balance: '0' }),
+        createMockAsset({ address: TOKEN_ADDRESS_2_MOCK, balance: '1000' }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(TOKEN_ADDRESS_2_MOCK);
+    });
+
+    it('marks token as disabled when no native balance', () => {
+      const tokens = [createMockAsset({ address: TOKEN_ADDRESS_MOCK })];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result[0].disabled).toBe(true);
+    });
+
+    it('marks token as enabled when native token has balance', () => {
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK }),
+        createMockAsset({
+          address: NATIVE_ADDRESS_MOCK,
+          balance: '1000000000000000000',
+        }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      const erc20Token = result.find((t) => t.address === TOKEN_ADDRESS_MOCK);
+      expect(erc20Token?.disabled).toBe(false);
+    });
+
+    it('marks selected token with isSelected true', () => {
+      const payToken = createMockPaymentToken({ address: TOKEN_ADDRESS_MOCK });
+      const tokens = [
+        createMockAsset({ address: TOKEN_ADDRESS_MOCK }),
+        createMockAsset({ address: TOKEN_ADDRESS_2_MOCK }),
+      ];
+
+      const result = getAvailableTokens({ payToken, tokens });
+
+      const selectedToken = result.find(
+        (t) => t.address === TOKEN_ADDRESS_MOCK,
+      );
+      const otherToken = result.find((t) => t.address === TOKEN_ADDRESS_2_MOCK);
+
+      expect(selectedToken?.isSelected).toBe(true);
+      expect(otherToken?.isSelected).toBe(false);
+    });
+
+    it('returns empty array when tokens is empty', () => {
+      const result = getAvailableTokens({ tokens: [] });
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -1,0 +1,145 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import type {
+  TransactionPayRequiredToken,
+  TransactionPaymentToken,
+} from '@metamask/transaction-pay-controller';
+import { BigNumber } from 'bignumber.js';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { Asset, AssetStandard } from '../types/send';
+import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from '../hooks/pay/types';
+
+const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+
+export function getNativeTokenAddress(chainId: Hex): Hex {
+  switch (chainId) {
+    case CHAIN_IDS.POLYGON:
+      return '0x0000000000000000000000000000000000001010' as Hex;
+    default:
+      return NATIVE_TOKEN_ADDRESS;
+  }
+}
+
+export function hasTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+  types: TransactionType[],
+): boolean {
+  return types.includes(transactionMeta?.type as TransactionType);
+}
+
+export function getTokenTransferData(
+  transactionMeta: TransactionMeta | undefined,
+):
+  | {
+      data: Hex;
+      to: Hex;
+      index?: number;
+    }
+  | undefined {
+  const { nestedTransactions, txParams } = transactionMeta ?? {};
+  const { data: singleData } = txParams ?? {};
+  const singleTo = txParams?.to as Hex | undefined;
+
+  if (singleData?.startsWith(FOUR_BYTE_TOKEN_TRANSFER) && singleTo) {
+    return { data: singleData as Hex, to: singleTo, index: undefined };
+  }
+
+  const nestedCallIndex = nestedTransactions?.findIndex((call) =>
+    call.data?.startsWith(FOUR_BYTE_TOKEN_TRANSFER),
+  );
+
+  const nestedCall =
+    nestedCallIndex !== undefined
+      ? nestedTransactions?.[nestedCallIndex]
+      : undefined;
+
+  if (nestedCall?.data && nestedCall.to) {
+    return {
+      data: nestedCall.data,
+      to: nestedCall.to,
+      index: nestedCallIndex,
+    };
+  }
+
+  return undefined;
+}
+
+export function getTokenAddress(
+  transactionMeta: TransactionMeta | undefined,
+): Hex {
+  const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
+
+  if (nestedCall) {
+    return nestedCall.to;
+  }
+
+  return transactionMeta?.txParams?.to as Hex;
+}
+
+export function getAvailableTokens({
+  payToken,
+  requiredTokens,
+  tokens,
+}: {
+  payToken?: TransactionPaymentToken;
+  requiredTokens?: TransactionPayRequiredToken[];
+  tokens: Asset[];
+}): TransactionPayAsset[] {
+  return tokens
+    .filter((token) => {
+      if (
+        token.standard !== AssetStandard.ERC20 ||
+        !token.accountType?.includes('eip155')
+      ) {
+        return false;
+      }
+
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address?.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      if (isSelected) {
+        return true;
+      }
+
+      const isRequiredToken = (requiredTokens ?? []).some(
+        (t) =>
+          t.address.toLowerCase() === token.address?.toLowerCase() &&
+          t.chainId === token.chainId &&
+          !t.skipIfBalance,
+      );
+
+      if (isRequiredToken) {
+        return true;
+      }
+
+      return new BigNumber(token.balance ?? 0).gt(0);
+    })
+    .map((token) => {
+      const chainId = (token.chainId as Hex) ?? '0x0';
+
+      const nativeToken = tokens.find(
+        (t) =>
+          t.chainId === chainId && t.address === getNativeTokenAddress(chainId),
+      );
+
+      const noNativeBalance =
+        !nativeToken || new BigNumber(nativeToken.balance ?? 0).isZero();
+
+      const disabled = noNativeBalance;
+
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address?.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      return {
+        ...token,
+        disabled,
+        isSelected,
+      };
+    });
+}
+

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -7,21 +7,12 @@ import type {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
-import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { Asset, AssetStandard } from '../types/send';
-import { TransactionPayAsset, NATIVE_TOKEN_ADDRESS } from '../hooks/pay/types';
+import { TransactionPayAsset } from '../hooks/pay/types';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
-
-export function getNativeTokenAddress(chainId: Hex): Hex {
-  switch (chainId) {
-    case CHAIN_IDS.POLYGON:
-      return '0x0000000000000000000000000000000000001010' as Hex;
-    default:
-      return NATIVE_TOKEN_ADDRESS;
-  }
-}
 
 export function hasTransactionType(
   transactionMeta: TransactionMeta | undefined,

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -52,9 +52,9 @@ export function getTokenTransferData(
   );
 
   const nestedCall =
-    nestedCallIndex !== undefined
-      ? nestedTransactions?.[nestedCallIndex]
-      : undefined;
+    nestedCallIndex === undefined
+      ? undefined
+      : nestedTransactions?.[nestedCallIndex];
 
   if (nestedCall?.data && nestedCall.to) {
     return {
@@ -142,4 +142,3 @@ export function getAvailableTokens({
       };
     });
 }
-

--- a/ui/selectors/transactionPayController.ts
+++ b/ui/selectors/transactionPayController.ts
@@ -1,0 +1,62 @@
+import { createSelector } from 'reselect';
+import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
+
+type TransactionPayState = {
+  metamask: {
+    TransactionPayController?: TransactionPayControllerState;
+  };
+};
+
+const selectTransactionPayControllerState = (state: TransactionPayState) =>
+  state.metamask.TransactionPayController ?? {
+    transactionData: {},
+  };
+
+export const selectTransactionDataByTransactionId = createSelector(
+  selectTransactionPayControllerState,
+  (_state: TransactionPayState, transactionId: string) => transactionId,
+  (transactionPayControllerState, transactionId) =>
+    transactionPayControllerState.transactionData[transactionId],
+);
+
+export const selectTransactionPayTotalsByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.totals,
+);
+
+export const selectIsTransactionPayLoadingByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.isLoading ?? false,
+);
+
+export const selectTransactionPayQuotesByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.quotes,
+);
+
+export const selectTransactionPayTokensByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.tokens ?? [],
+);
+
+export const selectTransactionPaymentTokenByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.paymentToken,
+);
+
+export const selectTransactionPaySourceAmountsByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.sourceAmounts,
+);
+
+export const selectTransactionPayIsMaxAmountByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (transactionData) => (transactionData as any)?.isMaxAmount ?? false,
+);
+
+export const selectTransactionPayTransactionData = createSelector(
+  selectTransactionPayControllerState,
+  (state) => state.transactionData,
+);
+

--- a/ui/selectors/transactionPayController.ts
+++ b/ui/selectors/transactionPayController.ts
@@ -1,22 +1,15 @@
 import { createSelector } from 'reselect';
 import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
 
-type TransactionPayState = {
-  metamask: {
-    TransactionPayController?: TransactionPayControllerState;
-  };
+export type TransactionPayState = {
+  metamask: TransactionPayControllerState;
 };
 
-const selectTransactionPayControllerState = (state: TransactionPayState) =>
-  state.metamask.TransactionPayController ?? {
-    transactionData: {},
-  };
-
 export const selectTransactionDataByTransactionId = createSelector(
-  selectTransactionPayControllerState,
+  (state: TransactionPayState) => state,
   (_state: TransactionPayState, transactionId: string) => transactionId,
-  (transactionPayControllerState, transactionId) =>
-    transactionPayControllerState.transactionData[transactionId],
+  (state: TransactionPayState, transactionId: string) =>
+    state.metamask.transactionData[transactionId],
 );
 
 export const selectTransactionPayTotalsByTransactionId = createSelector(
@@ -48,15 +41,3 @@ export const selectTransactionPaySourceAmountsByTransactionId = createSelector(
   selectTransactionDataByTransactionId,
   (transactionData) => transactionData?.sourceAmounts,
 );
-
-export const selectTransactionPayIsMaxAmountByTransactionId = createSelector(
-  selectTransactionDataByTransactionId,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (transactionData) => (transactionData as any)?.isMaxAmount ?? false,
-);
-
-export const selectTransactionPayTransactionData = createSelector(
-  selectTransactionPayControllerState,
-  (state) => state.transactionData,
-);
-

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -18,4 +18,3 @@ export async function updateTransactionPaymentToken({
     },
   ]);
 }
-

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -1,0 +1,21 @@
+import type { Hex } from '@metamask/utils';
+import { submitRequestToBackground } from '../background-connection';
+
+export async function updateTransactionPaymentToken({
+  transactionId,
+  tokenAddress,
+  chainId,
+}: {
+  transactionId: string;
+  tokenAddress: Hex;
+  chainId: Hex;
+}): Promise<void> {
+  return await submitRequestToBackground('updateTransactionPaymentToken', [
+    {
+      transactionId,
+      tokenAddress,
+      chainId,
+    },
+  ]);
+}
+


### PR DESCRIPTION
## **Description**

Add initial React hooks for MetaMask Pay that use `TransactionPayController` state.

No functional changes yet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39167?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to: [#6499](https://github.com/MetaMask/MetaMask-planning/issues/6499)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes foundational Transaction Pay infrastructure in confirmations UI and controller init.
> 
> - Adds hooks: `useTransactionPayToken` (read/set pay token via background), `useAutomaticTransactionPayToken` (auto-selects token with hardware/preference logic), `useTransactionPayData` (quotes/tokens/totals/loading/source amounts), `useTransactionPayAvailableTokens` (filters/send tokens), `useTransactionPayMetrics` (emits analytics props)
> - Introduces utils in `utils/transaction-pay` for `hasTransactionType`, token transfer parsing (`getTokenTransferData`, `getTokenAddress`), and `getAvailableTokens` (balance/required/selection/native-gas logic)
> - Adds reselect selectors in `ui/selectors/transactionPayController.ts` for per-transaction data
> - Wires controller/background: `controller-init` now returns `api.updateTransactionPaymentToken`; new action `updateTransactionPaymentToken` submits to background
> - Includes comprehensive unit tests for hooks and utils
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e4a1b9a93334a115d8b8f79b650745496dc74d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->