### PR TITLE
refactor: replace deprecated Popup with Modal in PermissionCellOptions

### DIFF
--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import Box from '../../ui/box';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { IconName, ButtonIcon, Text } from '../../component-library';
+import {
+  IconName,
+  ButtonIcon,
+  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+} from '../../component-library';
 import { Menu, MenuItem } from '../../ui/menu';
 import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import Popover from '../../ui/popover/popover.component';
 import { DynamicSnapPermissions } from '../../../../shared/constants/snaps/permissions';
 import { revokeDynamicSnapPermissions } from '../../../store/actions';
 
@@ -90,13 +97,15 @@ export const PermissionCellOptions = ({
           )}
         </Menu>
       )}
-      {showDetails && (
-        <Popover title={t('details')} onClose={handleDetailsClose}>
-          <Box marginLeft={4} marginRight={4} marginBottom={4}>
+      <Modal isOpen={showDetails} onClose={handleDetailsClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader onClose={handleDetailsClose}>{t('details')}</ModalHeader>
+          <Box paddingLeft={4} paddingRight={4}>
             <Text>{description}</Text>
           </Box>
-        </Popover>
-      )}
+        </ModalContent>
+      </Modal>
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This pull request addresses the issue of replacing the deprecated Popover component with the new Modal component in `permission-cell-options.js`. The Popover component was replaced with the Modal component and all props have been migrated appropriately.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39451?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null 

## **Related issues**

#19555

## **Manual testing steps**

1. Pull this branch
2. Run Storybook: `yarn storybook`
3. Navigate to `Components/App/PermissionCell`
4. In the Controls panel, set the following properties:
   - `snapId`: "foo"
   - `showOptions`: true
5. Click the `PermissionCellOptions` button to open the modal
6. Verify the modal displays correctly with proper styling and functionality

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f72a9873-6cbb-45b2-8d69-b0574c524453


### **After**
<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/95aef22b-c123-4a71-89d9-7ef41be6b849

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps the details overlay implementation; behavior changes are limited to modal rendering/close handling.
> 
> **Overview**
> Replaces the deprecated `Popover` details UI in `PermissionCellOptions` with the component-library `Modal` (`ModalOverlay`/`ModalContent`/`ModalHeader`).
> 
> The “Details” action now opens a modal that renders the permission description and uses the modal’s `onClose`/header close handler instead of the popover close flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ff6899b6ee3e2e70da573a9561f488f60c8110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->