### PR TITLE
fix: Replace broken icon with proper dot in `SnapListItem`

### DIFF
--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -9,14 +9,10 @@ import {
   BlockSize,
   TextVariant,
   IconColor,
+  BorderRadius,
+  BackgroundColor,
 } from '../../../../helpers/constants/design-system';
-import {
-  Text,
-  Box,
-  IconName,
-  IconSize,
-  Icon,
-} from '../../../component-library';
+import { Text, Box } from '../../../component-library';
 import { SnapIcon } from '../snap-icon';
 
 const SnapListItem = ({
@@ -72,13 +68,12 @@ const SnapListItem = ({
         </Box>
       </Box>
       {showUpdateDot && (
-        <Box display={Display.Flex}>
-          <Icon
-            name={IconName.FullCircle}
-            size={IconSize.Xs}
-            color={IconColor.primaryDefault}
-          />
-        </Box>
+        <Box
+          display={Display.Flex}
+          style={{ width: '10px', height: '10px', content: '' }}
+          borderRadius={BorderRadius.full}
+          backgroundColor={BackgroundColor.primaryDefault}
+        />
       )}
     </Box>
   );

--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -8,7 +8,6 @@ import {
   Display,
   BlockSize,
   TextVariant,
-  IconColor,
   BorderRadius,
   BackgroundColor,
 } from '../../../../helpers/constants/design-system';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Same fix as https://github.com/MetaMask/metamask-extension/pull/39042 but applied to `SnapListItem` which shows the same dot when a Snap has a pending update.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39212?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the update indicator from an `Icon` to a styled `Box` for reliability and consistency.
> 
> - Removes `Icon` usage and related imports; adds `BorderRadius` and `BackgroundColor`
> - Renders a 10x10 circle via `Box` with `borderRadius={BorderRadius.full}` and `backgroundColor={BackgroundColor.primaryDefault}` when `showUpdateDot` is true
> - Keeps component structure and props unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46d5a4e7f1e6fa3e8523bb71cec430af52f8e76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->