### PR TITLE
fix: transaction list

### DIFF
--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -106,6 +106,9 @@ import { getSelectedAccountGroupMultichainTransactions } from '../../../selector
 import { TransactionActivityEmptyState } from '../transaction-activity-empty-state';
 import { useScrollContainer } from '../../../contexts/scroll-container';
 
+const normalizeHex = (hex) => (hex || '').toLowerCase();
+const stripHexPrefix = (hex) => normalizeHex(hex).replace(/^0x/u, '');
+
 // When we are on a token page, we only want to show transactions that involve that token.
 // In the case of token transfers or approvals, these will be transactions sent to the
 // token contract. In the case of swaps, these will be transactions sent to the swaps contract
@@ -118,13 +121,17 @@ const getTransactionGroupRecipientAddressFilter = (
   chainIds,
 ) => {
   return ({ initialTransaction: { txParams } }) => {
+    const dataMatchesToken = normalizeHex(txParams?.data).includes(
+      stripHexPrefix(recipientAddress),
+    );
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some(
         (chainId) =>
-          txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
+          normalizeHex(txParams?.to) ===
+          normalizeHex(SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId]),
       ) &&
-        txParams.data.match(recipientAddress.slice(2)))
+        dataMatchesToken)
     );
   };
 };
@@ -145,13 +152,17 @@ const getTransactionGroupRecipientAddressFilterAllChain = (
     if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
       return true;
     }
+    const dataMatchesToken = normalizeHex(txParams?.data).includes(
+      stripHexPrefix(recipientAddress),
+    );
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some(
         (chainId) =>
-          txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
+          normalizeHex(txParams?.to) ===
+          normalizeHex(SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId]),
       ) &&
-        txParams.data.match(recipientAddress.slice(2)))
+        dataMatchesToken)
     );
   };
 };

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -105,9 +105,18 @@ import {
 import { getSelectedAccountGroupMultichainTransactions } from '../../../selectors/multichain-transactions';
 import { TransactionActivityEmptyState } from '../transaction-activity-empty-state';
 import { useScrollContainer } from '../../../contexts/scroll-container';
+import { stripHexPrefix } from '../../../../shared/modules/hexstring-utils';
 
-const normalizeHex = (hex) => (hex || '').toLowerCase();
-const stripHexPrefix = (hex) => normalizeHex(hex).replace(/^0x/u, '');
+const doesDataIncludeTokenAddress = (data, tokenAddress) => {
+  if (!data || !tokenAddress) {
+    return false;
+  }
+  const normalizedTokenAddress = stripHexPrefix(tokenAddress).toLowerCase();
+  if (!normalizedTokenAddress) {
+    return false;
+  }
+  return data.toLowerCase().includes(normalizedTokenAddress);
+};
 
 // When we are on a token page, we only want to show transactions that involve that token.
 // In the case of token transfers or approvals, these will be transactions sent to the
@@ -121,15 +130,18 @@ const getTransactionGroupRecipientAddressFilter = (
   chainIds,
 ) => {
   return ({ initialTransaction: { txParams } }) => {
-    const dataMatchesToken = normalizeHex(txParams?.data).includes(
-      stripHexPrefix(recipientAddress),
+    const dataMatchesToken = doesDataIncludeTokenAddress(
+      txParams?.data,
+      recipientAddress,
     );
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some(
         (chainId) =>
-          normalizeHex(txParams?.to) ===
-          normalizeHex(SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId]),
+          isEqualCaseInsensitive(
+            txParams?.to,
+            SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
+          ),
       ) &&
         dataMatchesToken)
     );
@@ -152,15 +164,18 @@ const getTransactionGroupRecipientAddressFilterAllChain = (
     if (isNativeAssetActivityFilter && isSimpleSendTx && isOnSameChain) {
       return true;
     }
-    const dataMatchesToken = normalizeHex(txParams?.data).includes(
-      stripHexPrefix(recipientAddress),
+    const dataMatchesToken = doesDataIncludeTokenAddress(
+      txParams?.data,
+      recipientAddress,
     );
     return (
       isEqualCaseInsensitive(txParams?.to, recipientAddress) ||
       (chainIds.some(
         (chainId) =>
-          normalizeHex(txParams?.to) ===
-          normalizeHex(SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId]),
+          isEqualCaseInsensitive(
+            txParams?.to,
+            SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId],
+          ),
       ) &&
         dataMatchesToken)
     );


### PR DESCRIPTION
Ensure swap transactions appear correctly in token details by normalizing address/calldata case and fixing swap contract comparison logic.

Previously, the token details view's transaction filter for swaps was overly strict. It failed to match transactions due to case-sensitive comparisons between checksummed token addresses and lowercase calldata, and a bug in the legacy list prevented completed swaps from being displayed by incorrectly comparing the swap contract address. This led to swaps being visible in the main Activity View but not within the specific token's details.

---
<a href="https://cursor.com/background-agent?bcId=bc-05e756cd-41ce-4268-9d4a-74e53518aef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05e756cd-41ce-4268-9d4a-74e53518aef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

