### PR TITLE
feat: display short id for claims list

### DIFF
--- a/ui/pages/settings/transaction-shield-tab/claims-list/claims-list.tsx
+++ b/ui/pages/settings/transaction-shield-tab/claims-list/claims-list.tsx
@@ -77,6 +77,10 @@ const ClaimsList = () => {
       const id = isDraft
         ? (claimData as ClaimDraft).draftId
         : (claimData as Claim).id;
+
+      const displayId = isDraft
+        ? (claimData as ClaimDraft).draftId
+        : (claimData as Claim).shortId;
       return (
         <Box
           asChild
@@ -105,7 +109,7 @@ const ClaimsList = () => {
                 fontWeight={FontWeight.Medium}
                 textAlign={TextAlign.Left}
               >
-                {t('shieldClaimsNumber', [id])}
+                {t('shieldClaimsNumber', [displayId])}
               </Text>
               <Text
                 variant={TextVariant.BodySm}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
For claims on claims list page. Show shortId on the UI instead of full ID which is long

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39308?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show shortId on the UI instead of full ID which is long

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="364" height="392" alt="image" src="https://github.com/user-attachments/assets/4259576e-8485-493c-826c-014339d4e0ed" />

<!-- [screenshots/recordings] -->

### **After**
<img width="375" height="510" alt="image" src="https://github.com/user-attachments/assets/e5bb4d4a-c8c9-454b-b022-06128b79e9b2" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the claims list to display concise identifiers while preserving internal IDs for logic.
> 
> - In `claims-list.tsx`, introduces `displayId` and uses `Claim.shortId` for non-draft claim labels (`t('shieldClaimsNumber', [displayId])`)
> - Continues using full `id`/`draftId` for keys, test ids, and navigation; date formatting unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00c22d5e81559ec0e82f645b5733c79af6d92f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->