### PR TITLE
perf: Replace `JSON.stringify` with `useSyncEqualityCheck` in confirmation hooks

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
@@ -7,6 +7,7 @@ import {
 import { add0x } from '@metamask/utils';
 import { useMemo } from 'react';
 
+import { useSyncEqualityCheck } from '../../../../../../hooks/useSyncEqualityCheck';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useAsyncResult } from '../../../../../../hooks/useAsync';
 import { getTokenStandardAndDetails } from '../../../../../../store/actions';
@@ -68,9 +69,16 @@ function useBatchApproveSimulationBalanceChanges({
 }: {
   nestedTransactions?: BatchTransactionParams[];
 }) {
+  const stableNestedTransactions = useSyncEqualityCheck(
+    nestedTransactions ?? [],
+  );
+
   return useAsyncResult(
-    async () => buildSimulationTokenBalanceChanges({ nestedTransactions }),
-    [JSON.stringify(nestedTransactions)],
+    async () =>
+      buildSimulationTokenBalanceChanges({
+        nestedTransactions: stableNestedTransactions,
+      }),
+    [stableNestedTransactions],
   );
 }
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
@@ -7,7 +7,7 @@ import {
 import { add0x } from '@metamask/utils';
 import { useMemo } from 'react';
 
-import { useSyncEqualityCheck } from '../../../../../../hooks/useSyncEqualityCheck';
+import { useDeepMemo } from '../../../../hooks/useDeepMemo';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useAsyncResult } from '../../../../../../hooks/useAsync';
 import { getTokenStandardAndDetails } from '../../../../../../store/actions';
