### PR TITLE
fix: fix native token transfers not showing in token activity view

### DIFF
--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -158,6 +158,24 @@ const normalizeChainIdToHex = (chainId) => {
   }
 };
 
+// Extracts address from CAIP format or returns hex address
+const extractAddressFromRecipient = (recipientAddress) => {
+  if (!recipientAddress) {
+    return recipientAddress;
+  }
+
+  if (isCaipAssetType(recipientAddress)) {
+    try {
+      const { assetReference } = parseCaipAssetType(recipientAddress);
+      return assetReference;
+    } catch {
+      return recipientAddress;
+    }
+  }
+
+  return recipientAddress;
+};
+
 // When we are on a token page, we only want to show transactions that involve that token.
 // In the case of token transfers or approvals, these will be transactions sent to the
 // token contract. In the case of swaps, these will be transactions sent to the swaps contract
@@ -184,13 +202,15 @@ const getTransactionGroupRecipientAddressFilter = (
     if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
       return true;
     }
+    const addressForMatching = extractAddressFromRecipient(recipientAddress);
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some((chainId) => {
         const hexChainId = normalizeChainIdToHex(chainId);
         return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];
       }) &&
-        txParams.data.match(recipientAddress.slice(2)))
+        addressForMatching &&
+        txParams.data.match(addressForMatching.slice(2)))
     );
   };
 };
@@ -214,13 +234,15 @@ const getTransactionGroupRecipientAddressFilterAllChain = (
     if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
       return true;
     }
+    const addressForMatching = extractAddressFromRecipient(recipientAddress);
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some((chainId) => {
         const hexChainId = normalizeChainIdToHex(chainId);
         return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];
       }) &&
