### PR TITLE
fix: arrow icon color consistency

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -18,7 +18,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
         >
           <button
             aria-label="Back"
-            class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+            class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             data-testid="nft__back"
           >
             <span

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -387,7 +387,7 @@ export function NftDetailsComponent({
           justifyContent={JustifyContent.spaceBetween}
         >
           <ButtonIcon
-            color={IconColor.iconAlternative}
+            color={IconColor.iconDefault}
             size={ButtonIconSize.Sm}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AssetPage should render a native asset 1`] = `
       >
         <button
           aria-label="Back"
-          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
             class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
@@ -432,7 +432,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
       >
         <button
           aria-label="Back"
-          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
             class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
@@ -879,7 +879,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
       >
         <button
           aria-label="Back"
-          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+          class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
             class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -339,7 +339,7 @@ const AssetPage = ({
       >
         <Box display={Display.Flex}>
           <ButtonIcon
-            color={IconColor.iconAlternative}
+            color={IconColor.iconDefault}
             marginRight={1}
             size={ButtonIconSize.Sm}
             ariaLabel={t('back')}

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
     >
       <button
         aria-label="Back"
-        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-right-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="defi-details-page-back-button"
       >
         <span

--- a/ui/pages/defi/components/defi-details-page.tsx
+++ b/ui/pages/defi/components/defi-details-page.tsx
@@ -96,7 +96,7 @@ const DeFiPage = () => {
       >
         <ButtonIcon
           data-testid="defi-details-page-back-button"
-          color={IconColor.iconAlternative}
+          color={IconColor.iconDefault}
           marginRight={1}
           size={ButtonIconSize.Sm}
           ariaLabel={t('back')}


### PR DESCRIPTION
## **Description**

This PR fixes the back arrow icon color across multiple detail pages (NFT details, Asset page, and DeFi details page). The back arrow buttons were previously using `IconColor.iconAlternative` which resulted in incorrect visual appearance. They now use `IconColor.iconDefault` for consistency with the design system.

**Changes:**
- Updated back arrow icon color in NFT details page
- Updated back arrow icon color in Asset page
- Updated back arrow icon color in DeFi details page

## **Changelog**

CHANGELOG entry: Fixed back arrow icon colors on NFT details, asset, and DeFi detail pages

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-665

## **Manual testing steps**

1. Navigate to an NFT details page (Assets tab → NFTs → select any NFT)
2. Verify the back arrow icon color appears correct
3. Navigate to an Asset page (Assets tab → Tokens → select any token)
4. Verify the back arrow icon color appears correct
5. Navigate to a DeFi details page (if available)
6. Verify the back arrow icon color appears correct

## **Screenshots/Recordings**

### **Before**
<img width="400" height="601" alt="Screenshot 2026-01-16 at 13 54 41" src="https://github.com/user-attachments/assets/5badd514-b562-426c-a844-dc26a70d35d2" />

<!-- Back arrow icons were using iconAlternative color -->

### **After**
<img width="399" height="599" alt="Screenshot 2026-01-16 at 13 49 44" src="https://github.com/user-attachments/assets/771bbf4e-092c-4ae1-a806-6831c5cf2674" />

<!-- Back arrow icons now use iconDefault color -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns back-arrow icon styling with the design system across detail pages.
> 
> - Change `ButtonIcon` color from `IconColor.iconAlternative` to `IconColor.iconDefault` in `nft-details.tsx`, `asset-page.tsx`, and `defi-details-page.tsx`
> - Update associated Jest snapshots for NFT details, Asset page, and DeFi details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6661727efc96337f4d1186a946168df952ba3b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->