### PR TITLE
feat: Improve networks menu focus management

### DIFF
--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -25,33 +25,29 @@ export const NetworkListItemMenu = ({
 }) => {
   const t = useI18nContext();
 
-  // Track refs for menu items to handle keyboard navigation
-  const discoverItemRef = useRef(null);
-  const editItemRef = useRef(null);
-  const deleteItemRef = useRef(null);
-  const lastItemRef = useRef(null);
   const popoverDialogRef = useRef(null);
 
-  // Determine the last menu item that is not disabled
-  useEffect(() => {
-    if (deleteItemRef.current) {
-      lastItemRef.current = deleteItemRef.current;
-    } else if (editItemRef.current) {
-      lastItemRef.current = editItemRef.current;
-    } else if (discoverItemRef.current) {
-      lastItemRef.current = discoverItemRef.current;
+  const getLastMenuItem = useCallback(() => {
+    if (!popoverDialogRef.current) {
+      return null;
     }
-  });
+    const menuItems =
+      popoverDialogRef.current.querySelectorAll('[role="menuitem"]');
+    return menuItems.length > 0 ? menuItems[menuItems.length - 1] : null;
+  }, []);
 
   // Handle Tab key press for accessibility - close popover on last MenuItem
   const handleKeyDown = useCallback(
     (event) => {
-      if (event.key === 'Tab' && event.target === lastItemRef.current) {
-        // If Tab is pressed at the last item, close popover and focus to next element in DOM
-        onClose();
+      if (event.key === 'Tab') {
+        const lastMenuItem = getLastMenuItem();
+        if (event.target === lastMenuItem) {
+          // If Tab is pressed at the last item, close popover and focus to next element in DOM
+          onClose();
+        }
       }
     },
-    [onClose],
+    [onClose, getLastMenuItem],
   );
 
   const menuContent = (
@@ -59,7 +55,6 @@ export const NetworkListItemMenu = ({
       <Box>
         {onDiscoverClick ? (
           <MenuItem
-            ref={discoverItemRef}
             iconName={IconName.Eye}
             onClick={(e) => {
               e.stopPropagation();
@@ -72,7 +67,6 @@ export const NetworkListItemMenu = ({
         ) : null}
         {onEditClick ? (
           <MenuItem
-            ref={editItemRef}
             iconName={IconName.Edit}
             onClick={(e) => {
               e.stopPropagation();
@@ -85,7 +79,6 @@ export const NetworkListItemMenu = ({
         ) : null}
         {onDeleteClick ? (
           <MenuItem
-            ref={deleteItemRef}
             iconName={IconName.Trash}
             iconColor={IconColor.errorDefault}
             onClick={(e) => {

--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -20,8 +20,86 @@ export const NetworkListItemMenu = ({
   onDeleteClick,
   onDiscoverClick,
   isOpen,
+  finalFocusRef,
+  isClosing: isClosingProp,
 }) => {
   const t = useI18nContext();
+
+  // Track refs for menu items to handle keyboard navigation
+  const discoverItemRef = useRef(null);
+  const editItemRef = useRef(null);
+  const deleteItemRef = useRef(null);
+  const lastItemRef = useRef(null);
+  const popoverDialogRef = useRef(null);
+
+  // Determine the last menu item that is not disabled
+  useEffect(() => {
+    if (deleteItemRef.current) {
+      lastItemRef.current = deleteItemRef.current;
+    } else if (editItemRef.current) {
+      lastItemRef.current = editItemRef.current;
+    } else if (discoverItemRef.current) {
+      lastItemRef.current = discoverItemRef.current;
+    }
+  });
+
+  // Handle Tab key press for accessibility - close popover on last MenuItem
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === 'Tab' && event.target === lastItemRef.current) {
+        // If Tab is pressed at the last item, close popover and focus to next element in DOM
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const menuContent = (
+    <div onKeyDown={handleKeyDown} ref={popoverDialogRef}>
+      <Box>
+        {onDiscoverClick ? (
+          <MenuItem
+            ref={discoverItemRef}
+            iconName={IconName.Eye}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDiscoverClick();
+            }}
+            data-testid="network-list-item-options-discover"
+          >
+            <Text>{t('discover')}</Text>
+          </MenuItem>
+        ) : null}
+        {onEditClick ? (
+          <MenuItem
+            ref={editItemRef}
+            iconName={IconName.Edit}
+            onClick={(e) => {
+              e.stopPropagation();
+              onEditClick();
+            }}
+            data-testid="network-list-item-options-edit"
+          >
+            <Text> {t('edit')}</Text>
+          </MenuItem>
+        ) : null}
+        {onDeleteClick ? (
+          <MenuItem
+            ref={deleteItemRef}
+            iconName={IconName.Trash}
+            iconColor={IconColor.errorDefault}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDeleteClick();
+            }}
+            data-testid="network-list-item-options-delete"
+          >
+            <Text color={TextColor.errorDefault}>{t('delete')}</Text>
+          </MenuItem>
+        ) : null}
+      </Box>
+    </div>
+  );
 
   return (
     <Popover
@@ -37,47 +115,18 @@ export const NetworkListItemMenu = ({
       preventOverflow
       flip
     >
-      <ModalFocus restoreFocus initialFocusRef={anchorElement}>
-        <Box>
-          {onDiscoverClick ? (
-            <MenuItem
-              iconName={IconName.Eye}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDiscoverClick();
-              }}
-              data-testid="network-list-item-options-discover"
-            >
-              <Text>{t('discover')}</Text>
-            </MenuItem>
-          ) : null}
-          {onEditClick ? (
-            <MenuItem
-              iconName={IconName.Edit}
-              onClick={(e) => {
-                e.stopPropagation();
-                onEditClick();
-              }}
-              data-testid="network-list-item-options-edit"
-            >
-              <Text> {t('edit')}</Text>
-            </MenuItem>
-          ) : null}
-          {onDeleteClick ? (
-            <MenuItem
-              iconName={IconName.Trash}
-              iconColor={IconColor.errorDefault}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDeleteClick();
-              }}
-              data-testid="network-list-item-options-delete"
-            >
-              <Text color={TextColor.errorDefault}>{t('delete')}</Text>
-            </MenuItem>
-          ) : null}
-        </Box>
-      </ModalFocus>
+      {isClosingProp ? (
+        // When closing, render without ModalFocus to prevent focus management
+        menuContent
+      ) : (
+        <ModalFocus
+          restoreFocus={!finalFocusRef}
+          autoFocus={false}
+          finalFocusRef={finalFocusRef}
+        >
+          {menuContent}
+        </ModalFocus>
+      )}
     </Popover>
   );
 };
@@ -109,4 +158,14 @@ NetworkListItemMenu.propTypes = {
    * @type {boolean}
    */
   isOpen: PropTypes.bool.isRequired,
+  /**
+   * Ref of the element that should receive focus when the menu closes
+   */
+  finalFocusRef: PropTypes.shape({
+    current: PropTypes.instanceOf(window.Element),
+  }),
+  /**
+   * Indicates if the menu is currently closing (used to prevent focus management)
+   */
+  isClosing: PropTypes.bool,
 };

--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -32,7 +32,7 @@ export const NetworkListItemMenu = ({
       return null;
     }
     const menuItems =
-      popoverDialogRef.current.querySelectorAll('[role="menuitem"]');
+      popoverDialogRef.current.querySelectorAll('button.menu-item');
     return menuItems.length > 0 ? menuItems[menuItems.length - 1] : null;
   }, []);
 

--- a/ui/components/multichain/network-list-item/network-list-item.test.js
+++ b/ui/components/multichain/network-list-item/network-list-item.test.js
@@ -87,6 +87,27 @@ describe('NetworkListItem', () => {
     expect(onDeleteClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledTimes(0);
   });
+
+  it('toggles menu open and closed when clicking the menu button', () => {
+    const onDeleteClick = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <NetworkListItem {...DEFAULT_PROPS} onDeleteClick={onDeleteClick} />,
+    );
+
+    const menuButton = getByTestId('network-list-item-options-button-0x1');
+
+    // First click should open the menu
+    fireEvent.click(menuButton);
+    expect(
+      queryByTestId('network-list-item-options-delete'),
+    ).toBeInTheDocument();
+
+    // Second click should close the menu
+    fireEvent.click(menuButton);
+    expect(
+      queryByTestId('network-list-item-options-delete'),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('NetworkListItem - Gas fees sponsored', () => {


### PR DESCRIPTION
## **Description**

This PR fixes the focus behavior in the network list item menu. Previously, when clicking the menu button to close an already-open menu, the first menu item would briefly receive focus before the menu closed. Additionally, the menu button now properly toggles the menu open/closed instead of always opening it.

**What is the reason for the change?**
- The menu had inconsistent focus behavior when toggling - clicking the button when the menu was open would focus the first menu item instead of just closing
- The menu button always opened the menu instead of toggling it
- Missing keyboard navigation support for accessibility

**What is the improvement/solution?**
- Menu button now properly toggles the menu (opens when closed, closes when open)
- Added proper focus management using `ModalFocus` with `finalFocusRef` to return focus to the button when closing
- Conditionally render `ModalFocus` only when menu is open and not closing to prevent focus management during closing transition
- Added keyboard navigation support (Tab key handling to close menu on last item)
- Prevented focus from jumping to first menu item when opening or closing the menu
- Added test coverage for toggle behavior

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39279?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed focus behavior in network list menu - menu button now properly toggles menu open/closed without focusing menu items

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-659

## **Manual testing steps**

1. Open MetaMask extension
2. Navigate to the network list (click on network selector in header)
3. Find a network item that has menu options (three dots icon)
4. Click the menu button (three dots) - menu should open
5. Click the menu button again - menu should close without focusing the first menu item
6. Open the menu again and press Tab key to navigate through menu items
7. Press Tab on the last menu item - menu should close
8. Verify that focus returns to the menu button when closing (not to the first menu item)
9. Verify that when opening the menu, no element is automatically focused

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="400" height="596" alt="Screenshot 2026-01-16 at 15 35 35" src="https://github.com/user-attachments/assets/48a8209c-aacf-4f5b-bc44-65bae630b851" />

<!-- Before: Clicking menu button when menu is open would focus the first menu item before closing -->

### **After**
<img width="400" height="597" alt="Screenshot 2026-01-16 at 15 33 19" src="https://github.com/user-attachments/assets/437fd298-6b52-4ef9-a334-da752e3fe4d1" />

<!-- After: Clicking menu button when menu is open closes the menu without focusing any menu items -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Implementation Details**

### Changes Made:

1. **Fixed menu toggle behavior** (`network-list-item.tsx`):
   - Changed menu button `onClick` handler from `setNetworkOptionsMenuOpen(true)` to `setNetworkOptionsMenuOpen((prev) => !prev)` to properly toggle the menu state
   - Added `onMouseDown` handler to prevent button from losing focus when clicked to close menu
   - Added `isMenuClosing` state to track when menu is closing
   - Focus button before closing to ensure it maintains focus

2. **Added focus management** (`network-list-item-menu.js`):
   - Added `ModalFocus` wrapper with `autoFocus={false}` to prevent automatic focusing
   - Added `finalFocusRef` support to return focus to button when menu closes
   - Conditionally render `ModalFocus` only when menu is open and not closing to prevent focus management during closing transition
   - This prevents `react-focus-lock` from trying to focus menu items during the closing transition

3. **Added keyboard navigation** (`network-list-item-menu.js`):
   - Added refs for menu items to track keyboard navigation
   - Added `handleKeyDown` to close menu when Tab is pressed on last menu item
   - Matches the pattern used in `account-list-item-menu`

4. **Added test coverage** (`network-list-item.test.js`):
   - Added test to verify menu toggle behavior (open on first click, close on second click)

### Technical Notes:

- The key fix is conditionally rendering `ModalFocus` - when `isClosing` is true, we render the menu content without `ModalFocus`, which prevents `react-focus-lock` from managing focus during the closing transition
- This approach maintains consistency with other menus in the codebase while solving the focus issue
- The implementation follows the same patterns as `account-list-item-menu` for consistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves focus and keyboard behavior for the network list item options menu and makes the menu button a true toggle.
> 
> - `NetworkListItemMenu`: adds `ModalFocus` with `autoFocus={false}`, supports `finalFocusRef`, conditionally omits focus management when `isClosing` is true, and handles `Tab` on the last item to close the popover
> - `NetworkListItem`: converts menu button to toggle with `onMouseDown` + `prepareMenuClose` to prevent focus jump, manages `isMenuClosing`, restores focus to the button on close, and passes `finalFocusRef`/`isClosing` to the menu; updates click-outside close behavior accordingly
> - Tests: adds coverage for menu toggle open/close behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c77539820c9e968d32848bb5a5029512973f1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->