### PR TITLE
chore: swap out defi referrals boolean flag to new json flag

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5913,9 +5913,8 @@ export default class MetamaskController extends EventEmitter {
    */
   async handleDefiReferral(partner, tabId, triggerType) {
     const isReferralEnabled =
-      this.remoteFeatureFlagController?.state?.remoteFeatureFlags?.[
-        partner.featureFlagKey
-      ];
+      this.remoteFeatureFlagController?.state?.remoteFeatureFlags
+        ?.extensionUxDefiReferralPartners?.[partner.id];
 
     if (!isReferralEnabled) {
       return;

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -4516,7 +4516,9 @@ describe('MetaMaskController', () => {
           .spyOn(metamaskController.remoteFeatureFlagController, 'state', 'get')
           .mockReturnValue({
             remoteFeatureFlags: {
-              extensionUxDefiReferral: true,
+              extensionUxDefiReferralPartners: {
+                [DefiReferralPartner.Hyperliquid]: true,
+              },
             },
           });
         jest.spyOn(metamaskController.approvalController, 'add');
@@ -4537,7 +4539,9 @@ describe('MetaMaskController', () => {
           .spyOn(metamaskController.remoteFeatureFlagController, 'state', 'get')
           .mockReturnValueOnce({
             remoteFeatureFlags: {
-              extensionUxDefiReferral: false,
+              extensionUxDefiReferralPartners: {
+                [DefiReferralPartner.Hyperliquid]: false,
+              },
             },
           });
         jest.spyOn(metamaskController, 'getPermittedAccounts');

--- a/shared/constants/defi-referrals.ts
+++ b/shared/constants/defi-referrals.ts
@@ -22,8 +22,6 @@ export type DefiReferralPartnerConfig = {
   learnMoreUrl: string;
   /** Approval type string for ApprovalController */
   approvalType: string;
-  /** Remote feature flag key to check if referral is enabled */
-  featureFlagKey: string;
 };
 
 /**
@@ -40,7 +38,6 @@ export const DEFI_REFERRAL_PARTNERS: Record<
     referralUrl: 'https://app.hyperliquid.xyz/join/MMREFCSI',
     learnMoreUrl: 'https://hyperliquid.gitbook.io/hyperliquid-docs/referrals',
     approvalType: 'hyperliquid_referral_consent',
-    featureFlagKey: 'extensionUxDefiReferral',
   },
   // [DefiReferralPartner.AsterDex]: {
   //   id: DefiReferralPartner.AsterDex,
@@ -49,7 +46,6 @@ export const DEFI_REFERRAL_PARTNERS: Record<
   //   referralUrl: 'https://www.asterdex.com/en/referral/wsuZBc',
   //   learnMoreUrl: 'https://docs.asterdex.com/product/aster-perpetuals/referral-program',
   //   approvalType: 'asterdex_referral_consent',
-  //   featureFlagKey: 'tbd',
   // },
 };
 


### PR DESCRIPTION
## **Description**

The old `extensionUxDefiReferral` flag was a boolean that doesn't scale well to multiple referral partners. 

To avoid creating a new flag for each new referral partner, a new `extensionUxDefiReferralPartners` flag has been created containing an object to house any number of referral partners, e.g.
```
{
  "asterdex": false,
  "hyperliquid": true
}
```

The keys in this new flag match up to the `DefiReferralPartner`s in the codebase. This PR migrates the existing code to use the new flag. The old flag will be maintained in LD and left ON so that older app users still receive the correct flag values.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-744

## **Manual testing steps**

[Flag](https://app.launchdarkly.com/projects/metamask-client-config-api-extension/flags/extension-ux-defi-referral-partners/targeting?env=main-dev&env=test&env=production&selected-env=main-dev) in ON in main-dev.

1. Go to Hyperliquid app
2. Connect with an account that doesn't have a referral code applied
3. See the MetaMask referral screen after connection

Turn flag OFF in main-dev and wait 15 minutes

1. Go to Hyperliquid app
2. Connect with an account that doesn't have a referral code applied
3. Verify no MetaMask referral screen is shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates DeFi referral gating from a single boolean to a partner-scoped JSON flag.
> 
> - `handleDefiReferral` now checks `remoteFeatureFlags.extensionUxDefiReferralPartners[partner.id]` instead of a global flag
> - Removes `featureFlagKey` from `DefiReferralPartnerConfig` and corresponding usage in `DEFI_REFERRAL_PARTNERS`
> - Updates tests to mock `extensionUxDefiReferralPartners` and verify early return when a partner flag is disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d575778d6128501d990d01698313c612321c269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->