### PR TITLE
fix: Fix metric events on error page

### DIFF
--- a/test/e2e/page-objects/flows/crash.flow.ts
+++ b/test/e2e/page-objects/flows/crash.flow.ts
@@ -1,0 +1,21 @@
+import { Driver } from '../../webdriver/driver';
+import HeaderNavbar from '../pages/header-navbar';
+import SettingsPage from '../pages/settings/settings-page';
+import DevelopOptions from '../pages/developer-options-page';
+
+/**
+ * Trigger a UI crash.
+ *
+ * @param driver
+ */
+export const triggerCrash = async (driver: Driver): Promise<void> => {
+  const headerNavbar = new HeaderNavbar(driver);
+  await headerNavbar.openSettingsPage();
+  const settingsPage = new SettingsPage(driver);
+  await settingsPage.checkPageIsLoaded();
+  await settingsPage.goToDeveloperOptions();
+
+  const developOptionsPage = new DevelopOptions(driver);
+  await developOptionsPage.checkPageIsLoaded();
+  await developOptionsPage.clickGenerateCrashButton();
+};

--- a/test/e2e/tests/metrics/developer-options-sentry.spec.ts
+++ b/test/e2e/tests/metrics/developer-options-sentry.spec.ts
@@ -4,23 +4,9 @@ import { withFixtures, sentryRegEx } from '../../helpers';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
-import HeaderNavbar from '../../page-objects/pages/header-navbar';
-import DevelopOptions from '../../page-objects/pages/developer-options-page';
+import { triggerCrash } from '../../page-objects/flows/crash.flow';
 import ErrorPage from '../../page-objects/pages/error-page';
 import { MOCK_META_METRICS_ID } from '../../constants';
-
-const triggerCrash = async (driver: Driver): Promise<void> => {
-  const headerNavbar = new HeaderNavbar(driver);
-  await headerNavbar.openSettingsPage();
-  const settingsPage = new SettingsPage(driver);
-  await settingsPage.checkPageIsLoaded();
-  await settingsPage.goToDeveloperOptions();
-
-  const developOptionsPage = new DevelopOptions(driver);
-  await developOptionsPage.checkPageIsLoaded();
-  await developOptionsPage.clickGenerateCrashButton();
-};
 
 async function mockSentryError(mockServer: MockttpServer) {
   return [

--- a/test/e2e/tests/metrics/error-page.spec.ts
+++ b/test/e2e/tests/metrics/error-page.spec.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from 'assert';
+import { Mockttp } from 'mockttp';
+import { getEventPayloads, withFixtures } from '../../helpers';
+import { MOCK_META_METRICS_ID } from '../../constants';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import ErrorPage from '../../page-objects/pages/error-page';
+import { triggerCrash } from '../../page-objects/flows/crash.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+
+/**
+ * Mocks the segment API for events tracked from the error page.
+ *
+ * @param mockServer - The mock server instance.
+ * @returns The mocked endpoints
+ */
+async function mockSegment(mockServer: Mockttp) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Support Link Clicked' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+  ];
+}
+
+describe('Error Page', function () {
+  it('sends "Support Link Click" event with metrics ID when user consents', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+        ignoredConsoleErrors: [
+          'Unable to find value of key "developerOptions" for locale "en"',
+        ],
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await loginWithBalanceValidation(driver);
+        await triggerCrash(driver);
+
+        const errorPage = new ErrorPage(driver);
+        await errorPage.checkPageIsLoaded();
+
+        await errorPage.clickContactButton();
+        await errorPage.consentDataToMetamaskSupport();
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        const metricEvent = events[0];
+        assert.equal(metricEvent.event, 'Support Link Clicked');
+        const trackedUrl = metricEvent.properties.url;
+        const queryString = new URL(trackedUrl).search;
+        assert.match(
+          queryString,
+          /metamask_metametrics_id/u,
+          'Metrics ID missing from tracked URL',
+        );
+      },
+    );
+  });
+
+  it('sends "Support Link Click" event without metrics ID when user does not consent', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withMetaMetricsController({
+            metaMetricsId: MOCK_META_METRICS_ID,
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+        ignoredConsoleErrors: [
+          'Unable to find value of key "developerOptions" for locale "en"',
+        ],
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await loginWithBalanceValidation(driver);
+        await triggerCrash(driver);
+
+        const errorPage = new ErrorPage(driver);
+        await errorPage.checkPageIsLoaded();
+
+        await errorPage.clickContactButton();
+        await errorPage.rejectDataToMetamaskSupport();
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        const metricEvent = events[0];
+        assert.equal(metricEvent.event, 'Support Link Clicked');
+        const trackedUrl = metricEvent.properties.url;
+        const queryString = new URL(trackedUrl).search;
+        assert.equal(queryString, '', 'Unexpected query string on tracked URL');
+      },
+    );
+  });
+});

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -35,11 +35,13 @@ class Index extends PureComponent {
     if (error) {
       return (
         <Provider store={store}>
-          <I18nProvider>
-            <LegacyI18nProvider>
-              <ErrorPage error={error} />
-            </LegacyI18nProvider>
-          </I18nProvider>
+          <MetaMetricsProvider>
+            <I18nProvider>
+              <LegacyI18nProvider>
+                <ErrorPage error={error} />
+              </LegacyI18nProvider>
+            </I18nProvider>
+          </MetaMetricsProvider>
         </Provider>
       );
     }

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -35,13 +35,15 @@ class Index extends PureComponent {
     if (error) {
       return (
         <Provider store={store}>
-          <MetaMetricsProvider>
-            <I18nProvider>
-              <LegacyI18nProvider>
-                <ErrorPage error={error} />
-              </LegacyI18nProvider>
-            </I18nProvider>
-          </MetaMetricsProvider>
+          <HashRouter>
+            <MetaMetricsProvider>
+              <I18nProvider>
+                <LegacyI18nProvider>
+                  <ErrorPage error={error} />
+                </LegacyI18nProvider>
+              </I18nProvider>
+            </MetaMetricsProvider>
+          </HashRouter>
         </Provider>
       );
     }


### PR DESCRIPTION
## **Description**

The error page shown upon a React render error was not setup with a metrics context provider, so attempts to track metric events would fail.

The error boundary has been updated to include a metrics context provider.

The legacy metrics context provider was omitted because the error page uses solely functional components. The legacy metrics context provider is just used to support legacy class-based components.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39283?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

There is an E2E test, it shows the steps I used to reproduce the issue

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the error boundary renders `ErrorPage` within routing and metrics contexts so events are tracked, and adds focused E2E coverage.
> 
> - Wraps `ErrorPage` with `HashRouter` and `MetaMetricsProvider` in `ui/pages/index.js` error path
> - Introduces shared `triggerCrash` flow for tests; updates Sentry test to use it
> - Adds `error-page.spec.ts` E2E tests verifying "Support Link Clicked" Segment event behavior with/without metrics ID based on consent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49ed13f02c4a99da325cf0fe1f1897093bb5d510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->