### PR TITLE
fix: `yarn start:with-state` script which got broken due to outdated account and tx wallet state

### DIFF
--- a/app/scripts/fixtures/generate-wallet-state.js
+++ b/app/scripts/fixtures/generate-wallet-state.js
@@ -131,14 +131,13 @@ function generateKeyringControllerState(vault) {
 function generateAccountsControllerState(accounts) {
   console.log('Generating AccountsController state');
   const internalAccounts = {
-    selectedAccount: 'account-id',
+    selectedAccount: 'account-id-0',
     accounts: {},
   };
 
   accounts.forEach((account, index) => {
-    internalAccounts.accounts[`acount-id-${index}`] = {
-      selectedAccount: 'account-id',
-      id: 'account-id',
+    internalAccounts.accounts[`account-id-${index}`] = {
+      id: `account-id-${index}`,
       address: account,
       metadata: {
         name: `Account ${index + 1}`,

--- a/app/scripts/fixtures/with-confirmed-transactions.js
+++ b/app/scripts/fixtures/with-confirmed-transactions.js
@@ -10,7 +10,7 @@ import { ALL_POPULAR_NETWORKS } from './with-networks';
  */
 export const withConfirmedTransactions = (from, numEntries) => {
   const networks = Object.keys(ALL_POPULAR_NETWORKS.eip155);
-  const transactions = {};
+  const transactions = [];
 
   networks.forEach((network) => {
     for (let i = 0; i < numEntries; i++) {
@@ -91,7 +91,7 @@ export const withConfirmedTransactions = (from, numEntries) => {
         type: 'simpleSend',
       };
 
-      transactions[id] = transaction;
+      transactions.push(transaction);
     }
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

@gantunesr raised an issue with the `yarn start:with-state` command which got broken.

This PR fixes the issue by updating the needed state (accounts and txs)-

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39248?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1274

## **Manual testing steps**

1. Add these 2 envars in your metamaskrc file: PASSWORD and TEST_SRP with your desired values
2. Run `yarn start:with-state --withAccounts=50``
3. Import the wallet
4. You should be able to see you are logged in with 50 accounts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
<img width="394" height="595" alt="image" src="https://github.com/user-attachments/assets/7a251969-33ee-4e5f-9334-fbe3490cf3b1" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 08767b054798083324b61d05bbfd2694dfb43032. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->