### PR TITLE
feat: track storageKind in metametrics cp-13.15.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -764,6 +764,10 @@ async function initialize(backup) {
     cronjobControllerStorageManager,
   );
 
+  controller.metaMetricsController.updateTraits({
+    [MetaMetricsUserTrait.StorageKind]: persistenceManager.storageKind,
+  });
+
   // `setupController` sets up the `controller` object, so we can use it now:
   maybeDetectPhishing(controller);
 

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -1446,6 +1446,10 @@ describe('MetaMetricsController', function () {
       };
 
       await withController(({ controller }) => {
+        controller.updateTraits({
+          [MetaMetricsUserTrait.StorageKind]: 'split',
+        });
+
         const traits = controller._buildUserTraitsObject({
           addressBook: {
             [CHAIN_IDS.MAINNET]: {
@@ -1575,6 +1579,7 @@ describe('MetaMetricsController', function () {
             'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
           ],
           [MetaMetricsUserTrait.InstallDateExt]: '',
+          [MetaMetricsUserTrait.StorageKind]: 'split',
           [MetaMetricsUserTrait.LedgerConnectionType]:
             LedgerTransportTypes.webhid,
           [MetaMetricsUserTrait.NetworksAdded]: [

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1360,6 +1360,7 @@ export default class MetaMetricsController extends BaseController<
     metamaskState: MetaMaskState,
   ): Partial<MetaMetricsUserTraits> | null {
     const { traits } = this.state;
+    const storageKindTrait = traits[MetaMetricsUserTrait.StorageKind];
 
     const currentTraits = {
       [MetaMetricsUserTrait.AddressBookEntries]: sum(
@@ -1369,6 +1370,9 @@ export default class MetaMetricsController extends BaseController<
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         traits[MetaMetricsUserTrait.InstallDateExt] || '',
+      ...(storageKindTrait
+        ? { [MetaMetricsUserTrait.StorageKind]: storageKindTrait }
+        : {}),
       [MetaMetricsUserTrait.LedgerConnectionType]:
         metamaskState.ledgerTransportType,
       [MetaMetricsUserTrait.NetworksAdded]: Object.values(

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -518,6 +518,12 @@ export type MetaMetricsUserTraits = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   install_date_ext?: string;
   /**
+   * The persistence storage kind currently in use.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  storage_kind?: 'data' | 'split';
+  /**
    * Whether the security provider feature has been enabled.
    */
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -578,6 +584,10 @@ export enum MetaMetricsUserTrait {
    * Identified when the user installed the extension.
    */
   InstallDateExt = 'install_date_ext',
+  /**
+   * Identifies which persistence storage kind is in use.
+   */
+  StorageKind = 'storage_kind',
   /**
    * Identified when the Ledger Live connection type is changed.
    */

--- a/test/e2e/tests/settings/state-logs-helpers.ts
+++ b/test/e2e/tests/settings/state-logs-helpers.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { Driver } from '../../webdriver/driver';
 
 export type StateLogsPrimitiveType =
@@ -443,7 +444,7 @@ const readStateLogsFile = async (
   downloadsFolder: string,
 ): Promise<MinimalStateLogsJson | null> => {
   try {
-    const stateLogs = `${downloadsFolder}/MetaMask state logs.json`;
+    const stateLogs = join(downloadsFolder, 'MetaMask state logs.json');
     const { promises: fs } = await import('fs');
     const contents = await fs.readFile(stateLogs);
     const parsedContents = JSON.parse(contents.toString());

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1093,7 +1093,8 @@
     },
     "tracesBeforeMetricsOptIn": [],
     "traits": {
-      "install_date_ext": "string"
+      "install_date_ext": "string",
+      "storage_kind": "string"
     },
     "transactionBatches": [],
     "transactionData": {},

--- a/test/e2e/tests/settings/state-logs.spec.ts
+++ b/test/e2e/tests/settings/state-logs.spec.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert';
+import { join } from 'path';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { createDownloadFolder, withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
@@ -22,7 +23,7 @@ import {
   StateLogsTypeMap,
 } from './state-logs-helpers';
 
-const downloadsFolder = `${process.cwd()}/test-artifacts/downloads`;
+const downloadsFolder = join(process.cwd(), "test-artifacts", "downloads");
 
 describe('State logs', function () {
   it('should download state logs for the account', async function () {

--- a/test/e2e/tests/settings/state-logs.spec.ts
+++ b/test/e2e/tests/settings/state-logs.spec.ts
@@ -23,7 +23,7 @@ import {
   StateLogsTypeMap,
 } from './state-logs-helpers';
 
-const downloadsFolder = join(process.cwd(), "test-artifacts", "downloads");
+const downloadsFolder = join(process.cwd(), 'test-artifacts', 'downloads');
 
 describe('State logs', function () {
   it('should download state logs for the account', async function () {

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -67,7 +67,7 @@ class FirefoxDriver {
     options.setPreference('browser.download.folderList', 2);
     options.setPreference(
       'browser.download.dir',
-      `${process.cwd()}/test-artifacts/downloads`,
+      path.join(process.cwd(), 'test-artifacts', 'downloads'),
     );
 
     if (isHeadless('SELENIUM')) {


### PR DESCRIPTION
## **Description**

Track `storageKind` in metametrics

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39192?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: track `storageKind` in metametrics events
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**


### **After**

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces tracking of the current persistence storage kind in MetaMetrics and aligns tests and state logs.
> 
> - Add `storage_kind` trait to `MetaMetricsUserTraits` and `MetaMetricsUserTrait` enum; include it in `_buildUserTraitsObject`
> - Set the trait on startup from `PersistenceManager.storageKind` in `background.js`
> - Update unit tests to set/expect `storage_kind`; extend state logs schema to include it
> - Use `path.join` for download/state log paths in E2E helpers, tests, and Firefox WebDriver config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24cb9fc263bbba0a4b6a7a0d7b8c1d1b2cc7ec68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->