### PR TITLE
feat: MegaETH add infura RPC and blockscout URL

### DIFF
--- a/app/scripts/migrations/189.test.ts
+++ b/app/scripts/migrations/189.test.ts
@@ -1,0 +1,293 @@
+import { cloneDeep } from 'lodash';
+
+const mockUnitTestInfuraIdInitialValue = 'unitTestInfuraId';
+let mockUnitTestInfuraId: string | undefined = mockUnitTestInfuraIdInitialValue;
+
+jest.mock('../../../shared/constants/network', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  ...jest.requireActual('../../../shared/constants/network'),
+  get infuraProjectId() {
+    return mockUnitTestInfuraId;
+  },
+}));
+
+// eslint-disable-next-line import/first
+import {
+  migrate,
+  version,
+  MEGAETH_MAINNET_CHAIN_ID,
+  type VersionedData,
+} from './189';
+
+const VERSION = version;
+const oldVersion = VERSION - 1;
+
+const megaEthMainnetInitialConfiguration = {
+  [MEGAETH_MAINNET_CHAIN_ID]: {
+    chainId: MEGAETH_MAINNET_CHAIN_ID,
+    name: 'MegaETH Mainnet',
+    nativeCurrency: 'ETH',
+    blockExplorerUrls: ['https://explorer.com'],
+    defaultRpcEndpointIndex: 0,
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'megaeth-mainnet',
+        type: 'custom',
+        url: 'https://rpc.com',
+      },
+    ],
+  },
+};
+
+const MEGAETH_MAINNET_CLEAN_CONFIG = {
+  chainId: MEGAETH_MAINNET_CHAIN_ID,
+  name: 'MegaETH Mainnet',
+  nativeCurrency: 'ETH',
+  blockExplorerUrls: ['https://megaeth.blockscout.com'],
+  defaultRpcEndpointIndex: 0,
+  defaultBlockExplorerUrlIndex: 0,
+  rpcEndpoints: [
+    {
+      failoverUrls: [],
+      networkClientId: 'megaeth-mainnet',
+      type: 'custom',
+      url: `https://megaeth-mainnet.infura.io/v3/${mockUnitTestInfuraIdInitialValue}`,
+    },
+  ],
+};
+
+describe(`migration #${VERSION}`, () => {
+  let mockedCaptureException: jest.Mock;
+  beforeEach(() => {
+    mockedCaptureException = jest.fn();
+    global.sentry = { captureException: mockedCaptureException };
+    mockUnitTestInfuraId = mockUnitTestInfuraIdInitialValue;
+  });
+
+  afterEach(() => {
+    global.sentry = undefined;
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: {},
+          selectedNetworkClientId: 'mainnet',
+        },
+      },
+    };
+
+    const localChangedControllers = new Set<string>();
+    await migrate(oldStorage, localChangedControllers);
+
+    expect(oldStorage.meta).toStrictEqual({ version: VERSION });
+  });
+
+  const invalidStates = [
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {},
+      },
+      scenario: 'NetworkController not found',
+    },
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {
+          NetworkController: 'invalid',
+        },
+      },
+      scenario: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {
+          NetworkController: {},
+        },
+      },
+      scenario: 'missing networkConfigurationsByChainId property',
+    },
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {
+          NetworkController: {
+            networkConfigurationsByChainId: 'invalid',
+          },
+        },
+      },
+      scenario: 'invalid networkConfigurationsByChainId state',
+    },
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {
+          NetworkController: {
+            networkConfigurationsByChainId: {},
+          },
+        },
+      },
+      scenario: 'missing selectedNetworkClientId property',
+    },
+    {
+      state: {
+        meta: { version: VERSION },
+        data: {
+          NetworkController: {
+            networkConfigurationsByChainId: {},
+            selectedNetworkClientId: 123,
+          },
+        },
+      },
+      scenario: 'invalid selectedNetworkClientId type',
+    },
+  ];
+
+  // @ts-expect-error 'each' function is not recognized by TypeScript types
+  it.each(invalidStates)(
+    'should capture exception if $scenario',
+    async ({ state }: { errorMessage: string; state: VersionedData }) => {
+      const orgState = cloneDeep(state);
+      const localChangedControllers = new Set<string>();
+
+      await migrate(state, localChangedControllers);
+
+      // State should be unchanged
+      expect(state).toStrictEqual(orgState);
+      expect(localChangedControllers.has('NetworkController')).toBe(false);
+      expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    },
+  );
+
+  it('doesnt add the MegaETH network if not present', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: {},
+          selectedNetworkClientId: 'mainnet',
+        },
+      },
+    };
+
+    const localChangedControllers = new Set<string>();
+    await migrate(oldStorage, localChangedControllers);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    expect(
+      oldStorage.data.NetworkController.networkConfigurationsByChainId,
+    ).not.toHaveProperty(MEGAETH_MAINNET_CHAIN_ID);
+  });
+
+  // Covers both cases where RPC and Infura are already the right values
+  it('keeps MegaETH config as is if already present and clean', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: {
+            [MEGAETH_MAINNET_CLEAN_CONFIG.chainId]: {
+              ...MEGAETH_MAINNET_CLEAN_CONFIG,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      },
+    };
+
+    const localChangedControllers = new Set<string>();
+    await migrate(oldStorage, localChangedControllers);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+
+    const migratedConfig =
+      oldStorage.data.NetworkController.networkConfigurationsByChainId[
+        MEGAETH_MAINNET_CLEAN_CONFIG.chainId
+      ];
+    expect(migratedConfig).toStrictEqual(MEGAETH_MAINNET_CLEAN_CONFIG);
+  });
+
+  it('merges the MegaETH mainnet network configuration with both RPC and block exploer URL if user already has it', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: megaEthMainnetInitialConfiguration,
+          selectedNetworkClientId: 'mainnet',
+        },
+      },
+    };
+
+    const localChangedControllers = new Set<string>();
+    await migrate(oldStorage, localChangedControllers);
+
+    // After migration, the name and nativeCurrency should be updated
+    // and the new RPC endpoint should be added
+    const migratedConfig =
+      oldStorage.data.NetworkController.networkConfigurationsByChainId[
+        MEGAETH_MAINNET_CLEAN_CONFIG.chainId
+      ];
+    expect(migratedConfig.name).toBe(MEGAETH_MAINNET_CLEAN_CONFIG.name);
+    expect(migratedConfig.nativeCurrency).toBe(
+      MEGAETH_MAINNET_CLEAN_CONFIG.nativeCurrency,
+    );
+    expect(migratedConfig.rpcEndpoints).toHaveLength(2);
+    expect(migratedConfig.rpcEndpoints[0].url).toBe('https://rpc.com');
+    expect(migratedConfig.rpcEndpoints[1].url).toBe(
+      `https://megaeth-mainnet.infura.io/v3/${mockUnitTestInfuraId}`,
+    );
+    expect(migratedConfig.defaultRpcEndpointIndex).toBe(1);
+    expect(migratedConfig.blockExplorerUrls).toEqual([
+      'https://explorer.com',
+      'https://megaeth.blockscout.com',
+    ]);
+    expect(migratedConfig.defaultBlockExplorerUrlIndex).toBe(1);
+  });
+
+  it('only changes the blockExplorer RPC when Infura key project ID doesnt exist', async () => {
+    mockUnitTestInfuraId = undefined;
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {
+        NetworkController: {
+          networkConfigurationsByChainId: megaEthMainnetInitialConfiguration,
+          selectedNetworkClientId: 'mainnet',
+        },
+      },
+    };
+
+    const localChangedControllers = new Set<string>();
+    await migrate(oldStorage, localChangedControllers);
+
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Infura project ID is not set, skip the MegaETH RPC part of the migration',
+        ),
+      }),
+    );
+    // After migration, the name and nativeCurrency should be updated
+    // and the new RPC endpoint should be added
+    const migratedConfig =
+      oldStorage.data.NetworkController.networkConfigurationsByChainId[
+        MEGAETH_MAINNET_CLEAN_CONFIG.chainId
+      ];
+    expect(migratedConfig.name).toBe(MEGAETH_MAINNET_CLEAN_CONFIG.name);
+    expect(migratedConfig.nativeCurrency).toBe(
+      MEGAETH_MAINNET_CLEAN_CONFIG.nativeCurrency,
+    );
+    expect(migratedConfig.rpcEndpoints).toHaveLength(1);
+    expect(migratedConfig.rpcEndpoints[0].url).toBe('https://rpc.com');
+    expect(migratedConfig.defaultRpcEndpointIndex).toBe(0);
+    expect(migratedConfig.blockExplorerUrls).toEqual([
+      'https://explorer.com',
+      'https://megaeth.blockscout.com',
+    ]);
+    expect(migratedConfig.defaultBlockExplorerUrlIndex).toBe(1);
+  });
+});

