### PR TITLE
fix: cp-13.15.0 make sure network icon is shown and correct network connected is displayed when connecting to a tron dapp

### DIFF
--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, RefObject, useMemo } from 'react';
+import React, { useContext, RefObject } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { parseCaipChainId } from '@metamask/utils';
 import {
@@ -20,8 +20,8 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { I18nContext } from '../../../contexts/i18n';
-import { getAllDomains, getOriginOfCurrentTab } from '../../../selectors';
-import { getNetworkConfigurationsByChainId } from '../../../../shared/modules/selectors/networks';
+import { getOriginOfCurrentTab } from '../../../selectors';
+import { getDappActiveNetwork } from '../../../selectors/dapp';
 import { getURLHost } from '../../../helpers/utils/util';
 import { getImageForChainId } from '../../../selectors/multichain';
 import { toggleNetworkMenu } from '../../../store/actions';
@@ -52,35 +52,11 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
   const siteHost = isWebOrigin ? getURLHost(activeTabOrigin) : '';
   const siteName = siteHost || t('urlUnknown');
 
-  const allDomains = useSelector(getAllDomains);
-  const networkConfigurationsByChainId = useSelector(
-    getNetworkConfigurationsByChainId,
-  );
   const dispatch = useDispatch();
 
-  // Get the network that this dapp is actually connected to using domain mapping
-  const dappActiveNetwork = useMemo(() => {
-    if (!activeTabOrigin || !allDomains) {
-      return null;
-    }
-
-    // Get the networkClientId for this domain
-    const networkClientId = allDomains[activeTabOrigin];
-    if (!networkClientId) {
-      return null;
-    }
-
-    // Find the network configuration that has this networkClientId
-    const networkConfiguration = Object.values(
-      networkConfigurationsByChainId,
-    ).find((network) => {
-      return network.rpcEndpoints.some(
-        (rpcEndpoint) => rpcEndpoint.networkClientId === networkClientId,
-      );
-    });
-
-    return networkConfiguration || null;
-  }, [activeTabOrigin, allDomains, networkConfigurationsByChainId]);
+  // Get the network that this dapp is actually connected to
+  // This handles both EVM and non-EVM networks (Solana, Bitcoin, Tron)
+  const dappActiveNetwork = useSelector(getDappActiveNetwork);
 
   const getChainIdForImage = (chainId: `${string}:${string}`): string => {
     const { namespace, reference } = parseCaipChainId(chainId);

--- a/ui/selectors/dapp.ts
+++ b/ui/selectors/dapp.ts
@@ -59,9 +59,11 @@ export const getDappActiveNetwork = createDeepEqualSelector(
         }
       }
     } else {
-      // TODO: Add support for other networks (Bitcoin, Solana)
-      const nonEvmScope = selectedAccount.scopes.find((scope: string) =>
-        scope.startsWith('solana:'),
+      const nonEvmScope = selectedAccount.scopes.find(
+        (scope: string) =>
+          scope.startsWith('solana:') ||
+          scope.startsWith('bip122:') ||
+          scope.startsWith('tron:'),
       );
 
       if (nonEvmScope) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the issue reported [here](https://github.com/MetaMask/metamask-extension/issues/39320), by removing inline `useMemo` logic in `ui/components/multichain/connected-site-popover/connected-site-popover.tsx` that only worked for EVM networks, and using the `getDappActiveNetwork` selector instead, while also adding tron and bitcoin support on  `ui/selectors/dapp.ts` so proper non-EVM network scope detection exists for other supported networks.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39386?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix network icon not shown and incorrect network connected displayed when connecting to a tron dapp

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39320

## **Manual testing steps**

1. Go to tron test dapp
2. Connect with only Tron network
3. Open side panel
4. See network icon next to the dapp icon
5. Click on the dapp icon
6. See correct network is displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/700cbd46-0803-4626-829f-9c5299e43365

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the connected-site popover shows the correct network and icon across EVM and non-EVM dapps.
> 
> - `ConnectedSitePopover`: replaced inline EVM-only `useMemo` logic with `useSelector(getDappActiveNetwork)` to determine the active dapp network and icon
> - `selectors/dapp`: expanded `getDappActiveNetwork` to detect non-EVM scopes (`solana:`, `bip122:`, `tron:`) and return matching multichain configs with an `isEvm` flag
> - Removed unused imports and EVM-only domain-to-network mapping in the component
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0bdff07da9a72b34b6f6b724cb4bbac0ad8b51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->