### PR TITLE
feat: add analytics tracking for account pin, hide, and list viewed events

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -8574,6 +8574,13 @@ export default class MetamaskController extends EventEmitter {
     }
   };
 
+  /**
+   * Updates the pinned accounts list
+   *
+   * @deprecated This method is deprecated and will be removed in the future.
+   * use AccountTreeController.setAccountGroupPinned instead
+   * @param {AccountAddress[]} pinnedAccountList - The list of accounts to update in the state.
+   */
   updateAccountsList = (pinnedAccountList) => {
     try {
       this.accountOrderController.updateAccountsList(pinnedAccountList);
@@ -8605,6 +8612,13 @@ export default class MetamaskController extends EventEmitter {
     await this.lookupSelectedNetworks();
   };
 
+  /**
+   * Updates the hidden accounts list
+   *
+   * @deprecated This method is deprecated and will be removed in the future.
+   * use AccountTreeController.setAccountGroupHidden instead
+   * @param {AccountAddress[]} hiddenAccountList - The list of accounts to update in the state.
+   */
   updateHiddenAccountsList = (hiddenAccountList) => {
     try {
       this.accountOrderController.updateHiddenAccountsList(hiddenAccountList);

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -705,6 +705,8 @@ export enum MetaMetricsEventName {
   AccountImportFailed = 'Account Import Failed',
   AccountDetailsOpened = 'Account Details Opened',
   AccountPasswordCreated = 'Account Password Created',
+  AccountPinned = 'Account Pinned',
+  AccountHidden = 'Account Hidden',
   AccountReset = 'Account Reset',
   AccountRenamed = 'Account Renamed',
   AccountsSyncAdded = 'Accounts Sync Added',

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.test.tsx
@@ -4,6 +4,11 @@ import { fireEvent, act, within } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import mockDefaultState from '../../../../test/data/mock-state.json';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { MultichainAccountMenu } from './multichain-account-menu';
 import type { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
@@ -15,6 +20,8 @@ jest.mock('../../../../shared/lib/trace', () => {
     endTrace: jest.fn(),
   };
 });
+
+const mockTrackEvent = jest.fn();
 
 const popoverOpenSelector = '.mm-popover--open';
 const menuButtonSelector = '.multichain-account-cell-popover-menu-button';
@@ -83,9 +90,15 @@ describe('MultichainAccountMenu', () => {
       isOpen: false,
       onToggle: jest.fn(),
     },
+    state = mockState,
   ) => {
-    const store = configureStore(mockState);
-    return renderWithProvider(<MultichainAccountMenu {...props} />, store);
+    const store = configureStore(state);
+    return renderWithProvider(
+      <MetaMetricsContext.Provider value={mockTrackEvent}>
+        <MultichainAccountMenu {...props} />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
   };
 
   beforeEach(() => {
@@ -330,15 +343,14 @@ describe('MultichainAccountMenu', () => {
       },
     };
 
-    const store = configureStore(stateWithPinnedAccount);
-    renderWithProvider(
-      <MultichainAccountMenu
-        accountGroupId={accountGroupId}
-        isRemovable={false}
-        isOpen={true}
-        onToggle={mockOnToggle}
-      />,
-      store,
+    renderComponent(
+      {
+        accountGroupId,
+        isRemovable: false,
+        isOpen: true,
+        onToggle: mockOnToggle,
+      },
+      stateWithPinnedAccount,
     );
 
     // Hide option should be the fifth menu item
@@ -399,15 +411,14 @@ describe('MultichainAccountMenu', () => {
       },
     };
 
-    const store = configureStore(stateWithHiddenAccount);
-    renderWithProvider(
-      <MultichainAccountMenu
-        accountGroupId={accountGroupId}
-        isRemovable={false}
-        isOpen={true}
-        onToggle={mockOnToggle}
-      />,
-      store,
+    renderComponent(
+      {
+        accountGroupId,
+        isRemovable: false,
+        isOpen: true,
+        onToggle: mockOnToggle,
+      },
+      stateWithHiddenAccount,
     );
 
     // Pin option should be the fourth menu item
@@ -431,6 +442,68 @@ describe('MultichainAccountMenu', () => {
     );
   });
 
+  it('tracks Account Pinned event when clicking the pin option', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    renderComponent({
+      accountGroupId,
+      isRemovable: false,
+      isOpen: true,
+      onToggle: mockOnToggle,
+    });
+
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    const pinOption = menuItems[3];
+
+    if (pinOption) {
+      await act(async () => {
+        fireEvent.click(pinOption);
+      });
+    }
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.AccountPinned,
+      category: MetaMetricsEventCategory.Accounts,
+      properties: {
+        pinned: true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        pinned_count_after: 1,
+      },
+    });
+  });
+
+  it('tracks Account Hidden event when clicking the hide option', async () => {
+    const mockOnToggle = jest.fn();
+    const accountGroupId = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/default';
+
+    renderComponent({
+      accountGroupId,
+      isRemovable: false,
+      isOpen: true,
+      onToggle: mockOnToggle,
+    });
+
+    const menuItems = document.querySelectorAll(menuItemSelector);
+    const hideOption = menuItems[4];
+
+    if (hideOption) {
+      await act(async () => {
+        fireEvent.click(hideOption);
+      });
+    }
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.AccountHidden,
+      category: MetaMetricsEventCategory.Accounts,
+      properties: {
+        hidden: true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        hidden_count_after: 1,
+      },
+    });
+  });
+
   describe('tracing', () => {
     const groupId = mockDefaultState.metamask.accountTree
       .selectedAccountGroup as AccountGroupId;
@@ -442,12 +515,14 @@ describe('MultichainAccountMenu', () => {
     it('calls trace ShowAccountAddressList when clicking Addresses', async () => {
       const store = configureStore(mockDefaultState);
       renderWithProvider(
-        <MultichainAccountMenu
-          accountGroupId={groupId}
-          isRemovable={false}
-          isOpen
-          onToggle={() => undefined}
-        />,
+        <MetaMetricsContext.Provider value={mockTrackEvent}>
+          <MultichainAccountMenu
+            accountGroupId={groupId}
+            isRemovable={false}
+            isOpen
+            onToggle={() => undefined}
+          />
+        </MetaMetricsContext.Provider>,
         store,
       );
 

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -71,7 +71,7 @@ export const MultichainAccountMenu = ({
       let count = 0;
       const { wallets } = accountTree;
       for (const wallet of Object.values(wallets)) {
-        for (const [groupId, group] of Object.entries(wallet.groups || {})) {
+        for (const [groupId, group] of Object.entries(wallet.groups)) {
           if (groupId === accountGroupId) {
             // Use the new value for the current account
             if (newValue) {

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useCallback, useContext, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -29,6 +29,11 @@ import {
 } from '../../../store/actions';
 import { getAccountTree } from '../../../selectors/multichain-accounts/account-tree';
 import { trace, TraceName, TraceOperation } from '../../../../shared/lib/trace';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { MultichainAccountMenuProps } from './multichain-account-menu.types';
 
 export const MultichainAccountMenu = ({
@@ -43,6 +48,7 @@ export const MultichainAccountMenu = ({
   const dispatch = useDispatch();
   const popoverRef = useRef<HTMLDivElement>(null);
   const accountTree = useSelector(getAccountTree);
+  const trackEvent = useContext(MetaMetricsContext);
 
   // Get the account group metadata to check pinned/hidden state
   const accountGroupMetadata = useMemo(() => {
@@ -58,6 +64,28 @@ export const MultichainAccountMenu = ({
 
   const isPinned = accountGroupMetadata?.pinned ?? false;
   const isHidden = accountGroupMetadata?.hidden ?? false;
+
+  // Helper function to count pinned/hidden accounts from the account tree
+  const countAccountsByStatus = useCallback(
+    (status: 'pinned' | 'hidden', newValue: boolean): number => {
+      let count = 0;
+      const { wallets } = accountTree;
+      for (const wallet of Object.values(wallets)) {
+        for (const [groupId, group] of Object.entries(wallet.groups || {})) {
+          if (groupId === accountGroupId) {
+            // Use the new value for the current account
+            if (newValue) {
+              count += 1;
+            }
+          } else if (group.metadata?.[status]) {
+            count += 1;
+          }
+        }
+      }
+      return count;
+    },
+    [accountTree, accountGroupId],
+  );
 
   const togglePopover = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
@@ -94,12 +122,26 @@ export const MultichainAccountMenu = ({
       mouseEvent.stopPropagation();
       mouseEvent.preventDefault();
 
+      const newPinnedState = !isPinned;
+
       // If account is hidden, unhide it first before pinning
       if (isHidden) {
         await dispatch(setAccountGroupHidden(accountGroupId, false));
       }
 
-      await dispatch(setAccountGroupPinned(accountGroupId, !isPinned));
+      await dispatch(setAccountGroupPinned(accountGroupId, newPinnedState));
+
+      // Track the Account Pinned event
+      trackEvent({
+        event: MetaMetricsEventName.AccountPinned,
+        category: MetaMetricsEventCategory.Accounts,
+        properties: {
+          pinned: newPinnedState,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          pinned_count_after: countAccountsByStatus('pinned', newPinnedState),
+        },
+      });
+
       onToggle?.();
     };
 
@@ -107,12 +149,26 @@ export const MultichainAccountMenu = ({
       mouseEvent.stopPropagation();
       mouseEvent.preventDefault();
 
+      const newHiddenState = !isHidden;
+
       // If account is pinned, unpin it first before hiding
       if (isPinned) {
         await dispatch(setAccountGroupPinned(accountGroupId, false));
       }
 
-      await dispatch(setAccountGroupHidden(accountGroupId, !isHidden));
+      await dispatch(setAccountGroupHidden(accountGroupId, newHiddenState));
+
+      // Track the Account Hidden event
+      trackEvent({
+        event: MetaMetricsEventName.AccountHidden,
+        category: MetaMetricsEventCategory.Accounts,
+        properties: {
+          hidden: newHiddenState,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hidden_count_after: countAccountsByStatus('hidden', newHiddenState),
+        },
+      });
+
       onToggle?.();
     };
 
@@ -169,6 +225,8 @@ export const MultichainAccountMenu = ({
     isHidden,
     dispatch,
     onToggle,
+    trackEvent,
+    countAccountsByStatus,
   ]);
 
   return (

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -76,7 +76,7 @@ import {
 import { PreferredAvatar } from '../../app/preferred-avatar';
 import { AccountIconTour } from '../../app/account-icon-tour/account-icon-tour';
 import {
-  getAccountTree,
+  getAccountListStats,
   getMultichainAccountGroupById,
   getSelectedAccountGroup,
 } from '../../../selectors/multichain-accounts/account-tree';
@@ -106,30 +106,7 @@ export const AppHeaderUnlockedContent = ({
   const selectedMultichainAccount = useSelector((state) =>
     getMultichainAccountGroupById(state, selectedMultichainAccountId),
   );
-  const accountTree = useSelector(getAccountTree);
-
-  // Calculate account list stats for analytics
-  const accountListStats = useMemo(() => {
-    let pinnedCount = 0;
-    let hiddenCount = 0;
-    let totalAccounts = 0;
-
-    if (accountTree?.wallets) {
-      for (const wallet of Object.values(accountTree.wallets)) {
-        for (const group of Object.values(wallet.groups || {})) {
-          totalAccounts += 1;
-          if (group.metadata?.pinned) {
-            pinnedCount += 1;
-          }
-          if (group.metadata?.hidden) {
-            hiddenCount += 1;
-          }
-        }
-      }
-    }
-
-    return { pinnedCount, hiddenCount, totalAccounts };
-  }, [accountTree]);
+  const accountListStats = useSelector(getAccountListStats);
 
   // Used for account picker
   const internalAccount = useSelector(getSelectedInternalAccount);

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -76,6 +76,7 @@ import {
 import { PreferredAvatar } from '../../app/preferred-avatar';
 import { AccountIconTour } from '../../app/account-icon-tour/account-icon-tour';
 import {
+  getAccountTree,
   getMultichainAccountGroupById,
   getSelectedAccountGroup,
 } from '../../../selectors/multichain-accounts/account-tree';
@@ -105,6 +106,30 @@ export const AppHeaderUnlockedContent = ({
   const selectedMultichainAccount = useSelector((state) =>
     getMultichainAccountGroupById(state, selectedMultichainAccountId),
   );
+  const accountTree = useSelector(getAccountTree);
+
+  // Calculate account list stats for analytics
+  const accountListStats = useMemo(() => {
+    let pinnedCount = 0;
+    let hiddenCount = 0;
+    let totalAccounts = 0;
+
+    if (accountTree?.wallets) {
+      for (const wallet of Object.values(accountTree.wallets)) {
+        for (const group of Object.values(wallet.groups || {})) {
+          totalAccounts += 1;
+          if (group.metadata?.pinned) {
+            pinnedCount += 1;
+          }
+          if (group.metadata?.hidden) {
+            hiddenCount += 1;
+          }
+        }
+      }
+    }
+
+    return { pinnedCount, hiddenCount, totalAccounts };
+  }, [accountTree]);
 
   // Used for account picker
   const internalAccount = useSelector(getSelectedInternalAccount);
@@ -236,6 +261,15 @@ export const AppHeaderUnlockedContent = ({
                 category: MetaMetricsEventCategory.Navigation,
                 properties: {
                   location: 'Home',
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  pinned_count: accountListStats.pinnedCount,
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  hidden_count: accountListStats.hiddenCount,
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  total_accounts: accountListStats.totalAccounts,
                 },
               });
             }}
@@ -280,6 +314,7 @@ export const AppHeaderUnlockedContent = ({
     navigate,
     isMultichainAccountsState2Enabled,
     trackEvent,
+    accountListStats,
   ]);
 
   // TODO: [Multichain-Accounts-MUL-849] Delete this method once multichain accounts is released
@@ -324,6 +359,15 @@ export const AppHeaderUnlockedContent = ({
                   category: MetaMetricsEventCategory.Navigation,
                   properties: {
                     location: 'Home',
+                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    pinned_count: accountListStats.pinnedCount,
+                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    hidden_count: accountListStats.hiddenCount,
+                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    total_accounts: accountListStats.totalAccounts,
                   },
                 });
               }}
@@ -345,6 +389,7 @@ export const AppHeaderUnlockedContent = ({
     navigate,
     dispatch,
     trackEvent,
+    accountListStats,
   ]);
 
   return (

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -37,6 +37,7 @@ import { getMultichainNetworkConfigurationsByChainId } from '../multichain/netwo
 import { isTestNetwork } from '../../helpers/utils/network-helper';
 import {
   AccountGroupWithInternalAccounts,
+  AccountListStats,
   AccountTreeState,
   ConsolidatedWallets,
   MultichainAccountGroupScopeToCaipAccountId,
@@ -939,5 +940,37 @@ export const getWalletIdsByType = createSelector(
     return Object.entries(wallets)
       .filter(([, wallet]) => wallet.type === walletType)
       .map(([walletId]) => walletId) as AccountWalletId[];
+  },
+);
+
+/**
+ * Get account list statistics (pinned count, hidden count, total accounts).
+ * Used for analytics tracking in the account list views.
+ *
+ * @param accountTree - Account tree state.
+ * @returns Object with pinnedCount, hiddenCount, and totalAccounts.
+ */
+export const getAccountListStats = createSelector(
+  getAccountTree,
+  (accountTree: AccountTreeState): AccountListStats => {
+    let pinnedCount = 0;
+    let hiddenCount = 0;
+    let totalAccounts = 0;
+
+    if (accountTree?.wallets) {
+      for (const wallet of Object.values(accountTree.wallets)) {
+        for (const group of Object.values(wallet.groups || {})) {
+          totalAccounts += 1;
+          if (group.metadata?.pinned) {
+            pinnedCount += 1;
+          }
+          if (group.metadata?.hidden) {
+            hiddenCount += 1;
+          }
+        }
+      }
+    }
+
+    return { pinnedCount, hiddenCount, totalAccounts };
   },
 );

--- a/ui/selectors/multichain-accounts/account-tree.types.ts
+++ b/ui/selectors/multichain-accounts/account-tree.types.ts
@@ -78,3 +78,13 @@ export type AccountGroupWithInternalAccounts = {
     ? InternalAccount[]
     : AccountGroupObjectWithWalletNameAndId[K];
 };
+
+/**
+ * Statistics about account groups in the account tree.
+ * Used for analytics tracking.
+ */
+export type AccountListStats = {
+  pinnedCount: number;
+  hiddenCount: number;
+  totalAccounts: number;
+};


### PR DESCRIPTION
## **Description**

Add analytics tracking for the Pin & Hide Accounts feature to understand user engagement with account organization features.

This PR implements three new Segment events:
- **Account Pinned**: Tracks when users pin/unpin accounts with counts
- **Account Hidden**: Tracks when users hide/unhide accounts with counts  
- **Account List Viewed**: Tracks account list views with pinned, hidden, and total account counts

These events enable analysis of:
- Pin vs hide feature adoption
- Usage trends over time
- Average pinned/hidden accounts per user
- Total account distribution

<img width="700" alt="events" src="https://github.com/user-attachments/assets/d28da104-5199-45e9-ba30-2d32a374fb80" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/37545?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

[MUL-125](https://consensyssoftware.atlassian.net/browse/MUL-125)

Requires: https://github.com/Consensys/segment-schema/pull/353

## **Manual testing steps**

1. Open MetaMask extension and unlock wallet
2. Navigate to account list (click account menu)
3. Open the three-dot menu for any account
4. Click "Pin to top" - verify `Account Pinned` event fires with `pinned: true` and `pinned_count_after`
5. Click "Unpin" - verify `Account Pinned` event fires with `pinned: false` and updated count
6. Click "Hide account" - verify `Account Hidden` event fires with `hidden: true` and `hidden_count_after`
7. Open hidden accounts list and unhide - verify `Account Hidden` event fires with `hidden: false`
8. Close and reopen account list - verify `Account List Viewed` event fires with `pinned_count`, `hidden_count`, and `total_accounts`

## **Screenshots/Recordings**

Not applicable


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds analytics for account organization and list usage.
> 
> - Track `AccountPinned`/`AccountHidden` events from `MultichainAccountMenu` with `pinned`/`hidden` flags and post-action counts using a new in-component counter
> - Add `AccountPinned` and `AccountHidden` to `MetaMetricsEventName`
> - Introduce selector `getAccountListStats` (and `AccountListStats` type) to compute pinned/hidden/total counts and include them in `NavAccountMenuOpened` tracking from the app header
> - Update tests to inject `MetaMetricsContext` and assert new tracking; small render helper refactors
> - Add deprecation JSDoc to `updateAccountsList`/`updateHiddenAccountsList` in `metamask-controller`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a838a29580410d1e3eef7359c6a23c7c5bc6df9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUL-125]: https://consensyssoftware.atlassian.net/browse/MUL-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