### PR TITLE
fix: bridge asset picker loading skeleton bugs

### DIFF
--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/lazy-asset-list.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/lazy-asset-list.tsx
@@ -91,7 +91,7 @@ export const BridgeAssetList = ({
           }
         />
       ))}
-      {filteredTokenList.length < 1 && !shouldShowLoadingIndicator ? (
+      {filteredTokenList.length < 1 && !shouldShowLoadingIndicator && (
         <Text
           style={{ paddingInline: 16 }}
           fontWeight={FontWeight.Regular}
@@ -99,9 +99,10 @@ export const BridgeAssetList = ({
         >
           No tokens match &quot;{searchQuery}&quot;
         </Text>
-      ) : (
+      )}
+      {shouldShowLoadingIndicator && (
         <LoadingSkeleton
-          isLoading={shouldShowLoadingIndicator}
+          isLoading
           style={{ backgroundColor: BackgroundColor.backgroundSubsection }}
           ref={loadingRef}
         />

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/loading-skeleton.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/loading-skeleton.tsx
@@ -28,6 +28,7 @@ export const LoadingSkeleton = React.forwardRef(
           height={32}
           width={32}
           {...props}
+          style={{ ...props.style, flexShrink: 0 }}
         />
         <Column gap={1}>
           <Skeleton height={16} width={60} {...props} />


### PR DESCRIPTION
- Fix extra padding at end of token list by conditionally rendering LoadingSkeleton
- Fix squeezed/oval skeleton circle by adding flexShrink: 0

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39235?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the bridge asset picker loading UI.
> 
> - In `lazy-asset-list.tsx`, replace ternary with separate conditionals: render "No tokens match" only when not loading, and render `LoadingSkeleton` only when loading (`isLoading` shorthand), removing extra trailing padding
> - In `loading-skeleton.tsx`, add `flexShrink: 0` to the circular `Skeleton` to prevent squashing/oval appearance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4b8832108656622c39b7291bc4e66805d1a55e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->