### PR TITLE
feat: add transaction pay token selection

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4749,6 +4749,14 @@
     "message": "Enter your private key string here:",
     "description": "For importing an account from a private key"
   },
+  "payWith": {
+    "message": "Pay with",
+    "description": "Label for pay with row showing which token is used to pay transaction fees"
+  },
+  "payWithModalTitle": {
+    "message": "Pay with",
+    "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"
+  },
   "pending": {
     "message": "Pending"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4749,6 +4749,14 @@
     "message": "Enter your private key string here:",
     "description": "For importing an account from a private key"
   },
+  "payWith": {
+    "message": "Pay with",
+    "description": "Label for pay with row showing which token is used to pay transaction fees"
+  },
+  "payWithModalTitle": {
+    "message": "Pay with",
+    "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"
+  },
   "pending": {
     "message": "Pending"
   },

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -3439,6 +3439,12 @@
       "Reselect: Identity function warnings": 4,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/selectors/gator-permissions/gator-permissions.test.ts": {
       "MetaMask: Permission type warnings": 2
     }

--- a/ui/pages/confirmations/components/modals/pay-with-modal/index.ts
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/index.ts
@@ -1,0 +1,2 @@
+export { PayWithModal } from './pay-with-modal';
+export type { PayWithModalProps } from './pay-with-modal';

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.stories.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.stories.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { cloneDeep, merge } from 'lodash';
+
+import mockState from '../../../../../../test/data/mock-state.json';
+import configureStore from '../../../../../store/store';
+import { ConfirmContextProvider } from '../../../context/confirm';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
+import { ApprovalType } from '@metamask/controller-utils';
+
+import { PayWithModal } from './pay-with-modal';
+
+const CHAIN_ID_MOCK = '0x5';
+const TOKEN_ADDRESS_MOCK = '0x6b175474e89094c44da98b954eedeac495271d0f';
+const USDC_ADDRESS_MOCK = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+const ACCOUNT_1_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+const ACCOUNT_2_ADDRESS = '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b';
+
+const transaction = genUnapprovedContractInteractionConfirmation({
+  chainId: CHAIN_ID_MOCK,
+});
+
+const createMockState = () => {
+  const state = cloneDeep(mockState);
+
+  merge(state, {
+    metamask: {
+      pendingApprovals: {
+        [transaction.id]: {
+          id: transaction.id,
+          type: ApprovalType.Transaction,
+        },
+      },
+      transactions: [transaction],
+      transactionData: {
+        [transaction.id]: {
+          isLoading: false,
+          paymentToken: {
+            address: TOKEN_ADDRESS_MOCK,
+            chainId: CHAIN_ID_MOCK,
+          },
+          tokens: [],
+          quotes: [],
+        },
+      },
+      enabledNetworkMap: {
+        eip155: {
+          [CHAIN_ID_MOCK]: true,
+        },
+      },
+      allTokens: {
+        [CHAIN_ID_MOCK]: {
+          [ACCOUNT_1_ADDRESS]: [
+            {
+              address: TOKEN_ADDRESS_MOCK,
+              symbol: 'DAI',
+              decimals: 18,
+              name: 'Dai Stablecoin',
+            },
+            {
+              address: USDC_ADDRESS_MOCK,
+              symbol: 'USDC',
+              decimals: 6,
+              name: 'USD Coin',
+            },
+          ],
+          [ACCOUNT_2_ADDRESS]: [],
+        },
+      },
+      allIgnoredTokens: {},
+      tokenBalances: {
+        [ACCOUNT_1_ADDRESS]: {
+          [CHAIN_ID_MOCK]: {
+            [TOKEN_ADDRESS_MOCK]: '0x1111d67bb1bb0000', // 1.23 DAI (18 decimals)
+            [USDC_ADDRESS_MOCK]: '0x23bdb0', // 2.34 USDC (6 decimals)
+          },
+        },
+        [ACCOUNT_2_ADDRESS]: {
+          [CHAIN_ID_MOCK]: {},
+        },
+      },
+      accountsByChainId: {
+        [CHAIN_ID_MOCK]: {
+          [ACCOUNT_1_ADDRESS]: {
+            balance: '0x346ba7725f412cbfdb',
+          },
+          [ACCOUNT_2_ADDRESS]: {
+            balance: '0x0',
+          },
+        },
+      },
+      marketData: {
+        [CHAIN_ID_MOCK]: {
+          [TOKEN_ADDRESS_MOCK]: { price: 1, currency: 'usd' },
+          [USDC_ADDRESS_MOCK]: { price: 1, currency: 'usd' },
+          '0x0000000000000000000000000000000000000000': {
+            price: 2000,
+            currency: 'usd',
+          },
+        },
+      },
+      currencyRates: {
+        ETH: { conversionRate: 2000 },
+        usd: { conversionRate: 1 },
+      },
+      currentCurrency: 'usd',
+      preferences: {
+        ...state.metamask.preferences,
+        showFiatInTestnets: true,
+      },
+    },
+  });
+
+  return state;
+};
+
+const store = configureStore(createMockState());
+
+const Story = {
+  title: 'Confirmations/Components/Modals/PayWithModal',
+  component: PayWithModal,
+  decorators: [
+    (story: () => JSX.Element) => (
+      <Provider store={store}>
+        <ConfirmContextProvider>{story()}</ConfirmContextProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export default Story;
+
+export const DefaultStory = () => (
+  <PayWithModal isOpen={true} onClose={() => console.log('Modal closed')} />
+);
+
+DefaultStory.storyName = 'Default';

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { getAvailableTokens } from '../../../utils/transaction-pay';
+import { PayWithModal } from './pay-with-modal';
+
+jest.mock('../../../hooks/pay/useTransactionPayToken');
+jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../utils/transaction-pay');
+
+jest.mock('../../send/asset', () => ({
+  Asset: ({
+    onAssetSelect,
+    tokenFilter,
+    hideNfts,
+    includeNoBalance,
+  }: {
+    onAssetSelect?: (token: {
+      address: string;
+      chainId: string;
+      disabled?: boolean;
+    }) => void;
+    tokenFilter?: (tokens: unknown[]) => unknown[];
+    hideNfts?: boolean;
+    includeNoBalance?: boolean;
+  }) => {
+    if (tokenFilter) {
+      tokenFilter([]);
+    }
+
+    return (
+      <div data-testid="asset-component">
+        <span data-testid="hide-nfts">{String(hideNfts)}</span>
+        <span data-testid="include-no-balance">{String(includeNoBalance)}</span>
+        <button
+          data-testid="select-token"
+          onClick={() => onAssetSelect?.({ address: '0x123', chainId: '0x1' })}
+        >
+          Select Token
+        </button>
+        <button
+          data-testid="select-disabled-token"
+          onClick={() =>
+            onAssetSelect?.({
+              address: '0x456',
+              chainId: '0x1',
+              disabled: true,
+            })
+          }
+        >
+          Select Disabled Token
+        </button>
+      </div>
+    );
+  },
+}));
+
+const CHAIN_ID_MOCK = '0x1';
+
+describe('PayWithModal', () => {
+  const setPayTokenMock = jest.fn();
+  const onCloseMock = jest.fn();
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+  const getAvailableTokensMock = jest.mocked(getAvailableTokens);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    getAvailableTokensMock.mockImplementation(({ tokens }) => tokens as never);
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: CHAIN_ID_MOCK,
+        balanceFiat: '$100.00',
+        balanceHuman: '0.05',
+        balanceRaw: '50000000000000000',
+        balanceUsd: '100.00',
+        decimals: 18,
+        symbol: 'ETH',
+      },
+      setPayToken: setPayTokenMock,
+      isNative: true,
+    });
+  });
+
+  it('renders modal with header', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    expect(screen.getByText('Pay with')).toBeInTheDocument();
+  });
+
+  it('renders Asset component with correct props', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    expect(screen.getByTestId('asset-component')).toBeInTheDocument();
+    expect(screen.getByTestId('hide-nfts')).toHaveTextContent('true');
+    expect(screen.getByTestId('include-no-balance')).toHaveTextContent('true');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('calls setPayToken and closes modal when token is selected', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    const selectButton = screen.getByTestId('select-token');
+    fireEvent.click(selectButton);
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: '0x123',
+      chainId: '0x1',
+    });
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('filters tokens using getAvailableTokens', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    expect(getAvailableTokensMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payToken: expect.objectContaining({
+          address: '0x0000000000000000000000000000000000000000',
+          chainId: CHAIN_ID_MOCK,
+        }),
+        requiredTokens: [],
+      }),
+    );
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderWithProvider(<PayWithModal isOpen={false} onClose={onCloseMock} />);
+
+    expect(screen.queryByText('Pay with')).not.toBeInTheDocument();
+  });
+
+  it('does not call setPayToken when disabled token is selected', () => {
+    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+
+    const selectDisabledButton = screen.getByTestId('select-disabled-token');
+    fireEvent.click(selectDisabledButton);
+
+    expect(setPayTokenMock).not.toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback } from 'react';
+import { Hex } from '@metamask/utils';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '../../../../../components/component-library';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { getAvailableTokens } from '../../../utils/transaction-pay';
+import { Asset } from '../../send/asset';
+import { type Asset as AssetType } from '../../../types/send';
+
+export type PayWithModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
+  const t = useI18nContext();
+  const { payToken, setPayToken } = useTransactionPayToken();
+  const requiredTokens = useTransactionPayRequiredTokens();
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const handleTokenSelect = useCallback(
+    (token: AssetType) => {
+      if (token.disabled) {
+        return;
+      }
+
+      setPayToken({
+        address: token.address as Hex,
+        chainId: token.chainId as Hex,
+      });
+
+      handleClose();
+    },
+    [handleClose, setPayToken],
+  );
+
+  const tokenFilter = useCallback(
+    (tokens: AssetType[]) => {
+      return getAvailableTokens({
+        payToken,
+        requiredTokens,
+        tokens,
+      });
+    },
+    [payToken, requiredTokens],
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={handleClose}>
+          {t('payWithModalTitle')}
+        </ModalHeader>
+        <Asset
+          includeNoBalance
+          hideNfts
+          tokenFilter={tokenFilter}
+          onAssetSelect={handleTokenSelect}
+        />
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/pages/confirmations/components/rows/pay-with-row/index.ts
+++ b/ui/pages/confirmations/components/rows/pay-with-row/index.ts
@@ -1,0 +1,1 @@
+export { PayWithRow, PayWithRowSkeleton } from './pay-with-row';

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.stories.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.stories.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { cloneDeep, merge } from 'lodash';
+import { TransactionMeta } from '@metamask/transaction-controller';
+
+import mockState from '../../../../../../test/data/mock-state.json';
+import configureStore from '../../../../../store/store';
+import { ConfirmContextProvider } from '../../../context/confirm';
+import {
+  genUnapprovedContractInteractionConfirmation,
+  CONTRACT_INTERACTION_SENDER_ADDRESS,
+} from '../../../../../../test/data/confirmations/contract-interaction';
+import { ApprovalType } from '@metamask/controller-utils';
+
+import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
+
+const CHAIN_ID_MOCK = '0x5';
+const TOKEN_ADDRESS_MOCK = '0x6b175474e89094c44da98b954eedeac495271d0f';
+
+const SENDER_ADDRESS = CONTRACT_INTERACTION_SENDER_ADDRESS;
+
+const transaction = genUnapprovedContractInteractionConfirmation({
+  chainId: CHAIN_ID_MOCK,
+}) as TransactionMeta;
+
+const createMockState = (hasPaymentToken = true) => {
+  const state = cloneDeep(mockState);
+
+  merge(state, {
+    metamask: {
+      pendingApprovals: {
+        [transaction.id]: {
+          id: transaction.id,
+          type: ApprovalType.Transaction,
+          time: transaction.time, // Required for sorting in oldestPendingConfirmationSelector
+        },
+      },
+      transactions: [transaction],
+      transactionData: {
+        [transaction.id]: {
+          isLoading: false,
+          paymentToken: hasPaymentToken
+            ? {
+                address: TOKEN_ADDRESS_MOCK,
+                chainId: CHAIN_ID_MOCK,
+                symbol: 'DAI',
+                decimals: 18,
+                balanceUsd: '123.45',
+              }
+            : undefined,
+          tokens: [],
+          quotes: [],
+        },
+      },
+      enabledNetworkMap: {
+        eip155: {
+          [CHAIN_ID_MOCK]: true,
+        },
+      },
+      accountsByChainId: {
+        [CHAIN_ID_MOCK]: {
+          [SENDER_ADDRESS]: {
+            balance: '0x346ba7725f412cbfdb',
+          },
+        },
+      },
+      // Add internal account for the sender address
+      internalAccounts: {
+        accounts: {
+          'mock-account-id': {
+            id: 'mock-account-id',
+            address: SENDER_ADDRESS,
+            metadata: {
+              name: 'Test Account',
+              keyring: {
+                type: 'HD Key Tree',
+              },
+            },
+            options: {},
+            methods: [],
+            type: 'eip155:eoa',
+          },
+        },
+        selectedAccount: 'mock-account-id',
+      },
+      currentCurrency: 'usd',
+      currencyRates: {
+        ETH: { conversionRate: 2000 },
+        usd: { conversionRate: 1 },
+      },
+      preferences: {
+        ...state.metamask.preferences,
+        showFiatInTestnets: true,
+      },
+    },
+  });
+
+  return state;
+};
+
+const Story = {
+  title: 'Confirmations/Components/Rows/PayWithRow',
+  component: PayWithRow,
+  decorators: [
+    (story: () => JSX.Element) => (
+      <Provider store={configureStore(createMockState())}>
+        <ConfirmContextProvider confirmationId={transaction.id}>
+          {story()}
+        </ConfirmContextProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export default Story;
+
+export const DefaultStory = () => <PayWithRow />;
+DefaultStory.storyName = 'Default';
+
+export const SkeletonStory = () => <PayWithRowSkeleton />;
+SkeletonStory.storyName = 'Skeleton';
+
+export const LoadingStory = () => {
+  const store = configureStore(createMockState(false));
+  return (
+    <Provider store={store}>
+      <ConfirmContextProvider confirmationId={transaction.id}>
+        <PayWithRow />
+      </ConfirmContextProvider>
+    </Provider>
+  );
+};
+LoadingStory.storyName = 'Loading (No Payment Token)';

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { useConfirmContext } from '../../../context/confirm';
+import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
+import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
+
+jest.mock('../../../hooks/pay/useTransactionPayToken');
+jest.mock('../../../context/confirm');
+jest.mock('../../../../multichain-accounts/account-details/account-type-utils');
+jest.mock('../../../../../hooks/useFiatFormatter');
+
+jest.mock('../../confirm/info/shared/gas-fee-token-icon', () => ({
+  GasFeeTokenIcon: ({ tokenAddress }: { tokenAddress: string }) => (
+    <div data-testid="gas-fee-token-icon">{tokenAddress}</div>
+  ),
+  GasFeeTokenIconSize: {
+    Sm: 'sm',
+    Md: 'md',
+  },
+}));
+
+jest.mock('../../modals/pay-with-modal', () => ({
+  PayWithModal: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="pay-with-modal">
+        <button data-testid="close-modal" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+const ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const CHAIN_ID_MOCK = '0x1';
+const FROM_ADDRESS_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12';
+
+const mockStore = configureStore([thunk]);
+
+const getMockState = () => ({
+  metamask: {
+    internalAccounts: {
+      accounts: {
+        'account-1': {
+          address: FROM_ADDRESS_MOCK,
+          id: 'account-1',
+          metadata: { name: 'Account 1', keyring: { type: 'HD Key Tree' } },
+          type: 'eip155:eoa',
+        },
+      },
+      selectedAccount: 'account-1',
+    },
+    accounts: {
+      [FROM_ADDRESS_MOCK]: {
+        address: FROM_ADDRESS_MOCK,
+        balance: '0x0',
+      },
+    },
+    keyrings: [
+      {
+        type: 'HD Key Tree',
+        accounts: [FROM_ADDRESS_MOCK],
+      },
+    ],
+    completedOnboarding: true,
+  },
+});
+
+describe('PayWithRow', () => {
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useConfirmContextMock = jest.mocked(useConfirmContext);
+  const isHardwareAccountMock = jest.mocked(isHardwareAccount);
+  const useFiatFormatterMock = jest.mocked(useFiatFormatter);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useFiatFormatterMock.mockReturnValue(
+      (value: number) => `$${value.toFixed(2)}`,
+    );
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        address: ADDRESS_MOCK,
+        balanceHuman: '1.5',
+        balanceFiat: '$150.00',
+        balanceRaw: '1500000000000000000',
+        balanceUsd: '150',
+        chainId: CHAIN_ID_MOCK,
+        decimals: 18,
+        symbol: 'ETH',
+      },
+      setPayToken: jest.fn(),
+      isNative: true,
+    });
+
+    useConfirmContextMock.mockReturnValue({
+      currentConfirmation: {
+        txParams: {
+          from: FROM_ADDRESS_MOCK,
+        },
+      },
+    } as never);
+
+    isHardwareAccountMock.mockReturnValue(false);
+  });
+
+  it('renders selected pay token with symbol and balance', () => {
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
+    expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent(
+      'Pay with ETH',
+    );
+    expect(screen.getByTestId('pay-with-balance')).toBeInTheDocument();
+    expect(screen.getByTestId('gas-fee-token-icon')).toHaveTextContent(
+      ADDRESS_MOCK,
+    );
+  });
+
+  it('opens modal when clicked', () => {
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('pay-with-row'));
+
+    expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
+  });
+
+  it('closes modal when onClose is called', () => {
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    fireEvent.click(screen.getByTestId('pay-with-row'));
+    expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('close-modal'));
+    expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders skeleton when no pay token selected', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+      isNative: false,
+    });
+
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    expect(screen.getByTestId('pay-with-row-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('pay-with-row')).not.toBeInTheDocument();
+  });
+
+  it('does not open modal when hardware account', () => {
+    isHardwareAccountMock.mockReturnValue(true);
+
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    fireEvent.click(screen.getByTestId('pay-with-row'));
+
+    expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
+  });
+
+  it('does not show arrow icon when hardware account', () => {
+    isHardwareAccountMock.mockReturnValue(true);
+
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    expect(screen.queryByTestId('arrow-down-icon')).not.toBeInTheDocument();
+  });
+
+  it('shows arrow icon when not hardware account and from address exists', () => {
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRow />, store);
+
+    const payWithRow = screen.getByTestId('pay-with-row');
+    expect(payWithRow).toBeInTheDocument();
+  });
+});
+
+describe('PayWithRowSkeleton', () => {
+  it('renders skeleton elements', () => {
+    const store = mockStore(getMockState());
+    renderWithProvider(<PayWithRowSkeleton />, store);
+
+    expect(screen.getByTestId('pay-with-row-skeleton')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+import { BigNumber } from 'bignumber.js';
+
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../../../components/component-library';
+import { Skeleton } from '../../../../../components/component-library/skeleton';
+import {
+  AlignItems,
+  BackgroundColor,
+  BorderRadius,
+  Display,
+  FlexDirection,
+  IconColor,
+  JustifyContent,
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { getInternalAccountByAddress } from '../../../../../selectors/accounts';
+import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
+import { useConfirmContext } from '../../../context/confirm';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { PayWithModal } from '../../modals/pay-with-modal';
+import {
+  GasFeeTokenIcon,
+  GasFeeTokenIconSize,
+} from '../../confirm/info/shared/gas-fee-token-icon';
+
+export const PayWithRowSkeleton = () => {
+  return (
+    <Box
+      data-testid="pay-with-row-skeleton"
+      backgroundColor={BackgroundColor.backgroundDefault}
+      borderRadius={BorderRadius.pill}
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      alignItems={AlignItems.center}
+      justifyContent={JustifyContent.center}
+      gap={2}
+      paddingTop={2}
+      paddingBottom={2}
+      paddingLeft={2}
+      paddingRight={4}
+    >
+      <Skeleton height="32px" width="32px" style={{ borderRadius: '50%' }} />
+      <Skeleton height="18px" width="100px" />
+      <Skeleton height="18px" width="100px" />
+    </Box>
+  );
+};
+
+export const PayWithRow = () => {
+  const t = useI18nContext();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { payToken } = useTransactionPayToken();
+  const fiatFormatter = useFiatFormatter();
+
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const from = currentConfirmation?.txParams?.from;
+
+  const fromAccount = useSelector((state) =>
+    getInternalAccountByAddress(state, from ?? ''),
+  );
+
+  const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
+
+  const handleClick = useCallback(() => {
+    if (!canEdit) {
+      return;
+    }
+    setIsModalOpen(true);
+  }, [canEdit]);
+
+  const handleClose = useCallback(() => {
+    setIsModalOpen(false);
+  }, []);
+
+  const balanceUsdFormatted = useMemo(
+    () => fiatFormatter(new BigNumber(payToken?.balanceUsd ?? '0').toNumber()),
+    [fiatFormatter, payToken?.balanceUsd],
+  );
+
+  if (!payToken) {
+    return <PayWithRowSkeleton />;
+  }
+
+  return (
+    <>
+      {isModalOpen && (
+        <PayWithModal isOpen={isModalOpen} onClose={handleClose} />
+      )}
+      <Box
+        data-testid="pay-with-row"
+        onClick={handleClick}
+        backgroundColor={BackgroundColor.backgroundDefault}
+        borderRadius={BorderRadius.pill}
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.center}
+        gap={3}
+        paddingTop={2}
+        paddingBottom={2}
+        paddingLeft={2}
+        paddingRight={4}
+        style={{
+          cursor: canEdit ? 'pointer' : 'default',
+        }}
+      >
+        <GasFeeTokenIcon
+          tokenAddress={payToken.address}
+          size={GasFeeTokenIconSize.Md}
+        />
+        <Text
+          variant={TextVariant.bodyMdMedium}
+          color={TextColor.textDefault}
+          data-testid="pay-with-symbol"
+        >
+          {`${t('payWith')} ${payToken.symbol}`}
+        </Text>
+        <Text
+          variant={TextVariant.bodyMdMedium}
+          color={TextColor.textAlternative}
+          data-testid="pay-with-balance"
+        >
+          {balanceUsdFormatted}
+        </Text>
+        {canEdit && from && (
+          <Icon
+            name={IconName.ArrowDown}
+            size={IconSize.Sm}
+            color={IconColor.iconAlternative}
+          />
+        )}
+      </Box>
+    </>
+  );
+};

--- a/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
@@ -10,16 +10,8 @@ import { AssetList } from './asset-list';
 
 jest.mock('../../../../../hooks/useI18nContext');
 jest.mock('../../../../../components/component-library', () => ({
-  Box: ({
-    children,
-    ...props
-  }: {
-    children: React.ReactNode;
-    [key: string]: unknown;
-  }) => (
-    <div data-testid="box" {...props}>
-      {children}
-    </div>
+  Box: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="box">{children}</div>
   ),
   Text: ({ children }: { children: React.ReactNode }) => (
     <span data-testid="text">{children}</span>
@@ -220,5 +212,110 @@ describe('AssetList', () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  describe('hideNfts', () => {
+    it('hides NFTs section when hideNfts is true', () => {
+      const { getAllByTestId, queryByText } = render(
+        <AssetList
+          tokens={mockTokens}
+          nfts={mockNfts}
+          allTokens={mockTokens}
+          allNfts={mockNfts}
+          hideNfts={true}
+        />,
+      );
+
+      const assetComponents = getAllByTestId('asset-component');
+      expect(assetComponents).toHaveLength(2);
+      expect(queryByText('NFTs')).not.toBeInTheDocument();
+    });
+
+    it('shows NFTs section when hideNfts is false', () => {
+      const { getAllByTestId, getByText } = render(
+        <AssetList
+          tokens={mockTokens}
+          nfts={mockNfts}
+          allTokens={mockTokens}
+          allNfts={mockNfts}
+          hideNfts={false}
+        />,
+      );
+
+      const assetComponents = getAllByTestId('asset-component');
+      expect(assetComponents).toHaveLength(3);
+      expect(getByText('NFTs')).toBeInTheDocument();
+    });
+
+    it('renders empty when hideNfts is true and only NFTs exist', () => {
+      const { container } = render(
+        <AssetList
+          tokens={[]}
+          nfts={mockNfts}
+          allTokens={[]}
+          allNfts={mockNfts}
+          hideNfts={true}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('does not show no results message when hideNfts excludes all assets', () => {
+      const { queryByText } = render(
+        <AssetList
+          tokens={[]}
+          nfts={mockNfts}
+          allTokens={[]}
+          allNfts={mockNfts}
+          hideNfts={true}
+        />,
+      );
+
+      expect(
+        queryByText('noTokensMatchingYourFilters'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('onAssetSelect', () => {
+    it('calls only onAssetSelect when provided', () => {
+      const mockOnAssetSelect = jest.fn();
+      const { getAllByTestId } = render(
+        <AssetList
+          tokens={mockTokens}
+          nfts={[]}
+          allTokens={mockTokens}
+          allNfts={[]}
+          onAssetSelect={mockOnAssetSelect}
+        />,
+      );
+
+      const assetComponents = getAllByTestId('asset-component');
+      fireEvent.click(assetComponents[0]);
+
+      expect(mockOnAssetSelect).toHaveBeenCalledWith(mockTokens[0]);
+      expect(mockUpdateAsset).not.toHaveBeenCalled();
+      expect(mockGoToAmountRecipientPage).not.toHaveBeenCalled();
+      expect(mockCaptureAssetSelected).not.toHaveBeenCalled();
+    });
+
+    it('calls default handlers when onAssetSelect is not provided', () => {
+      const { getAllByTestId } = render(
+        <AssetList
+          tokens={mockTokens}
+          nfts={[]}
+          allTokens={mockTokens}
+          allNfts={[]}
+        />,
+      );
+
+      const assetComponents = getAllByTestId('asset-component');
+      fireEvent.click(assetComponents[0]);
+
+      expect(mockUpdateAsset).toHaveBeenCalledWith(mockTokens[0]);
+      expect(mockGoToAmountRecipientPage).toHaveBeenCalled();
+      expect(mockCaptureAssetSelected).toHaveBeenCalledWith(mockTokens[0]);
+    });
   });
 });

--- a/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
@@ -30,6 +30,8 @@ type AssetListProps = {
   allTokens: Asset[];
   allNfts: Asset[];
   onClearFilters?: () => void;
+  hideNfts?: boolean;
+  onAssetSelect?: (asset: Asset) => void;
 };
 
 type ListItem =
@@ -46,22 +48,33 @@ export const AssetList = ({
   allTokens,
   allNfts,
   onClearFilters,
+  hideNfts = false,
+  onAssetSelect,
 }: AssetListProps) => {
   const t = useI18nContext();
   const scrollContainerRef = useScrollContainer();
   const { goToAmountRecipientPage } = useNavigateSendPage();
   const { updateAsset } = useSendContext();
   const { captureAssetSelected } = useAssetSelectionMetrics();
-  const hasFilteredResults = tokens.length > 0 || nfts.length > 0;
-  const hasAnyAssets = allTokens.length > 0 || allNfts.length > 0;
+
+  const effectiveNfts = hideNfts ? [] : nfts;
+  const effectiveAllNfts = hideNfts ? [] : allNfts;
+
+  const hasFilteredResults = tokens.length > 0 || effectiveNfts.length > 0;
+  const hasAnyAssets = allTokens.length > 0 || effectiveAllNfts.length > 0;
 
   const handleAssetClick = useCallback(
     (asset: Asset) => {
+      if (onAssetSelect) {
+        onAssetSelect(asset);
+        return;
+      }
+
       updateAsset(asset);
       goToAmountRecipientPage();
       captureAssetSelected(asset);
     },
-    [updateAsset, goToAmountRecipientPage, captureAssetSelected],
+    [updateAsset, goToAmountRecipientPage, captureAssetSelected, onAssetSelect],
   );
 
   const items: ListItem[] = [];
@@ -70,9 +83,9 @@ export const AssetList = ({
     items.push({ type: 'token', asset: token });
   });
 
-  if (nfts.length > 0) {
+  if (effectiveNfts.length > 0) {
     items.push({ type: 'nft-header' });
-    nfts.forEach((nft) => {
+    effectiveNfts.forEach((nft) => {
       items.push({ type: 'nft', asset: nft });
     });
   }

--- a/ui/pages/confirmations/hooks/pay/types.ts
+++ b/ui/pages/confirmations/hooks/pay/types.ts
@@ -1,11 +1,4 @@
 import type { Hex } from '@metamask/utils';
-import { Asset } from '../../types/send';
-
-export type TransactionPayAsset = Asset & {
-  disabled?: boolean;
-  disabledMessage?: string;
-  isSelected?: boolean;
-};
 
 export type SetPayTokenRequest = {
   address: Hex;

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -5,11 +5,12 @@ import React from 'react';
 import type { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 import { ConfirmContext } from '../../context/confirm';
+import { Asset } from '../../types/send';
 import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import type { TransactionPayAsset, SetPayTokenRequest } from './types';
+import type { SetPayTokenRequest } from './types';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayData');
@@ -113,7 +114,7 @@ describe('useAutomaticTransactionPayToken', () => {
         address: TOKEN_ADDRESS_1_MOCK,
         chainId: CHAIN_ID_1_MOCK,
       },
-    ] as TransactionPayAsset[]);
+    ] as Asset[]);
 
     renderHookWithProvider();
 
@@ -124,9 +125,7 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects target token if no tokens with balance', () => {
-    useTransactionPayAvailableTokensMock.mockReturnValue(
-      [] as TransactionPayAsset[],
-    );
+    useTransactionPayAvailableTokensMock.mockReturnValue([] as Asset[]);
 
     renderHookWithProvider();
 
@@ -151,7 +150,7 @@ describe('useAutomaticTransactionPayToken', () => {
         address: TOKEN_ADDRESS_1_MOCK,
         chainId: CHAIN_ID_1_MOCK,
       },
-    ] as TransactionPayAsset[]);
+    ] as Asset[]);
 
     renderHookWithProvider({ disable: true });
 
@@ -172,7 +171,7 @@ describe('useAutomaticTransactionPayToken', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_2_MOCK,
       },
-    ] as TransactionPayAsset[]);
+    ] as Asset[]);
 
     renderHookWithProvider({
       preferredToken: {
@@ -188,9 +187,7 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects target token when preferred payment token provided but no tokens available', () => {
-    useTransactionPayAvailableTokensMock.mockReturnValue(
-      [] as TransactionPayAsset[],
-    );
+    useTransactionPayAvailableTokensMock.mockReturnValue([] as Asset[]);
 
     renderHookWithProvider({
       preferredToken: {
@@ -215,7 +212,7 @@ describe('useAutomaticTransactionPayToken', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_2_MOCK,
       },
-    ] as TransactionPayAsset[]);
+    ] as Asset[]);
 
     renderHookWithProvider({
       preferredToken: {

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
 import { getHardwareWalletType } from '../../../../selectors';
+import { Asset } from '../../types/send';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import type { TransactionPayAsset, SetPayTokenRequest } from './types';
+import type { SetPayTokenRequest } from './types';
 
 export function useAutomaticTransactionPayToken({
   disable = false,
@@ -77,7 +78,7 @@ function getBestToken({
   isHardwareWallet: boolean;
   preferredToken?: SetPayTokenRequest;
   targetToken?: { address: Hex; chainId: Hex };
-  tokens: TransactionPayAsset[];
+  tokens: Asset[];
 }): { address: Hex; chainId: Hex } | undefined {
   const targetTokenFallback = targetToken
     ? {

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.tsx
@@ -3,7 +3,6 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import * as transactionPayUtils from '../../utils/transaction-pay';
 import { useSendTokens } from '../send/useSendTokens';
 import { Asset, AssetStandard } from '../../types/send';
-import type { TransactionPayAsset } from './types';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 
 jest.mock('../send/useSendTokens');
@@ -26,7 +25,7 @@ const SEND_TOKEN_MOCK: Asset = {
   fiat: { balance: 1.23 },
 };
 
-const TOKEN_MOCK: TransactionPayAsset = {
+const TOKEN_MOCK: Asset = {
   ...SEND_TOKEN_MOCK,
   disabled: false,
   isSelected: false,

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import type { Json } from '@metamask/utils';
 import { ConfirmContext } from '../../context/confirm';
+import { Asset } from '../../types/send';
 import { useTransactionPayMetrics } from './useTransactionPayMetrics';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import {
@@ -18,7 +19,6 @@ import {
   useTransactionPayTotals,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
-import type { TransactionPayAsset } from './types';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayData');
@@ -117,7 +117,7 @@ describe('useTransactionPayMetrics', () => {
       {},
       {},
       {},
-    ] as TransactionPayAsset[]);
+    ] as Asset[]);
 
     useTransactionPayTotalsMock.mockReturnValue(undefined);
   });

--- a/ui/pages/confirmations/hooks/send/useSendAssets.ts
+++ b/ui/pages/confirmations/hooks/send/useSendAssets.ts
@@ -13,8 +13,15 @@ type SendAssets = {
   tokens: Asset[];
 };
 
-export const useSendAssets = (): SendAssets => {
-  const tokens = useSendTokens();
+type UseSendAssetsOptions = {
+  includeNoBalance?: boolean;
+};
+
+export const useSendAssets = (
+  options: UseSendAssetsOptions = {},
+): SendAssets => {
+  const { includeNoBalance = false } = options;
+  const tokens = useSendTokens({ includeNoBalance });
   const nfts = useSendNfts();
   const useExternalServices = useSelector(getUseExternalServices);
   const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);

--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -136,13 +136,25 @@ describe('useSendTokens', () => {
     expect(testNetAsset?.chainId).toBe('0xaa36a7');
   });
 
-  it('excludes assets with zero balance and zero fiat', async () => {
+  it('excludes assets with zero balance and zero fiat by default', async () => {
     const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
 
     const zeroBalanceAsset = result.current.find(
       (asset: Asset) => asset.symbol === 'ZERO',
     );
     expect(zeroBalanceAsset).toBeUndefined();
+  });
+
+  it('includes assets with zero balance when includeNoBalance is true', async () => {
+    const { result } = renderHookWithProvider(
+      () => useSendTokens({ includeNoBalance: true }),
+      mockState,
+    );
+
+    const zeroBalanceAsset = result.current.find(
+      (asset: Asset) => asset.symbol === 'ZERO',
+    );
+    expect(zeroBalanceAsset).toBeDefined();
   });
 
   it('sorts assets by fiat balance descending', async () => {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -10,18 +10,26 @@ import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
 import { AssetStandard, type Asset } from '../../types/send';
 import { useChainNetworkNameAndImageMap } from '../useChainNetworkNameAndImage';
 
-export const useSendTokens = (): Asset[] => {
+type UseSendTokensOptions = {
+  includeNoBalance?: boolean;
+};
+
+export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
+  const { includeNoBalance = false } = options;
   const chainNetworkNAmeAndImageMap = useChainNetworkNameAndImageMap();
   const assets = useSelector(getAssetsBySelectedAccountGroup);
 
   const flatAssets = useMemo(() => Object.values(assets).flat(), [assets]);
 
   const assetsWithBalance = useMemo(() => {
+    if (includeNoBalance) {
+      return flatAssets;
+    }
     return flatAssets.filter((asset) => {
       const haveBalance = asset.rawBalance !== '0x0';
       return asset.isNative || haveBalance;
     });
-  }, [flatAssets]);
+  }, [flatAssets, includeNoBalance]);
 
   const processedAssets = useMemo(() => {
     return assetsWithBalance.map((asset) => {

--- a/ui/pages/confirmations/types/send.ts
+++ b/ui/pages/confirmations/types/send.ts
@@ -23,6 +23,8 @@ export type Asset = {
     [key: string]: unknown;
   };
   decimals?: number | undefined;
+  disabled?: boolean;
+  disabledMessage?: string;
   fiat?: {
     balance?: number;
     currency?: string;
@@ -30,6 +32,7 @@ export type Asset = {
   };
   image?: string;
   isNative?: boolean;
+  isSelected?: boolean;
   name?: string | undefined;
   networkName?: string;
   networkImage?: string;

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -10,7 +10,6 @@ import type {
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
 import { Asset, AssetStandard } from '../types/send';
-import { TransactionPayAsset } from '../hooks/pay/types';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 
@@ -78,7 +77,7 @@ export function getAvailableTokens({
   payToken?: TransactionPaymentToken;
   requiredTokens?: TransactionPayRequiredToken[];
   tokens: Asset[];
-}): TransactionPayAsset[] {
+}): Asset[] {
   return tokens
     .filter((token) => {
       if (


### PR DESCRIPTION
## **Description**

Add components required for MetaMask Pay token selection.

No functional changes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39200?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to: [#6499](https://github.com/MetaMask/MetaMask-planning/issues/6499)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="755" height="707" alt="pay-with-modal-default" src="https://github.com/user-attachments/assets/bb3b6c6d-c3e1-41f9-9de9-81d45f387670" />

<img width="541" height="346" alt="pay-with-row-default" src="https://github.com/user-attachments/assets/7a741f5f-aeed-4324-b186-51e96dcdadab" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces fee payment token selection in confirmations.
> 
> - Adds `PayWithModal` and `PayWithRow` with i18n (`payWith`, `payWithModalTitle`); integrates with `useTransactionPayToken` and required-token filtering
> - Extends `Asset`/`AssetList` to support `hideNfts`, `includeNoBalance`, `tokenFilter`, and `onAssetSelect`; `useSendTokens`/`useSendAssets` now accept `includeNoBalance`
> - Unifies pay-token logic to use `Asset` type (removes `TransactionPayAsset`), updates `getAvailableTokens`, auto-selection (`useAutomaticTransactionPayToken`), and related metrics/available-token hooks
> - Adds Storybook stories and comprehensive unit tests; updates console baseline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc5f651d7b4067aaa62de505fc5c0de415c700a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->