### PR TITLE
test: Fix timezone mismatch with unit test

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,8 @@
+# DO NOT store secrets or configuration here. Use `.metamaskrc` for that instead.
+
+# These environment variables are injected into any subprocess spawned by Yarn.
+
+# The timezone is set here to ensure our tests and builds use the same default timezone on all
+# machines, and because the default Node.js time zone cannot be changed after the process has
+# started (some APIs/libraries ignore later changes to process.env.TZ)
+TZ='UTC'

--- a/test/env.js
+++ b/test/env.js
@@ -15,6 +15,5 @@ process.env.PUSH_NOTIFICATIONS_SERVICE_URL =
   'https://mock-test-push-notifications-api.metamask.io';
 process.env.PORTFOLIO_URL = 'https://portfolio.test';
 process.env.METAMASK_VERSION = 'MOCK_VERSION';
-process.env.TZ = 'UTC';
 process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
 process.env.METAMASK_SHIELD_ENABLED = 'false';


### PR DESCRIPTION
## **Description**

The unit test `ui/components/app/transaction-activity-log/transaction-activity-log.component.test.js` was consistently failing locally because the snapshot was created using a `UTC` time zone, but I have a different local time zone.

We do try to normalize the timezone to `UTC` already in our test setup, but certain APIs (like the `Date` API) always use the original default time zone even after it has been updated.

Instead the timezone is now set to `UTC` by Yarn, using the `.env.yarn` file (see https://yarnpkg.com/configuration/yarnrc#injectEnvironmentFiles). This will more reliably normalize the timezone across all scripts/APIs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39378?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. In your terminal, ensure that `TZ` is set to something _other than_ UTC.
2. Run `yarn jest ./ui/components/app/transaction-activity-log/transaction-activity-log.component.test.js`
  * On `main`, this should fail with a snapshot error.
  * On this PR, it should pass.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes tests by enforcing a consistent UTC timezone across Yarn-run processes.
> 
> - Add `.env.yarn` setting `TZ='UTC'` so all Yarn subprocesses use UTC by default
> - Remove `process.env.TZ = 'UTC'` from `test/env.js` since Node’s timezone must be set before process start
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519c43ebc7f7f8377bb0980faa1787f2a04b5e17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->