### PR TITLE
fix(bridge): prevent max button loop when switching from swap to bridge

### DIFF
--- a/ui/pages/bridge/hooks/useGasIncluded7702.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.ts
@@ -2,7 +2,7 @@ import {
   formatChainIdToHex,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 import { isRelaySupported } from '../../../store/actions';
@@ -44,6 +44,11 @@ export function useGasIncluded7702({
     getIsSmartTransaction(state as never, fromChain?.chainId),
   );
 
+  // Ref to track current isSwap value for async callback guard
+  // This prevents state updates when isSwap changes during API call
+  const isSwapRef = useRef(isSwap);
+  isSwapRef.current = isSwap;
+
   useEffect(() => {
     let isCancelled = false;
 
@@ -69,11 +74,14 @@ export function useGasIncluded7702({
         const chainIdInHex = formatChainIdToHex(fromChain.chainId);
         const is7702Supported = await isRelaySupported(chainIdInHex);
 
-        if (!isCancelled) {
+        // Guard: only update state if isSwap is still true
+        // This prevents stale API results from updating state when
+        // isSwap has changed (e.g., user switched from swap to bridge)
+        if (!isCancelled && isSwapRef.current) {
           setIsGasIncluded7702Supported(is7702Supported);
         }
       } catch (error) {
-        if (!isCancelled) {
+        if (!isCancelled && isSwapRef.current) {
           console.error('Error checking gasless 7702 support:', error);
           setIsGasIncluded7702Supported(false);
         }


### PR DESCRIPTION
## **Description**

Fixes infinite loop causing max button to flicker and repeated `/networks` requests to tx-sentinel when switching from swap to bridge mode.

## **Changelog**

CHANGELOG entry: Fixed Bridge max button flickering when switching from swap to bridge mode

## **Related issues**

Fixes: Bridge UI loop when changing destination chain

## **Manual testing steps**

1. Go to Bridge view
2. Select ETH on Base (source) and USDC on Base (dest)
3. Click Max
4. Change destination to POL on Polygon
5. Verify max button no longer flickers

## **Screenshots/Recordings**

### **Before**

Max button flickers repeatedly, `/networks` requests fire continuously

### **After**

Max button stable, no repeated requests

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a re-render loop and flickering by guarding async state updates in `useGasIncluded7702`.
> 
> - Introduces `useRef` (`isSwapRef`) to ensure `setIsGasIncluded7702Supported` only runs when `isSwap` remains true during `isRelaySupported` resolution
> - Retains cancellation guard and updates error path to respect the ref
> - Adds a targeted test validating that API results are ignored when `isSwap` changes from true to false mid-flight, plus race-condition coverage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc2cfdb0979cc45299e644726897ea7a7f5ad0ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->