### PR TITLE
fix: align additional networks info icon

### DIFF
--- a/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AdditionalNetworksInfo renders correctly 1`] = `
       class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
     >
       <div
-        class="mm-box mm-box--display-inline-flex mm-box--align-items-center"
+        class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
       >
         <p
           class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative"
@@ -17,7 +17,7 @@ exports[`AdditionalNetworksInfo renders correctly 1`] = `
           Additional networks
         </p>
         <div
-          class="mm-box"
+          class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
         >
           <span
             class="mm-box add-network__warning-icon mm-icon mm-icon--size-md mm-box--margin-left-2 mm-box--display-inline-block mm-box--color-icon-alternative"

--- a/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AdditionalNetworksInfo renders correctly 1`] = `
       class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
     >
       <div
-        class="mm-box mm-box--display-inline-flex"
+        class="mm-box mm-box--display-inline-flex mm-box--align-items-center"
       >
         <p
           class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative"
@@ -17,10 +17,10 @@ exports[`AdditionalNetworksInfo renders correctly 1`] = `
           Additional networks
         </p>
         <div
-          class="mm-box mm-box--margin-top-1"
+          class="mm-box"
         >
           <span
-            class="mm-box add-network__warning-icon mm-icon mm-icon--size-sm mm-box--margin-left-2 mm-box--display-inline-block mm-box--color-icon-muted"
+            class="mm-box add-network__warning-icon mm-icon mm-icon--size-md mm-box--margin-left-2 mm-box--display-inline-block mm-box--color-icon-alternative"
             style="mask-image: url('./images/icons/info.svg');"
           />
         </div>

--- a/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
@@ -66,8 +66,9 @@ export const AdditionalNetworksInfo = memo(() => {
       <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
         {/* Container for the "Additional Networks" text and info icon */}
         <Box
-          display={Display.InlineFlex}
+          display={Display.Flex}
           alignItems={AlignItems.center}
+          justifyContent={JustifyContent.center}
           ref={setBoxRef}
         >
           {/* Label text - uses translation key "additionalNetworks" */}
@@ -79,7 +80,11 @@ export const AdditionalNetworksInfo = memo(() => {
           </Text>
 
           {/* Info icon with hover trigger for popover */}
-          <Box>
+          <Box
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            justifyContent={JustifyContent.center}
+          >
             <Icon
               onMouseEnter={handleMouseEnter}
               className="add-network__warning-icon"

--- a/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useState } from 'react';
 import {
+  AlignItems,
   BackgroundColor,
   Display,
   IconColor,
@@ -64,7 +65,11 @@ export const AdditionalNetworksInfo = memo(() => {
     >
       <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
         {/* Container for the "Additional Networks" text and info icon */}
-        <Box display={Display.InlineFlex} ref={setBoxRef}>
+        <Box
+          display={Display.InlineFlex}
+          alignItems={AlignItems.center}
+          ref={setBoxRef}
+        >
           {/* Label text - uses translation key "additionalNetworks" */}
           <Text
             color={TextColor.textAlternative}
@@ -74,13 +79,13 @@ export const AdditionalNetworksInfo = memo(() => {
           </Text>
 
           {/* Info icon with hover trigger for popover */}
-          <Box marginTop={1}>
+          <Box>
             <Icon
               onMouseEnter={handleMouseEnter}
               className="add-network__warning-icon"
               name={IconName.Info}
-              color={IconColor.iconMuted}
-              size={IconSize.Sm}
+              color={IconColor.iconAlternative}
+              size={IconSize.Md}
               marginLeft={2}
             />
             {/* Popover component that shows when user hovers over the info icon */}


### PR DESCRIPTION
## **Description**

The info icon next to the Additional networks label is too small, wrong color and not centered

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39444?quickstart=1)

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-668

## **Manual testing steps**

1. Go to this the network picker
2. Scroll down to Additional Networks
3. Observe change

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/df5f3c35-13a1-4cfd-ab9a-b967a117e9df) | ![after](https://github.com/user-attachments/assets/75580de0-46ea-44af-9dd9-89982233809f) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the layout and styling of the Additional Networks info icon.
> 
> - Switches container from `InlineFlex` to `Flex` with centered `alignItems`/`justifyContent` for proper alignment
> - Updates info icon to `size=Md` and `color=iconAlternative`; removes top margin and wraps in centered `Box`
> - Imports `AlignItems`; adjusts related props and updates snapshot
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e0b8852995825017c0d5394f26a53daee424f40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->