--- a/app/scripts/migrations/189.ts
+++ b/app/scripts/migrations/189.ts
@@ -1,0 +1,280 @@
+import {
+  getErrorMessage,
+  hasProperty,
+  Hex,
+  isHexString,
+  isObject,
+} from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+import { v4 } from 'uuid';
+import { captureException } from '../../../shared/lib/sentry';
+import { infuraProjectId } from '../../../shared/constants/network';
+
+export type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+/**
+ * A Copy of the RpcEndpoint type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+type RpcEndpoint = {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+};
+
+/**
+ * A Copy of the NetworkConfiguration type from the network controller,
+ * This is used to avoid the dependency on the network controller.
+ */
+type NetworkConfiguration = {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+};
+
+export const version = 189;
+
+export const MEGAETH_MAINNET_CHAIN_ID: string = '0x10e6';
+
+/**
+ * This migration does:
+ * - Update the MegaETH Mainnet network configuration if present set RPC endpoint URL to Infura and Block Explorer to Blockscout.
+ *
+ * @param versionedData - Versioned MetaMask extension state, exactly
+ * what we persist to disk.
+ * @param localChangedControllers - A set of controller keys that have been changed by the migration.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  versionedData: VersionedData,
+  localChangedControllers: Set<string>,
+): Promise<void> {
+  versionedData.meta.version = version;
+  const changedVersionedData = cloneDeep(versionedData);
+  const changedLocalChangedControllers = new Set<string>();
+
+  try {
+    transformState(changedVersionedData.data, changedLocalChangedControllers);
+    versionedData.data = changedVersionedData.data;
+    changedLocalChangedControllers.forEach((controller) =>
+      localChangedControllers.add(controller),
+    );
+  } catch (error) {
+    console.error(error);
+    const newError = new Error(
+      `Migration #${version}: ${getErrorMessage(error)}`,
+    );
+    captureException(newError);
+    // Even though we encountered an error, we need the migration to pass for
+    // the migrator tests to work
+  }
+}
+
+function transformState(
+  state: Record<string, unknown>,
+  changedLocalChangedControllers: Set<string>,
+) {
+  const networkControllerState = validateNetworkController(state);
+  if (networkControllerState === undefined) {
+    // There used to be a warning "Migration 189: Missing or invalid NetworkController state, skip the migration"
+    // But it is expected during some tests and caused new baseline violations se we removed it.
+    return state;
+  }
+
+  const { networkConfigurationsByChainId } = networkControllerState;
+  // Migrate NetworkController:
+  // - Migrates the MegaETH Mainnet network configuration if user already has it.
+  if (hasProperty(networkConfigurationsByChainId, MEGAETH_MAINNET_CHAIN_ID)) {
+    const megaethMainnetConfiguration =
+      networkConfigurationsByChainId[MEGAETH_MAINNET_CHAIN_ID];
+
+    if (!isValidNetworkConfiguration(megaethMainnetConfiguration)) {
+      console.warn(
+        `Migration ${version}: Invalid MegaETH Mainnet network configuration, skip the migration`,
+      );
+      return state;
+    }
+
+    mergeMegaEthMainnetNetworkConfiguration(megaethMainnetConfiguration);
+    changedLocalChangedControllers.add('NetworkController');
+  }
+
+  return state;
+}
+
+function mergeMegaEthMainnetNetworkConfiguration(
+  megaethMainnetConfiguration: NetworkConfiguration,
+) {
+  // If the Infura Project ID is set and the same RPC doesn't already exist, we add it and set by default
+  if (infuraProjectId) {
+    const newInfuraURL = `https://megaeth-mainnet.infura.io/v3/${infuraProjectId}`;
+    const isInfuraRpcPresent = megaethMainnetConfiguration.rpcEndpoints.find(
+      (rpc) => rpc.url === newInfuraURL,
+    );
+    // Avoid RPC duplication if Infura is already present.
+    if (!isInfuraRpcPresent) {
+      megaethMainnetConfiguration.rpcEndpoints.push({
+        failoverUrls: [],
+        networkClientId: v4(),
+        type: 'custom',
+        url: newInfuraURL,
+      });
+      megaethMainnetConfiguration.defaultRpcEndpointIndex =
+        megaethMainnetConfiguration.rpcEndpoints.length - 1;
+    }
+  } else {
+    captureException(
+      new Error(
+        `Migration ${version}: Infura project ID is not set, skip the MegaETH RPC part of the migration`,
+      ),
+    );
+  }
+
+  // If  Blockscout is not part of the already present explorers, add it and set as default.
+  const newBlockExplorerUrl = 'https://megaeth.blockscout.com';
+  const isBlockExplorerUrlExist =
+    megaethMainnetConfiguration.blockExplorerUrls.find(
+      (url) => url.includes(newBlockExplorerUrl), // Using "includes" for in case of trailing slash.
+    );
+  if (!isBlockExplorerUrlExist) {
+    megaethMainnetConfiguration.blockExplorerUrls.push(newBlockExplorerUrl);
+    megaethMainnetConfiguration.defaultBlockExplorerUrlIndex =
+      megaethMainnetConfiguration.blockExplorerUrls.length - 1;
+  }
+}
+
+function validateNetworkController(state: Record<string, unknown>):
+  | {
+      networkConfigurationsByChainId: Record<Hex, unknown>;
+      selectedNetworkClientId: string;
+    }
+  | undefined {
+  if (!hasProperty(state, 'NetworkController')) {
+    // We catch the exception here, as we don't expect the NetworkController state is missing.
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: missing NetworkController`,
+      ),
+    );
+    return undefined;
+  }
+
+  const networkControllerState = state.NetworkController;
+
+  // To narrow the type of the networkControllerState to the expected type.
+  if (!isValidNetworkControllerState(networkControllerState)) {
+    return undefined;
+  }
+
+  return networkControllerState;
+}
+
+function isValidNetworkControllerState(value: unknown): value is {
+  networkConfigurationsByChainId: Record<Hex, unknown>;
+  selectedNetworkClientId: string;
+} {
+  if (!isObject(value)) {
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: NetworkController state is not an object: '${typeof value}'`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'networkConfigurationsByChainId')) {
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: missing networkConfigurationsByChainId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (
+    !isValidNetworkConfigurationsByChainId(value.networkConfigurationsByChainId)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: networkConfigurationsByChainId is not a valid Record<Hex, unknown>`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'selectedNetworkClientId')) {
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: missing selectedNetworkClientId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (typeof value.selectedNetworkClientId !== 'string') {
+    captureException(
+      new Error(
+        `Migration ${version}: Invalid NetworkController state: selectedNetworkClientId is not a string: '${typeof value.selectedNetworkClientId}'`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function isValidNetworkConfigurationsByChainId(
+  value: unknown,
+): value is Record<Hex, unknown> {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([chainId]) => typeof chainId === 'string' && isHexString(chainId),
+    )
+  );
+}
+
+function isValidNetworkConfiguration(
+  object: unknown,
+): object is NetworkConfiguration {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'chainId') &&
+    typeof object.chainId === 'string' &&
+    isHexString(object.chainId) &&
+    hasProperty(object, 'rpcEndpoints') &&
+    Array.isArray(object.rpcEndpoints) &&
+    object.rpcEndpoints.every(isValidRpcEndpoint) &&
+    hasProperty(object, 'name') &&
+    typeof object.name === 'string' &&
+    hasProperty(object, 'nativeCurrency') &&
+    typeof object.nativeCurrency === 'string' &&
+    hasProperty(object, 'blockExplorerUrls') &&
+    Array.isArray(object.blockExplorerUrls) &&
+    object.blockExplorerUrls.every((url) => typeof url === 'string') &&
+    hasProperty(object, 'defaultRpcEndpointIndex') &&
+    typeof object.defaultRpcEndpointIndex === 'number' &&
+    (!hasProperty(object, 'defaultBlockExplorerUrlIndex') ||
+      (hasProperty(object, 'defaultBlockExplorerUrlIndex') &&
+        typeof object.defaultBlockExplorerUrlIndex === 'number'))
+  );
+}
+
+function isValidRpcEndpoint(object: unknown): boolean {
+  return (
+    isObject(object) &&
+    hasProperty(object, 'networkClientId') &&
+    typeof object.networkClientId === 'string' &&
+    hasProperty(object, 'url') &&
+    typeof object.url === 'string'
+  );
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -224,6 +224,7 @@ const migrations = [
   require('./186'),
   require('./187'),
   require('./188'),
+  require('./189'),
 ];
 
 export default migrations;

--- a/shared/constants/common.ts
+++ b/shared/constants/common.ts
@@ -32,8 +32,9 @@ const MONAD_DEFAULT_BLOCK_EXPLORER_URL = 'https://monadscan.com/';
 const MONAD_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'MonadScan';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_URL = 'https://hyperevmscan.io/';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'HyperEVMScan';
-const MEGAETH_DEFAULT_BLOCK_EXPLORER_URL = 'https://explorer.megaeth.com/';
-const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'MegaExplorer';
+const MEGAETH_DEFAULT_BLOCK_EXPLORER_URL = 'https://megaeth.blockscout.com/';
+const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL =
+  'MEGA Mainnet Explorer';
 
 type BlockExplorerUrlMap = {
   [key: string]: string;

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -1675,12 +1675,13 @@ export const FEATURED_RPCS: AddNetworkFields[] = [
     nativeCurrency: CURRENCY_SYMBOLS.ETH,
     rpcEndpoints: [
       {
-        url: `https://mainnet.megaeth.com/rpc`,
+        url: `https://megaeth-mainnet.infura.io/v3/${infuraProjectId}`,
+        failoverUrls: [],
         type: RpcEndpointType.Custom,
       },
     ],
     defaultRpcEndpointIndex: 0,
-    blockExplorerUrls: ['https://explorer.megaeth.com/'],
+    blockExplorerUrls: ['https://megaeth.blockscout.com/'],
     defaultBlockExplorerUrlIndex: 0,
   },
 ];

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -316,5 +316,5 @@
     "config": "object",
     "firstTimeInfo": "object"
   },
-  "meta": { "version": 188 }
+  "meta": { "version": 189 }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Infura to support MegaETH.
- Blockscout to become the preferred block explorer for MegaETH.
--> This PR updates the RPC and block explorer URL of MegaETH.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39398?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update MegaETH RPC (Infura) and explorer (Blockscout) URLs

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-69?atlOrigin=eyJpIjoiNmZhYmQ4OTI5Njg0NDYwYjk3NDk2NTFmNTM1YmYzN2YiLCJwIjoiaiJ9

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/0970816c-206b-4e32-9f16-108938df7bc4" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates MegaETH Mainnet RPC and block explorer across constants and via a migration.
> 
> - Adds migration `189` to update existing `MegaETH Mainnet` configs: append Infura RPC `https://megaeth-mainnet.infura.io/v3/${infuraProjectId}` (set as default if added) and add Blockscout `https://megaeth.blockscout.com` as default explorer; validates `NetworkController` state and captures errors; no-op if MegaETH config absent
> - Updates built-in network constants to use the new MegaETH Infura RPC and Blockscout URLs; adjusts human-readable explorer name
> - Registers migration in `migrations/index.js` and bumps snapshot `meta.version` to `189`
> - Adds comprehensive tests for migration behavior, including invalid states and missing Infura project ID
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 976a05d6bb3ed2e8f3215ccba8cd778355a20c2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->