-        txParams.data.match(recipientAddress.slice(2)))
+        addressForMatching &&
+        txParams.data.match(addressForMatching.slice(2)))
     );
   };
 };

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -13,6 +13,11 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { TransactionType as KeyringTransactionType } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF
 import {
+  parseCaipAssetType,
+  isCaipAssetType,
+  isCaipChainId,
+} from '@metamask/utils';
+import {
   nonceSortedCompletedTransactionsSelectorAllChains,
   nonceSortedPendingTransactionsSelectorAllChains,
   getTransactions,
@@ -43,6 +48,9 @@ import {
 } from '../../../../shared/constants/transaction';
 import { SWAPS_CHAINID_CONTRACT_ADDRESS_MAP } from '../../../../shared/constants/swaps';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
+import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
+import { hasTransactionData } from '../../../../shared/modules/transaction.utils';
+import { isNativeAddress } from '../../../helpers/utils/token-insights';
 import {
   useEarliestNonceByChain,
   isTransactionEarliestNonce,
@@ -109,6 +117,47 @@ import { TransactionActivityEmptyState } from '../transaction-activity-empty-sta
 
 const PAGE_DAYS_INCREMENT = 10;
 
+// Checks if address represents a native token (zero address or CAIP format)
+const isNativeTokenAddress = (recipientAddress) => {
+  if (!recipientAddress) {
+    return false;
+  }
+
+  if (isNativeAddress(recipientAddress)) {
+    return true;
+  }
+
+  if (isCaipAssetType(recipientAddress)) {
+    try {
+      const { assetReference, assetNamespace } =
+        parseCaipAssetType(recipientAddress);
+      if (assetNamespace === 'native' || isNativeAddress(assetReference)) {
+        return true;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  return false;
+};
+
+// Normalizes chainId to hex format for comparison (handles CAIP and hex)
+const normalizeChainIdToHex = (chainId) => {
+  if (!chainId || typeof chainId !== 'string') {
+    return chainId;
+  }
+
+  try {
+    return isCaipChainId(chainId)
+      ? convertCaipToHexChainId(chainId).toLowerCase()
+      : chainId.toLowerCase();
+  } catch {
+    // If conversion fails, return lowercase version
+    return chainId.toLowerCase();
+  }
+};
+
 // When we are on a token page, we only want to show transactions that involve that token.
 // In the case of token transfers or approvals, these will be transactions sent to the
 // token contract. In the case of swaps, these will be transactions sent to the swaps contract
@@ -120,13 +169,27 @@ const getTransactionGroupRecipientAddressFilter = (
   recipientAddress,
   chainIds,
 ) => {
-  return ({ initialTransaction: { txParams } }) => {
+  return ({ initialTransaction }) => {
+    const { txParams } = initialTransaction;
+    const isNativeAssetActivityFilter = isNativeTokenAddress(recipientAddress);
+    const isSimpleSendTx =
+      !hasTransactionData(txParams.data) || txParams?.data === '0x0';
+    const normalizedTxChainId = normalizeChainIdToHex(
+      initialTransaction?.chainId,
+    );
+    const isOnSameChain = chainIds.some((chainId) => {
+      const normalizedChainId = normalizeChainIdToHex(chainId);
+      return normalizedTxChainId === normalizedChainId;
+    });
+    if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
+      return true;
+    }
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
-      (chainIds.some(
-        (chainId) =>
-          txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
-      ) &&
+      (chainIds.some((chainId) => {
+        const hexChainId = normalizeChainIdToHex(chainId);
+        return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];
+      }) &&
         txParams.data.match(recipientAddress.slice(2)))
     );
   };
@@ -136,24 +199,27 @@ const getTransactionGroupRecipientAddressFilterAllChain = (
   recipientAddress,
   chainIds,
 ) => {
-  return ({ initialTransaction: { txParams } }) => {
-    const isNativeAssetActivityFilter =
-      recipientAddress === '0x0000000000000000000000000000000000000000';
+  return ({ initialTransaction }) => {
+    const { txParams } = initialTransaction;
+    const isNativeAssetActivityFilter = isNativeTokenAddress(recipientAddress);
     const isSimpleSendTx =
-      !txParams.data ||
-      txParams?.data === '' ||
-      txParams?.data === '0x' ||
-      txParams?.data === '0x0';
-    const isOnSameChain = chainIds.includes(txParams?.chainId);
+      !hasTransactionData(txParams.data) || txParams?.data === '0x0';
+    const normalizedTxChainId = normalizeChainIdToHex(
+      initialTransaction?.chainId,
+    );
+    const isOnSameChain = chainIds.some((chainId) => {
+      const normalizedChainId = normalizeChainIdToHex(chainId);
+      return normalizedTxChainId === normalizedChainId;
+    });
     if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
       return true;
     }
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
-      (chainIds.some(
-        (chainId) =>
-          txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
-      ) &&
+      (chainIds.some((chainId) => {
+        const hexChainId = normalizeChainIdToHex(chainId);
+        return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];
+      }) &&
         txParams.data.match(recipientAddress.slice(2)))
     );
   };

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -204,7 +204,7 @@ const getTransactionGroupRecipientAddressFilter = (
     }
     const addressForMatching = extractAddressFromRecipient(recipientAddress);
     return (
-      isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
+      isEqualCaseInsensitive(txParams?.to, addressForMatching) ||
       (chainIds.some((chainId) => {
         const hexChainId = normalizeChainIdToHex(chainId);
         return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];
@@ -236,7 +236,7 @@ const getTransactionGroupRecipientAddressFilterAllChain = (
     }
     const addressForMatching = extractAddressFromRecipient(recipientAddress);
     return (
-      isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
+      isEqualCaseInsensitive(txParams?.to, addressForMatching) ||
       (chainIds.some((chainId) => {
         const hexChainId = normalizeChainIdToHex(chainId);
         return txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[hexChainId];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Native token transfers were not appearing in the token-specific activity view for chains using CAIP asset ID format (e.g., Flow network). The filter only recognized zero address format (0x0000...), not CAIP formats like eip155:747/native:0x...

**Solution**
Added native token detection for CAIP asset ID format
Fixed chainId comparison to handle both CAIP and hex formats

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39191?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed native token transfers not appearing in token-specific activity view for chains using CAIP asset ID format

## **Related issues**

Fixes:

## **Manual testing steps**

**Test Steps**
1. Switch to a network that uses CAIP format (e.g., Flow)
2. Send a native token transfer
3. Navigate to the native token page : 
- Click on the native token (e.g., Flow)
- You should see the token details page
4. Check "Your activity" tab
5. Verify the transfer appears : 
- Expected: The native token transfer you sent should be visible in the activity list
- Expected: Transaction details (amount, recipient, status) should be correct
- Expected: Transaction should be grouped by date

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="600"  alt="Screenshot 2026-01-12 at 10 14 14" src="https://github.com/user-attachments/assets/b987d9d0-5e00-405d-9f45-f6addc1bb1e1" />


### **After**

<img width="600" alt="Screenshot 2026-01-12 at 16 33 40" src="https://github.com/user-attachments/assets/b9169e87-8a07-48ae-9eb7-53cb17d38749" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes token activity filtering to include native transfers on CAIP networks.
> 
> - Adds CAIP-aware helpers: `isNativeTokenAddress`, `normalizeChainIdToHex`, `extractAddressFromRecipient`
> - Updates token activity filters to detect native assets (zero address or CAIP) and handle `chainId` comparison across CAIP/hex
> - Uses `hasTransactionData` to identify simple sends and matches swaps via `SWAPS_CHAINID_CONTRACT_ADDRESS_MAP` with normalized chain IDs
> - Imports CAIP utilities (`parseCaipAssetType`, `isCaipAssetType`, `isCaipChainId`) and network/tx helpers (`convertCaipToHexChainId`, `isNativeAddress`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac898cfa1b82b99aeca40aa5cb0590d30bd2b3fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->