### PR TITLE
Drag interaction simplification

### DIFF
--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -20,86 +20,8 @@ export const NetworkListItemMenu = ({
   onDeleteClick,
   onDiscoverClick,
   isOpen,
-  finalFocusRef,
-  isClosing: isClosingProp,
 }) => {
   const t = useI18nContext();
-
-  // Track refs for menu items to handle keyboard navigation
-  const discoverItemRef = useRef(null);
-  const editItemRef = useRef(null);
-  const deleteItemRef = useRef(null);
-  const lastItemRef = useRef(null);
-  const popoverDialogRef = useRef(null);
-
-  // Determine the last menu item that is not disabled
-  useEffect(() => {
-    if (deleteItemRef.current) {
-      lastItemRef.current = deleteItemRef.current;
-    } else if (editItemRef.current) {
-      lastItemRef.current = editItemRef.current;
-    } else if (discoverItemRef.current) {
-      lastItemRef.current = discoverItemRef.current;
-    }
-  });
-
-  // Handle Tab key press for accessibility - close popover on last MenuItem
-  const handleKeyDown = useCallback(
-    (event) => {
-      if (event.key === 'Tab' && event.target === lastItemRef.current) {
-        // If Tab is pressed at the last item, close popover and focus to next element in DOM
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  const menuContent = (
-    <div onKeyDown={handleKeyDown} ref={popoverDialogRef}>
-      <Box>
-        {onDiscoverClick ? (
-          <MenuItem
-            ref={discoverItemRef}
-            iconName={IconName.Eye}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDiscoverClick();
-            }}
-            data-testid="network-list-item-options-discover"
-          >
-            <Text>{t('discover')}</Text>
-          </MenuItem>
-        ) : null}
-        {onEditClick ? (
-          <MenuItem
-            ref={editItemRef}
-            iconName={IconName.Edit}
-            onClick={(e) => {
-              e.stopPropagation();
-              onEditClick();
-            }}
-            data-testid="network-list-item-options-edit"
-          >
-            <Text> {t('edit')}</Text>
-          </MenuItem>
-        ) : null}
-        {onDeleteClick ? (
-          <MenuItem
-            ref={deleteItemRef}
-            iconName={IconName.Trash}
-            iconColor={IconColor.errorDefault}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDeleteClick();
-            }}
-            data-testid="network-list-item-options-delete"
-          >
-            <Text color={TextColor.errorDefault}>{t('delete')}</Text>
-          </MenuItem>
-        ) : null}
-      </Box>
-    </div>
-  );
 
   return (
     <Popover
@@ -115,18 +37,47 @@ export const NetworkListItemMenu = ({
       preventOverflow
       flip
     >
-      {isClosingProp ? (
-        // When closing, render without ModalFocus to prevent focus management
-        menuContent
-      ) : (
-        <ModalFocus
-          restoreFocus={!finalFocusRef}
-          autoFocus={false}
-          finalFocusRef={finalFocusRef}
-        >
-          {menuContent}
-        </ModalFocus>
-      )}
+      <ModalFocus restoreFocus>
+        <Box>
+          {onDiscoverClick ? (
+            <MenuItem
+              iconName={IconName.Eye}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDiscoverClick();
+              }}
+              data-testid="network-list-item-options-discover"
+            >
+              <Text>{t('discover')}</Text>
+            </MenuItem>
+          ) : null}
+          {onEditClick ? (
+            <MenuItem
+              iconName={IconName.Edit}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEditClick();
+              }}
+              data-testid="network-list-item-options-edit"
+            >
+              <Text> {t('edit')}</Text>
+            </MenuItem>
+          ) : null}
+          {onDeleteClick ? (
+            <MenuItem
+              iconName={IconName.Trash}
+              iconColor={IconColor.errorDefault}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteClick();
+              }}
+              data-testid="network-list-item-options-delete"
+            >
+              <Text color={TextColor.errorDefault}>{t('delete')}</Text>
+            </MenuItem>
+          ) : null}
+        </Box>
+      </ModalFocus>
     </Popover>
   );
 };
