### PR TITLE
fix: prevent poisoning of backups, re-enable split state storage migration cp-13.15.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -985,14 +985,8 @@ export async function loadStateFromPersistence(backup) {
   if (persistenceManager.storageKind === 'data') {
     const alreadyTried =
       versionedData.meta.platformSplitStateGradualRolloutAttempted === true;
-    // const shouldUseSplitStateStorage =
-    //   !alreadyTried && (await useSplitStateStorage(versionedData.data));
-    // disabling split state rollout for now
-    const disableSplitStateMigration = true;
-    const shouldUseSplitStateStorage = disableSplitStateMigration
-      ? false
-      : !alreadyTried && (await useSplitStateStorage(versionedData.data));
-    // disabling split state rollout for now
+    const shouldUseSplitStateStorage =
+      !alreadyTried && (await useSplitStateStorage(versionedData.data));
     log.debug(
       '[Split State]: shouldUseSplitStateStorage: %s (alreadyTried: %s)',
       shouldUseSplitStateStorage,

--- a/test/e2e/tests/state-persistence/state-persistence.spec.ts
+++ b/test/e2e/tests/state-persistence/state-persistence.spec.ts
@@ -370,9 +370,7 @@ describe('State Persistence', function () {
       });
     });
 
-    // Temporarily disabled
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('should update from data state to split state', async function () {
+    it('should update from data state to split state', async function () {
       const accountName = 'Account 2';
 
       await withFixtures(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We had code that would have written secrets to backup storage had certain controllers triggered state changes in a way that would affect our backups. We don't _currently_ have any controllers that do this, but we will in the near future. This PR prevents future changes in this area from poisoning the backup with properties that aren't meant to be persisted.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39301?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent poisoning of backups, re-enable split state storage migration
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**


### **After**

-->
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix: Safe backup persistence & split-state migration**
> 
> - Re-enables split-state storage migration by removing the temporary rollout block; `shouldUseSplitStateStorage` now evaluates `useSplitStateStorage` from runtime flags in `background.js`.
> - Prevents secret leakage into backups: on `controller.store` `stateChange`, backs up other `backedUpStateKeys` via `controllerMessenger` and filters with `deriveStateFromMetadata` to persist only metadata-marked fields; throws if controller lacks `metadata`.
> 
> **Tests**
> - Unskips and exercises data→split migration e2e (`state-persistence.spec.ts`), verifies default split-state storage shape and end-to-end migration (including account creation) remains intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9d3ae144d5ddef9c707ddf2ab9c8b8dbec5545. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->