### PR TITLE
feat: virtualize the send flow asset list

### DIFF
--- a/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
@@ -63,6 +63,12 @@ jest.mock('../../../hooks/send/useNavigateSendPage');
 jest.mock('../../../context/send');
 jest.mock('../../../hooks/send/metrics/useAssetSelectionMetrics');
 
+function mockVirtualizerDOM() {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    value: 800,
+  });
+}
+
 describe('AssetList', () => {
   const mockUseI18nContext = jest.mocked(useI18nContext);
   const mockUseNavigateSendPage = jest.mocked(useNavigateSendPage);
@@ -83,6 +89,7 @@ describe('AssetList', () => {
   ];
 
   beforeEach(() => {
+    mockVirtualizerDOM();
     mockUseI18nContext.mockReturnValue((key: string) => key);
     mockUseNavigateSendPage.mockReturnValue({
       goToAmountRecipientPage: mockGoToAmountRecipientPage,
@@ -182,7 +189,7 @@ describe('AssetList', () => {
     expect(mockOnClearFilters).toHaveBeenCalled();
   });
 
-  it('calls updateAsset and navigation when asset is clicked', () => {
+  it.skip('calls updateAsset and navigation when asset is clicked', () => {
     const { getAllByTestId } = render(
       <AssetList
         tokens={mockTokens}
@@ -201,7 +208,7 @@ describe('AssetList', () => {
     expect(mockCaptureAssetSelected).toHaveBeenCalledWith(mockTokens[0]);
   });
 
-  it('renders empty when no assets available', () => {
+  it.skip('renders empty when no assets available', () => {
     const { container } = render(
       <AssetList
         tokens={[]}

--- a/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.test.tsx
@@ -189,7 +189,7 @@ describe('AssetList', () => {
     expect(mockOnClearFilters).toHaveBeenCalled();
   });
 
-  it.skip('calls updateAsset and navigation when asset is clicked', () => {
+  it('calls updateAsset and navigation when asset is clicked', () => {
     const { getAllByTestId } = render(
       <AssetList
         tokens={mockTokens}
@@ -208,7 +208,7 @@ describe('AssetList', () => {
     expect(mockCaptureAssetSelected).toHaveBeenCalledWith(mockTokens[0]);
   });
 
-  it.skip('renders empty when no assets available', () => {
+  it('renders empty when no assets available', () => {
     const { container } = render(
       <AssetList
         tokens={[]}

--- a/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
@@ -168,9 +168,9 @@ export const AssetList = ({
 };
 
 function extractKey(item: { type: 'token' | 'nft'; asset: Asset }) {
-  const { asset: token } = item;
+  const { asset } = item;
   if (item.type === 'token') {
-    return `${token.address ?? token.assetId}-${token.chainId}`;
+    return `${asset.address ?? asset.assetId}-${asset.chainId}`;
   }
-  return `${token.address}-${token.chainId}-${token.tokenId}`;
+  return `${asset.address}-${asset.chainId}-${asset.tokenId}`;
 }

--- a/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
+++ b/ui/pages/confirmations/components/send/asset-list/asset-list.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 import {
   Text,
@@ -21,6 +22,7 @@ import { useNavigateSendPage } from '../../../hooks/send/useNavigateSendPage';
 import { useAssetSelectionMetrics } from '../../../hooks/send/metrics/useAssetSelectionMetrics';
 import { useSendContext } from '../../../context/send';
 import { Asset as AssetComponent } from '../../UI/asset';
+import { useScrollContainer } from '../../../../../contexts/scroll-container';
 
 type AssetListProps = {
   tokens: Asset[];
@@ -30,6 +32,14 @@ type AssetListProps = {
   onClearFilters?: () => void;
 };
 
+type ListItem =
+  | { type: 'token'; asset: Asset }
+  | { type: 'nft-header' }
+  | { type: 'nft'; asset: Asset };
+
+const ITEM_HEIGHT = 70;
+const HEADER_HEIGHT = 40;
+
 export const AssetList = ({
   tokens,
   nfts,
@@ -38,6 +48,7 @@ export const AssetList = ({
   onClearFilters,
 }: AssetListProps) => {
   const t = useI18nContext();
+  const scrollContainerRef = useScrollContainer();
   const { goToAmountRecipientPage } = useNavigateSendPage();
   const { updateAsset } = useSendContext();
   const { captureAssetSelected } = useAssetSelectionMetrics();
@@ -52,6 +63,27 @@ export const AssetList = ({
     },
     [updateAsset, goToAmountRecipientPage, captureAssetSelected],
   );
+
+  const items: ListItem[] = [];
+
+  tokens.forEach((token) => {
+    items.push({ type: 'token', asset: token });
+  });
+
+  if (nfts.length > 0) {
+    items.push({ type: 'nft-header' });
+    nfts.forEach((nft) => {
+      items.push({ type: 'nft', asset: nft });
+    });
+  }
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollContainerRef?.current || document.body,
+    estimateSize: (index) =>
+      items[index].type === 'nft-header' ? HEADER_HEIGHT : ITEM_HEIGHT,
+    overscan: 10,
+  });
 
   // Show "no results" message only if there are assets available but none match the search
   if (!hasFilteredResults && hasAnyAssets) {
@@ -84,33 +116,61 @@ export const AssetList = ({
     );
   }
 
+  if (items.length === 0) {
+    return null;
+  }
+
+  const virtualItems = virtualizer.getVirtualItems();
+
   return (
-    <>
-      {tokens.map((token) => (
-        <AssetComponent
-          key={`${token.address ?? token.assetId}-${token.chainId}`}
-          asset={token}
-          onClick={() => handleAssetClick(token)}
-        />
-      ))}
-      {nfts.length > 0 && (
-        <Text
-          variant={TextVariant.bodyMdMedium}
-          color={TextColor.textAlternative}
-          marginInline={4}
-          marginTop={2}
-          marginBottom={2}
-        >
-          NFTs
-        </Text>
-      )}
-      {nfts.map((nft) => (
-        <AssetComponent
-          key={`${nft.address}-${nft.chainId}-${nft.tokenId}`}
-          asset={nft}
-          onClick={() => handleAssetClick(nft)}
-        />
-      ))}
-    </>
+    <div
+      className="relative w-full"
+      style={{
+        height: `${virtualizer.getTotalSize()}px`,
+      }}
+    >
+      {virtualItems.map((virtualItem) => {
+        const item = items[virtualItem.index];
+
+        return (
+          <div
+            key={
+              item.type === 'nft-header'
+                ? String(virtualItem.key)
+                : extractKey(item)
+            }
+            className="absolute top-0 left-0 w-full"
+            style={{
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+          >
+            {item.type === 'nft-header' ? (
+              <Text
+                variant={TextVariant.bodyMdMedium}
+                color={TextColor.textAlternative}
+                marginInline={4}
+                marginTop={2}
+                marginBottom={2}
+              >
+                NFTs
+              </Text>
+            ) : (
+              <AssetComponent
+                asset={item.asset}
+                onClick={() => handleAssetClick(item.asset)}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 };
+
+function extractKey(item: { type: 'token' | 'nft'; asset: Asset }) {
+  const { asset: token } = item;
+  if (item.type === 'token') {
+    return `${token.address ?? token.assetId}-${token.chainId}`;
+  }
+  return `${token.address}-${token.chainId}-${token.tokenId}`;
+}

--- a/ui/pages/confirmations/send/send-inner.tsx
+++ b/ui/pages/confirmations/send/send-inner.tsx
@@ -10,6 +10,7 @@ import {
   BorderRadius,
 } from '../../../helpers/constants/design-system';
 import { Box } from '../../../components/component-library';
+import { ScrollContainer } from '../../../contexts/scroll-container';
 import { AmountRecipient } from '../components/send/amount-recipient';
 import { Header } from '../components/send/header';
 import { Asset } from '../components/send/asset';
@@ -50,7 +51,9 @@ const SendContainer = ({ children }: { children: React.ReactNode }) => {
           <Box className="redesigned__send__sticky-header">
             <Header />
           </Box>
-          <Box className="redesigned__send__content-wrapper">{children}</Box>
+          <ScrollContainer className="redesigned__send__content-wrapper">
+            {children}
+          </ScrollContainer>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## **Description**

Virtualize the Send flow assets list

No UI design changes in this PR

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39230?quickstart=1)

## **Changelog**


CHANGELOG entry: feat: virtualize send flow asset list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-750

## **Manual testing steps**

1. Choose an account with many assets
2. Click Send
3. Scroll through the list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements virtualization for the Send flow asset list to improve performance with large inventories.
> 
> - Replaces sequential rendering with `@tanstack/react-virtual`, building a combined token/NFT list (with `nft-header`) and absolute-positioned rows; uses `useScrollContainer` as the scroll root and adds `extractKey` for stable keys
> - Wraps send content in `ScrollContainer` in `send-inner.tsx` to provide a consistent scroll element
> - Updates tests to mock DOM sizing for the virtualizer and verify rendering, empty/no-results states, and click handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08e446b7d17910ddfc0fee77d7d45c6d824be8aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->