### PR TITLE
fix: token currency bug on activity view

### DIFF
--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -160,10 +160,10 @@ export function useCurrencyDisplay(
   // Check if the transaction's chain is EVM, not just the account
   const isTransactionOnEvmChain = chainId ? isEvmChainId(chainId) : isEvm;
 
-  // When chainId is provided, use the chain-specific native currency and conversion rate
-  const chainNativeCurrency = chainId
-    ? CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]
-    : nativeCurrency;
+  // When chainId is provided, use the chain-specific native currency and conversion rate.
+  // Fall back to account defaults if the chain is not in the predefined map (custom networks).
+  const chainNativeCurrency =
+    (chainId && CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]) || nativeCurrency;
   const chainConversionRate = chainId
     ? currencyRates?.[chainNativeCurrency]?.conversionRate
     : conversionRate;

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -160,6 +160,14 @@ export function useCurrencyDisplay(
   // Check if the transaction's chain is EVM, not just the account
   const isTransactionOnEvmChain = chainId ? isEvmChainId(chainId) : isEvm;
 
+  // When chainId is provided, use the chain-specific native currency and conversion rate
+  const chainNativeCurrency = chainId
+    ? CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]
+    : nativeCurrency;
+  const chainConversionRate = chainId
+    ? currencyRates?.[chainNativeCurrency]?.conversionRate
+    : conversionRate;
+
   const value = useMemo(() => {
     if (displayValue) {
       return displayValue;
@@ -167,17 +175,14 @@ export function useCurrencyDisplay(
 
     if (!isTransactionOnEvmChain && !isAggregatedFiatOverviewBalance) {
       return formatNonEvmAssetCurrencyDisplay({
-        tokenSymbol: nativeCurrency,
+        tokenSymbol: chainNativeCurrency,
         isNativeCurrency,
         isUserPreferredCurrency,
         currency,
         currentCurrency,
-        nativeCurrency,
+        nativeCurrency: chainNativeCurrency,
         inputValue,
-        conversionRate: chainId
-          ? currencyRates?.[CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]]
-              ?.conversionRate
-          : conversionRate,
+        conversionRate: chainConversionRate,
       });
     }
 
@@ -185,12 +190,12 @@ export function useCurrencyDisplay(
       return formatCurrency(inputValue, currency);
     }
 
-    if (!isNativeCurrency && isUserPreferredCurrency && conversionRate) {
+    if (!isNativeCurrency && isUserPreferredCurrency && chainConversionRate) {
       const valueFromHex = getValueFromWeiHex({
         value: inputValue,
-        fromCurrency: nativeCurrency,
+        fromCurrency: chainNativeCurrency,
         toCurrency: currency,
-        conversionRate,
+        conversionRate: chainConversionRate,
         numberOfDecimals: numberOfDecimals || 2,
         toDenomination: denomination,
       });
@@ -200,7 +205,7 @@ export function useCurrencyDisplay(
     return formatEthCurrencyDisplay({
       isNativeCurrency,
       isUserPreferredCurrency,
-      nativeCurrency,
+      nativeCurrency: chainNativeCurrency,
       inputValue,
       denomination,
       numberOfDecimals,
@@ -211,15 +216,13 @@ export function useCurrencyDisplay(
     isNativeCurrency,
     isUserPreferredCurrency,
     currency,
-    nativeCurrency,
+    chainNativeCurrency,
     inputValue,
-    conversionRate,
+    chainConversionRate,
     denomination,
     numberOfDecimals,
     currentCurrency,
     isAggregatedFiatOverviewBalance,
-    chainId,
-    currencyRates,
     formatCurrency,
   ]);
 

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -160,13 +160,12 @@ export function useCurrencyDisplay(
   // Check if the transaction's chain is EVM, not just the account
   const isTransactionOnEvmChain = chainId ? isEvmChainId(chainId) : isEvm;
 
-  // When chainId is provided, use the chain-specific native currency and conversion rate.
-  // Fall back to account defaults if the chain is not in the predefined map (custom networks).
+  // When chainId is provided, use the chain-specific native currency and conversion rate
+  // Fall back to account defaults if the chain is not in the predefined map (custom networks)
   const chainNativeCurrency =
     (chainId && CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]) || nativeCurrency;
-  const chainConversionRate = chainId
-    ? currencyRates?.[chainNativeCurrency]?.conversionRate
-    : conversionRate;
+  const chainConversionRate =
+    currencyRates?.[chainNativeCurrency]?.conversionRate ?? conversionRate;
 
   const value = useMemo(() => {
     if (displayValue) {


### PR DESCRIPTION
## **Description**

When viewing the activity list in "all enabled networks" mode, transactions that occurred on non-Ethereum chains (e.g., Polygon) were displaying incorrect fiat amounts. The fiat conversion was using the currently selected network's native currency rate (e.g., ETH→USD) instead of the transaction's chain native currency rate (e.g., POL→USD).

**Root cause:** The `useCurrencyDisplay` hook was using `nativeCurrency` and `conversionRate` derived from the user's currently selected network, even when a `chainId` parameter was provided indicating the transaction occurred on a different chain.

**Solution:** When `chainId` is provided, use chain-specific values:
- `chainNativeCurrency` from `CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[chainId]`
- `chainConversionRate` from `currencyRates[chainNativeCurrency]`

This ensures Polygon transactions use POL→USD rate, Avalanche transactions use AVAX→USD rate, etc.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39280?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed incorrect fiat amounts shown for transactions on non-Ethereum chains when viewing all networks

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/35558 https://consensyssoftware.atlassian.net/browse/CEUX-867

## **Manual testing steps**

1. Enable multiple networks (Ethereum Mainnet and Polygon)
2. Ensure you have transaction history on Polygon
3. Switch to "All networks" view in the network selector
4. View the Activity tab
5. Verify that Polygon transactions show fiat amounts based on POL price, not ETH price
6. Compare: a 1 POL transaction should show ~$0.15 (not ~$3000+ as if it were 1 ETH)

## **Screenshots/Recordings**

### **Before**

<img width="980" height="1468" alt="image" src="https://github.com/user-attachments/assets/285e927c-5da3-4a02-80dd-a0e12d5f81ea" />

### **After**

<img width="481" height="727" alt="image" src="https://github.com/user-attachments/assets/d0675600-7efc-401b-bdc1-1c7a496427ef" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves incorrect fiat amounts by honoring the transaction `chainId` when formatting values.
> 
> - In `useCurrencyDisplay`, derive `chainNativeCurrency` and `chainConversionRate` from `CHAIN_ID_TO_CURRENCY_SYMBOL_MAP` and `currencyRates` when `chainId` is provided, and use them for non‑EVM formatting, fiat conversion, and native display; fall back to account defaults when the chain is unknown or `chainId` is absent
> - Update memo deps to use chain-specific values to keep outputs consistent
> - Add tests validating EVM formatting with `POL`, fiat conversion using chain rate, fallback to account rate without `chainId`, and fallback for custom networks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a811671144e0ce4d9fa6d5a7ba7ef6d3eaf944e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->