### PR TITLE
fix: remove emphasized "stable" styling in gas fee tooltip

### DIFF
--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/tooltips.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/tooltips.js
@@ -67,17 +67,22 @@ PriorityFeeTooltip.propTypes = {
 
 export const NetworkStabilityTooltip = ({ children, color, tooltipLabel }) => {
   const t = useI18nContext();
+  const isStableTooltip = tooltipLabel === 'stableLowercase';
 
   return (
     <NetworkStatusTooltip
       html={t('networkStatusStabilityFeeTooltip', [
-        <strong
-          key="network-status__tooltip"
-          className="network-status__tooltip-label"
-          style={{ color }}
-        >
-          {t(tooltipLabel)}
-        </strong>,
+        isStableTooltip ? (
+          <span key="network-status__tooltip">{t(tooltipLabel)}</span>
+        ) : (
+          <strong
+            key="network-status__tooltip"
+            className="network-status__tooltip-label"
+            style={{ color }}
+          >
+            {t(tooltipLabel)}
+          </strong>
+        ),
       ])}
     >
       {children}

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/tooltips.test.tsx
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/tooltips.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { NetworkStabilityTooltip } from './tooltips';
+
+jest.mock('../../../../../hooks/useI18nContext', () => ({
+  useI18nContext:
+    () =>
+    (key: string, substitutions: React.ReactNode[] = []) => {
+      const dictionary: Record<string, React.ReactNode> = {
+        networkStatusStabilityFeeTooltip: (
+          <>Gas fees are {substitutions[0]} relative to the past 72 hours.</>
+        ),
+        stableLowercase: 'stable',
+        lowLowercase: 'low',
+        highLowercase: 'high',
+      };
+
+      return dictionary[key] ?? key;
+    },
+}));
+
+jest.mock('../../../../../components/ui/box', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('../../../../../components/ui/tooltip', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: ({
+    children,
+    html,
+    title,
+  }: {
+    children: React.ReactNode;
+    html?: React.ReactNode;
+    title?: string;
+  }) => (
+    <div>
+      {title ? <div data-testid="tooltip-title">{title}</div> : null}
+      <div data-testid="tooltip-html">{html}</div>
+      <div data-testid="tooltip-children">{children}</div>
+    </div>
+  ),
+}));
+
+describe('NetworkStabilityTooltip', () => {
+  it('renders stable tooltip label without special styling', () => {
+    const { container, getByTestId } = render(
+      <NetworkStabilityTooltip color="#ff0000" tooltipLabel="stableLowercase">
+        <div>child</div>
+      </NetworkStabilityTooltip>,
+    );
+
+    expect(getByTestId('tooltip-html')).toHaveTextContent(
+      'Gas fees are stable relative to the past 72 hours.',
+    );
+    expect(container.querySelector('strong')).not.toBeInTheDocument();
+  });
+
+  it('renders non-stable tooltip label with color styling', () => {
+    const { container, getByTestId } = render(
+      <NetworkStabilityTooltip color="#ff0000" tooltipLabel="highLowercase">
+        <div>child</div>
+      </NetworkStabilityTooltip>,
+    );
+
+    expect(getByTestId('tooltip-html')).toHaveTextContent(
+      'Gas fees are high relative to the past 72 hours.',
+    );
+    const label = container.querySelector('strong');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveStyle('color: #ff0000');
+  });
+});


### PR DESCRIPTION
## **Description**

Removes the special red/bold styling from the “stable” label in the gas fee stability tooltip so the word renders with the same styling as the rest of the sentence.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39256?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed the gas fee stability tooltip text styling.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-498

## **Manual testing steps**

1. Open the confirmation flow and click Edit gas fee.
2. Hover the network status/stability indicator tooltip (“Gas fees are … relative to the past 72 hours.”).
3. Verify “stable” is not red/bold and matches the rest of the tooltip text.

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts gas fee stability tooltip styling and adds tests.
> 
> - Updates `NetworkStabilityTooltip` to render `stableLowercase` as plain text (no bold/color) while retaining styled emphasis for other labels
> - Adds `tooltips.test.tsx` to validate both stable and non-stable tooltip rendering and color application
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c8c973fc59f741ae6ce321a6e1a6e4b32b69044. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->