### PR TITLE
fix: fixed stop subscription polling

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -8532,6 +8532,9 @@ export default class MetamaskController extends EventEmitter {
         await this.seedlessOnboardingController.setLocked();
       }
       await this.keyringController.setLocked();
+
+      // stop polling for the subscriptions when the wallet is locked manually and window/side-panel is still open
+      this.subscriptionController.stopAllPolling();
     } catch (error) {
       log.error('Error setting locked state', error);
       throw error;

--- a/shared/constants/subscriptions.ts
+++ b/shared/constants/subscriptions.ts
@@ -88,3 +88,11 @@ export enum ShieldUnexpectedErrorEventLocationEnum {
   ShieldPlanPage = 'shield_plan_page',
   Other = 'other',
 }
+
+/**
+ * The input used to poll for subscriptions.
+ *
+ * We need to provide this value to compute the subscription requests polling `key` in the polling controller.
+ * We need to provide this value to start/stop the polling for subscriptions.
+ */
+export const SUBSCRIPTIONS_POLLING_INPUT = 'subscriptionsPollingInput';

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -204,6 +204,7 @@ import {
 } from '../../shared/types';
 // eslint-disable-next-line import/no-restricted-paths
 import { OAuthLoginResult } from '../../app/scripts/services/oauth/types';
+import { SUBSCRIPTIONS_POLLING_INPUT } from '../../shared/constants/subscriptions';
 import * as actionConstants from './actionConstants';
 
 import {
@@ -416,7 +417,9 @@ export function subscriptionsStartPolling(): ThunkAction<
     try {
       const pollingToken = await submitRequestToBackground(
         'subscriptionsStartPolling',
-        [],
+        // We need to provide the polling input when start polling
+        // Otherwise, stop polling won't work with `undefined` input.
+        [SUBSCRIPTIONS_POLLING_INPUT],
       );
       return pollingToken;
     } catch (error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes stop the subscription polling when the wallet is locked or the wallet window/sidepanel is no longer active.

Issue:
When we start the subscription polling via `subscriptionController.startPolling`, we don't provide any input param which will be used to generate the **polling interval key** in the `@metamask/polling-controller`. 
This results in failure to stop the polling inside `subscriptionController.stopAllPolling`.

Fix:
Provide the hardcoded constant value (`subscriptionsPollingInput`) when start the polling so that the stop will successfully cancel the polling interval.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39435?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed subscription polling when wallet is locked or the wallet window/sidepanel/pop-up is no longer active.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f06008da3d856c1e4962ee13ee03460f6014bebf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->