### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,0 +1,56 @@
+# Fix for ERC-1155 Decimal Display Issue in OpenSea Bids
+
+## Problem
+MetaMask was displaying incorrect WETH amounts for ERC-1155 NFT bids on OpenSea. When users placed a 0.001 WETH offer on ERC-1155 collections, the signature request showed an extremely high WETH value instead of 0.001 WETH.
+
+## Root Cause
+The `PermitSimulationValueDisplay` component (`value-display.tsx`) was applying decimal conversion to ALL token types, including NFTs (ERC-721 and ERC-1155). 
+
+The `calcTokenAmount()` function divides the raw value by 10^decimals, which is correct for ERC-20 tokens but incorrect for NFTs:
+- **ERC-20 tokens** (like WETH): Need decimal conversion (e.g., 1000000000000000 ÷ 10^18 = 0.001)
+- **ERC-721 NFTs**: Don't have amounts, only tokenIds
+- **ERC-1155 NFTs**: Have integer amounts that should NOT be divided (e.g., 1 means 1 item, not 0.000000000000000001)
+
+When displaying Seaport order signatures (used by OpenSea), if an ERC-1155 consideration item had decimals incorrectly applied, it would inflate the displayed value massively.
+
+## Solution
+Modified the `PermitSimulationValueDisplay` component to:
+1. Accept an `assetType` parameter to identify the token standard
+2. Only apply decimal conversion (`calcTokenAmount`) for ERC-20 tokens
+3. Display ERC-721 and ERC-1155 amounts as-is without decimal conversion
+
+### Files Changed
+
+#### 1. `value-display.tsx`
+- Added `assetType` parameter to component props
+- Modified fiat value calculation to only apply for ERC-20 tokens
+- Modified token amount calculation to skip decimal conversion for NFTs
+- Added `TokenStandard` import
+
+#### 2. `decoded-simulation.tsx`
+- Passed `assetType` prop to `TokenValueDisplay` component
+
+#### 3. `value-display.test.tsx`
+- Updated all existing tests to include `assetType="ERC20"` parameter
+- Added new test cases for ERC-1155 and ERC-721 to verify amounts are displayed without decimal conversion
+
+## Testing
+Added specific test cases to verify:
+- ERC-1155 amounts display as-is (e.g., 1000000000000000 displays as "1,000,000,000,000,000")
+- ERC-721 amounts display as-is (e.g., 5 displays as "5")
+- ERC-20 tokens continue to work correctly with decimal conversion (e.g., 4321 with 4 decimals displays as "0.432")
+
+## Impact
+- **Severity**: HIGH - Prevents potential asset loss from users signing incorrect values
+- **Complexity**: LOW-MEDIUM - Frontend-only fix
+- **Affected Users**: Anyone using OpenSea or similar marketplaces to bid on ERC-1155 NFTs
+
+## Files Modified
+1. `/workspace/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.tsx`
+2. `/workspace/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx`
+3. `/workspace/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx`
+
+## Additional Notes
+- The fix is backwards compatible - the `assetType` parameter is optional
+- For Permit signatures (which are always ERC-20 or ERC-721), the existing behavior continues to work
+- The main benefit is for Seaport/OpenSea order signatures which can have mixed token types

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
@@ -129,6 +129,7 @@ const StateChangeRow = ({
           }
           debit={changeType === DecodingDataChangeType.Transfer}
           canDisplayValueAsUnlimited={canDisplayValueAsUnlimited}
+          assetType={assetType}
         />
       )}
       {assetType === 'NATIVE' && (

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/value-display/value-display.test.tsx
@@ -27,6 +27,7 @@ describe('PermitSimulationValueDisplay', () => {
           tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
           value="4321"
           chainId="0x1"
+          assetType="ERC20"
         />,
         mockStore,
       );
@@ -47,6 +48,7 @@ describe('PermitSimulationValueDisplay', () => {
             tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
             value="4321"
             chainId="0x1"
+            assetType="ERC20"
           />
         </MetaMetricsContext.Provider>,
         mockStore,
@@ -66,6 +68,7 @@ describe('PermitSimulationValueDisplay', () => {
           value={UNLIMITED_THRESHOLD}
           chainId="0x1"
           canDisplayValueAsUnlimited
+          assetType="ERC20"
         />
       </MetaMetricsContext.Provider>,
       mockStore,
@@ -88,6 +91,7 @@ describe('PermitSimulationValueDisplay', () => {
           value={`${UNLIMITED_THRESHOLD.slice(0, -1)}1`}
           chainId="0x1"
           canDisplayValueAsUnlimited
+          assetType="ERC20"
         />
       </MetaMetricsContext.Provider>,
       mockStore,
@@ -110,6 +114,7 @@ describe('PermitSimulationValueDisplay', () => {
           value={UNLIMITED_THRESHOLD.slice(0, -1)}
           chainId="0x1"
           canDisplayValueAsUnlimited
+          assetType="ERC20"
         />
       </MetaMetricsContext.Provider>,
       mockStore,
@@ -120,5 +125,44 @@ describe('PermitSimulationValueDisplay', () => {
     });
 
     expect(queryByText('Unlimited')).toBeNull();
+  });
+
+  it('renders ERC1155 amount without decimal conversion', async () => {
+    const mockStore = configureMockStore([])(mockState);
+
+    await act(async () => {
+      const { findByText } = renderWithProvider(
+        <PermitSimulationValueDisplay
+          tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          value="1000000000000000"
+          chainId="0x1"
+          assetType="ERC1155"
+        />,
+        mockStore,
+      );
+
+      // For ERC1155, the value should be displayed as-is (1000000000000000)
+      // not divided by decimals (which would be 0.001 for 18 decimals)
+      expect(await findByText('1,000,000,000,000,000')).toBeInTheDocument();
+    });
+  });
+
+  it('renders ERC721 amount without decimal conversion', async () => {
+    const mockStore = configureMockStore([])(mockState);
+
+    await act(async () => {
+      const { findByText } = renderWithProvider(
+        <PermitSimulationValueDisplay
+          tokenContract="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          value="5"
+          chainId="0x1"
+          assetType="ERC721"
+        />,
+        mockStore,
+      );
+
+      // For ERC721, the value should be displayed as-is (5)
+      expect(await findByText('5')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Correctly display ERC-1155 NFT amounts in signature requests by preventing erroneous decimal conversion.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1423f1c-0a53-4687-b335-a5b393d474fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1423f1c-0a53-4687-b335-a5b393d474fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents erroneous decimal scaling for NFT items in typed-sign simulations, fixing inflated values (e.g., OpenSea ERC-1155 bids).
> 
> - **`value-display.tsx`**: Add `assetType` prop; only apply `calcTokenAmount` and fiat calculation for `ERC20`; display `ERC721/ERC1155` amounts as-is; adjust "Unlimited" logic to exclude NFTs; import `TokenStandard`.
> - **`decoded-simulation.tsx`**: Pass `assetType` to `TokenValueDisplay`.
> - **Tests**: Update existing cases to include `assetType="ERC20"`; add new ERC-1155 and ERC-721 cases verifying no decimal conversion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffd1e7a86fcee29b548bfdb9d4f5ebbce1039d80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->