### PR TITLE
chore: Replace deprecated `sha256FromString`

### DIFF
--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
-import { sha256FromString } from 'ethereumjs-util';
+import { sha256 } from '@noble/hashes/sha2';
+import { hexToBytes } from '@metamask/utils';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
 import { migrate } from './105';
 import type { Identity, InternalAccountV1 } from './105';
@@ -18,7 +19,7 @@ global.sentry = {
 
 function addressToUUID(address: string): string {
   return uuid({
-    random: sha256FromString(address).slice(0, 16),
+    random: sha256(hexToBytes(address)).slice(0, 16),
   });
 }
 

--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { sha256 } from '@noble/hashes/sha2';
-import { stringToBytes } from '@metamask/utils';
+import { hexToBytes } from '@metamask/utils';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
 import { migrate } from './105';
 import type { Identity, InternalAccountV1 } from './105';
@@ -19,7 +19,7 @@ global.sentry = {
 
 function addressToUUID(address: string): string {
   return uuid({
-    random: sha256(stringToBytes(address)).slice(0, 16),
+    random: sha256(hexToBytes(address)).slice(0, 16),
   });
 }
 

--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { sha256 } from '@noble/hashes/sha2';
-import { hexToBytes } from '@metamask/utils';
+import { stringToBytes } from '@metamask/utils';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
 import { migrate } from './105';
 import type { Identity, InternalAccountV1 } from './105';
@@ -19,7 +19,7 @@ global.sentry = {
 
 function addressToUUID(address: string): string {
   return uuid({
-    random: sha256(hexToBytes(address)).slice(0, 16),
+    random: sha256(stringToBytes(address)).slice(0, 16),
   });
 }
 

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -1,7 +1,7 @@
 import { EthAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { sha256 } from '@noble/hashes/sha2';
-import { hexToBytes } from '@metamask/utils';
+import { stringToBytes } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { cloneDeep } from 'lodash';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
@@ -93,7 +93,7 @@ function createInternalAccountsForAccountsController(
 
   Object.values(identities).forEach((identity) => {
     const expectedId = uuid({
-      random: sha256(hexToBytes(identity.address)).slice(0, 16),
+      random: sha256(stringToBytes(identity.address)).slice(0, 16),
     });
 
     accounts[expectedId] = {

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -1,7 +1,7 @@
 import { EthAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { sha256 } from '@noble/hashes/sha2';
-import { stringToBytes } from '@metamask/utils';
+import { hexToBytes } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { cloneDeep } from 'lodash';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
@@ -93,7 +93,7 @@ function createInternalAccountsForAccountsController(
 
   Object.values(identities).forEach((identity) => {
     const expectedId = uuid({
-      random: sha256(stringToBytes(identity.address)).slice(0, 16),
+      random: sha256(hexToBytes(identity.address)).slice(0, 16),
     });
 
     accounts[expectedId] = {

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -1,6 +1,7 @@
 import { EthAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
-import { sha256FromString } from 'ethereumjs-util';
+import { sha256 } from '@noble/hashes/sha2';
+import { hexToBytes } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 import { cloneDeep } from 'lodash';
 import { ETH_EOA_METHODS } from '../../../shared/constants/eth-methods';
@@ -92,7 +93,7 @@ function createInternalAccountsForAccountsController(
 
   Object.values(identities).forEach((identity) => {
     const expectedId = uuid({
-      random: sha256FromString(identity.address).slice(0, 16),
+      random: sha256(hexToBytes(identity.address)).slice(0, 16),
     });
 
     accounts[expectedId] = {


### PR DESCRIPTION
## **Description**

The function `sha256FromString` from `ethereumjs-util` was removed in the next major version (v8). It has been replaced by `sha256` from `@noble/hashes`, and `hexToBytes` from `@metamask/utils`.

This supersedes #28171

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39334?quickstart=1)

## **Changelog**

CHANGELOG entry: N/A

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates migration `105` and its test to remove `ethereumjs-util` usage.
> 
> - Replace `sha256FromString` with `sha256` from `@noble/hashes/sha2` and `hexToBytes` from `@metamask/utils`
> - Change UUID derivation to `sha256(hexToBytes(address)).slice(0, 16)` when generating `id` for internal accounts and in test helper
> - No other migration logic modified; version remains `105`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55c360db226fe72d99c80f9a52bfbda04b993c8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->