### PR TITLE
feat: remove IS_SIDEPANEL flag

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -75,7 +75,6 @@ jobs:
       RUN_ID: ${{ github.run_id }}
       PR_NUMBER: ${{ github.event.pull_request.number || '' }}
       TEST_SUITE_NAME: ${{ inputs.test-suite-name }}
-      IS_SIDEPANEL: true
       RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Checkout and setup environment

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1833,9 +1833,8 @@ function onNavigateToTab() {
 // Sidepanel-specific functionality
 // Set initial side panel behavior based on user preference
 const initSidePanelBehavior = async () => {
-  // Only initialize sidepanel behavior if the feature flag is enabled
-  // and the browser supports the sidePanel API (not Firefox)
-  if (process.env.IS_SIDEPANEL?.toString() !== 'true' || !browser?.sidePanel) {
+  // Only initialize sidepanel behavior if the browser supports the sidePanel API (not Firefox)
+  if (!browser?.sidePanel) {
     return;
   }
 
@@ -1863,9 +1862,8 @@ initSidePanelBehavior();
 
 // Listen for preference changes to update side panel behavior dynamically
 const setupPreferenceListener = async () => {
-  // Only setup preference listener if the feature flag is enabled
-  // and the browser supports the sidePanel API (not Firefox)
-  if (process.env.IS_SIDEPANEL?.toString() !== 'true' || !browser?.sidePanel) {
+  // Only setup preference listener if the browser supports the sidePanel API (not Firefox)
+  if (!browser?.sidePanel) {
     return;
   }
 

--- a/builds.yml
+++ b/builds.yml
@@ -34,7 +34,6 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.3.0/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
       - EXTENSION_UX_PNA25: true
       # for seedless onboarding (social login)
       - GOOGLE_PROD_CLIENT_ID
@@ -69,7 +68,6 @@ buildTypes:
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.3.0/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
-      - IS_SIDEPANEL: true
       - EXTENSION_UX_PNA25: true
       # for seedless onboarding (social login)
       - GOOGLE_BETA_CLIENT_ID
@@ -100,7 +98,6 @@ buildTypes:
       - INFURA_ENV_KEY_REF: INFURA_EXPERIMENTAL_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_EXPERIMENTAL_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
-      - IS_SIDEPANEL: true
       - REQUIRE_SNAPS_ALLOWLIST: true
       - REJECT_INVALID_SNAPS_PLATFORM_VERSION: true
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/10.3.0/index.html
@@ -140,7 +137,6 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://metamask.github.io/snaps-directory-staging/main/account-management
       - EIP_4337_ENTRYPOINT: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
-      - IS_SIDEPANEL: true
       - EXTENSION_UX_PNA25: true
       # for seedless onboarding (social login)
       - GOOGLE_FLASK_CLIENT_ID
@@ -464,7 +460,6 @@ env:
 
   # PNA25 (Privacy Notice)
   - EXTENSION_UX_PNA25: true
-  - IS_SIDEPANEL: true
 
   # Authentication (Backup & Sync, Profile metrics...)
   - FORCE_AUTH_MATCH_BUILD: false

--- a/shared/modules/environment.ts
+++ b/shared/modules/environment.ts
@@ -40,11 +40,6 @@ export const isGatorPermissionsRevocationFeatureEnabled = (): boolean => {
 };
 
 export const getIsSidePanelFeatureEnabled = (): boolean => {
-  // First check if build supports sidepanel
-  if (process.env.IS_SIDEPANEL?.toString() !== 'true') {
-    return false;
-  }
-
   // In browser context, check if the API exists (Firefox doesn't have it)
   if (
     typeof window !== 'undefined' &&

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -770,9 +770,8 @@ const sentryRegEx = /^https:\/\/sentry\.io\/api\/\d+\/envelope/gu;
  */
 async function isSidePanelEnabled() {
   try {
-    const hasSidepanel =
-      process.env.SELENIUM_BROWSER === 'chrome' &&
-      process.env.IS_SIDEPANEL === 'true';
+    // Check if browser is Chrome (sidepanel is only supported in Chrome)
+    const hasSidepanel = process.env.SELENIUM_BROWSER === 'chrome';
 
     // Log for debugging
     console.log(`Sidepanel check: ${hasSidepanel ? 'enabled' : 'disabled'}`);

--- a/test/e2e/page-objects/flows/onboarding.flow.ts
+++ b/test/e2e/page-objects/flows/onboarding.flow.ts
@@ -27,9 +27,7 @@ export const handleSidepanelPostOnboarding = async (
   driver: Driver,
 ): Promise<void> => {
   // Only run when sidepanel is actually enabled on Chrome
-  const isSidepanelEnabled =
-    process.env.SELENIUM_BROWSER === 'chrome' &&
-    process.env.IS_SIDEPANEL === 'true';
+  const isSidepanelEnabled = process.env.SELENIUM_BROWSER === 'chrome';
 
   if (!isSidepanelEnabled) {
     return;

--- a/test/env.js
+++ b/test/env.js
@@ -18,4 +18,3 @@ process.env.METAMASK_VERSION = 'MOCK_VERSION';
 process.env.TZ = 'UTC';
 process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
 process.env.METAMASK_SHIELD_ENABLED = 'false';
-process.env.IS_SIDEPANEL = 'true';


### PR DESCRIPTION
This PR is to remove IS_SIDEPANEL flag

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [link](https://consensyssoftware.atlassian.net/browse/CEUX-411?atlOrigin=eyJpIjoiYTZhMzc4Y2Y0NDAzNGQzNGFhZTFmYmFmODg2MjdmNDIiLCJwIjoiaiJ9)

## **Manual testing steps**

1. No change, just code cleanup
2. Everything should work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

NA
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies sidepanel enablement by removing the build-time/test `IS_SIDEPANEL` flag and using runtime browser API checks instead.
> 
> - Background: sidepanel init and preference listeners no longer check `process.env.IS_SIDEPANEL`, only `browser.sidePanel`
> - `shared/modules/environment.ts`: `getIsSidePanelFeatureEnabled` no longer depends on `IS_SIDEPANEL`
> - CI/builds: remove `IS_SIDEPANEL` from `builds.yml`, `.github/workflows/run-e2e.yml`
> - Tests: update E2E helpers and onboarding flow to detect sidepanel via browser (`SELENIUM_BROWSER === 'chrome'`); remove `IS_SIDEPANEL` from `test/env.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb189386eb6c0d8b3b97400be904dbed7b42c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->