### PR TITLE
fix: resolve sentence case violations in locale strings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -415,7 +415,7 @@
     "message": "This is the transaction number of an account. Nonce for the first transaction is 0 and it increases in sequential order."
   },
   "advancedEIP1559ModalTitle": {
-    "message": "Advanced Network Fee"
+    "message": "Advanced network fee"
   },
   "advancedGasFeeDefaultOptIn": {
     "message": "Save these values as my default for the $1 network.",
@@ -425,7 +425,7 @@
     "message": "Advanced gas fee"
   },
   "advancedGasPriceModalTitle": {
-    "message": "Advanced Network Fee"
+    "message": "Advanced network fee"
   },
   "advancedGasPriceTitle": {
     "message": "Gas price"
@@ -443,7 +443,7 @@
     "message": "The token's on-chain history reveals prior instances of suspicious airdrop activities."
   },
   "airDropPatternTitle": {
-    "message": "Airdrop Pattern"
+    "message": "Airdrop pattern"
   },
   "airgapVault": {
     "message": "AirGap Vault"
@@ -458,7 +458,7 @@
     "message": "Account type"
   },
   "alertActionBurnAddress": {
-    "message": "Sending Assets to Burn Address"
+    "message": "Sending assets to burn address"
   },
   "alertActionBuyWithNativeCurrency": {
     "message": "Buy $1"
@@ -533,7 +533,7 @@
     "message": "I have acknowledged the risk and still want to proceed"
   },
   "alertModalDetails": {
-    "message": "Alert Details"
+    "message": "Alert details"
   },
   "alertModalReviewAllAlerts": {
     "message": "Review all alerts"
@@ -631,10 +631,10 @@
     "message": "Amount"
   },
   "amountReceived": {
-    "message": "Amount Received"
+    "message": "Amount received"
   },
   "amountSent": {
-    "message": "Amount Sent"
+    "message": "Amount sent"
   },
   "andForListItems": {
     "message": "$1, and $2",
@@ -860,7 +860,7 @@
     "message": "MetaMask Beta Version"
   },
   "betaTerms": {
-    "message": "Beta Terms of use"
+    "message": "Beta Terms of Use"
   },
   "blockExplorerAccountAction": {
     "message": "Account",
@@ -1046,7 +1046,7 @@
     "message": "Price impact"
   },
   "bridgePriceImpactWarningTitle": {
-    "message": "Price Impact Warning"
+    "message": "Price impact warning"
   },
   "bridgeQuoteExpired": {
     "message": "Your quote timed out."
@@ -1078,7 +1078,7 @@
     "description": "Status text indicating a bridge transaction has failed."
   },
   "bridgeStatusInProgress": {
-    "message": "In Progress",
+    "message": "In progress",
     "description": "Status text indicating a bridge transaction is currently processing."
   },
   "bridgeStepActionBridgeComplete": {
@@ -1195,7 +1195,7 @@
     "description": "$1 is the ticker symbol of a an asset the user is being prompted to purchase"
   },
   "buyNow": {
-    "message": "Buy Now"
+    "message": "Buy now"
   },
   "bytes": {
     "message": "Bytes"
@@ -1326,7 +1326,7 @@
     "message": "The majority of the token's supply is held by the top token holders, posing a risk of centralized price manipulation"
   },
   "concentratedSupplyDistributionTitle": {
-    "message": "Concentrated Supply Distribution"
+    "message": "Concentrated supply distribution"
   },
   "configureSnapPopupDescription": {
     "message": "You're now leaving MetaMask to configure this snap."
@@ -1447,7 +1447,7 @@
     "message": "Now"
   },
   "confirmInfoSwitchingTo": {
-    "message": "Switching To"
+    "message": "Switching to"
   },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"
