### PR TITLE
feat(send): support `InsufficientBalanceToCoverFee` error response from Snaps

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3256,6 +3256,9 @@
   "insufficientBalance": {
     "message": "Insufficient balance."
   },
+  "insufficientBalanceToCoverFees": {
+    "message": "Insufficient balance to cover fees"
+  },
   "insufficientFunds": {
     "message": "Insufficient funds."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3256,6 +3256,9 @@
   "insufficientBalance": {
     "message": "Insufficient balance."
   },
+  "insufficientBalanceToCoverFees": {
+    "message": "Insufficient balance to cover fees"
+  },
   "insufficientFunds": {
     "message": "Insufficient funds."
   },

--- a/ui/pages/confirmations/hooks/send/useAmountValidation.test.ts
+++ b/ui/pages/confirmations/hooks/send/useAmountValidation.test.ts
@@ -11,6 +11,7 @@ import {
   validateERC1155Balance,
   validateTokenBalance,
   validatePositiveNumericString,
+  mapSnapErrorCodeIntoTranslation,
 } from './useAmountValidation';
 
 const MOCK_ADDRESS_1 = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
@@ -193,6 +194,38 @@ describe('validateTokenBalance', () => {
         (str: string) => str,
       ),
     ).toEqual(undefined);
+  });
+});
+
+describe('mapSnapErrorCodeIntoTranslation', () => {
+  it('returns insufficientFundsSend for InsufficientBalance', () => {
+    expect(
+      mapSnapErrorCodeIntoTranslation(
+        'InsufficientBalance',
+        (str: string) => str,
+      ),
+    ).toEqual('insufficientFundsSend');
+  });
+
+  it('returns insufficientBalanceToCoverFees for InsufficientBalanceToCoverFee', () => {
+    expect(
+      mapSnapErrorCodeIntoTranslation(
+        'InsufficientBalanceToCoverFee',
+        (str: string) => str,
+      ),
+    ).toEqual('insufficientBalanceToCoverFees');
+  });
+
+  it('returns invalidValue for Invalid', () => {
+    expect(
+      mapSnapErrorCodeIntoTranslation('Invalid', (str: string) => str),
+    ).toEqual('invalidValue');
+  });
+
+  it('returns invalidValue for unknown error codes', () => {
+    expect(
+      mapSnapErrorCodeIntoTranslation('UnknownErrorCode', (str: string) => str),
+    ).toEqual('invalidValue');
   });
 });
 

--- a/ui/pages/confirmations/hooks/send/useAmountValidation.ts
+++ b/ui/pages/confirmations/hooks/send/useAmountValidation.ts
@@ -141,13 +141,15 @@ export function validatePositiveNumericString(
   return undefined;
 }
 
-function mapSnapErrorCodeIntoTranslation(
+export function mapSnapErrorCodeIntoTranslation(
   errorCode: string,
   t: ReturnType<typeof useI18nContext>,
 ): string {
   switch (errorCode) {
     case 'InsufficientBalance':
       return t('insufficientFundsSend');
+    case 'InsufficientBalanceToCoverFee':
+      return t('insufficientBalanceToCoverFees');
     case 'Invalid':
     default:
       return t('invalidValue');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We were missing support for a type of error that can occur on the Send flow where a user inserts an amount but does not have enough balance to cover its fees.

## **Changelog**

CHANGELOG entry: Add support for `InsufficientBalanceToCoverFee` error response from Snaps

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6627

## **Manual testing steps**

1. Using a Tron account that has a certain amount of USDT tokens but very few TRX and no energy
2. Try to send USDT to another address
3. Error message should show up, "Insufficient balance to cover fees"

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="976" height="1756" alt="image" src="https://github.com/user-attachments/assets/3ccf0915-973b-4a42-8a8b-d54eb4e118fa" />

### **After**

<img width="974" height="1442" alt="image" src="https://github.com/user-attachments/assets/4a958db8-9e5a-45c1-8327-266fc8a987ce" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds handling for a new Snap error in the Send flow and corresponding localization.
> 
> - Map `InsufficientBalanceToCoverFee` to `insufficientBalanceToCoverFees` in `useAmountValidation` and export `mapSnapErrorCodeIntoTranslation`
> - Add `insufficientBalanceToCoverFees` string to `en` and `en_GB` locales
> - Add unit tests for error-code-to-translation mapping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dbd3b88cccdca4ca8bd335fe1e861d695a27ccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->