### PR TITLE
chore: Replace deprecated `displayWarning` usage on `import-account` page

### DIFF
--- a/ui/components/multichain/import-account/bottom-buttons.js
+++ b/ui/components/multichain/import-account/bottom-buttons.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import {
   Box,
   ButtonPrimary,
@@ -9,7 +8,6 @@ import {
 } from '../../component-library';
 import { Display } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import * as actions from '../../../store/actions';
 
 export default function BottomButtons({
   importAccountFunc,
@@ -17,13 +15,11 @@ export default function BottomButtons({
   onActionComplete,
 }) {
   const t = useI18nContext();
-  const dispatch = useDispatch();
 
   return (
     <Box display={Display.Flex} gap={4}>
       <ButtonSecondary
         onClick={() => {
-          dispatch(actions.hideWarning());
           onActionComplete();
         }}
         size={ButtonSecondarySize.Lg}

--- a/ui/components/multichain/import-account/import-account.js
+++ b/ui/components/multichain/import-account/import-account.js
@@ -38,6 +38,7 @@ export const ImportAccount = ({ onActionComplete }) => {
   const menuItems = [t('privateKey'), t('jsonFile')];
 
   const [type, setType] = useState(menuItems[0]);
+  const [importErrorMessage, setImportErrorMessage] = useState();
 
   async function importAccount(strategy, importArgs) {
     const loadingMessage = getLoadingMessage(strategy);
@@ -57,10 +58,10 @@ export const ImportAccount = ({ onActionComplete }) => {
       );
       if (selectedAddress) {
         trackImportEvent(strategy, true);
-        dispatch(actions.hideWarning());
+        setImportErrorMessage();
         onActionComplete(true);
       } else {
-        dispatch(actions.displayWarning(t('importAccountError')));
+        setImportErrorMessage(t('importAccountError'));
         return false;
       }
     } catch (error) {
@@ -128,12 +129,12 @@ export const ImportAccount = ({ onActionComplete }) => {
   function translateWarning(message) {
     if (message && !message.startsWith('t(')) {
       // This is just a normal error message
-      dispatch(actions.displayWarning(message));
+      setImportErrorMessage(message);
     } else {
       // This is an error message in a form like
       // `t('importAccountErrorNotHexadecimal')`
       // so slice off the first 3 chars and last 2 chars, and feed to i18n
-      dispatch(actions.displayWarning(t(message.slice(3, -2))));
+      setImportErrorMessage(t(message.slice(3, -2)));
     }
   }
 
@@ -198,7 +199,7 @@ export const ImportAccount = ({ onActionComplete }) => {
             options={menuItems.map((text) => ({ value: text }))}
             selectedOption={type}
             onChange={(value) => {
-              dispatch(actions.hideWarning());
+              setImportErrorMessage();
               setType(value);
             }}
           />
@@ -206,12 +207,20 @@ export const ImportAccount = ({ onActionComplete }) => {
         {type === menuItems[0] ? (
           <PrivateKeyImportView
             importAccountFunc={importAccount}
-            onActionComplete={onActionComplete}
+            onActionComplete={(confirmed) => {
+              setImportErrorMessage();
+              onActionComplete(confirmed);
+            }}
+            importErrorMessage={importErrorMessage}
           />
         ) : (
           <JsonImportView
             importAccountFunc={importAccount}
-            onActionComplete={onActionComplete}
+            onActionComplete={(confirmed) => {
+              setImportErrorMessage();
+              onActionComplete(confirmed);
+            }}
+            importErrorMessage={importErrorMessage}
           />
         )}
       </Box>

--- a/ui/components/multichain/import-account/json.js
+++ b/ui/components/multichain/import-account/json.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
 import FileInput from 'react-simple-file-input';
 import {
   ButtonLink,
@@ -16,17 +15,17 @@ import {
 import { FormTextField } from '../../component-library/form-text-field/deprecated';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { displayWarning } from '../../../store/actions';
 import BottomButtons from './bottom-buttons';
 
 export default function JsonImportSubview({
   importAccountFunc,
   onActionComplete,
+  importErrorMessage,
 }) {
   const t = useI18nContext();
-  const warning = useSelector((state) => state.appState.warning);
   const [password, setPassword] = useState('');
   const [fileContents, setFileContents] = useState('');
+  const [errorMessage, setErrorMessage] = useState();
 
   const isPrimaryDisabled = fileContents === '';
 
@@ -39,7 +38,7 @@ export default function JsonImportSubview({
 
   function _importAccountFunc() {
     if (isPrimaryDisabled) {
-      displayWarning(t('needImportFile'));
+      setErrorMessage(t('needImportFile'));
     } else {
       importAccountFunc('json', [fileContents, password]);
     }
@@ -63,7 +62,10 @@ export default function JsonImportSubview({
         id="file-input"
         data-testid="file-input"
         readAs="text"
-        onLoad={(event) => setFileContents(event.target.result)}
+        onLoad={(event) => {
+          setErrorMessage();
+          setFileContents(event.target.result);
+        }}
         style={{
           padding: '20px 0px 12px 15%',
           fontSize: '16px',
@@ -78,7 +80,7 @@ export default function JsonImportSubview({
         size={TextFieldSize.Lg}
         autoFocus
         type={TextFieldType.Password}
-        helpText={warning}
+        helpText={errorMessage ?? importErrorMessage}
         error
         placeholder={t('enterOptionalPassword')}
         value={password}
@@ -94,7 +96,10 @@ export default function JsonImportSubview({
       <BottomButtons
         importAccountFunc={_importAccountFunc}
         isPrimaryDisabled={isPrimaryDisabled}
-        onActionComplete={onActionComplete}
+        onActionComplete={(confirmed) => {
+          setErrorMessage();
+          onActionComplete(confirmed);
+        }}
       />
     </>
   );
@@ -109,4 +114,8 @@ JsonImportSubview.propTypes = {
    * Executes when the key is imported
    */
   onActionComplete: PropTypes.func.isRequired,
+  /**
+   * Import error message
+   */
+  importErrorMessage: PropTypes.string,
 };

--- a/ui/components/multichain/import-account/json.stories.js
+++ b/ui/components/multichain/import-account/json.stories.js
@@ -4,6 +4,13 @@ import JsonImportSubview from './json';
 export default {
   title: 'Components/Multichain/JsonImportSubview',
   component: JsonImportSubview,
+  argTypes: {
+    importErrorMessage: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
 };
 
 export const DefaultStory = () => <JsonImportSubview />;

--- a/ui/components/multichain/import-account/private-key.js
+++ b/ui/components/multichain/import-account/private-key.js
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useState } from 'react';
 import {
   FormTextField,
   TextFieldSize,
   TextFieldType,
 } from '../../component-library';
-import { hideWarning } from '../../../store/actions';
 
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import ShowHideToggle from '../../ui/show-hide-toggle';
@@ -15,21 +13,11 @@ import BottomButtons from './bottom-buttons';
 export default function PrivateKeyImportView({
   importAccountFunc,
   onActionComplete,
+  importErrorMessage,
 }) {
   const t = useI18nContext();
-  const dispatch = useDispatch();
   const [privateKey, setPrivateKey] = useState('');
   const [showPrivateKey, setShowPrivateKey] = useState(false);
-
-  // Since MetaMask still uses a global warning state,
-  // hide the "invalid" warning when the private key import view is unmounted
-  useEffect(() => {
-    return () => {
-      dispatch(hideWarning());
-    };
-  }, [dispatch]);
-
-  const warning = useSelector((state) => state.appState.warning);
 
   function handleKeyPress(event) {
     if (privateKey !== '' && event.key === 'Enter') {
@@ -48,8 +36,8 @@ export default function PrivateKeyImportView({
         id="private-key-box"
         size={TextFieldSize.Lg}
         autoFocus
-        helpText={warning}
-        error={Boolean(warning)}
+        helpText={importErrorMessage}
+        error={Boolean(importErrorMessage)}
         label={t('pastePrivateKey')}
         value={privateKey}
         onChange={(event) => setPrivateKey(event.target.value)}
@@ -90,4 +78,8 @@ PrivateKeyImportView.propTypes = {
    * Executes when the key is imported
    */
   onActionComplete: PropTypes.func.isRequired,
+  /**
+   * Import error message
+   */
+  importErrorMessage: PropTypes.string,
 };

--- a/ui/components/multichain/import-account/private-key.stories.js
+++ b/ui/components/multichain/import-account/private-key.stories.js
@@ -10,6 +10,11 @@ export default {
         type: 'function',
       },
     },
+    errorMessage: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 };
 

--- a/ui/components/multichain/import-account/private-key.stories.js
+++ b/ui/components/multichain/import-account/private-key.stories.js
@@ -10,7 +10,7 @@ export default {
         type: 'function',
       },
     },
-    errorMessage: {
+    importErrorMessage: {
       control: {
         type: 'text',
       },


### PR DESCRIPTION
## **Description**

The `import-account` page now uses component state to store error messages rather than the deprecated `displayWarning` action. The end-user behaviour on this page should be identical, but it does ensure these errors aren't shown in other contexts (e.g. on the Settings page).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39265?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

Try to import an account, using either a private key or JSON file. Invalid private keys or files should result in an error.

Similarly, importing an account you already have in the wallet shows a duplicate account error.

I don't know of a complete list of error scenarios here, but the logic for how those are handled isn't being changed here (at least not intentionally!), just how the error is displayed.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/63852e85-7254-43d2-8e0e-aaf7682211b9

### **After**

https://github.com/user-attachments/assets/cd4dfe0e-1d61-4d3a-bac0-dfe33ff8178b

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts import-account error handling from global Redux warnings to local component state and updates UI/tests accordingly.
> 
> - Adds `importErrorMessage` state in `ImportAccount`, translating KeyringController/i18n messages and clearing on success/type change; passes to `PrivateKeyImportView` and `JsonImportSubview`
> - Removes `displayWarning`/`hideWarning` usages and related `useDispatch`/`useSelector`; `BottomButtons` now only calls callbacks and respects `isPrimaryDisabled`
> - `JsonImportSubview`: local `errorMessage` for missing file, clears on file load; shows `errorMessage ?? importErrorMessage`
> - `PrivateKeyImportView`: shows `importErrorMessage`; simplifies by removing warning lifecycle logic
> - Tests updated to assert in-DOM error messages and error-clearing on type switch; stories accept `importErrorMessage` prop
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10491ee045522ae020781329e5ba1387c902e3e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->