### PR TITLE
fix: flaky test `Send NFTs user should only be able to view ERC721 NFTs on send flow that belong on selected network `

### DIFF
--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -10,6 +10,11 @@ class SendPage {
     tag: 'button',
   };
 
+  private readonly header = {
+    tag: 'h4',
+    text: 'Send',
+  };
+
   private readonly hexDataInput = '[placeholder="Enter hex data (optional)"]';
 
   private readonly inputRecipient =
@@ -31,6 +36,10 @@ class SendPage {
     text: 'Max',
     tag: 'button',
   };
+
+  private readonly networkPicker = {
+    testId: 'send-network-filter-toggle',
+  }
 
   private readonly recipientModalButton =
     '[data-testid="open-recipient-modal-btn"]';
@@ -59,6 +68,20 @@ class SendPage {
   async checkInvalidAddressError(): Promise<void> {
     console.log('Checking for invalid address error');
     await this.driver.findElement(this.invalidAddressError);
+  }
+
+  async checkPageIsLoaded(): Promise<void> {
+    console.log('Checking if send page is loaded');
+    try {
+      await this.driver.waitForMultipleSelectors([
+        this.header,
+        this.networkPicker,
+      ]);
+    } catch (e) {
+      console.log('Timeout while waiting for send page to be loaded', e);
+      throw e;
+    }
+    console.log('Send page is loaded');
   }
 
   async checkSolanaNetworkIsPresent(): Promise<void> {
@@ -182,6 +205,7 @@ class SendPage {
 
   async selectNft(nftName: string): Promise<void> {
     console.log(`Selecting nft ${nftName}`);
+    await this.driver.waitForElementToStopMoving({ text: nftName });
     await this.driver.clickElement({ text: nftName });
   }
 

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -39,7 +39,7 @@ class SendPage {
 
   private readonly networkPicker = {
     testId: 'send-network-filter-toggle',
-  }
+  };
 
   private readonly recipientModalButton =
     '[data-testid="open-recipient-modal-btn"]';

--- a/test/e2e/tests/tokens/nft/send-nft.spec.ts
+++ b/test/e2e/tests/tokens/nft/send-nft.spec.ts
@@ -35,6 +35,7 @@ describe('Send NFTs', function () {
         await homepage.startSendFlow();
 
         const sendPage = new SendPage(driver);
+        await sendPage.checkPageIsLoaded();
         await sendPage.selectNft('Test Dapp NFTs #1');
         await sendPage.fillRecipient(
           '0x1234567890123456789012345678901234567890',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The spec is flaky because sometimes after selecting the NFT we remain at the same page instea of seeing the recipient component 

`TimeoutError: Waiting for element to be located By(css selector, input[placeholder="Enter or paste an address or name"]) Wait timed out after 10195ms ...`

The reason for that is due to a re-render happening after clicking the token, which invalidates the click.

The fix is to wait until the send page is fully loaded, before selecting the token.



<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/f7d3fcf1-5556-4182-9c30-20bb676e1bef" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39449?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of the NFT send flow tests by ensuring the page and elements are ready before interactions.
> 
> - Adds `checkPageIsLoaded` in `send-page.ts` to wait for `h4 Send` header and `send-network-filter-toggle`
> - Updates `selectNft` to `waitForElementToStopMoving` before clicking the NFT
> - Calls `sendPage.checkPageIsLoaded()` in `send-nft.spec.ts` before selecting an NFT
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbd60a9a9829815dcd88992be42f3ebf0d466795. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->