### PR TITLE
fix: flaky test `Ledger Hardware mints an ERC-721 token`

### DIFF
--- a/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-erc721.spec.ts
@@ -101,14 +101,15 @@ describe('Ledger Hardware', function (this: Suite) {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
         const homePage = new HomePage(driver);
-        await homePage.goToNftTab();
-        const nftListPage = new NFTListPage(driver);
-        // Check that NFT image is displayed in NFT tab on homepage
-        await nftListPage.checkNftImageIsDisplayed();
         await homePage.goToActivityList();
         const activityListPage = new ActivityListPage(driver);
         await activityListPage.checkTransactionActivityByText('Deposit');
         await activityListPage.checkWaitForTransactionStatus('confirmed');
+
+        // Check that NFT image is displayed in NFT tab on homepage
+        await homePage.goToNftTab();
+        const nftListPage = new NFTListPage(driver);
+        await nftListPage.checkNftImageIsDisplayed();
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky because after minting an NFT, we go straight to the NFT tab and try to find the NFT image. There is a race condition where, after we click the NFT tab, there's a hompage re-render (the tx item is updated to Confirmed tx) causing the NFT tab click to take no effect, and we remain at the Activity list page. Then we try to find the NFT image but we can't.

The solution is to reverse the checks: first let's look for a confirmed tx in the activity list, then let's check for the nft image in the nft tab (so no re-renders happen)

<img width="848" height="105" alt="image" src="https://github.com/user-attachments/assets/849b79f4-9643-40bb-b5a4-6e78c63599c8" />

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39170?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci (it has the e2e quality gate enabled)

## **Screenshots/Recordings**

<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/2aaed1b0-315c-457d-a1ed-9b573bc43e23" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the ERC-721 mint e2e test for Ledger by ensuring transaction confirmation precedes UI assertions.
> 
> - Moves NFT tab image check to occur after navigating to `Activity` and waiting for `Deposit` to be `confirmed` in `ledger-erc721.spec.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2db201f5aca7433df93ee04dae98a673720b67e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->