### PR TITLE
fix: added reusable web-origin function

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -51,6 +51,7 @@ import getFirstPreferredLangCode from '../../shared/lib/get-first-preferred-lang
 import { getManifestFlags } from '../../shared/lib/manifestFlags';
 import { DISPLAY_GENERAL_STARTUP_ERROR } from '../../shared/constants/start-up-errors';
 import { getPartnerByOrigin } from '../../shared/constants/defi-referrals';
+import { isWebOrigin } from '../../shared/lib/origin-utils';
 import {
   CorruptionHandler,
   hasVault,
@@ -76,11 +77,7 @@ import MetamaskController, {
 } from './metamask-controller';
 import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
-import {
-  getPlatform,
-  isWebOrigin,
-  shouldEmitDappViewedEvent,
-} from './lib/util';
+import { getPlatform, shouldEmitDappViewedEvent } from './lib/util';
 import { createOffscreen } from './offscreen';
 import { setupMultiplex } from './lib/stream-utils';
 import rawFirstTimeState from './first-time-state';

--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -24,13 +24,13 @@ import {
   getPlatform,
   getValidUrl,
   isWebUrl,
-  isWebOrigin,
   getMethodDataName,
   getBooleanFlag,
   extractRpcDomain,
   isKnownDomain,
   initializeRpcProviderDomains,
 } from './util';
+import { isWebOrigin } from '../../../shared/lib/origin-utils';
 
 // Mock the module
 jest.mock('./util', () => ({

--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -16,6 +16,7 @@ import {
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import * as FourBiteUtils from '../../../shared/lib/four-byte';
 import { withResolvers } from '../../../shared/lib/promise-with-resolvers';
+import { isWebOrigin } from '../../../shared/lib/origin-utils';
 import {
   shouldEmitDappViewedEvent,
   addUrlProtocolPrefix,
@@ -30,7 +31,6 @@ import {
   isKnownDomain,
   initializeRpcProviderDomains,
 } from './util';
-import { isWebOrigin } from '../../../shared/lib/origin-utils';
 
 // Mock the module
 jest.mock('./util', () => ({

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -257,20 +257,6 @@ export function isWebUrl(urlString: string): boolean {
 }
 
 /**
- * Checks if an origin string is a web origin (http:// or https://).
- * This is used to filter out non-web origins like chrome://, about://, moz-extension://, etc.
- *
- * @param origin - The origin string to check (e.g., "https://example.com", "chrome://newtab")
- * @returns true if the origin starts with http:// or https://, false otherwise
- */
-export function isWebOrigin(origin: string | undefined | null): boolean {
-  if (!origin) {
-    return false;
-  }
-  return origin.startsWith('http://') || origin.startsWith('https://');
-}
-
-/**
  * Determines whether to emit a MetaMetrics event for a given metaMetricsId.
  * Relies on the last 4 characters of the metametricsId. Assumes the IDs are evenly distributed.
  * If metaMetricsIds are distributed evenly, this should be a 1% sample rate

--- a/shared/lib/origin-utils.ts
+++ b/shared/lib/origin-utils.ts
@@ -11,4 +11,3 @@ export function isWebOrigin(origin: string | undefined | null): boolean {
   }
   return origin.startsWith('http://') || origin.startsWith('https://');
 }
-

--- a/shared/lib/origin-utils.ts
+++ b/shared/lib/origin-utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Checks if an origin string is a web origin (http:// or https://).
+ * This is used to filter out non-web origins like chrome://, about://, moz-extension://, etc.
+ *
+ * @param origin - The origin string to check (e.g., "https://example.com", "chrome://newtab")
+ * @returns true if the origin starts with http:// or https://, false otherwise
+ */
+export function isWebOrigin(origin: string | undefined | null): boolean {
+  if (!origin) {
+    return false;
+  }
+  return origin.startsWith('http://') || origin.startsWith('https://');
+}
+

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -25,6 +25,7 @@ import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/se
 import { getURLHost } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { toggleNetworkMenu } from '../../../store/actions';
+import { isWebOrigin } from '../../../../shared/lib/origin-utils';
 import Tooltip from '../../ui/tooltip';
 
 type ConnectedSitePopoverProps = {
@@ -46,10 +47,9 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
 
   // Only show the host for valid web URLs (http/https), otherwise show "URL unknown"
-  const isWebOrigin =
-    activeTabOrigin?.startsWith('http://') ||
-    activeTabOrigin?.startsWith('https://');
-  const siteHost = isWebOrigin ? getURLHost(activeTabOrigin) : '';
+  const siteHost = isWebOrigin(activeTabOrigin)
+    ? getURLHost(activeTabOrigin)
+    : '';
   const siteName = siteHost || t('urlUnknown');
 
   const allDomains = useSelector(getAllDomains);


### PR DESCRIPTION
This PR is to add the webOrigin function and use it across the app

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

Case 1: 
1. Open MM on the side panel
2. Open test dapp
3. Click on the Connected site icon
4. See test dapp url
5. Open a new browser tab
6. If it's not a dapp, connected site popover would render URL unknown in the title

Case 2: For hyperliquid : 
1. Connect MM to hyperliquid in popup mode
2. Switch to sidepanel, sidepanel should show the connected site icon correctly
3. Switch to a different tab, check the connected site popover renders correct URL or unknown if it's an empty tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes web-origin detection and applies it where tab state is derived.
> 
> - Adds shared `isWebOrigin` in `shared/lib/origin-utils.ts`
> - Removes prior `isWebOrigin` from `app/scripts/lib/util.ts` and updates imports
> - Uses `isWebOrigin` in `background.js` to filter non-web pages when setting `appActiveTab`
> - Updates tests (`util.test.js`) and UI (`connected-site-popover.tsx`) to consume the shared helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca74652ba90968359e7d7243f23d71c14216a3a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->