@@ -2154,7 +2154,7 @@
     "message": "Details"
   },
   "developerOptions": {
-    "message": "Developer Options"
+    "message": "Developer options"
   },
   "disabledGasOptionToolTipMessage": {
     "message": "“$1” is disabled because it does not meet the minimum of a 10% increase from the original gas fee.",
@@ -2249,7 +2249,7 @@
     "message": "Get our mobile app"
   },
   "downloadNow": {
-    "message": "Download Now"
+    "message": "Download now"
   },
   "downloadStateLogs": {
     "message": "Download state logs"
@@ -2519,7 +2519,7 @@
     "message": "Enter password to continue"
   },
   "enterYourPasswordSocialLoginFlow": {
-    "message": "Enter MetaMask Password"
+    "message": "Enter MetaMask password"
   },
   "errorCode": {
     "message": "Code: $1",
@@ -2650,7 +2650,7 @@
     "description": "Banner description displayed on Snaps list page in Settings when less than 6 Snaps is installed."
   },
   "externalAccount": {
-    "message": "External Account"
+    "message": "External account"
   },
   "externalExtension": {
     "message": "External extension"
@@ -2872,7 +2872,7 @@
     "description": "Label for a permission with no expiration"
   },
   "gatorPermissionTokenPeriodicFrequencyLabel": {
-    "message": "Transfer Window",
+    "message": "Transfer window",
     "description": "Label for the transfer window of a token periodic permission"
   },
   "gatorPermissionTokenStreamFrequencyLabel": {
@@ -2888,7 +2888,7 @@
     "description": "Label for the expiration date of a permission"
   },
   "gatorPermissionsHideDetails": {
-    "message": "Hide Details",
+    "message": "Hide details",
     "description": "Button text to hide permission details"
   },
   "gatorPermissionsInitialAllowance": {
@@ -2912,7 +2912,7 @@
     "description": "Label for the revoke button of a gator permission"
   },
   "gatorPermissionsShowDetails": {
-    "message": "Show Details",
+    "message": "Show details",
     "description": "Button text to show permission details"
   },
   "gatorPermissionsStartDate": {
@@ -3105,7 +3105,7 @@
     "message": "This token might pose a honeypot risk. It is advised to conduct due diligence before interacting to prevent any potential financial loss."
   },
   "honeypotTitle": {
-    "message": "Honey Pot"
+    "message": "Honey pot"
   },
   "hyperliquidReferralCheckboxLabel": {
     "message": "Allow MetaMask to add a referral code. This is permanent. The site offers discounts per their terms. MetaMask earns a fee.",
@@ -3269,7 +3269,7 @@
     "message": "The lack of adequately locked or burned liquidity leaves the token vulnerable to sudden liquidity withdrawals, potentially causing market instability."
   },
   "insufficientLockedLiquidityTitle": {
-    "message": "Insufficient Locked Liquidity"
+    "message": "Insufficient locked liquidity"
   },
   "insufficientTokens": {
     "message": "Insufficient tokens."
@@ -3375,7 +3375,7 @@
     "message": "Account name"
   },
   "keyringAccountPublicAddress": {
-    "message": "Public Address"
+    "message": "Public address"
   },
   "keyringSnapRemovalResult1": {
     "message": "$1 $2removed",
@@ -3439,7 +3439,7 @@
     "message": "Learn more about privacy best practices."
   },
   "learnMoreKeystone": {
-    "message": "Learn More"
+    "message": "Learn more"
   },
   "learnMoreUpperCase": {
     "message": "Learn more"
@@ -3597,7 +3597,7 @@
     "description": "$1 is the key 'loginErrorGenericSupport'"
   },
   "loginErrorGenericSupport": {
-    "message": "MetaMask Support"
+    "message": "MetaMask support"
   },
   "loginErrorGenericTitle": {
     "message": "Something went wrong"
@@ -3652,7 +3652,7 @@
     "message": "Manage default settings"
   },
   "manageInstitutionalWallets": {
-    "message": "Manage Institutional Wallets"
+    "message": "Manage institutional wallets"
   },
   "manageInstitutionalWalletsDescription": {
     "message": "Turn this on to enable institutional wallets."
@@ -3753,7 +3753,7 @@
     "message": "The minimum you'll get if the price changes while your transaction processes, based on your slippage setting. The estimate comes from liquidity providers, so the final amount may differ."
   },
   "minimumReceivedExplanationTitle": {
-    "message": "Minimum Amount Received"
+    "message": "Minimum amount received"
   },
   "minimumReceivedLabel": {
     "message": "Minimum received"
@@ -3926,7 +3926,7 @@
     "description": "Title of the modal created by the name component when address is verified."
   },
   "nameModalTitleWarning": {
-    "message": "Address Needs Review",
+    "message": "Address needs review",
     "description": "Title of the modal created by the name component when address has warning trust signals."
   },
   "nameProviderProposedBy": {
@@ -3972,7 +3972,7 @@
     "description": "graceful fallback for when token symbol isn't found"
   },
   "nativeTokenScamWarningTitle": {
-    "message": "Unexpected Native Token Symbol",
+    "message": "Unexpected native token symbol",
     "description": "Title for nativeTokenScamWarningDescription"
   },
   "needHelp": {
@@ -4021,13 +4021,13 @@
     "message": "Network fees depend on how busy the network is and how complex your transaction is."
   },
   "networkFeeExplanationTitle": {
-    "message": "Network Fee"
+    "message": "Network fee"
   },
   "networkIsBusy": {
     "message": "Network is busy. Gas prices are high and estimates are less accurate."
   },
   "networkMenu": {
-    "message": "Network Menu"
+    "message": "Network menu"
   },
   "networkMenuHeading": {
     "message": "Select a network"
@@ -4241,7 +4241,7 @@
     "message": "NFTs"
   },
   "nftsPreviouslyOwned": {
-    "message": "Previously Owned"
+    "message": "Previously owned"
   },
   "nickname": {
     "message": "Nickname"
@@ -4343,7 +4343,7 @@
     "message": "Priority fee (GWEI)"
   },
   "notificationItemCheckBlockExplorer": {
-    "message": "Check on the Block Explorer"
+    "message": "Check on the block explorer"
   },
   "notificationItemCollection": {
     "message": "Collection"
@@ -4358,7 +4358,7 @@
     "message": "From"
   },
   "notificationItemLidoStakeReadyToBeWithdrawn": {
-    "message": "Withdrawal Ready"
+    "message": "Withdrawal ready"
   },
   "notificationItemLidoStakeReadyToBeWithdrawnMessage": {
     "message": "You can now withdraw your unstaked $1"
@@ -4397,7 +4397,7 @@
     "message": "Staked"
   },
   "notificationItemStakingProvider": {
-    "message": "Staking Provider"
+    "message": "Staking provider"
   },
   "notificationItemStatus": {
     "message": "Status"
@@ -4447,7 +4447,7 @@
     "message": "Notifications"
   },
   "notificationsFeatureToggle": {
-    "message": "Enable Wallet Notifications",
+    "message": "Enable wallet notifications",
     "description": "Experimental feature title"
   },
   "notificationsFeatureToggleDescription": {
@@ -4731,10 +4731,10 @@
     "message": "If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me."
   },
   "passwordToggleHide": {
-    "message": "Hide Password"
+    "message": "Hide password"
   },
   "passwordToggleShow": {
-    "message": "Show Password"
+    "message": "Show password"
   },
   "passwordsDontMatch": {
     "message": "Passwords don't match"
@@ -5122,7 +5122,7 @@
     "message": "Priority fee"
   },
   "priorityFeeProperCase": {
-    "message": "Priority Fee"
+    "message": "Priority fee"
   },
   "priorityFeeTooHigh": {
     "message": "Priority fee must be less than max base fee"
@@ -5639,7 +5639,7 @@
     "message": "An unknown error occurred while authenticating this account with the rewards program. Please try again later."
   },
   "rewardsAuthFailTitle": {
-    "message": "Unknown Error."
+    "message": "Unknown error."
   },
   "rewardsErrorMessagesAccountAlreadyRegistered": {
     "message": "This account is already registered with another Rewards profile. Please switch account to continue."
@@ -5775,7 +5775,7 @@
     "description": "Text shown when points balance couldn't be loaded"
   },
   "rewardsPointsIcon": {
-    "message": "Rewards Points",
+    "message": "Rewards points",
     "description": "Alt text for the rewards points icon"
   },
   "rewardsQRCodeDescription": {
@@ -6704,7 +6704,7 @@
     "message": "You're giving someone else permission to spend this amount from your account."
   },
   "simulationDetailsFiatNotAvailable": {
-    "message": "Not Available"
+    "message": "Not available"
   },
   "simulationDetailsIncomingHeading": {
     "message": "You receive"
@@ -7311,13 +7311,13 @@
     "message": "Staked"
   },
   "stakingDeposit": {
-    "message": "Staking Deposit"
+    "message": "Staking deposit"
   },
   "stakingWithdrawal": {
-    "message": "Staking Withdrawal"
+    "message": "Staking withdrawal"
   },
   "standardAccountLabel": {
-    "message": "Standard Account"
+    "message": "Standard account"
   },
   "stateCorruptionAreYouSure": {
     "message": "Are you sure you want to proceed?"
@@ -7337,7 +7337,7 @@
     "message": "Your vault can be recovered from an automated backup. Automatic recovery will delete your current settings and preferences, and restore only your vault."
   },
   "stateCorruptionMetamaskDatabaseCannotBeAccessed": {
-    "message": "Internal Error: Database cannot be accessed"
+    "message": "Internal error: database cannot be accessed"
   },
   "stateCorruptionResetMetaMaskState": {
     "message": "Reset MetaMask State"
@@ -7346,7 +7346,7 @@
     "message": "Resetting database…"
   },
   "stateCorruptionRestoreAccountsFromBackup": {
-    "message": "Restore Accounts"
+    "message": "Restore accounts"
   },
   "stateCorruptionRestoringDatabase": {
     "message": "Restoring database…"
@@ -7949,7 +7949,7 @@
     "message": "10% increase"
   },
   "terms": {
-    "message": "Terms of use"
+    "message": "Terms of Use"
   },
   "termsOfService": {
     "message": "Terms of service"
@@ -8046,10 +8046,10 @@
     "message": "Token standard"
   },
   "tokenStream": {
-    "message": "Token Stream"
+    "message": "Token stream"
   },
   "tokenSubscription": {
-    "message": "Token Subscription"
+    "message": "Token subscription"
   },
   "tokenSymbol": {
     "message": "Token symbol"
@@ -8366,7 +8366,7 @@
     "message": "The price of this token in USD is highly volatile, indicating a high risk of losing significant value by interacting with it."
   },
   "unstableTokenPriceTitle": {
-    "message": "Unstable Token Price"
+    "message": "Unstable token price"
   },
   "upArrow": {
     "message": "up arrow"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5131,7 +5131,7 @@
     "message": "Privacy"
   },
   "privacyMsg": {
-    "message": "Privacy policy"
+    "message": "Privacy Policy"
   },
   "privateKey": {
     "message": "Private key",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -415,7 +415,7 @@
     "message": "This is the transaction number of an account. Nonce for the first transaction is 0 and it increases in sequential order."
   },
   "advancedEIP1559ModalTitle": {
-    "message": "Advanced Network Fee"
+    "message": "Advanced network fee"
   },
   "advancedGasFeeDefaultOptIn": {
     "message": "Save these values as my default for the $1 network.",
@@ -425,7 +425,7 @@
     "message": "Advanced gas fee"
   },
   "advancedGasPriceModalTitle": {
-    "message": "Advanced Network Fee"
+    "message": "Advanced network fee"
   },
   "advancedGasPriceTitle": {
     "message": "Gas price"
@@ -443,7 +443,7 @@
     "message": "The token's on-chain history reveals prior instances of suspicious airdrop activities."
   },
   "airDropPatternTitle": {
-    "message": "Airdrop Pattern"
+    "message": "Airdrop pattern"
   },
   "airgapVault": {
     "message": "AirGap Vault"
@@ -458,7 +458,7 @@
     "message": "Account type"
   },
   "alertActionBurnAddress": {
-    "message": "Sending Assets to Burn Address"
+    "message": "Sending assets to burn address"
   },
   "alertActionBuyWithNativeCurrency": {
     "message": "Buy $1"
@@ -533,7 +533,7 @@
     "message": "I have acknowledged the risk and still want to proceed"
   },
   "alertModalDetails": {
-    "message": "Alert Details"
+    "message": "Alert details"
   },
   "alertModalReviewAllAlerts": {
     "message": "Review all alerts"
@@ -631,10 +631,10 @@
     "message": "Amount"
   },
   "amountReceived": {
-    "message": "Amount Received"
+    "message": "Amount received"
   },
   "amountSent": {
-    "message": "Amount Sent"
+    "message": "Amount sent"
   },
   "andForListItems": {
     "message": "$1, and $2",
@@ -860,7 +860,7 @@
     "message": "MetaMask Beta Version"
   },
   "betaTerms": {
-    "message": "Beta Terms of use"
+    "message": "Beta Terms of Use"
   },
   "blockExplorerAccountAction": {
     "message": "Account",
@@ -1046,7 +1046,7 @@
     "message": "Price impact"
   },
   "bridgePriceImpactWarningTitle": {
-    "message": "Price Impact Warning"
+    "message": "Price impact warning"
   },
   "bridgeQuoteExpired": {
     "message": "Your quote timed out."
@@ -1078,7 +1078,7 @@
     "description": "Status text indicating a bridge transaction has failed."
   },
   "bridgeStatusInProgress": {
-    "message": "In Progress",
+    "message": "In progress",
     "description": "Status text indicating a bridge transaction is currently processing."
   },
   "bridgeStepActionBridgeComplete": {
@@ -1195,7 +1195,7 @@
     "description": "$1 is the ticker symbol of a an asset the user is being prompted to purchase"
   },
   "buyNow": {
-    "message": "Buy Now"
+    "message": "Buy now"
   },
   "bytes": {
     "message": "Bytes"
@@ -1326,7 +1326,7 @@
     "message": "The majority of the token's supply is held by the top token holders, posing a risk of centralized price manipulation"
   },
   "concentratedSupplyDistributionTitle": {
-    "message": "Concentrated Supply Distribution"
+    "message": "Concentrated supply distribution"
   },
   "configureSnapPopupDescription": {
     "message": "You're now leaving MetaMask to configure this snap."
@@ -1447,7 +1447,7 @@
     "message": "Now"
   },
   "confirmInfoSwitchingTo": {
-    "message": "Switching To"
+    "message": "Switching to"
   },
   "confirmNestedTransactionTitle": {
     "message": "Transaction $1"
@@ -2154,7 +2154,7 @@
     "message": "Details"
   },
   "developerOptions": {
-    "message": "Developer Options"
+    "message": "Developer options"
   },
   "disabledGasOptionToolTipMessage": {
     "message": "“$1” is disabled because it does not meet the minimum of a 10% increase from the original gas fee.",
@@ -2249,7 +2249,7 @@
     "message": "Get our mobile app"
   },
   "downloadNow": {
-    "message": "Download Now"
+    "message": "Download now"
   },
   "downloadStateLogs": {
     "message": "Download state logs"
@@ -2519,7 +2519,7 @@
     "message": "Enter password to continue"
   },
   "enterYourPasswordSocialLoginFlow": {
-    "message": "Enter MetaMask Password"
+    "message": "Enter MetaMask password"
   },
   "errorCode": {
     "message": "Code: $1",
@@ -2650,7 +2650,7 @@
     "description": "Banner description displayed on Snaps list page in Settings when less than 6 Snaps is installed."
   },
   "externalAccount": {
-    "message": "External Account"
+    "message": "External account"
   },
   "externalExtension": {
     "message": "External extension"
@@ -2872,7 +2872,7 @@
     "description": "Label for a permission with no expiration"
   },
   "gatorPermissionTokenPeriodicFrequencyLabel": {
-    "message": "Transfer Window",
+    "message": "Transfer window",
     "description": "Label for the transfer window of a token periodic permission"
   },
   "gatorPermissionTokenStreamFrequencyLabel": {
@@ -2888,7 +2888,7 @@
     "description": "Label for the expiration date of a permission"
   },
   "gatorPermissionsHideDetails": {
-    "message": "Hide Details",
+    "message": "Hide details",
     "description": "Button text to hide permission details"
   },
   "gatorPermissionsInitialAllowance": {
@@ -2912,7 +2912,7 @@
     "description": "Label for the revoke button of a gator permission"
   },
   "gatorPermissionsShowDetails": {
-    "message": "Show Details",
+    "message": "Show details",
     "description": "Button text to show permission details"
   },
   "gatorPermissionsStartDate": {
@@ -3105,7 +3105,7 @@
     "message": "This token might pose a honeypot risk. It is advised to conduct due diligence before interacting to prevent any potential financial loss."
   },
   "honeypotTitle": {
-    "message": "Honey Pot"
+    "message": "Honey pot"
   },
   "hyperliquidReferralCheckboxLabel": {
     "message": "Allow MetaMask to add a referral code. This is permanent. The site offers discounts per their terms. MetaMask earns a fee.",
@@ -3269,7 +3269,7 @@
     "message": "The lack of adequately locked or burned liquidity leaves the token vulnerable to sudden liquidity withdrawals, potentially causing market instability."
   },
   "insufficientLockedLiquidityTitle": {
-    "message": "Insufficient Locked Liquidity"
+    "message": "Insufficient locked liquidity"
   },
   "insufficientTokens": {
     "message": "Insufficient tokens."
@@ -3375,7 +3375,7 @@
     "message": "Account name"
   },
   "keyringAccountPublicAddress": {
-    "message": "Public Address"
+    "message": "Public address"
   },
   "keyringSnapRemovalResult1": {
     "message": "$1 $2removed",
@@ -3439,7 +3439,7 @@
     "message": "Learn more about privacy best practices."
   },
   "learnMoreKeystone": {
-    "message": "Learn More"
+    "message": "Learn more"
   },
   "learnMoreUpperCase": {
     "message": "Learn more"
@@ -3597,7 +3597,7 @@
     "description": "$1 is the key 'loginErrorGenericSupport'"
   },
   "loginErrorGenericSupport": {
-    "message": "MetaMask Support"
+    "message": "MetaMask support"
   },
   "loginErrorGenericTitle": {
     "message": "Something went wrong"
@@ -3652,7 +3652,7 @@
     "message": "Manage default settings"
   },
   "manageInstitutionalWallets": {
-    "message": "Manage Institutional Wallets"
+    "message": "Manage institutional wallets"
   },
   "manageInstitutionalWalletsDescription": {
     "message": "Turn this on to enable institutional wallets."
@@ -3753,7 +3753,7 @@
     "message": "The minimum you'll get if the price changes while your transaction processes, based on your slippage setting. The estimate comes from liquidity providers, so the final amount may differ."
   },
   "minimumReceivedExplanationTitle": {
-    "message": "Minimum Amount Received"
+    "message": "Minimum amount received"
   },
   "minimumReceivedLabel": {
     "message": "Minimum received"
@@ -3926,7 +3926,7 @@
     "description": "Title of the modal created by the name component when address is verified."
   },
   "nameModalTitleWarning": {
-    "message": "Address Needs Review",
+    "message": "Address needs review",
     "description": "Title of the modal created by the name component when address has warning trust signals."
   },
   "nameProviderProposedBy": {
@@ -3972,7 +3972,7 @@
     "description": "graceful fallback for when token symbol isn't found"
   },
   "nativeTokenScamWarningTitle": {
-    "message": "Unexpected Native Token Symbol",
+    "message": "Unexpected native token symbol",
     "description": "Title for nativeTokenScamWarningDescription"
   },
   "needHelp": {
@@ -4021,13 +4021,13 @@
     "message": "Network fees depend on how busy the network is and how complex your transaction is."
   },
   "networkFeeExplanationTitle": {
-    "message": "Network Fee"
+    "message": "Network fee"
   },
   "networkIsBusy": {
     "message": "Network is busy. Gas prices are high and estimates are less accurate."
   },
   "networkMenu": {
-    "message": "Network Menu"
+    "message": "Network menu"
   },
   "networkMenuHeading": {
     "message": "Select a network"
@@ -4241,7 +4241,7 @@
     "message": "NFTs"
   },
   "nftsPreviouslyOwned": {
-    "message": "Previously Owned"
+    "message": "Previously owned"
   },
   "nickname": {
     "message": "Nickname"
@@ -4343,7 +4343,7 @@
     "message": "Priority fee (GWEI)"
   },
   "notificationItemCheckBlockExplorer": {
-    "message": "Check on the Block Explorer"
+    "message": "Check on the block explorer"
   },
   "notificationItemCollection": {
     "message": "Collection"
@@ -4358,7 +4358,7 @@
     "message": "From"
   },
   "notificationItemLidoStakeReadyToBeWithdrawn": {
-    "message": "Withdrawal Ready"
+    "message": "Withdrawal ready"
   },
   "notificationItemLidoStakeReadyToBeWithdrawnMessage": {
     "message": "You can now withdraw your unstaked $1"
@@ -4397,7 +4397,7 @@
     "message": "Staked"
   },
   "notificationItemStakingProvider": {
-    "message": "Staking Provider"
+    "message": "Staking provider"
   },
   "notificationItemStatus": {
     "message": "Status"
@@ -4447,7 +4447,7 @@
     "message": "Notifications"
   },
   "notificationsFeatureToggle": {
-    "message": "Enable Wallet Notifications",
+    "message": "Enable wallet notifications",
     "description": "Experimental feature title"
   },
   "notificationsFeatureToggleDescription": {
@@ -4731,10 +4731,10 @@
     "message": "If I forget this password, I’ll lose access to my wallet permanently. MetaMask can’t reset it for me."
   },
   "passwordToggleHide": {
-    "message": "Hide Password"
+    "message": "Hide password"
   },
   "passwordToggleShow": {
-    "message": "Show Password"
+    "message": "Show password"
   },
   "passwordsDontMatch": {
     "message": "Passwords don't match"
@@ -5122,7 +5122,7 @@
     "message": "Priority fee"
   },
   "priorityFeeProperCase": {
-    "message": "Priority Fee"
+    "message": "Priority fee"
   },
   "priorityFeeTooHigh": {
     "message": "Priority fee must be less than max base fee"
@@ -5639,7 +5639,7 @@
     "message": "An unknown error occurred while authenticating this account with the rewards program. Please try again later."
   },
   "rewardsAuthFailTitle": {
-    "message": "Unknown Error."
+    "message": "Unknown error."
   },
   "rewardsErrorMessagesAccountAlreadyRegistered": {
     "message": "This account is already registered with another Rewards profile. Please switch account to continue."
@@ -5775,7 +5775,7 @@
     "description": "Text shown when points balance couldn't be loaded"
   },
   "rewardsPointsIcon": {
-    "message": "Rewards Points",
+    "message": "Rewards points",
     "description": "Alt text for the rewards points icon"
   },
   "rewardsQRCodeDescription": {
@@ -6704,7 +6704,7 @@
     "message": "You're giving someone else permission to spend this amount from your account."
   },
   "simulationDetailsFiatNotAvailable": {
-    "message": "Not Available"
+    "message": "Not available"
   },
   "simulationDetailsIncomingHeading": {
     "message": "You receive"
@@ -7311,13 +7311,13 @@
     "message": "Staked"
   },
   "stakingDeposit": {
-    "message": "Staking Deposit"
+    "message": "Staking deposit"
   },
   "stakingWithdrawal": {
-    "message": "Staking Withdrawal"
+    "message": "Staking withdrawal"
   },
   "standardAccountLabel": {
-    "message": "Standard Account"
+    "message": "Standard account"
   },
   "stateCorruptionAreYouSure": {
     "message": "Are you sure you want to proceed?"
@@ -7337,7 +7337,7 @@
     "message": "Your vault can be recovered from an automated backup. Automatic recovery will delete your current settings and preferences, and restore only your vault."
   },
   "stateCorruptionMetamaskDatabaseCannotBeAccessed": {
-    "message": "Internal Error: Database cannot be accessed"
+    "message": "Internal error: database cannot be accessed"
   },
   "stateCorruptionResetMetaMaskState": {
     "message": "Reset MetaMask State"
@@ -7346,7 +7346,7 @@
     "message": "Resetting database…"
   },
   "stateCorruptionRestoreAccountsFromBackup": {
-    "message": "Restore Accounts"
+    "message": "Restore accounts"
   },
   "stateCorruptionRestoringDatabase": {
     "message": "Restoring database…"
@@ -7949,7 +7949,7 @@
     "message": "10% increase"
   },
   "terms": {
-    "message": "Terms of use"
+    "message": "Terms of Use"
   },
   "termsOfService": {
     "message": "Terms of service"
@@ -8046,10 +8046,10 @@
     "message": "Token standard"
   },
   "tokenStream": {
-    "message": "Token Stream"
+    "message": "Token stream"
   },
   "tokenSubscription": {
-    "message": "Token Subscription"
+    "message": "Token subscription"
   },
   "tokenSymbol": {
     "message": "Token symbol"
@@ -8366,7 +8366,7 @@
     "message": "The price of this token in USD is highly volatile, indicating a high risk of losing significant value by interacting with it."
   },
   "unstableTokenPriceTitle": {
-    "message": "Unstable Token Price"
+    "message": "Unstable token price"
   },
   "upArrow": {
     "message": "up arrow"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5131,7 +5131,7 @@
     "message": "Privacy"
   },
   "privacyMsg": {
-    "message": "Privacy policy"
+    "message": "Privacy Policy"
   },
   "privateKey": {
     "message": "Private key",

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -888,7 +888,7 @@
     "message": "Kapag kinumpirma mo ang kahilingang ito, pinapayagan mo ang scammer na i-withdraw at gastusin ang mga asset mo. Hindi mo na mababawi ang mga iyon."
   },
   "blockaidDescriptionApproveFarming": {
-    "message": "Kung aaprubahan mo ang kahilingang ito, maaaring kunin ng third party na kilala sa mga panloloko ang lahat asset mo."
+    "message": "Kung aaprubahan mo ang kahilingang ito, maaaring kunin ng third-party na kilala sa mga panloloko ang lahat asset mo."
   },
   "blockaidDescriptionBlurFarming": {
     "message": "Kung aaprubahan mo ang kahilingang ito, posibleng nakawin ng ibang tao ang mga asset mo na nakalista sa Blur."
@@ -906,10 +906,10 @@
     "message": "Kung aaprubahan mo ang kahilingang ito, posibleng nakawin ng ibang tao ang mga asset mo na nakalista sa OpenSea."
   },
   "blockaidDescriptionTransferFarming": {
-    "message": "Kung aaprubahan mo ang kahilingang ito, kukunin ng third party na kilala sa mga panloloko ang lahat ng asset mo."
+    "message": "Kung aaprubahan mo ang kahilingang ito, kukunin ng third-party na kilala sa mga panloloko ang lahat ng asset mo."
   },
   "blockaidMessage": {
-    "message": "Pagpapanatili ng privacy - walang data na ibinabahagi sa mga third party. Available sa Arbitrum, Avalanche, BNB chain, Ethereum Mainnet, Linea, Optimism, Polygon, Base at Sepolia."
+    "message": "Pagpapanatili ng privacy - walang data na ibinabahagi sa mga third-party. Available sa Arbitrum, Avalanche, BNB chain, Ethereum Mainnet, Linea, Optimism, Polygon, Base at Sepolia."
   },
   "blockaidTitleDeceptive": {
     "message": "Isa itong mapanlinlang na kahilingan"
@@ -1983,7 +1983,7 @@
     "message": "Inire-redirect sa MetaMask"
   },
   "deepLink_ThirdPartyDescription": {
-    "message": "Ipinadala ka rito ng third party, hindi ng MetaMask.$1",
+    "message": "Ipinadala ka rito ng third-party, hindi ng MetaMask.$1",
     "description": "$1 is the message 'deepLink_ContinueDescription'"
   },
   "deepLink_theBuyPage": {
@@ -2168,7 +2168,7 @@
     "message": "Ipakita ang NFT media"
   },
   "displayNftMediaDescription": {
-    "message": "Ang pagpapakita ng NFT media at data ay naglalantad sa iyong IP address sa OpenSea o sa ibang mga third party. Maaari nitong payagan ang mga umaatake na iugnay ang iyong IP address sa iyong Ethereum address. Umaasa ang awtomatikong pagtuklas ng NFT sa setting na ito, at hindi magagamit kapag naka-off ito."
+    "message": "Ang pagpapakita ng NFT media at data ay naglalantad sa iyong IP address sa OpenSea o sa ibang mga third-party. Maaari nitong payagan ang mga umaatake na iugnay ang iyong IP address sa iyong Ethereum address. Umaasa ang awtomatikong pagtuklas ng NFT sa setting na ito, at hindi magagamit kapag naka-off ito."
   },
   "doNotShare": {
     "message": "Huwag itong ibahagi kahit kanino"
@@ -2423,7 +2423,7 @@
     "message": "Pinahihintulutan ng MetaMask na makita mo ang mga ENS mula mismo sa address bar ng iyong browser. Here's how it works:"
   },
   "ensDomainsSettingDescriptionOutroduction": {
-    "message": "Mangyaring tandaan na ang paggamit ng tampok na ito ay naglalantad sa iyong IP address sa serbisyong third party."
+    "message": "Mangyaring tandaan na ang paggamit ng tampok na ito ay naglalantad sa iyong IP address sa serbisyong third-party."
   },
   "ensDomainsSettingDescriptionPart1": {
     "message": "Sinusuri ng MetaMask ang kontrata ng ENS ng Ethereum para mahanap ang code na konektado sa pangalan ng ENS."
@@ -2611,7 +2611,7 @@
     "message": "Mga mungkahing palayaw"
   },
   "externalNameSourcesSettingDescription": {
-    "message": "Kami ay kukuha ng ilang mungkahing palayaw para sa mga address na nakikipag-ugnayan ka mula sa mga third-party source tulad ng Etherscan, Infura, at Lens Protocol. Ang mga source na ito ay maaaring makita ang mga address na ito at ang iyong iyong IP address. Ang iyong address ay hindi ilalantad sa mga third party."
+    "message": "Kami ay kukuha ng ilang mungkahing palayaw para sa mga address na nakikipag-ugnayan ka mula sa mga third-party source tulad ng Etherscan, Infura, at Lens Protocol. Ang mga source na ito ay maaaring makita ang mga address na ito at ang iyong iyong IP address. Ang iyong address ay hindi ilalantad sa mga third-party."
   },
   "failed": {
     "message": "Pumalya"
@@ -4434,7 +4434,7 @@
     "message": "Tulungan kami na paghusayin ang iyong karanasan"
   },
   "onboardingAdvancedPrivacyIPFSDescription": {
-    "message": "Ginagawang posible ng IPFS gateway na ma-access at makita ang datos na pinangangasiwaan ng mga third party. Maaari kang magdagdag ng custom na IPFS gateway o magpatuloy sa paggamit ng default."
+    "message": "Ginagawang posible ng IPFS gateway na ma-access at makita ang datos na pinangangasiwaan ng mga third-party. Maaari kang magdagdag ng custom na IPFS gateway o magpatuloy sa paggamit ng default."
   },
   "onboardingAdvancedPrivacyIPFSInvalid": {
     "message": "Maglagay ng wastong URL"
@@ -4972,7 +4972,7 @@
     "description": "$1 is a number of additional but unshown items in a list- this message will be shown in place of those items"
   },
   "popularNetworkAddToolTip": {
-    "message": "Umaasa sa mga third party ang ilan sa mga network na ito. Ang mga koneksyong ito ay maaaring hindi gaanong maaasahan o nagbibigay-daan sa mga third-party na sumubaybay ng aktibidad.",
+    "message": "Umaasa sa mga third-party ang ilan sa mga network na ito. Ang mga koneksyong ito ay maaaring hindi gaanong maaasahan o nagbibigay-daan sa mga third-party na sumubaybay ng aktibidad.",
     "description": "Learn more link"
   },
   "popularNetworks": {
@@ -8102,7 +8102,7 @@
     "message": "Maramihang kahilingan sa balanse ng account"
   },
   "useMultiAccountBalanceCheckerSettingDescription": {
-    "message": "Makakuha ng mas mabibilis na update sa balanse sa pamamagitan ng maramihang paghiling sa balanse ng account. Nagpapahintulot ito sa amin na makuha nang sama-sama ang iyong mga balanse ng account, para makakuha ka ng mas mabibilis na update para sa inaprubahang kasanayan. Kapag naka-off ang feature na ito, posibleng hindi maiugnay ng mga third party ang iyong mga account sa isa't isa."
+    "message": "Makakuha ng mas mabibilis na update sa balanse sa pamamagitan ng maramihang paghiling sa balanse ng account. Nagpapahintulot ito sa amin na makuha nang sama-sama ang iyong mga balanse ng account, para makakuha ka ng mas mabibilis na update para sa inaprubahang kasanayan. Kapag naka-off ang feature na ito, posibleng hindi maiugnay ng mga third-party ang iyong mga account sa isa't isa."
   },
   "useNftDetection": {
     "message": "Awtomatikong tuklasin and mga NFT"
@@ -8133,7 +8133,7 @@
     "message": "Gumamit ng smart account"
   },
   "useTokenDetectionPrivacyDesc": {
-    "message": "Awtomatikong ipinapakita ang mga token na ipinadala sa iyong account na nakapaloob sa komunikasyon ng mga server ng third party para makuha ang mga larawan ng token. Ang mga server na iyon ay magkakaroon ng access sa iyong IP address."
+    "message": "Awtomatikong ipinapakita ang mga token na ipinadala sa iyong account na nakapaloob sa komunikasyon ng mga server ng third-party para makuha ang mga larawan ng token. Ang mga server na iyon ay magkakaroon ng access sa iyong IP address."
   },
   "usedByClients": {
     "message": "Ginagamit ng iba't ibang kliyente"

--- a/test/e2e/page-objects/pages/developer-options-page.ts
+++ b/test/e2e/page-objects/pages/developer-options-page.ts
@@ -13,7 +13,7 @@ class DevelopOptions {
     '[data-testid="developer-options-generate-page-crash-button"]';
 
   private readonly developOptionsPageTitle: object = {
-    text: 'Developer Options',
+    text: 'Developer options',
     css: 'h4',
   };
 

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -17,7 +17,7 @@ class SettingsPage {
   };
 
   private readonly developerOptionsButton = {
-    text: 'Developer Options',
+    text: 'Developer options',
     css: '.tab-bar__tab__content__title',
   };
 
@@ -138,7 +138,7 @@ class SettingsPage {
   }
 
   async goToDeveloperOptions(): Promise<void> {
-    console.log('Navigating to Developer Options page');
+    console.log('Navigating to Developer options page');
     await this.driver.clickElement(this.developerOptionsButton);
   }
 

--- a/ui/components/app/name/name-details/name-details.test.tsx
+++ b/ui/components/app/name/name-details/name-details.test.tsx
@@ -940,7 +940,7 @@ describe('NameDetails', () => {
         store,
       );
 
-      expect(getByText('Address Needs Review')).toBeInTheDocument();
+      expect(getByText('Address needs review')).toBeInTheDocument();
     });
 
     it('renders verified state correctly', () => {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
@@ -139,8 +139,8 @@ describe('TransactionBreakdown', () => {
         getActualDataFrom(getAllByTestId('transaction-breakdown-row')),
       ).toStrictEqual([
         ['Nonce', '114'],
-        ['Amount Sent', '33.425656732428330864 BAT'],
-        ['Amount Received', '0.00222334422997802 ETH'],
+        ['Amount sent', '33.425656732428330864 BAT'],
+        ['Amount received', '0.00222334422997802 ETH'],
         ['Gas limit (units)', '246742'],
         ['Gas used (units)', '195177'],
         ['Base fee (GWEI)', '6.476394595'],
@@ -171,8 +171,8 @@ describe('TransactionBreakdown', () => {
       ).toStrictEqual([
         ['Nonce', '114'],
         // Verify small amounts not in scientific notation
-        ['Amount Sent', '0.0000000000000001 BAT'],
-        ['Amount Received', '0.0000000000000001 ETH'],
+        ['Amount sent', '0.0000000000000001 BAT'],
+        ['Amount received', '0.0000000000000001 ETH'],
         ['Gas limit (units)', '246742'],
         ['Gas used (units)', '195177'],
         ['Base fee (GWEI)', '6.476394595'],
@@ -201,8 +201,8 @@ describe('TransactionBreakdown', () => {
         getActualDataFrom(getAllByTestId('transaction-breakdown-row')),
       ).toStrictEqual([
         ['Nonce', '114'],
-        ['Amount Sent', '33.425656732428330864 BAT'],
-        ['Amount Received', '0.00222334422997802 ETH'],
+        ['Amount sent', '33.425656732428330864 BAT'],
+        ['Amount received', '0.00222334422997802 ETH'],
         ['Network fee', 'Paid by MetaMask'],
       ]);
     });

--- a/ui/components/component-library/avatar-favicon/README.mdx
+++ b/ui/components/component-library/avatar-favicon/README.mdx
@@ -6,7 +6,7 @@ import { AvatarFavicon } from './avatar-favicon';
 
 # AvatarFavicon (deprecated use @metamask/design-system-react)
 
-The `AvatarFavicon` is an image component that represents a dapp or third party service
+The `AvatarFavicon` is an image component that represents a dapp or third-party service
 
 [MetaMask Design System Guides](https://www.notion.so/MetaMask-Design-System-Guides-Design-f86ecc914d6b4eb6873a122b83c12940)
 

--- a/ui/components/multichain/account-menu/account-menu.test.tsx
+++ b/ui/components/multichain/account-menu/account-menu.test.tsx
@@ -476,6 +476,6 @@ describe('AccountMenu', () => {
     );
     actionButton.click();
 
-    expect(getByText('Manage Institutional Wallets')).toBeInTheDocument();
+    expect(getByText('Manage institutional wallets')).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -10,7 +10,7 @@ exports[`App Header locked state matches snapshot: locked 1`] = `
     >
       <div>
         <button
-          aria-label="Network Menu Goerli"
+          aria-label="Network menu Goerli"
           class="mm-box mm-picker-network multichain-app-header__contents__network-picker mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-background-alternative mm-box--rounded-pill"
           data-testid="network-display"
         >

--- a/ui/components/multichain/disconnect-permissions-modal/disconnect-permissions-modal.test.tsx
+++ b/ui/components/multichain/disconnect-permissions-modal/disconnect-permissions-modal.test.tsx
@@ -139,7 +139,7 @@ describe('DisconnectPermissionsModal', () => {
       <DisconnectPermissionsModal {...args} />,
       mockStore,
     );
-    expect(getByText('Token Stream')).toBeInTheDocument();
+    expect(getByText('Token stream')).toBeInTheDocument();
     expect(getByText('1 ETH per second • 0x12345...67890')).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
         <p
           class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-left"
         >
-          Transfer Window
+          Transfer window
         </p>
         <div
           class="flex flex-row gap-2 items-center justify-end"
@@ -165,7 +165,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"
@@ -360,7 +360,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"
@@ -535,7 +535,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"
@@ -725,7 +725,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"
@@ -812,7 +812,7 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
         <p
           class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default text-left"
         >
-          Transfer Window
+          Transfer window
         </p>
         <div
           class="flex flex-row gap-2 items-center justify-end"
@@ -915,7 +915,7 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"
@@ -1105,7 +1105,7 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
           <p
             class="text-primary-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
           >
-            Show Details
+            Show details
           </p>
           <button
             aria-label="expand"

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -95,7 +95,7 @@ const t = (key) => {
     case 'localhost':
       return 'Localhost 8545';
     case 'developerOptions':
-      return 'Developer Options';
+      return 'Developer options';
     case 'experimental':
       return 'Experimental';
     case 'autoDetectTokens':
@@ -119,9 +119,9 @@ const t = (key) => {
     case 'links':
       return 'Links';
     case 'privacyMsg':
-      return 'Privacy policy';
+      return 'Privacy Policy';
     case 'terms':
-      return 'Terms of use';
+      return 'Terms of Use';
     case 'attributions':
       return 'Attributions';
     case 'supportCenter':
@@ -196,7 +196,7 @@ describe('Settings Search Utils', () => {
       );
     });
 
-    it('returns 0 "Developer Options" section count when env flag is disabled', () => {
+    it('returns 0 "Developer options" section count when env flag is disabled', () => {
       expect(
         getNumberOfSettingRoutesInTab(t, t('developerOptions')),
       ).toStrictEqual(0);

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.test.tsx
@@ -82,12 +82,12 @@ describe('TransactionAccountDetails', () => {
       nestedTransactions: [{ to: FROM_MOCK }],
     });
 
-    expect(getByText('Switching To')).toBeInTheDocument();
+    expect(getByText('Switching to')).toBeInTheDocument();
   });
 
   it('renders required data for upgrade request with nested transactions', () => {
     const { getByText } = renderConfirmation(upgradeAccountConfirmation);
-    expect(getByText('Switching To')).toBeInTheDocument();
+    expect(getByText('Switching to')).toBeInTheDocument();
   });
 
   it('renders required data for upgrade only request', () => {

--- a/ui/pages/confirmations/components/confirm/smart-account-tab/smart-account-tab.test.tsx
+++ b/ui/pages/confirmations/components/confirm/smart-account-tab/smart-account-tab.test.tsx
@@ -42,6 +42,6 @@ describe('SmartAccountTab', () => {
     const { getAllByText } = renderComponent();
 
     expect(getAllByText('Smart Account')).toHaveLength(2);
-    expect(getAllByText('Standard Account')).toHaveLength(2);
+    expect(getAllByText('Standard account')).toHaveLength(2);
   });
 });

--- a/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.test.tsx
@@ -58,7 +58,7 @@ describe('AdvancedEIP1559Modal', () => {
 
   it('renders the modal with header', () => {
     const { getByText } = render();
-    expect(getByText('Advanced Network Fee')).toBeInTheDocument();
+    expect(getByText('Advanced network fee')).toBeInTheDocument();
   });
 
   it('renders all gas input components', () => {

--- a/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.test.tsx
@@ -51,7 +51,7 @@ describe('AdvancedGasPriceModal', () => {
   it('renders the modal with header', () => {
     const { getByText } = render();
 
-    expect(getByText('Advanced Network Fee')).toBeInTheDocument();
+    expect(getByText('Advanced network fee')).toBeInTheDocument();
   });
 
   it('renders all gas input components', () => {

--- a/ui/pages/confirmations/components/simulation-details/fiat-display.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/fiat-display.test.tsx
@@ -129,7 +129,7 @@ describe('FiatDisplay', () => {
         <TotalFiatDisplay fiatAmounts={[FIAT_UNAVAILABLE, FIAT_UNAVAILABLE]} />,
         mockStoreWithShowingFiatOnTestnets,
       );
-      expect(screen.getByText('Not Available')).toBeInTheDocument();
+      expect(screen.getByText('Not available')).toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.tsx.snap
+++ b/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
                 value=""
               />
               <button
-                aria-label="Show Password"
+                aria-label="Show password"
                 class="mm-box mm-button-icon mm-button-icon--size-lg mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="show-password"
                 type="button"
@@ -106,7 +106,7 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
                 value=""
               />
               <button
-                aria-label="Show Password"
+                aria-label="Show password"
                 class="mm-box mm-button-icon mm-button-icon--size-lg mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
                 data-testid="show-confirm-password"
                 type="button"

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -496,7 +496,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
         class="settings-page__content-item"
       >
         <span>
-          Manage Institutional Wallets
+          Manage institutional wallets
         </span>
         <div
           class="settings-page__content-description"

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -27,7 +27,7 @@ describe('InfoTab', () => {
     });
 
     it('should have correct href for "Terms of Use" link', () => {
-      const termsOfUseLink = getByText('Terms of use');
+      const termsOfUseLink = getByText('Terms of Use');
       expect(termsOfUseLink).toHaveAttribute(
         'href',
         'https://metamask.io/terms.html',

--- a/ui/pages/settings/info-tab/info-tab.test.tsx
+++ b/ui/pages/settings/info-tab/info-tab.test.tsx
@@ -19,7 +19,7 @@ describe('InfoTab', () => {
     });
 
     it('should have correct href for "Privacy Policy" link', () => {
-      const privacyPolicyLink = getByText('Privacy policy');
+      const privacyPolicyLink = getByText('Privacy Policy');
       expect(privacyPolicyLink).toHaveAttribute(
         'href',
         'https://metamask.io/privacy.html',

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -77,7 +77,7 @@ exports[`Security Tab should match snapshot 1`] = `
               rel="noreferrer noopener"
               target="_blank"
             >
-              Privacy policy
+              Privacy Policy
             </a>
             .
              
@@ -543,7 +543,7 @@ exports[`Security Tab should match snapshot 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                Privacy policy
+                Privacy Policy
               </a>
               
                
@@ -709,7 +709,7 @@ exports[`Security Tab should match snapshot 1`] = `
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Privacy policy
+                Privacy Policy
               </a>
               , and for Solana accounts, 
               <a
@@ -1459,7 +1459,7 @@ exports[`Security Tab should match snapshot 1`] = `
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Privacy policy
+                Privacy Policy
               </a>
               .
                

--- a/ui/pages/settings/security-tab/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
+++ b/ui/pages/settings/security-tab/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
@@ -61,7 +61,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy policy. "`,
+      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy Policy. "`,
     );
   });
   it('should enable the data deletion button when metrics is opted in and metametrics id is available ', async () => {
@@ -77,7 +77,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy policy. "`,
+      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy Policy. "`,
     );
   });
   it('should enable the data deletion button when page mounts after a deletion task is performed and more data is recoded after the deletion', async () => {
@@ -105,7 +105,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy policy. "`,
+      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy Policy. "`,
     );
   });
 
@@ -129,7 +129,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy policy. "`,
+      `" This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our Privacy Policy. "`,
     );
     expect(
       container.querySelector('.settings-page__content-item-col')?.textContent,
@@ -167,7 +167,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy policy "`,
+      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy Policy "`,
     );
   });
 
@@ -200,7 +200,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy policy "`,
+      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy Policy "`,
     );
   });
 


