### PR TITLE
fix: temporarily disable the ability to migrate to split state storage cp-13.14.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -988,7 +988,11 @@ export async function loadStateFromPersistence(backup) {
     // const shouldUseSplitStateStorage =
     //   !alreadyTried && (await useSplitStateStorage(versionedData.data));
     // disabling split state rollout for now
-    const shouldUseSplitStateStorage = false;
+    const disableSplitStateMigration = true;
+    const shouldUseSplitStateStorage = disableSplitStateMigration
+      ? false
+      : !alreadyTried && (await useSplitStateStorage(versionedData.data));
+    // disabling split state rollout for now
     log.debug(
       '[Split State]: shouldUseSplitStateStorage: %s (alreadyTried: %s)',
       shouldUseSplitStateStorage,

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -985,8 +985,10 @@ export async function loadStateFromPersistence(backup) {
   if (persistenceManager.storageKind === 'data') {
     const alreadyTried =
       versionedData.meta.platformSplitStateGradualRolloutAttempted === true;
-    const shouldUseSplitStateStorage =
-      !alreadyTried && (await useSplitStateStorage(versionedData.data));
+    // const shouldUseSplitStateStorage =
+    //   !alreadyTried && (await useSplitStateStorage(versionedData.data));
+    // disabling split state rollout for now
+    const shouldUseSplitStateStorage = false;
     log.debug(
       '[Split State]: shouldUseSplitStateStorage: %s (alreadyTried: %s)',
       shouldUseSplitStateStorage,

--- a/test/e2e/tests/state-persistence/state-persistence.spec.ts
+++ b/test/e2e/tests/state-persistence/state-persistence.spec.ts
@@ -370,7 +370,9 @@ describe('State Persistence', function () {
       });
     });
 
-    it('should update from data state to split state', async function () {
+    // Temporarily disabled
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('should update from data state to split state', async function () {
       const accountName = 'Account 2';
 
       await withFixtures(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Temporarily disable the ability to migrate to split state storage, as not all features are ready yet.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39292?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: temporarily disable the ability to migrate to split state storage
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**
 -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily halts the split-state storage rollout and disables the migration path in runtime, with corresponding e2e test adjustments.
> 
> - In `background.js`, forces `shouldUseSplitStateStorage` to `false` via a `disableSplitStateMigration` flag, preventing migration from `data` to `split` storage while retaining logging and metadata handling
> - In `state-persistence.spec.ts`, marks the migration test (`should update from data state to split state`) as skipped; the default-to-split-state test remains active
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc958574f77602a9c767b00dbc1b8695c0e7d3b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->