### PR TITLE
fix: Properly cleanup seen requests in dupeReqFilterStream

### DIFF
--- a/app/scripts/lib/createDupeReqFilterStream.ts
+++ b/app/scripts/lib/createDupeReqFilterStream.ts
@@ -41,7 +41,7 @@ const makeExpirySet = () => {
     },
 
     /**
-     * Destroy the set and tear down the underlying timer.
+     * Clear the map and tear down the underlying timer.
      */
     destroy() {
       clearInterval(timerId);

--- a/app/scripts/lib/createDupeReqFilterStream.ts
+++ b/app/scripts/lib/createDupeReqFilterStream.ts
@@ -13,7 +13,7 @@ export const THREE_MINUTES = MINUTE * 3;
 const makeExpirySet = () => {
   const map: Map<string | number | null, number> = new Map();
 
-  setInterval(() => {
+  const timerId = setInterval(() => {
     const cutoffTime = Date.now() - THREE_MINUTES;
 
     for (const [id, timestamp] of map.entries()) {
@@ -39,6 +39,14 @@ const makeExpirySet = () => {
       }
       return false;
     },
+
+    /**
+     * Destroy the set and tear down the underlying timer.
+     */
+    destroy() {
+      clearInterval(timerId);
+      map.clear();
+    }
   };
 };
 
@@ -62,6 +70,10 @@ export default function createDupeReqFilterStream() {
         log.debug(`RPC request with id "${chunk.id}" already seen.`);
         cb();
       }
+    },
+    destroy(error, cb) {
+      seenRequestIds.destroy();
+      cb(error);
     },
     objectMode: true,
   });

--- a/app/scripts/lib/createDupeReqFilterStream.ts
+++ b/app/scripts/lib/createDupeReqFilterStream.ts
@@ -46,7 +46,7 @@ const makeExpirySet = () => {
     destroy() {
       clearInterval(timerId);
       map.clear();
-    }
+    },
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ensure the "expiry set" for each filter stream is properly cleaned up when the stream is destroyed. Otherwise we leave running intervals and memory used for maps with every single page the user visits.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39415?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Reduce memory usage when visiting dapps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures proper teardown of the dupe-request filter’s internal state to avoid lingering timers and memory usage.
> 
> - Capture interval handle (`timerId`) in `makeExpirySet` and add `destroy()` to clear the interval and map
> - Implement `destroy(error, cb)` in `createDupeReqFilterStream` to call `seenRequestIds.destroy()` on stream teardown
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 506de5725a5fec34429d115f0083c879a0a5d014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->