@@ -158,14 +109,4 @@ NetworkListItemMenu.propTypes = {
    * @type {boolean}
    */
   isOpen: PropTypes.bool.isRequired,
-  /**
-   * Ref of the element that should receive focus when the menu closes
-   */
-  finalFocusRef: PropTypes.shape({
-    current: PropTypes.instanceOf(window.Element),
-  }),
-  /**
-   * Indicates if the menu is currently closing (used to prevent focus management)
-   */
-  isClosing: PropTypes.bool,
 };

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -88,7 +88,6 @@ export const NetworkListItem = ({
 }) => {
   const t = useI18nContext();
   const networkRef = useRef<HTMLInputElement>(null);
-  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const [networkListItemMenuElement, setNetworkListItemMenuElement] =
     useState();
@@ -99,12 +98,8 @@ export const NetworkListItem = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const setNetworkListItemMenuRef = useCallback((ref: any) => {
     setNetworkListItemMenuElement(ref);
-    // Store ref for finalFocusRef
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (menuButtonRef as any).current = ref;
   }, []);
   const [networkOptionsMenuOpen, setNetworkOptionsMenuOpen] = useState(false);
-  const [isMenuClosing, setIsMenuClosing] = useState(false);
 
   // This selector provides the indication if the "Gas sponsored" label
   // is enabled based on the remote feature flag.
@@ -152,18 +147,6 @@ export const NetworkListItem = ({
         ref={setNetworkListItemMenuRef}
         data-testid={`network-list-item-options-button-${chainId}`}
         ariaLabel={t('networkOptions')}
-        onMouseDown={(e: React.MouseEvent) => {
-          // Prevent button from losing focus when clicked to close menu
-          if (networkOptionsMenuOpen) {
-            e.preventDefault();
-            // Focus the button before closing to ensure it has focus
-            if (menuButtonRef.current) {
-              menuButtonRef.current.focus();
-            }
-            // Set closing state before toggling
-            setIsMenuClosing(true);
-          }
-        }}
         onClick={(e: React.MouseEvent) => {
           e.stopPropagation();
           setNetworkOptionsMenuOpen((prev) => !prev);
@@ -179,16 +162,8 @@ export const NetworkListItem = ({
     t,
     setNetworkListItemMenuRef,
     setNetworkOptionsMenuOpen,
-    networkOptionsMenuOpen,
-    menuButtonRef,
   ]);
 
-  // Reset closing state when menu opens
-  useEffect(() => {
-    if (networkOptionsMenuOpen) {
-      setIsMenuClosing(false);
-    }
-  }, [networkOptionsMenuOpen]);
   useEffect(() => {
     if (networkRef.current && focus) {
       networkRef.current.focus();
@@ -322,18 +297,7 @@ export const NetworkListItem = ({
               onDeleteClick={onDeleteClick}
               onEditClick={onEditClick}
               onDiscoverClick={onDiscoverClick}
-              onClose={() => {
-                // Ensure button has focus before closing to prevent focus jump
-                if (menuButtonRef.current) {
-                  menuButtonRef.current.focus();
-                }
-                setIsMenuClosing(true);
-                setNetworkOptionsMenuOpen(false);
-                // Reset closing state after a brief delay
-                setTimeout(() => setIsMenuClosing(false), 0);
-              }}
-              finalFocusRef={menuButtonRef}
-              isClosing={isMenuClosing}
+              onClose={() => setNetworkOptionsMenuOpen(false)}
             />
           ))
         : null}


### PR DESCRIPTION
Simplifies the network list item menu to a basic toggle, removing complex manual focus management and `onMouseDown` logic.

The previous implementation introduced multiple `useRef`s, `onMouseDown` handlers, and `isClosing` state for focus management. This PR streamlines the component to rely on `Popover`'s built-in `onClickOutside` and `onPressEscKey` for closing, and `ModalFocus` for basic accessibility, achieving the desired toggle behavior with significantly less code.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb9e31a4-605e-4fc6-a0bb-65dcb3f94090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb9e31a4-605e-4fc6-a0bb-65dcb3f94090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

