### PR TITLE
test: fetch failures

### DIFF
--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5241,6 +5241,14 @@ describe('MetaMaskController', () => {
         }),
       });
 
+      // Prevent RemoteFeatureFlagController from making real fetches in this block.
+      jest
+        .spyOn(
+          metamaskController.remoteFeatureFlagController,
+          'updateRemoteFeatureFlags',
+        )
+        .mockResolvedValue();
+
       jest
         .spyOn(metamaskController, '_importAccountsWithBalances')
         .mockResolvedValue({});


### PR DESCRIPTION
Stub `updateRemoteFeatureFlags` in `metamask-controller.test.js` to prevent fetch failures in onboarding tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-4df7678b-7662-4753-9f43-50b9cdcdb55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4df7678b-7662-4753-9f43-50b9cdcdb55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