@@ -69,8 +69,9 @@ function useBatchApproveSimulationBalanceChanges({
 }: {
   nestedTransactions?: BatchTransactionParams[];
 }) {
-  const stableNestedTransactions = useSyncEqualityCheck(
-    nestedTransactions ?? [],
+  const stableNestedTransactions = useDeepMemo(
+    () => nestedTransactions,
+    [nestedTransactions],
   );
 
   return useAsyncResult(

--- a/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useSendingValueMetric.ts
@@ -1,6 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useEffect } from 'react';
-import { useSyncEqualityCheck } from '../../../../../../hooks/useSyncEqualityCheck';
+import { useDeepMemo } from '../../../../hooks/useDeepMemo';
 import { useTransactionEventFragment } from '../../../../hooks/useTransactionEventFragment';
 
 export type UseSendingValueMetricProps = {
@@ -15,24 +15,17 @@ export const useSendingValueMetric = ({
   const { updateTransactionEventFragment } = useTransactionEventFragment();
 
   const transactionId = transactionMeta.id;
-  const hasValidFiatValue = fiatValue !== undefined && fiatValue !== '';
-
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const properties = { sending_value: hasValidFiatValue ? fiatValue : 0 };
+  const properties = { sending_value: fiatValue };
   const sensitiveProperties = {};
   const params = { properties, sensitiveProperties };
 
-  const stableParams = useSyncEqualityCheck(params);
+  const stableParams = useDeepMemo(() => params, [params]);
 
   useEffect(() => {
-    if (hasValidFiatValue) {
+    if (fiatValue !== undefined && fiatValue !== '') {
       updateTransactionEventFragment(stableParams, transactionId);
     }
-  }, [
-    updateTransactionEventFragment,
-    transactionId,
-    stableParams,
-    hasValidFiatValue,
-  ]);
+  }, [updateTransactionEventFragment, transactionId, stableParams, fiatValue]);
 };

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -9,7 +9,7 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { ContractExchangeRates } from '@metamask/assets-controllers';
 import { useAsyncResultOrThrow } from '../../../../hooks/useAsync';
-import { useSyncEqualityCheck } from '../../../../hooks/useSyncEqualityCheck';
+import { useDeepMemo } from '../../hooks/useDeepMemo';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
@@ -176,7 +176,10 @@ export const useBalanceChanges = ({
     .filter((tbc) => tbc.standard === SimulationTokenStandard.erc20)
     .map((tbc) => tbc.address);
 
-  const stableErc20Addresses = useSyncEqualityCheck(erc20TokenAddresses);
+  const stableErc20Addresses = useDeepMemo(
+    () => erc20TokenAddresses,
+    [erc20TokenAddresses],
+  );
 
   const erc20Decimals = useAsyncResultOrThrow(
     () => fetchAllErc20Decimals(stableErc20Addresses, chainId),

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -9,6 +9,7 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { ContractExchangeRates } from '@metamask/assets-controllers';
 import { useAsyncResultOrThrow } from '../../../../hooks/useAsync';
+import { useSyncEqualityCheck } from '../../../../hooks/useSyncEqualityCheck';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
@@ -175,27 +176,24 @@ export const useBalanceChanges = ({
     .filter((tbc) => tbc.standard === SimulationTokenStandard.erc20)
     .map((tbc) => tbc.address);
 
+  const stableErc20Addresses = useSyncEqualityCheck(erc20TokenAddresses);
+
   const erc20Decimals = useAsyncResultOrThrow(
-    () => fetchAllErc20Decimals(erc20TokenAddresses, chainId),
-    [chainId, JSON.stringify(erc20TokenAddresses)],
+    () => fetchAllErc20Decimals(stableErc20Addresses, chainId),
+    [chainId, stableErc20Addresses],
   );
 
   const erc20FiatRates = useAsyncResultOrThrow(
-    () => fetchTokenFiatRates(fiatCurrency, erc20TokenAddresses, chainId),
-    [JSON.stringify(erc20TokenAddresses), chainId, fiatCurrency],
+    () => fetchTokenFiatRates(fiatCurrency, stableErc20Addresses, chainId),
+    [stableErc20Addresses, chainId, fiatCurrency],
   );
 
   const erc20UsdRates = useAsyncResultOrThrow(
     async () =>
       fiatCurrency === CURRENCY_USD
         ? (erc20FiatRates.value ?? {})
-        : fetchTokenFiatRates(CURRENCY_USD, erc20TokenAddresses, chainId),
-    [
-      JSON.stringify(erc20TokenAddresses),
-      chainId,
-      fiatCurrency,
-      erc20FiatRates.value,
-    ],
+        : fetchTokenFiatRates(CURRENCY_USD, stableErc20Addresses, chainId),
+    [stableErc20Addresses, chainId, fiatCurrency, erc20FiatRates.value],
   );
 
   if (

--- a/ui/pages/confirmations/hooks/useDeepMemo.test.ts
+++ b/ui/pages/confirmations/hooks/useDeepMemo.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useDeepMemo } from './useDeepMemo';
+
+const RESULT_MOCK = { a: 1 };
+const RESULT_2_MOCK = { a: 2 };
+
+describe('useDeepMemo', () => {
+  const factoryMock = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    factoryMock
+      .mockReturnValueOnce(RESULT_MOCK)
+      .mockReturnValueOnce(RESULT_2_MOCK);
+  });
+
+  it('returns same factory result if deep equality', () => {
+    const { result, rerender } = renderHook(
+      ({ factory, deps }) => useDeepMemo(factory, deps),
+      { initialProps: { factory: factoryMock, deps: [{ b: 1 }] } },
+    );
+
+    rerender({ factory: factoryMock, deps: [{ b: 1 }] });
+
+    expect(factoryMock).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(RESULT_MOCK);
+  });
+
+  it('returns new factory result if not deep equality', () => {
+    const { result, rerender } = renderHook(
+      ({ factory, deps }) => useDeepMemo(factory, deps),
+      { initialProps: { factory: factoryMock, deps: [{ b: 1 }] } },
+    );
+
+    rerender({ factory: factoryMock, deps: [{ b: 2 }] });
+
+    expect(factoryMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(RESULT_2_MOCK);
+  });
+
+  it('returns same factory result if primitive dependencies not changed', () => {
+    const { result, rerender } = renderHook(
+      ({ factory, deps }) => useDeepMemo(factory, deps),
+      { initialProps: { factory: factoryMock, deps: [true, 'test', 1] } },
+    );
+
+    rerender({ factory: factoryMock, deps: [true, 'test', 1] });
+
+    expect(factoryMock).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(RESULT_MOCK);
+  });
+
+  it('returns new factory result if primitive dependencies changed', () => {
+    const { result, rerender } = renderHook(
+      ({ factory, deps }) => useDeepMemo(factory, deps),
+      { initialProps: { factory: factoryMock, deps: [true, 'test', 1] } },
+    );
+
+    rerender({ factory: factoryMock, deps: [true, 'test', 2] });
+
+    expect(factoryMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(RESULT_2_MOCK);
+  });
+
+  it('returns same factory result if no dependencies', () => {
+    const { result, rerender } = renderHook(
+      ({ factory, deps }) => useDeepMemo(factory, deps),
+      { initialProps: { factory: factoryMock, deps: [] } },
+    );
+
+    rerender({ factory: factoryMock, deps: [] });
+
+    expect(factoryMock).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(RESULT_MOCK);
+  });
+});

--- a/ui/pages/confirmations/hooks/useDeepMemo.ts
+++ b/ui/pages/confirmations/hooks/useDeepMemo.ts
@@ -1,0 +1,27 @@
+import { isEqual } from 'lodash';
+import { DependencyList, useRef } from 'react';
+
+/**
+ * Identical to `useMemo`, but compares dependencies using deep equality.
+ * Should only be used temporarily or as a last resort if dependencies, such
+ * as selectors and hooks, cannot be stabilized to return a consistent reference.
+ * Ensure dependencies are small otherwise performance cost may be worse than re-rendering.
+ *
+ * @param factory - Function that returns the memoized value
+ * @param deps - Dependency list to compare using deep equality
+ * @returns Memoized value from factory function
+ */
+export function useDeepMemo<Type>(
+  factory: () => Type,
+  deps: DependencyList,
+): Type {
+  const depsRef = useRef<DependencyList | undefined>(undefined);
+  const resultRef = useRef<Type>();
+
+  if (!isEqual(depsRef.current, deps)) {
+    depsRef.current = deps;
+    resultRef.current = factory();
+  }
+
+  return resultRef.current as Type;
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR replaces 5 instances of `JSON.stringify` in useEffect/async hook dependency arrays with the useSyncEqualityCheck hook to eliminate unnecessary serialization on every render, improving INP performance in confirmation flows.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39275?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6610

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a deep-equality memo hook to remove `JSON.stringify` from dependency arrays, reducing render-time serialization and stabilizing async/effect triggers.
> 
> - New `useDeepMemo` hook with unit tests
> - `useBalanceChanges`: memoizes ERC20 address list; updates async deps to use stable lists
> - `useBatchApproveBalanceChanges`: memoizes `nestedTransactions` before building simulation changes
> - `useSendingValueMetric`: memoizes event fragment params; effect now depends on stable params and `fiatValue`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 317ff5546e463baad6f8e0692d228e7e2c300c1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->