### PR TITLE
chore: Ignore new audit advisory from package deprecation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -59,6 +59,10 @@ npmAuditIgnoreAdvisories:
   # New package name format for new versions: @ethereumjs/wallet.
   - 'ethereumjs-wallet (deprecation)'
 
+  # Deprecated package still used by older versions of our packages, to be eliminated soon as we
+  # update.
+  - '@metamask/error-reporting-service (deprecation)'
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'


### PR DESCRIPTION
## **Description**

Resolve audit failure by ignoring the deprecation of the package `@metamask/error-reporting-service`. We'll get rid of the last usages of this package soon, but it'll be used for a little while longer in some older packages.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39364?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates audit configuration to avoid CI failures from a deprecation advisory.
> 
> - Adds `@metamask/error-reporting-service (deprecation)` to `npmAuditIgnoreAdvisories` in `.yarnrc.yml`
> - No application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c179ca76ecbfe131289d9fe919738bc34039480f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->