### PR TITLE
fix: state update on unmounted component

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -154,7 +154,6 @@ export const AccountOverviewTabs = ({
       <AssetListTokenDetection />
 
       <Tabs<AccountOverviewTab>
-        defaultActiveTabKey={activeTabKey ?? undefined}
         activeTabKey={activeTabKey}
         onTabClick={handleTabClick}
         tabListProps={{

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -47,7 +47,7 @@ export const Tabs = <TKey extends string = string>({
   );
 
   const [activeTabIndex, setActiveTabIndex] = useState<number>(() =>
-    Math.max(findChildByKey(defaultActiveTabKey), 0),
+    Math.max(findChildByKey(activeTabKey ?? defaultActiveTabKey), 0),
   );
 
   useEffect(() => {

--- a/ui/hooks/useIsOriginalNativeTokenSymbol.ts
+++ b/ui/hooks/useIsOriginalNativeTokenSymbol.ts
@@ -25,6 +25,8 @@ export function useIsOriginalNativeTokenSymbol(
   const providerConfig = useSelector(getMultichainCurrentNetwork);
 
   useEffect(() => {
+    let isMounted = true;
+
     const isLocalhost = (urlString: string) => {
       const url = getValidUrl(urlString);
 
@@ -53,10 +55,18 @@ export function useIsOriginalNativeTokenSymbol(
           useAPICall: useSafeChainsListValidation,
         });
 
-        setIsOriginalNativeSymbol(isOriginalNativeToken);
+        if (isMounted) {
+          setIsOriginalNativeSymbol(isOriginalNativeToken);
+        }
       } catch (err) {
-        setIsOriginalNativeSymbol(false);
+        if (isMounted) {
+          setIsOriginalNativeSymbol(false);
+        }
       }
+
+      return () => {
+        isMounted = false;
+      };
     }
 
     getNativeTokenSymbol(chainId);

--- a/ui/hooks/useIsOriginalNativeTokenSymbol.ts
+++ b/ui/hooks/useIsOriginalNativeTokenSymbol.ts
@@ -63,13 +63,13 @@ export function useIsOriginalNativeTokenSymbol(
           setIsOriginalNativeSymbol(false);
         }
       }
-
-      return () => {
-        isMounted = false;
-      };
     }
 
     getNativeTokenSymbol(chainId);
+
+    return () => {
+      isMounted = false;
+    };
   }, [
     isOriginalNativeSymbol,
     chainId,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removing the unnecessary `defaultActiveTabKey` of Tabs exposed an issue with the `useIsOriginalNativeTokenSymbol` hook - its async task to update state is left hanging once the component is unmounted. This fixes that hook.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39411?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

Should not see a lint violation 

Tabs work as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Tabs initialization**: `ui/components/ui/tabs/tabs.tsx` now derives initial `activeTabIndex` from `activeTabKey` (fallback to `defaultActiveTabKey`) and `account-overview-tabs.tsx` drops `defaultActiveTabKey` prop, relying solely on `activeTabKey`.
> - **Unmount safety**: `useIsOriginalNativeTokenSymbol` adds an `isMounted` guard and cleanup to avoid async `setState` on unmounted components, wrapping both success and error paths.
> 
> Minor: No functional changes to tab rendering beyond initialization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc0e63a5474df8230db1e65f3bf06f906b62232f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->