### PR TITLE
fix: Always reset transaction state on transaction submit

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -245,18 +245,22 @@ const Footer = () => {
       return;
     }
 
-    if (isAddEthereumChain) {
-      await onAddEthereumChain();
-      navigate(DEFAULT_ROUTE);
-    } else if (isTransactionConfirmation) {
-      await onTransactionConfirm();
-      navigateNext(currentConfirmation.id);
-    } else {
-      await dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
-      navigateNext(currentConfirmation.id);
+    try {
+      if (isAddEthereumChain) {
+        await onAddEthereumChain();
+        navigate(DEFAULT_ROUTE);
+      } else if (isTransactionConfirmation) {
+        await onTransactionConfirm();
+        navigateNext(currentConfirmation.id);
+      } else {
+        await dispatch(
+          resolvePendingApproval(currentConfirmation.id, undefined),
+        );
+        navigateNext(currentConfirmation.id);
+      }
+    } finally {
+      resetTransactionState();
     }
-
-    resetTransactionState();
   }, [
     currentConfirmation,
     dispatch,

--- a/ui/pages/confirmations/hooks/useConfirmActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.test.ts
@@ -30,10 +30,29 @@ function renderHook() {
 }
 
 describe('useConfirmActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns correct functions', () => {
     const result = renderHook();
     expect(result.onCancel).toBeDefined();
     expect(result.resetTransactionState).toBeDefined();
+  });
+
+  it('resetTransactionState dispatches actions to clear custom nonce and next nonce', () => {
+    const result = renderHook();
+    result.resetTransactionState();
+
+    // Verify that updateCustomNonce('') and setNextNonce('') are dispatched
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'UPDATE_CUSTOM_NONCE',
+      value: '',
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_NEXT_NONCE',
+      payload: '',
+    });
   });
 
   it('call navigateBackIfSend when onCancel is called, if navigateBackForSend is true', () => {


### PR DESCRIPTION
## **Description**
Always resets transaction state on transaction submit, which also resets custom low nonce.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39179?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Always reset transaction state on transaction submit

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39125

## **Manual testing steps**

1. Turn off smart transactions feature
2. Go to send flow
3. Edit nonce with any lower number
4. Send the failing transaction
5. Go to Send flow
6. See that the right nonce is displayed (not the lower one)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Always reset transaction state on submit**: Wrap `onSubmit` in `try/finally` in `ui/pages/confirmations/components/confirm/footer/footer.tsx` so `resetTransactionState()` is called regardless of flow (`addEthereumChain`, transaction confirm, or approval resolution).
> - **Tests for reset behavior**: In `ui/pages/confirmations/hooks/useConfirmActions.test.ts`, add `beforeEach(jest.clearAllMocks)` and a test asserting `resetTransactionState` dispatches `UPDATE_CUSTOM_NONCE` and `SET_NEXT_NONCE`. Retains test for `navigateBackIfSend` when `navigateBackForSend` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e495cc047082de5c39712fb4bb892cd294c81d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->