### PR TITLE
test: Fix `metamask-controller` unit test fetch errors

### DIFF
--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -430,10 +430,7 @@ describe('MetaMaskController', () => {
       .persist()
       .get('/v1/flags')
       .query(true)
-      .reply(
-        200,
-        JSON.stringify([]),
-      );
+      .reply(200, JSON.stringify([]));
 
     globalThis.sentry = {
       withIsolationScope: jest.fn(),

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -415,6 +415,17 @@ describe('MetaMaskController', () => {
           },
         ]),
       );
+    nock('https:///client-side-detection.api.cx.metamask.io')
+      .persist()
+      .get('/v1/request-blocklist')
+      .reply(
+        200,
+        JSON.stringify({
+          recentlyAdded: [],
+          recentlyRemoved: [],
+          lastFetchedAt: 0,
+        }),
+      );
 
     globalThis.sentry = {
       withIsolationScope: jest.fn(),

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -415,7 +415,7 @@ describe('MetaMaskController', () => {
           },
         ]),
       );
-    nock('https:///client-side-detection.api.cx.metamask.io')
+    nock('https://client-side-detection.api.cx.metamask.io')
       .persist()
       .get('/v1/request-blocklist')
       .reply(

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -430,7 +430,15 @@ describe('MetaMaskController', () => {
       .persist()
       .get('/v1/flags')
       .query(true)
-      .reply(200, JSON.stringify([]));
+      .reply(
+        200,
+        JSON.stringify([
+          {
+            // Required by validation in controller
+            smartTransactionsNetworks: {},
+          },
+        ]),
+      );
 
     globalThis.sentry = {
       withIsolationScope: jest.fn(),

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -426,6 +426,14 @@ describe('MetaMaskController', () => {
           lastFetchedAt: 0,
         }),
       );
+    nock('https://client-config.api.cx.metamask.io')
+      .persist()
+      .get('/v1/flags')
+      .query(true)
+      .reply(
+        200,
+        JSON.stringify([]),
+      );
 
     globalThis.sentry = {
       withIsolationScope: jest.fn(),

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -88,7 +88,6 @@
       "error: TypeError: Cannot convert undefined or": 2,
       "error: Error: invalid address (argument=\"address\", value=\"0x\",": 2,
       "MetaMask: Chain processing errors": 2,
-      "Test errors: Fetch failures": 5,
       "ObjectMultiplex: Malformed chunk warnings": 1,
       "error: { name: 'controller', data: {": 1,
       "MetaMask: MetaMetrics invalid trait types": 2,

--- a/test/jest/console-reporter-rules-unit.js
+++ b/test/jest/console-reporter-rules-unit.js
@@ -266,6 +266,7 @@ module.exports = [
   {
     match: /FetchError \{/u,
     group: 'Test errors: Fetch failures',
+    keep: true,
   },
 
   // ===========================================================================


### PR DESCRIPTION
## **Description**

Console errors about failing to fetch from the `metamask-controller.test.js` unit tests have been fixed by adding a fetch mock. The fetch errors have been removed from the baseline as well.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39402?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. Run `yarn jest ./app/scripts/metamask-controller.test.js`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes failing fetches in unit tests by mocking external services.
> 
> - Adds `nock` mocks in `metamask-controller.test.js` for `GET /v1/request-blocklist` (client-side-detection) and `GET /v1/flags` (client-config) to satisfy controller validation and prevent network errors
> - Updates `console-baseline-unit.json` to remove "Test errors: Fetch failures"
> - Adjusts `console-reporter-rules-unit.js` to mark "Test errors: Fetch failures" group with `keep: true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88b2c4b021b5b7803805390d7a635f6aaf6527d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->