### PR TITLE
ci: Run stable-main check in merge queue

### DIFF
--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, edited]
     branches:
       - main
+  merge_group:
 
 jobs:
   check-branch:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ensure the `stable-main` check runs in the merge queue as otherwise merging PRs when this check is required is impossible.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39211?quickstart=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the `stable-main` branch-block check also runs within GitHub’s merge queue.
> 
> - Adds `merge_group` trigger to `.github/workflows/block-stable-main-to-main.yml` alongside existing `pull_request` triggers
> - No changes to job logic; still blocks `stable-main-X.Y.Z` branches from merging directly into `main`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca372ca11622a4b5150125060c6fbbecf5d1f59a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->