### PR TITLE
fix: consistent gas tooltip arrow color

### DIFF
--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
@@ -6,26 +6,107 @@ import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { NetworkStabilityTooltip } from '../tooltips';
 
 /* eslint-disable @metamask/design-tokens/color-no-hex */
-const GRADIENT_COLORS = [
-  '#037DD6',
-  '#1876C8',
-  '#2D70BA',
-  '#4369AB',
-  '#57629E',
-  '#6A5D92',
-  '#805683',
-  '#9A4D71',
-  '#B44561',
-  '#C54055',
-  '#D73A49',
-];
+const DEFAULT_GRADIENT_START = '#037DD6';
+const DEFAULT_GRADIENT_END = '#D73A49';
 /* eslint-enable @metamask/design-tokens/color-no-hex */
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const normalizeHexColor = (value) => {
+  if (value.length === 4) {
+    return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`;
+  }
+  if (value.length === 7) {
+    return value;
+  }
+  return null;
+};
+
+const parseRgbColor = (value) => {
+  const match = value
+    .replace(/\s+/gu, '')
+    .match(/^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/u);
+  if (!match) {
+    return null;
+  }
+  return {
+    r: Number(match[1]),
+    g: Number(match[2]),
+    b: Number(match[3]),
+  };
+};
+
+const parseHexColor = (value) => {
+  const normalized = normalizeHexColor(value);
+  if (!normalized) {
+    return null;
+  }
+  return {
+    r: Number.parseInt(normalized.slice(1, 3), 16),
+    g: Number.parseInt(normalized.slice(3, 5), 16),
+    b: Number.parseInt(normalized.slice(5, 7), 16),
+  };
+};
+
+const parseColor = (value) => {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith('#')) {
+    return parseHexColor(trimmed);
+  }
+  if (trimmed.startsWith('rgb')) {
+    return parseRgbColor(trimmed);
+  }
+  return null;
+};
+
+const rgbToHex = ({ r, g, b }) => {
+  const toHex = (channel) => channel.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+};
+
+const getCssVariableValue = (variableName, fallback) => {
+  if (typeof window === 'undefined' || !window.getComputedStyle) {
+    return fallback;
+  }
+  const value = window
+    .getComputedStyle(document.documentElement)
+    .getPropertyValue(variableName)
+    .trim();
+  return value || fallback;
+};
+
+const getGradientColor = (ratio) => {
+  const startValue = getCssVariableValue(
+    '--color-primary-default',
+    DEFAULT_GRADIENT_START,
+  );
+  const endValue = getCssVariableValue(
+    '--color-error-default',
+    DEFAULT_GRADIENT_END,
+  );
+  const startColor =
+    parseColor(startValue) ?? parseColor(DEFAULT_GRADIENT_START);
+  const endColor = parseColor(endValue) ?? parseColor(DEFAULT_GRADIENT_END);
+  if (!startColor || !endColor) {
+    return DEFAULT_GRADIENT_START;
+  }
+  const clampedRatio = clamp(ratio, 0, 1);
+  const color = {
+    r: Math.round(startColor.r + (endColor.r - startColor.r) * clampedRatio),
+    g: Math.round(startColor.g + (endColor.g - startColor.g) * clampedRatio),
+    b: Math.round(startColor.b + (endColor.b - startColor.b) * clampedRatio),
+  };
+  return rgbToHex(color);
+};
 
 const determineStatusInfo = (givenNetworkCongestion) => {
   const networkCongestion = givenNetworkCongestion ?? 0.5;
   const colorIndex = Math.round(networkCongestion * 10);
-  const color = GRADIENT_COLORS[colorIndex];
   const sliderTickValue = colorIndex * 10;
+  const color = getGradientColor(sliderTickValue / 100);
 
   if (networkCongestion >= NetworkCongestionThresholds.busy) {
     return {

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
@@ -71,10 +71,18 @@ const getCssVariableValue = (variableName, fallback) => {
   if (typeof window === 'undefined' || !window.getComputedStyle) {
     return fallback;
   }
-  const value = window
-    .getComputedStyle(document.documentElement)
-    .getPropertyValue(variableName)
-    .trim();
+  const style = window.getComputedStyle(document.documentElement);
+  let value = style.getPropertyValue(variableName).trim();
+  let depth = 0;
+  while (value.startsWith('var(') && depth < 5) {
+    const match = value.match(/^var\((--[^,)\s]+)\s*(?:,([^)]+))?\)$/u);
+    if (!match) {
+      break;
+    }
+    const nextValue = style.getPropertyValue(match[1]).trim();
+    value = nextValue || (match[2] ? match[2].trim() : '');
+    depth += 1;
+  }
   return value || fallback;
 };
 

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.test.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.test.js
@@ -82,8 +82,8 @@ describe('StatusSlider', () => {
   it('should color the arrow and label for the middle position if networkCongestion has not been set yet', () => {
     const { getByTestId } = renderComponent({});
     expect(getByTestId('status-slider-arrow')).toHaveStyle(
-      'border-top-color: #6A5D92',
+      'border-top-color: #6D5C90',
     );
-    expect(getByTestId('status-slider-label')).toHaveStyle('color: #6A5D92');
+    expect(getByTestId('status-slider-label')).toHaveStyle('color: #6D5C90');
   });
 });


### PR DESCRIPTION
## **Description**

Aligns the advanced gas fee tooltip arrow color with the gradient indicator by deriving the arrow color from the same primary/error tokens and interpolating across the slider.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39344?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug that caused the gas fee tooltip arrow color to drift from the gradient indicator.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-499

## **Manual testing steps**

1. Prepare a send transaction
2. Click edit gas fee
43. Observe the update at the bottom right

## **Screenshots/Recordings**

#### Low
| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/8fa04e0f-a68f-48c5-82c6-ac77f8b9c51d) | ![after](https://github.com/user-attachments/assets/202b126e-334b-4efa-83ba-9bc7ae61f2d6) |

#### Stable
| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/d6f52d57-1aab-474f-86e8-d7c3bc3777e7) | ![after](https://github.com/user-attachments/assets/9c1ef4f1-5056-4810-9555-3d252290f609) |

#### High
| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/ea01358f-b3c1-4ab9-80b0-0fef5914d9aa) | ![after](https://github.com/user-attachments/assets/c6e4ad0b-1e4e-432e-882f-57cac48e5708) |


### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the status slider’s color with theme tokens by computing it dynamically instead of using a hardcoded palette.
> 
> - Replaces `GRADIENT_COLORS` with runtime interpolation between `--color-primary-default` and `--color-error-default` (with hex fallbacks), including robust CSS var resolution and RGB/HEX parsing helpers
> - `determineStatusInfo` now derives `color` via `getGradientColor` from the slider tick ratio, keeping existing status thresholds/logic
> - Updates tests to expect interpolated colors (e.g., middle position now `#6D5C90`) while preserving other assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b67c89be5a01c79a65b469351e10553f306ed70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->