### PR TITLE
chore: reduce e2e quality gate extra runs to avoid Cancelled jobs by timeout

### DIFF
--- a/.github/scripts/split-tests-by-timings.ts
+++ b/.github/scripts/split-tests-by-timings.ts
@@ -7,8 +7,8 @@ import {
   TestRun,
 } from './shared/test-reports';
 
-// Quality Gate Retries
-const RETRIES_FOR_NEW_OR_CHANGED_TESTS = 4;
+// Extra Quality Gate Runs for each new/changed test
+const RETRIES_FOR_NEW_OR_CHANGED_TESTS = 2;
 
 function readTestResults(TEST_RESULTS_PATH: string): TestRun {
   const testSuiteName =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a challenge with the current e2e quality gate re-runs which is that given there are 1+4 runs for each new/changed spec file, ci sometimes reaches the job limit of 30mins, timing out the e2e jobs.

See example of ocurrence here: https://github.com/MetaMask/metamask-extension/pull/39375#issuecomment-3776710161

or here:

<img width="573" height="346" alt="image" src="https://github.com/user-attachments/assets/ab4b65f3-378a-4f49-8d22-8d84d51e4ab3" />

This PR reduces the number of e2e extra runs to avoid Cancelled jobs by timeout.
Now we'll do 1+2, which seems a more balanced approach: still enough for capturing new flakiness (note that there are 2 extra runs on each build, meaning 12 runs from the same test in total), but at the same time, good for avoiding job timeouts.

Suggested by @jvbriones 



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39420?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
