### PR TITLE
refactor: match casing for loading in result type

### DIFF
--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -95,7 +95,7 @@ export enum BlockaidResultType {
 
   // MetaMask defined result types
   NotApplicable = 'NotApplicable',
-  Loading = 'loading',
+  Loading = 'Loading',
 }
 
 export const FALSE_POSITIVE_REPORT_BASE_URL =

--- a/shared/lib/trust-signals.ts
+++ b/shared/lib/trust-signals.ts
@@ -98,7 +98,7 @@ export enum ResultType {
   Benign = 'Benign',
   Trusted = 'Trusted',
   ErrorResult = 'Error',
-  Loading = 'loading',
+  Loading = 'Loading',
 }
 
 export type ScanAddressRequest = {

--- a/test/data/confirmations/typed_sign.ts
+++ b/test/data/confirmations/typed_sign.ts
@@ -192,7 +192,7 @@ export const orderSignatureMsg = {
   securityAlertResponse: {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    result_type: 'loading',
+    result_type: 'Loading',
     reason: 'validation_in_progress',
     securityAlertId: 'dadfc03d-43f9-4515-9aa2-cb00715c3e07',
   },
@@ -248,7 +248,7 @@ export const seaportSignatureMsg = {
   securityAlertResponse: {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    result_type: 'loading',
+    result_type: 'Loading',
     reason: 'validation_in_progress',
     securityAlertId: 'def3b0ef-c96b-4c87-b1b1-c69cc02a0f78',
   },

--- a/test/e2e/tests/confirmations/signatures/signature-helpers.ts
+++ b/test/e2e/tests/confirmations/signatures/signature-helpers.ts
@@ -378,11 +378,11 @@ function compareSecurityAlertProperties(
 ) {
   if (
     expectedProperties.security_alert_response &&
-    (expectedProperties.security_alert_response === 'loading' ||
+    (expectedProperties.security_alert_response === 'Loading' ||
       expectedProperties.security_alert_response === 'Benign')
   ) {
     if (
-      actualProperties.security_alert_response !== 'loading' &&
+      actualProperties.security_alert_response !== 'Loading' &&
       actualProperties.security_alert_response !== 'Benign'
     ) {
       assert.fail(

--- a/test/e2e/tests/metrics/signature-approved.spec.ts
+++ b/test/e2e/tests/metrics/signature-approved.spec.ts
@@ -52,7 +52,7 @@ const expectedEventPropertiesBase = {
   account_type: 'MetaMask',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  address_alert_response: 'loading',
+  address_alert_response: 'Loading',
   category: 'inpage_provider',
   locale: 'en',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -66,7 +66,7 @@ const expectedEventPropertiesBase = {
   security_alert_reason: 'validation_in_progress',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  security_alert_response: 'loading',
+  security_alert_response: 'Loading',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   api_source: MetaMetricsRequestedThrough.EthereumProvider,

--- a/ui/hooks/useTokenTrustSignals.ts
+++ b/ui/hooks/useTokenTrustSignals.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { ResultType } from '../../shared/lib/trust-signals';
 import { getTokenScanResultsForAddresses } from '../selectors/selectors';
 import { generateTokenCacheKey } from '../helpers/utils/token-cache-utils';
 import { TrustSignalDisplayState, TrustSignalResult } from './useTrustSignals';
@@ -22,11 +23,11 @@ function getTrustState(
   }
 
   switch (resultType) {
-    case 'Malicious':
+    case ResultType.Malicious:
       return TrustSignalDisplayState.Malicious;
-    case 'Warning':
+    case ResultType.Warning:
       return TrustSignalDisplayState.Warning;
-    case 'Benign':
+    case ResultType.Benign:
     default:
       return TrustSignalDisplayState.Unknown;
   }

--- a/ui/hooks/useTrustSignals.ts
+++ b/ui/hooks/useTrustSignals.ts
@@ -19,7 +19,7 @@ export type UseTrustSignalRequest = {
 };
 
 export enum TrustSignalDisplayState {
-  Loading = 'loading',
+  Loading = 'Loading',
   Malicious = 'malicious',
   Petname = 'petname',
   Verified = 'verified',

--- a/ui/pages/confirmations/hooks/alerts/useSpenderAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSpenderAlerts.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../../../../shared/modules/transaction.utils', () => ({
 jest.mock('../../../../hooks/useTrustSignals', () => ({
   useTrustSignal: jest.fn(),
   TrustSignalDisplayState: {
-    Loading: 'loading',
+    Loading: 'Loading',
     Malicious: 'malicious',
     Petname: 'petname',
     Verified: 'verified',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR standardizes the casing of `Loading` enum values across security/trust signal related enums for consistency.

**What is the reason for the change?**
The `Loading` member in `ResultType`, `BlockaidResultType`, and `TrustSignalDisplayState` enums used lowercase `'loading'` as the string value, while other members like `Malicious`, `Warning`, and `Benign` use PascalCase values. To achieve consistency for Segment, I've fixed that here.

**What is the improvement/solution?**
- Changed `Loading = 'loading'` to `Loading = 'Loading'` in:
  - `ResultType` (`shared/lib/trust-signals.ts`)
  - `BlockaidResultType` (`shared/constants/security-provider.ts`)
  - `TrustSignalDisplayState` (`ui/hooks/useTrustSignals.ts`)
- Updated test fixtures to match the new enum value
- Refactored `useTokenTrustSignals.ts` to use `ResultType` enum constants instead of hardcoded string literals


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39261?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns result casing for trust/security signals and updates dependent code/tests.
> 
> - Change `Loading = 'loading'` to `Loading = 'Loading'` in `BlockaidResultType` (`shared/constants/security-provider.ts`), `ResultType` (`shared/lib/trust-signals.ts`), and `TrustSignalDisplayState` (`ui/hooks/useTrustSignals.ts`)
> - Refactor `ui/hooks/useTokenTrustSignals.ts` to use `ResultType` enum constants instead of string literals
> - Update test fixtures and e2e tests to expect `'Loading'` (e.g., `test/data/confirmations/typed_sign.ts`, signature metrics helpers/specs, and comparison logic in `signature-helpers.ts`)
> - Ensure metrics defaults use `'Loading'` for `address_alert_response` and `security_alert_response`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e80577e866e5261a3dbb02ce702c6343e2d564d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->