### PR TITLE
fix: cp-13.15.0 feature flag blacklist network filtering missing in manage networks

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -71,6 +71,7 @@ import {
   getNetworkDiscoverButtonEnabled,
   getAllChainsToPoll,
 } from '../../../selectors';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../selectors/network-blacklist/network-blacklist';
 import ToggleButton from '../../ui/toggle-button';
 import {
   Display,
@@ -103,6 +104,7 @@ import {
   getNetworkIcon,
   getRpcDataByChainId,
   sortNetworksByPrioity,
+  getFilteredFeaturedNetworks,
 } from '../../../../shared/modules/network.utils';
 import {
   getCompletedOnboarding,
@@ -193,6 +195,10 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
   );
 
   const allChainIds = useSelector(getAllChainsToPoll);
+  // Get blacklisted chain IDs from feature flag
+  const blacklistedChainIds = useSelector(
+    selectAdditionalNetworksBlacklistFeatureFlag,
+  );
   const canSelectNetwork: boolean =
     Boolean(selectedTabOrigin) &&
     Boolean(domains[selectedTabOrigin]) &&
@@ -277,13 +283,21 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
     }
   };
 
-  const featuredNetworksNotYetEnabled = useMemo(
-    () =>
-      FEATURED_RPCS.filter(({ chainId }) => !evmNetworks[chainId]).sort(
-        (a, b) => a.name.localeCompare(b.name),
-      ),
-    [evmNetworks],
-  );
+  const featuredNetworksNotYetEnabled = useMemo(() => {
+    // Filter out networks that are already enabled
+    const availableNetworks = FEATURED_RPCS.filter(
+      ({ chainId }) => !evmNetworks[chainId],
+    );
+
+    // Apply blacklist filter to exclude blacklisted networks
+    const filteredNetworks = getFilteredFeaturedNetworks(
+      blacklistedChainIds,
+      availableNetworks,
+    );
+
+    // Sort alphabetically
+    return filteredNetworks.sort((a, b) => a.name.localeCompare(b.name));
+  }, [evmNetworks, blacklistedChainIds]);
 
   // This value needs to be tracked in case the user changes to a Non EVM
   // network and there is no account created for that network. This will


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39416?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix feature flag blacklist network filtering missing in manage networks

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39216

## **Manual testing steps**

1. Go to the networks
2. Ensure MegaETH does not display

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="402" height="815" alt="Screenshot 2026-01-21 at 10 15 59" src="https://github.com/user-attachments/assets/6956bf86-85ba-4ee1-802a-a5bcaaa47bcd" />

<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements feature-flag-driven filtering of featured networks in the Manage Networks UI.
> 
> - Reads blacklisted chain IDs via `selectAdditionalNetworksBlacklistFeatureFlag`
> - Applies `getFilteredFeaturedNetworks` to `FEATURED_RPCS` when computing `featuredNetworksNotYetEnabled` in `network-list-menu.tsx`
> - Preserves existing behavior (exclude already-enabled networks, then sort alphabetically) before rendering `PopularNetworkList`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5a243588659819cbbb2691243a3e8c057fea652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->