### PR TITLE
feat(rewards): add Bitcoin and Tron account support

### DIFF
--- a/app/scripts/controller-init/rewards-controller-init.test.ts
+++ b/app/scripts/controller-init/rewards-controller-init.test.ts
@@ -80,6 +80,8 @@ describe('RewardsControllerInit', () => {
         messenger: requestMock.controllerMessenger,
         state: expect.any(Object),
         isDisabled: expect.any(Function),
+        isBitcoinDisabled: expect.any(Function),
+        isTronDisabled: expect.any(Function),
       });
     });
 
@@ -101,6 +103,8 @@ describe('RewardsControllerInit', () => {
         messenger: requestMock.controllerMessenger,
         state: mockPersistedState,
         isDisabled: expect.any(Function),
+        isBitcoinDisabled: expect.any(Function),
+        isTronDisabled: expect.any(Function),
       });
     });
 
@@ -111,6 +115,104 @@ describe('RewardsControllerInit', () => {
 
       const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
       expect(constructorArgs.state).toBeDefined();
+    });
+  });
+
+  describe('isBitcoinDisabled', () => {
+    it('returns false when rewardsBitcoinEnabledExtension is true', () => {
+      const requestMock = buildInitRequestMock({
+        rewardsBitcoinEnabledExtension: true,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isBitcoinDisabled()).toBe(false);
+    });
+
+    it('returns true when rewardsBitcoinEnabledExtension is false', () => {
+      const requestMock = buildInitRequestMock({
+        rewardsBitcoinEnabledExtension: false,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isBitcoinDisabled()).toBe(true);
+    });
+
+    it('returns true when rewardsBitcoinEnabledExtension is not set', () => {
+      const requestMock = buildInitRequestMock({});
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isBitcoinDisabled()).toBe(true);
+    });
+
+    it('uses manifest flag override when available', () => {
+      mockGetManifestFlags.mockReturnValue({
+        remoteFeatureFlags: {
+          rewardsBitcoinEnabledExtension: true,
+        },
+      } as never);
+      const requestMock = buildInitRequestMock({
+        rewardsBitcoinEnabledExtension: false,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isBitcoinDisabled()).toBe(false);
+    });
+  });
+
+  describe('isTronDisabled', () => {
+    it('returns false when rewardsTronEnabledExtension is true', () => {
+      const requestMock = buildInitRequestMock({
+        rewardsTronEnabledExtension: true,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isTronDisabled()).toBe(false);
+    });
+
+    it('returns true when rewardsTronEnabledExtension is false', () => {
+      const requestMock = buildInitRequestMock({
+        rewardsTronEnabledExtension: false,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isTronDisabled()).toBe(true);
+    });
+
+    it('returns true when rewardsTronEnabledExtension is not set', () => {
+      const requestMock = buildInitRequestMock({});
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isTronDisabled()).toBe(true);
+    });
+
+    it('uses manifest flag override when available', () => {
+      mockGetManifestFlags.mockReturnValue({
+        remoteFeatureFlags: {
+          rewardsTronEnabledExtension: true,
+        },
+      } as never);
+      const requestMock = buildInitRequestMock({
+        rewardsTronEnabledExtension: false,
+      });
+
+      RewardsControllerInit(requestMock);
+
+      const [constructorArgs] = RewardsControllerClassMock.mock.calls[0];
+      expect(constructorArgs.isTronDisabled()).toBe(false);
     });
   });
 });

--- a/app/scripts/controller-init/rewards-controller-init.ts
+++ b/app/scripts/controller-init/rewards-controller-init.ts
@@ -14,6 +14,21 @@ import {
 import { ControllerInitFunction } from './types';
 
 /**
+ * Helper function to resolve a feature flag value.
+ *
+ * @param flag - The feature flag value to resolve.
+ * @returns The resolved boolean value.
+ */
+const resolveFlag = (flag: unknown) => {
+  if (typeof flag === 'boolean') {
+    return flag;
+  }
+  return Boolean(
+    validatedVersionGatedFeatureFlag(flag as VersionGatedFeatureFlag),
+  );
+};
+
+/**
  * Initialize the RewardsController.
  *
  * @param request - The request object.
@@ -43,14 +58,6 @@ export const RewardsControllerInit: ControllerInitFunction<
       // Seed with manifest override first; fallback to remote flag
       const manifestFlag =
         getManifestFlags().remoteFeatureFlags?.rewardsEnabled;
-      const resolveFlag = (flag: unknown) => {
-        if (typeof flag === 'boolean') {
-          return flag;
-        }
-        return Boolean(
-          validatedVersionGatedFeatureFlag(flag as VersionGatedFeatureFlag),
-        );
-      };
       const featureFlagEnabled =
         manifestFlag === undefined
           ? resolveFlag(rewardsFeatureFlag)
@@ -61,6 +68,44 @@ export const RewardsControllerInit: ControllerInitFunction<
         'PreferencesController:getState',
       );
       return !featureFlagEnabled || !useExternalServices;
+    },
+    isBitcoinDisabled: () => {
+      const { remoteFeatureFlags } = initMessenger.call(
+        'RemoteFeatureFlagController:getState',
+      );
+      const bitcoinFeatureFlag =
+        remoteFeatureFlags?.rewardsBitcoinEnabledExtension as
+          | VersionGatedFeatureFlag
+          | undefined;
+
+      // Seed with manifest override first; fallback to remote flag
+      const manifestFlag =
+        getManifestFlags().remoteFeatureFlags?.rewardsBitcoinEnabledExtension;
+      const featureFlagEnabled =
+        manifestFlag === undefined
+          ? resolveFlag(bitcoinFeatureFlag)
+          : resolveFlag(manifestFlag);
+
+      return !featureFlagEnabled;
+    },
+    isTronDisabled: () => {
+      const { remoteFeatureFlags } = initMessenger.call(
+        'RemoteFeatureFlagController:getState',
+      );
+      const tronFeatureFlag =
+        remoteFeatureFlags?.rewardsTronEnabledExtension as
+          | VersionGatedFeatureFlag
+          | undefined;
+
+      // Seed with manifest override first; fallback to remote flag
+      const manifestFlag =
+        getManifestFlags().remoteFeatureFlags?.rewardsTronEnabledExtension;
+      const featureFlagEnabled =
+        manifestFlag === undefined
+          ? resolveFlag(tronFeatureFlag)
+          : resolveFlag(manifestFlag);
+
+      return !featureFlagEnabled;
     },
   });
 

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -546,6 +546,58 @@ describe('RewardsController', () => {
         expect(result).toBe(false);
       });
     });
+
+    it('should return true for Bitcoin mainnet addresses', async () => {
+      await withController({ isDisabled: false }, ({ controller }) => {
+        const bitcoinAccount: InternalAccount = {
+          ...MOCK_INTERNAL_ACCOUNT,
+          address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+        };
+
+        const result = controller.isOptInSupported(bitcoinAccount);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should return true for Bitcoin testnet addresses', async () => {
+      await withController({ isDisabled: false }, ({ controller }) => {
+        const bitcoinAccount: InternalAccount = {
+          ...MOCK_INTERNAL_ACCOUNT,
+          address: 'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+        };
+
+        const result = controller.isOptInSupported(bitcoinAccount);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should return true for Bitcoin addresses', async () => {
+      await withController({ isDisabled: false }, ({ controller }) => {
+        const bitcoinAccount: InternalAccount = {
+          ...MOCK_INTERNAL_ACCOUNT,
+          address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+        };
+
+        const result = controller.isOptInSupported(bitcoinAccount);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should return true for Tron addresses', async () => {
+      await withController({ isDisabled: false }, ({ controller }) => {
+        const tronAccount: InternalAccount = {
+          ...MOCK_INTERNAL_ACCOUNT,
+          address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        };
+
+        const result = controller.isOptInSupported(tronAccount);
+
+        expect(result).toBe(true);
+      });
+    });
   });
 
   describe('getActualSubscriptionId', () => {
@@ -645,6 +697,260 @@ describe('RewardsController', () => {
             hasOptedIn: true,
             subscriptionId: MOCK_SUBSCRIPTION_ID,
           });
+        },
+      );
+    });
+
+    it('should successfully perform silent auth for Bitcoin mainnet account when Bitcoin rewards are enabled', async () => {
+      const bitcoinAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'bitcoin-account-1',
+        address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+        scopes: ['bip122:000000000019d6689c085ae165831e93'],
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'SnapController:handleRequest') {
+              return Promise.resolve({
+                signature: '0xbitcoinSignature123',
+                signedMessage: 'mockSignedMessage',
+                signatureType: 'ecdsa',
+              });
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            bitcoinAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'SnapController:handleRequest',
+            expect.objectContaining({
+              snapId: 'npm:@metamask/bitcoin-wallet-snap',
+              request: expect.objectContaining({
+                method: 'signRewardsMessage',
+              }),
+            }),
+          );
+        },
+      );
+    });
+
+    it('should successfully perform silent auth for Bitcoin testnet account when Bitcoin rewards are enabled', async () => {
+      const bitcoinAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'bitcoin-account-1',
+        address: 'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+        scopes: [
+          'bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+        ],
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'SnapController:handleRequest') {
+              return Promise.resolve({
+                signature: '0xbitcoinSignature123',
+                signedMessage: 'mockSignedMessage',
+                signatureType: 'ecdsa',
+              });
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            bitcoinAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'SnapController:handleRequest',
+            expect.objectContaining({
+              snapId: 'npm:@metamask/bitcoin-wallet-snap',
+              request: expect.objectContaining({
+                method: 'signRewardsMessage',
+              }),
+            }),
+          );
+        },
+      );
+    });
+
+    it('should successfully perform silent auth for Tron account when Tron rewards are enabled', async () => {
+      const tronAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'tron-account-1',
+        address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        scopes: ['tron:728126428'],
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'SnapController:handleRequest') {
+              return Promise.resolve({
+                signature: '0xtronSignature123',
+                signedMessage: 'mockSignedMessage',
+                signatureType: 'ecdsa',
+              });
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            tronAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'SnapController:handleRequest',
+            expect.objectContaining({
+              snapId: 'npm:@metamask/tron-wallet-snap',
+              request: expect.objectContaining({
+                method: 'signRewardsMessage',
+              }),
+            }),
+          );
+        },
+      );
+    });
+
+    it('should handle Bitcoin signature without 0x prefix', async () => {
+      const bitcoinAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'bitcoin-account-1',
+        address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+        scopes: ['bip122:000000000019d6689c085ae165831e93'],
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'SnapController:handleRequest') {
+              return Promise.resolve({
+                signature: 'bitcoinSignature123', // No 0x prefix
+                signedMessage: 'mockSignedMessage',
+                signatureType: 'ecdsa',
+              });
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            bitcoinAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+
+    it('should handle Tron signature without 0x prefix', async () => {
+      const tronAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'tron-account-1',
+        address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        scopes: ['tron:728126428'],
+      };
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'SnapController:handleRequest') {
+              return Promise.resolve({
+                signature: 'tronSignature123', // No 0x prefix
+                signedMessage: 'mockSignedMessage',
+                signatureType: 'ecdsa',
+              });
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            tronAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -191,6 +191,8 @@ type WithControllerArgs<ReturnValue> = [
   {
     state?: Partial<RewardsControllerState>;
     isDisabled?: boolean;
+    isBitcoinDisabled?: boolean;
+    isTronDisabled?: boolean;
   },
   WithControllerCallback<ReturnValue>,
 ];
@@ -199,7 +201,12 @@ async function withController<ReturnValue>(
   ...args: WithControllerArgs<ReturnValue>
 ): Promise<ReturnValue> {
   const [options, fn] = args;
-  const { state, isDisabled = false } = options;
+  const {
+    state,
+    isDisabled = false,
+    isBitcoinDisabled = false,
+    isTronDisabled = false,
+  } = options;
 
   type TestAllowedActions =
     | AccountsControllerGetSelectedMultichainAccountAction
@@ -271,6 +278,8 @@ async function withController<ReturnValue>(
     messenger: controllerMessenger,
     state,
     isDisabled: () => isDisabled,
+    isBitcoinDisabled: () => isBitcoinDisabled,
+    isTronDisabled: () => isTronDisabled,
   });
 
   return await fn({
@@ -597,6 +606,54 @@ describe('RewardsController', () => {
 
         expect(result).toBe(true);
       });
+    });
+
+    it('should return false for Bitcoin addresses when Bitcoin feature flag is disabled', async () => {
+      await withController(
+        { isDisabled: false, isBitcoinDisabled: true },
+        ({ controller }) => {
+          const bitcoinAccount: InternalAccount = {
+            ...MOCK_INTERNAL_ACCOUNT,
+            address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+          };
+
+          const result = controller.isOptInSupported(bitcoinAccount);
+
+          expect(result).toBe(false);
+        },
+      );
+    });
+
+    it('should return false for Bitcoin testnet addresses when Bitcoin feature flag is disabled', async () => {
+      await withController(
+        { isDisabled: false, isBitcoinDisabled: true },
+        ({ controller }) => {
+          const bitcoinAccount: InternalAccount = {
+            ...MOCK_INTERNAL_ACCOUNT,
+            address: 'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+          };
+
+          const result = controller.isOptInSupported(bitcoinAccount);
+
+          expect(result).toBe(false);
+        },
+      );
+    });
+
+    it('should return false for Tron addresses when Tron feature flag is disabled', async () => {
+      await withController(
+        { isDisabled: false, isTronDisabled: true },
+        ({ controller }) => {
+          const tronAccount: InternalAccount = {
+            ...MOCK_INTERNAL_ACCOUNT,
+            address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+          };
+
+          const result = controller.isOptInSupported(tronAccount);
+
+          expect(result).toBe(false);
+        },
+      );
     });
   });
 
@@ -951,6 +1008,78 @@ describe('RewardsController', () => {
           );
 
           expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+
+    it('should throw error when signing with Bitcoin account while Bitcoin is disabled', async () => {
+      const bitcoinAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'bitcoin-account-1',
+        address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+        scopes: ['bip122:000000000019d6689c085ae165831e93'],
+      };
+
+      await withController(
+        { isDisabled: false, isBitcoinDisabled: true },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            bitcoinAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalledWith(
+            'SnapController:handleRequest',
+            expect.anything(),
+          );
+        },
+      );
+    });
+
+    it('should throw error when signing with Tron account while Tron is disabled', async () => {
+      const tronAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        id: 'tron-account-1',
+        address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        scopes: ['tron:728126428'],
+      };
+
+      await withController(
+        { isDisabled: false, isTronDisabled: true },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            tronAccount,
+            true,
+            false,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalledWith(
+            'SnapController:handleRequest',
+            expect.anything(),
+          );
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -526,7 +526,7 @@ export class RewardsController extends BaseController<
         : `0x${result.signature}`;
     } else if (isTronAddress(account.address)) {
       if (this.#isTronDisabled()) {
-        throw new Error('nsupported account type for signing rewards message');
+        throw new Error('Unsupported account type for signing rewards message');
       }
       const result = await signTronRewardsMessage(
         this.messenger.call.bind(

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -226,6 +226,10 @@ export class RewardsController extends BaseController<
 
   #isDisabled: () => boolean;
 
+  #isBitcoinDisabled: () => boolean;
+
+  #isTronDisabled: () => boolean;
+
   /**
    * Calculate tier status and next tier information
    */
@@ -331,10 +335,14 @@ export class RewardsController extends BaseController<
     messenger,
     state,
     isDisabled,
+    isBitcoinDisabled,
+    isTronDisabled,
   }: {
     messenger: RewardsControllerMessenger;
     state?: Partial<RewardsControllerState>;
     isDisabled: () => boolean;
+    isBitcoinDisabled: () => boolean;
+    isTronDisabled: () => boolean;
   }) {
     super({
       name: controllerName,
@@ -349,6 +357,8 @@ export class RewardsController extends BaseController<
     this.#registerActionHandlers();
     this.#initializeEventSubscriptions();
     this.#isDisabled = isDisabled;
+    this.#isBitcoinDisabled = isBitcoinDisabled;
+    this.#isTronDisabled = isTronDisabled;
   }
 
   /**
@@ -499,6 +509,9 @@ export class RewardsController extends BaseController<
       isBtcMainnetAddress(account.address) ||
       isBtcTestnetAddress(account.address)
     ) {
+      if (this.#isBitcoinDisabled()) {
+        throw new Error('Unsupported account type for signing rewards message');
+      }
       const result = await signBitcoinRewardsMessage(
         this.messenger.call.bind(
           this.messenger,
@@ -512,6 +525,9 @@ export class RewardsController extends BaseController<
         ? result.signature
         : `0x${result.signature}`;
     } else if (isTronAddress(account.address)) {
+      if (this.#isTronDisabled()) {
+        throw new Error('nsupported account type for signing rewards message');
+      }
       const result = await signTronRewardsMessage(
         this.messenger.call.bind(
           this.messenger,
@@ -680,17 +696,17 @@ export class RewardsController extends BaseController<
         return true;
       }
 
-      // Check if it's a Bitcoin address
+      // Check if it's a Bitcoin address (gated by feature flag)
       if (
         isBtcMainnetAddress(account.address) ||
         isBtcTestnetAddress(account.address)
       ) {
-        return true;
+        return !this.#isBitcoinDisabled();
       }
 
-      // Check if it's a Tron address
+      // Check if it's a Tron address (gated by feature flag)
       if (isTronAddress(account.address)) {
-        return true;
+        return !this.#isTronDisabled();
       }
 
       // If it's none of the supported types, opt-in is not supported

--- a/app/scripts/controllers/rewards/utils/bitcoin-snap.test.ts
+++ b/app/scripts/controllers/rewards/utils/bitcoin-snap.test.ts
@@ -1,0 +1,219 @@
+import type { HandleSnapRequest } from '@metamask/snaps-controllers';
+import { HandlerType } from '@metamask/snaps-utils';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../../shared/lib/accounts';
+import {
+  signBitcoinRewardsMessage,
+  SignRewardsMessageResult,
+} from './bitcoin-snap';
+
+// Mock the snap request handler
+const mockHandleSnapRequest = jest.fn() as jest.MockedFunction<
+  HandleSnapRequest['handler']
+>;
+
+// Mock console.error to avoid test noise
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+
+describe('bitcoin-snap', () => {
+  const mockAccountId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockMessage = 'Test message for signing';
+  const mockSignatureResult: SignRewardsMessageResult = {
+    signature: 'mockSignature123',
+    signedMessage: 'mockSignedMessage',
+    signatureType: 'ecdsa',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleSnapRequest.mockClear();
+    // Clear console.error mock calls
+    mockConsoleError.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleError.mockRestore();
+  });
+
+  describe('signBitcoinRewardsMessage', () => {
+    it('successfully signs a Bitcoin rewards message', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signBitcoinRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        mockMessage,
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledTimes(1);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith({
+        origin: 'metamask',
+        snapId: BITCOIN_WALLET_SNAP_ID,
+        handler: HandlerType.OnClientRequest,
+        request: {
+          jsonrpc: '2.0',
+          id: expect.any(Number),
+          method: 'signRewardsMessage',
+          params: {
+            accountId: mockAccountId,
+            message: mockMessage,
+          },
+        },
+      });
+    });
+
+    it('passes correct parameters to handleSnapRequest', async () => {
+      // Arrange
+      const expectedTimestamp = Date.now();
+      jest.spyOn(Date, 'now').mockReturnValueOnce(expectedTimestamp);
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      await signBitcoinRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        mockMessage,
+      );
+
+      // Assert
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          origin: 'metamask',
+          snapId: BITCOIN_WALLET_SNAP_ID,
+          handler: HandlerType.OnClientRequest,
+          request: expect.objectContaining({
+            jsonrpc: '2.0',
+            id: expectedTimestamp,
+            method: 'signRewardsMessage',
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles network timeout errors', async () => {
+      // Arrange
+      const timeoutError = new Error('Network timeout');
+      mockHandleSnapRequest.mockRejectedValueOnce(timeoutError);
+
+      // Act & Assert
+      await expect(
+        signBitcoinRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+      ).rejects.toThrow('Network timeout');
+    });
+
+    it('handles snap not available error', async () => {
+      // Arrange
+      const snapError = new Error('Snap not found');
+      mockHandleSnapRequest.mockRejectedValueOnce(snapError);
+
+      // Act & Assert
+      await expect(
+        signBitcoinRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+      ).rejects.toThrow('Snap not found');
+    });
+
+    it('generates unique request IDs for concurrent calls', async () => {
+      // Arrange
+      const firstTimestamp = 1000;
+      const secondTimestamp = 2000;
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(firstTimestamp)
+        .mockReturnValueOnce(secondTimestamp);
+
+      mockHandleSnapRequest
+        .mockResolvedValueOnce(mockSignatureResult)
+        .mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const [result1, result2] = await Promise.all([
+        signBitcoinRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+        signBitcoinRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          'Different message',
+        ),
+      ]);
+
+      // Assert
+      expect(result1).toEqual(mockSignatureResult);
+      expect(result2).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledTimes(2);
+
+      // Verify different request IDs were used
+      const firstCall = mockHandleSnapRequest.mock.calls[0];
+      const secondCall = mockHandleSnapRequest.mock.calls[1];
+      expect(firstCall[0].request.id).toBe(firstTimestamp);
+      expect(secondCall[0].request.id).toBe(secondTimestamp);
+    });
+
+    it('handles empty accountId parameter', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signBitcoinRewardsMessage(
+        mockHandleSnapRequest,
+        '',
+        mockMessage,
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: '',
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles empty message parameter', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signBitcoinRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        '',
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: mockAccountId,
+              message: '',
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/app/scripts/controllers/rewards/utils/bitcoin-snap.ts
+++ b/app/scripts/controllers/rewards/utils/bitcoin-snap.ts
@@ -1,0 +1,38 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import log from 'loglevel';
+import type { HandleSnapRequest } from '@metamask/snaps-controllers';
+import { BITCOIN_WALLET_SNAP_ID } from '../../../../../shared/lib/accounts';
+
+export type SignRewardsMessageResult = {
+  signature: string;
+  signedMessage: string;
+  signatureType: string;
+};
+
+export async function signBitcoinRewardsMessage(
+  handleSnapRequest: HandleSnapRequest['handler'],
+  accountId: string,
+  message: string,
+): Promise<SignRewardsMessageResult> {
+  try {
+    const result = await handleSnapRequest({
+      origin: 'metamask',
+      snapId: BITCOIN_WALLET_SNAP_ID,
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'signRewardsMessage',
+        params: {
+          accountId,
+          message,
+        },
+      },
+    });
+
+    return result as SignRewardsMessageResult;
+  } catch (error) {
+    log.error('Error signing Bitcoin rewards message:', error);
+    throw error;
+  }
+}

--- a/app/scripts/controllers/rewards/utils/tron-snap.test.ts
+++ b/app/scripts/controllers/rewards/utils/tron-snap.test.ts
@@ -1,0 +1,216 @@
+import type { HandleSnapRequest } from '@metamask/snaps-controllers';
+import { HandlerType } from '@metamask/snaps-utils';
+import { TRON_WALLET_SNAP_ID } from '../../../../../shared/lib/accounts';
+import { signTronRewardsMessage, SignRewardsMessageResult } from './tron-snap';
+
+// Mock the snap request handler
+const mockHandleSnapRequest = jest.fn() as jest.MockedFunction<
+  HandleSnapRequest['handler']
+>;
+
+// Mock console.error to avoid test noise
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+
+describe('tron-snap', () => {
+  const mockAccountId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockMessage = 'Test message for signing';
+  const mockSignatureResult: SignRewardsMessageResult = {
+    signature: 'mockSignature123',
+    signedMessage: 'mockSignedMessage',
+    signatureType: 'ecdsa',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleSnapRequest.mockClear();
+    // Clear console.error mock calls
+    mockConsoleError.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleError.mockRestore();
+  });
+
+  describe('signTronRewardsMessage', () => {
+    it('successfully signs a Tron rewards message', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signTronRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        mockMessage,
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledTimes(1);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith({
+        origin: 'metamask',
+        snapId: TRON_WALLET_SNAP_ID,
+        handler: HandlerType.OnClientRequest,
+        request: {
+          jsonrpc: '2.0',
+          id: expect.any(Number),
+          method: 'signRewardsMessage',
+          params: {
+            accountId: mockAccountId,
+            message: mockMessage,
+          },
+        },
+      });
+    });
+
+    it('passes correct parameters to handleSnapRequest', async () => {
+      // Arrange
+      const expectedTimestamp = Date.now();
+      jest.spyOn(Date, 'now').mockReturnValueOnce(expectedTimestamp);
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      await signTronRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        mockMessage,
+      );
+
+      // Assert
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          origin: 'metamask',
+          snapId: TRON_WALLET_SNAP_ID,
+          handler: HandlerType.OnClientRequest,
+          request: expect.objectContaining({
+            jsonrpc: '2.0',
+            id: expectedTimestamp,
+            method: 'signRewardsMessage',
+            params: {
+              accountId: mockAccountId,
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles network timeout errors', async () => {
+      // Arrange
+      const timeoutError = new Error('Network timeout');
+      mockHandleSnapRequest.mockRejectedValueOnce(timeoutError);
+
+      // Act & Assert
+      await expect(
+        signTronRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+      ).rejects.toThrow('Network timeout');
+    });
+
+    it('handles snap not available error', async () => {
+      // Arrange
+      const snapError = new Error('Snap not found');
+      mockHandleSnapRequest.mockRejectedValueOnce(snapError);
+
+      // Act & Assert
+      await expect(
+        signTronRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+      ).rejects.toThrow('Snap not found');
+    });
+
+    it('generates unique request IDs for concurrent calls', async () => {
+      // Arrange
+      const firstTimestamp = 1000;
+      const secondTimestamp = 2000;
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(firstTimestamp)
+        .mockReturnValueOnce(secondTimestamp);
+
+      mockHandleSnapRequest
+        .mockResolvedValueOnce(mockSignatureResult)
+        .mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const [result1, result2] = await Promise.all([
+        signTronRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          mockMessage,
+        ),
+        signTronRewardsMessage(
+          mockHandleSnapRequest,
+          mockAccountId,
+          'Different message',
+        ),
+      ]);
+
+      // Assert
+      expect(result1).toEqual(mockSignatureResult);
+      expect(result2).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledTimes(2);
+
+      // Verify different request IDs were used
+      const firstCall = mockHandleSnapRequest.mock.calls[0];
+      const secondCall = mockHandleSnapRequest.mock.calls[1];
+      expect(firstCall[0].request.id).toBe(firstTimestamp);
+      expect(secondCall[0].request.id).toBe(secondTimestamp);
+    });
+
+    it('handles empty accountId parameter', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signTronRewardsMessage(
+        mockHandleSnapRequest,
+        '',
+        mockMessage,
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: '',
+              message: mockMessage,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('handles empty message parameter', async () => {
+      // Arrange
+      mockHandleSnapRequest.mockResolvedValueOnce(mockSignatureResult);
+
+      // Act
+      const result = await signTronRewardsMessage(
+        mockHandleSnapRequest,
+        mockAccountId,
+        '',
+      );
+
+      // Assert
+      expect(result).toEqual(mockSignatureResult);
+      expect(mockHandleSnapRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            params: {
+              accountId: mockAccountId,
+              message: '',
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/app/scripts/controllers/rewards/utils/tron-snap.ts
+++ b/app/scripts/controllers/rewards/utils/tron-snap.ts
@@ -1,0 +1,38 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import log from 'loglevel';
+import type { HandleSnapRequest } from '@metamask/snaps-controllers';
+import { TRON_WALLET_SNAP_ID } from '../../../../../shared/lib/accounts';
+
+export type SignRewardsMessageResult = {
+  signature: string;
+  signedMessage: string;
+  signatureType: string;
+};
+
+export async function signTronRewardsMessage(
+  handleSnapRequest: HandleSnapRequest['handler'],
+  accountId: string,
+  message: string,
+): Promise<SignRewardsMessageResult> {
+  try {
+    const result = await handleSnapRequest({
+      origin: 'metamask',
+      snapId: TRON_WALLET_SNAP_ID,
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'signRewardsMessage',
+        params: {
+          accountId,
+          message,
+        },
+      },
+    });
+
+    return result as SignRewardsMessageResult;
+  } catch (error) {
+    log.error('Error signing Tron rewards message:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## **Description**

Add Bitcoin and Tron account support for Rewards

## **Changelog**

CHANGELOG entry: add Bitcoin and Tron account support for rewards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends rewards opt-in and authentication signing flow to new account types (Bitcoin/Tron) and adds new feature-flag gates; mistakes could cause users to be incorrectly blocked/unblocked or generate invalid signatures for login.
> 
> **Overview**
> Adds **Bitcoin and Tron account support** to rewards by treating valid BTC (mainnet/testnet) and Tron addresses as opt-in capable and enabling silent auth to sign rewards messages via the `bitcoin-wallet-snap` and `tron-wallet-snap`.
> 
> Introduces new per-chain feature-flag gates (`rewardsBitcoinEnabledExtension`, `rewardsTronEnabledExtension`) with manifest overrides in `RewardsControllerInit`, wires `isBitcoinDisabled`/`isTronDisabled` into `RewardsController`, and adds snap helpers (`bitcoin-snap.ts`, `tron-snap.ts`) plus expanded tests for gating and signature formatting (ensuring `0x` prefix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f82568dffd6cd2010e6b3a7fad69fe1b083ae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->