### PR DESCRIPTION
## **Description**

This PR resolves sentence case violations across locale string files to ensure consistent capitalization throughout the MetaMask extension. The changes update various messages to follow proper sentence case formatting rules (capitalizing only the first word of sentences and proper nouns).

### What is the reason for the change?
Content guidelines require that UI strings follow sentence case formatting for consistency and improved readability. Several messages were using incorrect title case (capitalizing multiple words).

### What is the improvement/solution?
- Updated ~50+ messages across English (en), British English (en_GB), and Tagalog (tl) locales
- Fixed messages like:
  - "Advanced Network Fee" → "Advanced network fee"
  - "Amount Received" → "Amount received"
  - "Developer Options" → "Developer options"
  - "Price Impact Warning" → "Price impact warning"
  - And many more...
- Preserved proper nouns and acronyms (MetaMask, API, NFT, etc.)
- Updated related test snapshots

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39196?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed sentence case violations in locale strings for improved consistency

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-428

## **Manual testing steps**

1. Build the extension
2. Review any UI strings that were changed
3. Verify that capitalization follows sentence case (first word capitalized, rest lowercase unless proper nouns)
4. Check that the changes don't break any UI layouts or readability

## **Screenshots/Recordings**

### **Before**

Messages used inconsistent title case capitalization (e.g., "Advanced Network Fee", "Developer Options").

### **After**

Messages now consistently use sentence case (e.g., "Advanced network fee", "Developer options").

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns UI copy with sentence case guidelines across locales; no behavioral changes.
> 
> - Updates `messages.json` in `en`, `en_GB`, and `tl` to sentence case for numerous keys (e.g., "Advanced network fee", "Amount received", "Developer options")
> - Adjusts affected tests, snapshots, and e2e selectors/logs to match new casing (e.g., settings, modals, transaction breakdown, gator permissions, app header)
> - Tweaks minor docs copy (AvatarFavicon README) for third-party hyphenation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fb0cee95d4acee3b58c813376dc4b84e518d06b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->