### PR TITLE
feat(rewards): hardware wallet support

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5995,12 +5995,12 @@
   "rewardsQRCodeTitle": {
     "message": "Get the mobile app"
   },
-  "rewardsSignUp": {
-    "message": "Sign up for Rewards"
-  },
   "rewardsSignInToViewPoints": {
     "message": "Sign in to view points",
     "description": "Text shown when user needs to sign in to view their rewards points"
+  },
+  "rewardsSignUp": {
+    "message": "Sign up for Rewards"
   },
   "rpcNameOptional": {
     "message": "RPC Name (Optional)"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5891,9 +5891,6 @@
   "rewardsOnboardingIntroHardwareWalletDescription": {
     "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
   },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Account not supported"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Retry"
   },
@@ -6000,6 +5997,10 @@
   },
   "rewardsSignUp": {
     "message": "Sign up for Rewards"
+  },
+  "rewardsSignInToViewPoints": {
+    "message": "Sign in to view points",
+    "description": "Text shown when user needs to sign in to view their rewards points"
   },
   "rpcNameOptional": {
     "message": "RPC Name (Optional)"

--- a/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
@@ -25,12 +25,15 @@ import {
   RewardsDataServiceEstimatePointsAction,
   RewardsDataServiceGetSeasonStatusAction,
   RewardsDataServiceLoginAction,
+  RewardsDataServiceSiweLoginAction,
   RewardsDataServiceMobileJoinAction,
+  RewardsDataServiceSiweJoinAction,
   RewardsDataServiceMobileOptinAction,
   RewardsDataServiceValidateReferralCodeAction,
   RewardsDataServiceFetchGeoLocationAction,
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetDiscoverSeasonsAction,
+  RewardsDataServiceGenerateChallengeAction,
 } from '../../controllers/rewards/rewards-data-service-types';
 import {
   RewardsControllerState,
@@ -91,15 +94,18 @@ type AllowedActions =
   | AccountsControllerListMultichainAccountsAction
   | KeyringControllerSignPersonalMessageAction
   | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
   | RewardsDataServiceEstimatePointsAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceFetchGeoLocationAction
   | RewardsDataServiceMobileOptinAction
   | RewardsDataServiceValidateReferralCodeAction
   | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceGetSeasonMetadataAction
   | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGenerateChallengeAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | HandleSnapRequest;
 
@@ -136,15 +142,18 @@ export function getRewardsControllerMessenger(
       'AccountsController:listMultichainAccounts',
       'KeyringController:signPersonalMessage',
       'RewardsDataService:login',
+      'RewardsDataService:siweLogin',
       'RewardsDataService:estimatePoints',
       'RewardsDataService:getSeasonStatus',
       'RewardsDataService:fetchGeoLocation',
       'RewardsDataService:mobileOptin',
       'RewardsDataService:validateReferralCode',
       'RewardsDataService:mobileJoin',
+      'RewardsDataService:siweJoin',
       'RewardsDataService:getOptInStatus',
       'RewardsDataService:getSeasonMetadata',
       'RewardsDataService:getDiscoverSeasons',
+      'RewardsDataService:generateChallenge',
       'SnapController:handleRequest',
     ],
     events: [

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -46,7 +46,6 @@ import {
   getRewardsControllerDefaultState,
   wrapWithCache,
   DEFAULT_BLOCKED_REGIONS,
-  isHardwareAccount,
 } from './rewards-controller';
 import type {
   RewardsControllerState,
@@ -3916,44 +3915,6 @@ const MOCK_CHALLENGE: ChallengeDto = {
   expirationTime: new Date(Date.now() + 3600000).toISOString(),
   message: `rewards.metamask.io wants you to sign in with your Ethereum account:\n${MOCK_ACCOUNT_ADDRESS}\n\nSign in to MetaMask Rewards\n\nURI: https://rewards.metamask.io\nVersion: 1\nChain ID: 1\nNonce: 123456789\nIssued At: ${new Date().toISOString()}`,
 };
-
-describe('isHardwareAccount', () => {
-  it('should return true for Ledger hardware wallet', () => {
-    const result = isHardwareAccount(MOCK_LEDGER_ACCOUNT);
-    expect(result).toBe(true);
-  });
-
-  it('should return true for QR hardware wallet', () => {
-    const result = isHardwareAccount(MOCK_QR_ACCOUNT);
-    expect(result).toBe(true);
-  });
-
-  it('should return false for software wallet', () => {
-    const result = isHardwareAccount(MOCK_INTERNAL_ACCOUNT);
-    expect(result).toBe(false);
-  });
-
-  it('should return false for account with missing keyring metadata', () => {
-    const accountWithoutKeyring: InternalAccount = {
-      ...MOCK_INTERNAL_ACCOUNT,
-      metadata: {
-        name: 'Test Account',
-        importTime: Date.now(),
-      } as InternalAccount['metadata'],
-    };
-    const result = isHardwareAccount(accountWithoutKeyring);
-    expect(result).toBe(false);
-  });
-
-  it('should return false for account with null metadata', () => {
-    const accountWithNullMetadata = {
-      ...MOCK_INTERNAL_ACCOUNT,
-      metadata: null,
-    } as unknown as InternalAccount;
-    const result = isHardwareAccount(accountWithNullMetadata);
-    expect(result).toBe(false);
-  });
-});
 
 describe('Hardware Wallet Support for Rewards', () => {
   describe('optIn with hardware wallets', () => {

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -4929,7 +4929,9 @@ describe('Hardware Wallet Support for Rewards', () => {
               }
               return Promise.resolve(MOCK_SEASON_STATE);
             }
-            if (actionType === 'AccountsController:getSelectedMultichainAccount') {
+            if (
+              actionType === 'AccountsController:getSelectedMultichainAccount'
+            ) {
               return MOCK_INTERNAL_ACCOUNT; // Return software wallet for reauth
             }
             if (actionType === 'KeyringController:signPersonalMessage') {

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -11,7 +11,6 @@ import {
 import { base58, isAddress as isEvmAddress } from 'ethers/lib/utils';
 import { HandleSnapRequest } from '@metamask/snaps-controllers';
 import { detectSIWE } from '@metamask/controller-utils';
-import { KeyringTypes } from '@metamask/keyring-controller';
 import { RewardsControllerMessenger } from '../../controller-init/messengers/rewards-controller-messenger';
 import {
   EstimatedPointsDto,
@@ -23,7 +22,6 @@ import {
   OptInStatusInputDto,
   OptInStatusDto,
 } from '../../../../shared/types/rewards';
-import { DEVICE_KEYRING_MAP } from '../../../../shared/constants/hardware-wallets';
 import {
   type RewardsControllerState,
   type RewardsAccountState,
@@ -44,6 +42,7 @@ import {
 } from './rewards-data-service';
 import { signSolanaRewardsMessage } from './utils/solana-snap';
 import { sortAccounts } from './utils/sortAccounts';
+import { isHardwareAccount } from './utils/isHardwareAccount';
 
 export const DEFAULT_BLOCKED_REGIONS = ['UK'];
 
@@ -207,17 +206,6 @@ export async function wrapWithCache<T>({
   }
 
   return freshValue;
-}
-
-export function isHardwareAccount(account: InternalAccount): boolean {
-  try {
-    const keyringType = account?.metadata?.keyring?.type;
-    return Object.values(DEVICE_KEYRING_MAP).includes(
-      keyringType as KeyringTypes,
-    );
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -406,6 +406,110 @@ export type DiscoverSeasonsDto = {
    * Next season information
    */
   next: SeasonInfoDto | null;
+
+  /**
+   * Previous season information
+   */
+  previous: SeasonInfoDto | null;
+};
+
+/**
+ * Challenge DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type ChallengeDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  id: string;
+
+  /**
+   * The address of the challenge, either ethereum or solana
+   *
+   * @example '0xbd7d160C18b51527fEBd3D6B667143B5C519C32E'
+   */
+  address: string;
+
+  /**
+   * The domain of the challenge
+   *
+   * @example 'example.com'
+   */
+  domain: string;
+
+  /**
+   * The nonce of the challenge
+   *
+   * @example '1234567890'
+   */
+  nonce: bigint;
+
+  /**
+   * The issued at date of the challenge
+   *
+   * @example '2025-01-01T00:00:00.000Z'
+   */
+  issuedAt: string;
+
+  /**
+   * The expiration date of the challenge
+   *
+   * @example '2025-01-01T00:00:00.000Z'
+   */
+  expirationTime: string;
+
+  /**
+   * The SIWE (Sign-In with Ethereum) message to be signed
+   *
+   * @example 'example.com wants you to sign in with your Ethereum account: 0x...'
+   */
+  message: string;
+};
+
+/**
+ * Login DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type SiweLoginDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  challengeId: string;
+
+  /**
+   * The signature of the SIWE message
+   *
+   * @example '0x...'
+   */
+  signature: `0x${string}`;
+
+  /**
+   * Code provided by referrer
+   *
+   * @example '12345'
+   */
+  referralCode?: string;
+};
+
+/**
+ * Join DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type SiweJoinDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  challengeId: string;
+
+  /**
+   * The signature of the SIWE message
+   *
+   * @example '0x...'
+   */
+  signature: `0x${string}`;
 };
 
 export type SubscriptionReferralDetailsDto = {
@@ -600,7 +704,11 @@ export type RewardsControllerIsOptInSupportedAction = {
  */
 export type RewardsControllerLinkAccountToSubscriptionAction = {
   type: 'RewardsController:linkAccountToSubscriptionCandidate';
-  handler: (account: InternalAccount) => Promise<boolean>;
+  handler: (
+    account: InternalAccount,
+    invalidateRelatedData?: boolean,
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ) => Promise<boolean>;
 };
 
 /**
@@ -610,6 +718,7 @@ export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
   type: 'RewardsController:linkAccountsToSubscriptionCandidate';
   handler: (
     accounts: InternalAccount[],
+    primaryWalletGroupAccounts?: InternalAccount[],
   ) => Promise<{ account: InternalAccount; success: boolean }[]>;
 };
 
@@ -626,7 +735,9 @@ export type RewardsControllerGetGeoRewardsMetadataAction = {
  */
 export type RewardsControllerGetCandidateSubscriptionIdAction = {
   type: 'RewardsController:getCandidateSubscriptionId';
-  handler: () => Promise<string | null>;
+  handler: (
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ) => Promise<string | null>;
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-data-service-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-types.ts
@@ -10,6 +10,11 @@ export interface RewardsDataServiceLoginAction {
   handler: RewardsDataService['login'];
 }
 
+export interface RewardsDataServiceSiweLoginAction {
+  type: `${typeof SERVICE_NAME}:siweLogin`;
+  handler: RewardsDataService['siweLogin'];
+}
+
 export interface RewardsDataServiceEstimatePointsAction {
   type: `${typeof SERVICE_NAME}:estimatePoints`;
   handler: RewardsDataService['estimatePoints'];
@@ -40,6 +45,11 @@ export interface RewardsDataServiceMobileJoinAction {
   handler: RewardsDataService['mobileJoin'];
 }
 
+export interface RewardsDataServiceSiweJoinAction {
+  type: `${typeof SERVICE_NAME}:siweJoin`;
+  handler: RewardsDataService['siweJoin'];
+}
+
 export interface RewardsDataServiceGetOptInStatusAction {
   type: `${typeof SERVICE_NAME}:getOptInStatus`;
   handler: RewardsDataService['getOptInStatus'];
@@ -55,14 +65,22 @@ export interface RewardsDataServiceGetDiscoverSeasonsAction {
   handler: RewardsDataService['getDiscoverSeasons'];
 }
 
+export interface RewardsDataServiceGenerateChallengeAction {
+  type: `${typeof SERVICE_NAME}:generateChallenge`;
+  handler: RewardsDataService['generateChallenge'];
+}
+
 export type RewardsDataServiceActions =
   | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
   | RewardsDataServiceEstimatePointsAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceFetchGeoLocationAction
   | RewardsDataServiceMobileOptinAction
   | RewardsDataServiceValidateReferralCodeAction
   | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceGetSeasonMetadataAction
-  | RewardsDataServiceGetDiscoverSeasonsAction;
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGenerateChallengeAction;

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -696,9 +696,7 @@ export class RewardsDataService {
    * @param body.address
    * @returns The challenge DTO.
    */
-  async generateChallenge(body: {
-    address: string;
-  }): Promise<ChallengeDto> {
+  async generateChallenge(body: { address: string }): Promise<ChallengeDto> {
     const response = await this.makeRequest('/auth/challenge/generate', {
       method: 'POST',
       body: JSON.stringify(body),

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
@@ -94,4 +94,3 @@ describe('isHardwareAccount', () => {
     expect(result).toBe(false);
   });
 });
-

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment node
+ */
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { EthAccountType } from '@metamask/keyring-api';
+import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
+import { isHardwareAccount } from './isHardwareAccount';
+
+// Test constants
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+const MOCK_INTERNAL_ACCOUNT: InternalAccount = {
+  id: 'account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Test Account',
+    keyring: {
+      type: 'HD Key Tree',
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_LEDGER_ACCOUNT: InternalAccount = {
+  id: 'ledger-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Ledger Account',
+    keyring: {
+      type: HardwareKeyringType.ledger,
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_QR_ACCOUNT: InternalAccount = {
+  id: 'qr-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'QR Wallet Account',
+    keyring: {
+      type: HardwareKeyringType.qr,
+    },
+    importTime: Date.now(),
+  },
+};
+
+describe('isHardwareAccount', () => {
+  it('should return true for Ledger hardware wallet', () => {
+    const result = isHardwareAccount(MOCK_LEDGER_ACCOUNT);
+    expect(result).toBe(true);
+  });
+
+  it('should return true for QR hardware wallet', () => {
+    const result = isHardwareAccount(MOCK_QR_ACCOUNT);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for software wallet', () => {
+    const result = isHardwareAccount(MOCK_INTERNAL_ACCOUNT);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for account with missing keyring metadata', () => {
+    const accountWithoutKeyring: InternalAccount = {
+      ...MOCK_INTERNAL_ACCOUNT,
+      metadata: {
+        name: 'Test Account',
+        importTime: Date.now(),
+      } as InternalAccount['metadata'],
+    };
+    const result = isHardwareAccount(accountWithoutKeyring);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for account with null metadata', () => {
+    const accountWithNullMetadata = {
+      ...MOCK_INTERNAL_ACCOUNT,
+      metadata: null,
+    } as unknown as InternalAccount;
+    const result = isHardwareAccount(accountWithNullMetadata);
+    expect(result).toBe(false);
+  });
+});
+

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
@@ -18,4 +18,3 @@ export function isHardwareAccount(account: InternalAccount): boolean {
     return false;
   }
 }
-

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
@@ -1,0 +1,21 @@
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { DEVICE_KEYRING_MAP } from '../../../../../shared/constants/hardware-wallets';
+
+/**
+ * Check if an account is a hardware wallet account
+ *
+ * @param account - The internal account to check
+ * @returns True if the account is a hardware wallet, false otherwise
+ */
+export function isHardwareAccount(account: InternalAccount): boolean {
+  try {
+    const keyringType = account?.metadata?.keyring?.type;
+    return Object.values(DEVICE_KEYRING_MAP).includes(
+      keyringType as KeyringTypes,
+    );
+  } catch {
+    return false;
+  }
+}
+

--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -18,7 +18,10 @@ import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/a
 ///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../constants/multichain/networks';
 import { captureException } from '../sentry';
-import { HardwareDeviceNames } from '../../constants/hardware-wallets';
+import {
+  DEVICE_KEYRING_MAP,
+  HardwareDeviceNames,
+} from '../../constants/hardware-wallets';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
 import { TRON_WALLET_SNAP_ID } from './tron-wallet-snap';
@@ -83,8 +86,8 @@ export async function getNextAvailableSnapAccountName(
 export function isHardwareAccount(account: InternalAccount): boolean {
   try {
     const keyringType = account?.metadata?.keyring?.type;
-    return Object.values(HardwareDeviceNames).includes(
-      keyringType as HardwareDeviceNames,
+    return Object.values(DEVICE_KEYRING_MAP).includes(
+      keyringType as KeyringTypes,
     );
   } catch {
     return false;

--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -18,10 +18,7 @@ import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/a
 ///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../constants/multichain/networks';
 import { captureException } from '../sentry';
-import {
-  DEVICE_KEYRING_MAP,
-  HardwareDeviceNames,
-} from '../../constants/hardware-wallets';
+import { HardwareDeviceNames } from '../../constants/hardware-wallets';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
 import { TRON_WALLET_SNAP_ID } from './tron-wallet-snap';
@@ -86,8 +83,8 @@ export async function getNextAvailableSnapAccountName(
 export function isHardwareAccount(account: InternalAccount): boolean {
   try {
     const keyringType = account?.metadata?.keyring?.type;
-    return Object.values(DEVICE_KEYRING_MAP).includes(
-      keyringType as KeyringTypes,
+    return Object.values(HardwareDeviceNames).includes(
+      keyringType as HardwareDeviceNames,
     );
   } catch {
     return false;

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -42,6 +42,7 @@
 @import 'permissions-connect-permission-list/index';
 @import 'permission-cell/index';
 @import 'recovery-phrase-reminder/index';
+@import 'rewards/onboarding/onboarding-modal';
 @import 'step-progress-bar/index.scss';
 @import 'selected-account/index';
 @import 'multichain-bridge-transaction-details-modal/index';

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -524,7 +524,8 @@ describe('RewardsPointsBalance', () => {
     } as ReturnType<typeof useOptIn>);
 
     setSelectorValues({
-      candidateSubscriptionId: 'error-existing-subscription-hardware-wallet-explicit-sign',
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
     });
 
     render(<RewardsPointsBalance />);
@@ -551,7 +552,8 @@ describe('RewardsPointsBalance', () => {
     } as ReturnType<typeof useOptIn>);
 
     setSelectorValues({
-      candidateSubscriptionId: 'error-existing-subscription-hardware-wallet-explicit-sign',
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
     });
 
     render(<RewardsPointsBalance />);
@@ -574,7 +576,8 @@ describe('RewardsPointsBalance', () => {
     } as ReturnType<typeof useOptIn>);
 
     setSelectorValues({
-      candidateSubscriptionId: 'error-existing-subscription-hardware-wallet-explicit-sign',
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
     });
 
     render(<RewardsPointsBalance />);

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -26,12 +26,12 @@ import {
   setStorageItem,
 } from '../../../../shared/lib/storage-helpers';
 import { useAppSelector } from '../../../store/store';
+import { CandidateSubscriptionId } from '../../../ducks/rewards/types';
 import { RewardsBadge } from './RewardsBadge';
 import {
   REWARDS_BADGE_HIDDEN,
   REWARDS_GTM_MODAL_SHOWN,
 } from './utils/constants';
-import { CandidateSubscriptionId } from '../../../ducks/rewards/types';
 
 /**
  * Component to display the rewards points balance
@@ -47,7 +47,9 @@ export const RewardsPointsBalance = () => {
   const rewardsBadgeHidden = useSelector(selectRewardsBadgeHidden);
   const seasonStatus = useSelector(selectSeasonStatus);
   const seasonStatusError = useSelector(selectSeasonStatusError);
-  const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId) as CandidateSubscriptionId;
+  const candidateSubscriptionId = useSelector(
+    selectCandidateSubscriptionId,
+  ) as CandidateSubscriptionId;
   const onboardingModalRendered = useSelector(selectOnboardingModalRendered);
   const rewardsActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
@@ -57,9 +59,13 @@ export const RewardsPointsBalance = () => {
     !rewardsActiveAccountSubscriptionId &&
     (candidateSubscriptionId === 'pending' ||
       candidateSubscriptionId === 'retry');
-  const candidateSubscriptionIdError = candidateSubscriptionId === 'error' || candidateSubscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign';
+  const candidateSubscriptionIdError =
+    candidateSubscriptionId === 'error' ||
+    candidateSubscriptionId ===
+      'error-existing-subscription-hardware-wallet-explicit-sign';
   const candidateSubscriptionIdErrorNeedsSignIn =
-    candidateSubscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign';
+    candidateSubscriptionId ===
+    'error-existing-subscription-hardware-wallet-explicit-sign';
 
   const { optin } = useOptIn();
 

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
@@ -266,32 +266,6 @@ describe('OnboardingIntroStep', () => {
     );
   });
 
-  it('on confirm: shows error toast for hardware wallet usage', () => {
-    // Trigger the hardware wallet branch
-    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
-    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
-    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
-    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
-    (isHardwareWallet as jest.Mock).mockReturnValue(true);
-
-    render(<OnboardingIntroStep />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
-    );
-
-    expect(setErrorToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isOpen: true,
-        title: 'rewardsOnboardingIntroHardwareWalletTitle',
-        description: 'rewardsOnboardingIntroHardwareWalletDescription',
-      }),
-    );
-    expect(dispatchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
-    );
-  });
-
   it('on confirm: proceeds to STEP1 when allowed and not hardware wallet', () => {
     (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
     (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -31,7 +31,6 @@ import {
 import { useGeoRewardsMetadata } from '../../../../hooks/rewards/useGeoRewardsMetadata';
 import { useCandidateSubscriptionId } from '../../../../hooks/rewards/useCandidateSubscriptionId';
 import { useAppSelector } from '../../../../store/store';
-import { isHardwareWallet } from '../../../../../shared/modules/selectors';
 
 /**
  * OnboardingIntroStep Component
@@ -58,12 +57,10 @@ const OnboardingIntroStep: React.FC = () => {
   );
   const optinAllowedForGeoError = useSelector(selectOptinAllowedForGeoError);
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
-  const candidateSubscriptionIdError = candidateSubscriptionId === 'error';
+  const candidateSubscriptionIdError = candidateSubscriptionId === 'error' || candidateSubscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign';
   const rewardsActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
   );
-
-  const hardwareWalletUsed = useSelector(isHardwareWallet);
 
   // If we don't know of a subscription id, we need to fetch the geo metadata
   const { fetchGeoRewardsMetadata } = useGeoRewardsMetadata({
@@ -130,7 +127,6 @@ const OnboardingIntroStep: React.FC = () => {
     dispatch,
     fetchCandidateSubscriptionId,
     fetchGeoRewardsMetadata,
-    hardwareWalletUsed,
     optinAllowedForGeo,
     optinAllowedForGeoError,
     optinAllowedForGeoLoading,

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -123,18 +123,6 @@ const OnboardingIntroStep: React.FC = () => {
       return;
     }
 
-    // Show error modal if hardware wallet
-    if (hardwareWalletUsed) {
-      dispatch(
-        setErrorToast({
-          isOpen: true,
-          title: t('rewardsOnboardingIntroHardwareWalletTitle'),
-          description: t('rewardsOnboardingIntroHardwareWalletDescription'),
-        }),
-      );
-      return;
-    }
-
     // Proceed to next onboarding step
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP1));
   }, [

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -57,7 +57,10 @@ const OnboardingIntroStep: React.FC = () => {
   );
   const optinAllowedForGeoError = useSelector(selectOptinAllowedForGeoError);
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
-  const candidateSubscriptionIdError = candidateSubscriptionId === 'error' || candidateSubscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign';
+  const candidateSubscriptionIdError =
+    candidateSubscriptionId === 'error' ||
+    candidateSubscriptionId ===
+      'error-existing-subscription-hardware-wallet-explicit-sign';
   const rewardsActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
   );

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -71,6 +71,7 @@ export default function OnboardingModal({
     () =>
       candidateSubscriptionId &&
       candidateSubscriptionId !== 'error' &&
+      candidateSubscriptionId !== 'error-existing-subscription-hardware-wallet-explicit-sign' &&
       candidateSubscriptionId !== 'pending' &&
       candidateSubscriptionId !== 'retry',
     [candidateSubscriptionId],

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -29,12 +29,12 @@ import { useTheme } from '../../../../hooks/useTheme';
 import RewardsErrorToast from '../RewardsErrorToast';
 import RewardsQRCode from '../RewardsQRCode';
 import { useAppSelector } from '../../../../store/store';
+import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
 import OnboardingIntroStep from './OnboardingIntroStep';
 import OnboardingStep1 from './OnboardingStep1';
 import OnboardingStep2 from './OnboardingStep2';
 import OnboardingStep3 from './OnboardingStep3';
 import OnboardingStep4 from './OnboardingStep4';
-import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
 
 type OnboardingModalProps = {
   onClose?: () => void;
@@ -71,7 +71,8 @@ export default function OnboardingModal({
     () =>
       candidateSubscriptionId &&
       candidateSubscriptionId !== 'error' &&
-      candidateSubscriptionId !== 'error-existing-subscription-hardware-wallet-explicit-sign' &&
+      candidateSubscriptionId !==
+        'error-existing-subscription-hardware-wallet-explicit-sign' &&
       candidateSubscriptionId !== 'pending' &&
       candidateSubscriptionId !== 'retry',
     [candidateSubscriptionId],

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -17,6 +17,7 @@ import {
   selectOnboardingActiveStep,
   selectCandidateSubscriptionId,
 } from '../../../../ducks/rewards/selectors';
+import { getHardwareWalletType } from '../../../../selectors';
 import {
   setOnboardingActiveStep,
   setOnboardingModalOpen,
@@ -33,6 +34,7 @@ import OnboardingStep1 from './OnboardingStep1';
 import OnboardingStep2 from './OnboardingStep2';
 import OnboardingStep3 from './OnboardingStep3';
 import OnboardingStep4 from './OnboardingStep4';
+import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
 
 type OnboardingModalProps = {
   onClose?: () => void;
@@ -60,6 +62,7 @@ export default function OnboardingModal({
   const rewardActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
   );
+  const hardwareWalletType = useSelector(getHardwareWalletType);
   const dispatch = useDispatch();
 
   const theme = useTheme();
@@ -121,9 +124,12 @@ export default function OnboardingModal({
       data-testid="rewards-onboarding-modal"
       isOpen={isOpen}
       onClose={handleClose}
+      // qr code hadware wallet uses a popover signing modal, so we don't want to close the onboarding modal when clicking to sign a message
+      isClosedOnOutsideClick={hardwareWalletType !== HardwareKeyringType.qr}
     >
-      <ModalOverlay />
+      <ModalOverlay className="rewards-onboarding-modal__overlay" />
       <ModalContent
+        className="rewards-onboarding-modal__content"
         alignItems={AlignItems.center}
         justifyContent={JustifyContent.center}
         size={ModalContentSize.Md}

--- a/ui/components/app/rewards/onboarding/onboarding-modal.scss
+++ b/ui/components/app/rewards/onboarding/onboarding-modal.scss
@@ -1,0 +1,10 @@
+@use "design-system";
+
+// Lower z-index to ensure this modal appears behind other modals (e.g., QR code signing modal)
+.rewards-onboarding-modal {
+  &__overlay,
+  &__content {
+    z-index: design-system.$modal-z-index - 50;
+  }
+}
+

--- a/ui/ducks/rewards/types.ts
+++ b/ui/ducks/rewards/types.ts
@@ -10,5 +10,6 @@ export type CandidateSubscriptionId =
   | 'pending'
   | 'retry'
   | 'error'
+  | 'error-existing-subscription-hardware-wallet-explicit-sign'
   | string
   | null;

--- a/ui/helpers/utils/rewards-utils.test.ts
+++ b/ui/helpers/utils/rewards-utils.test.ts
@@ -1,0 +1,421 @@
+import * as bridgeControllerUtils from '@metamask/bridge-controller';
+import log from 'loglevel';
+import { formatAccountToCaipAccountId } from './rewards-utils';
+
+jest.mock('loglevel', () => ({
+  error: jest.fn(),
+}));
+
+describe('rewards-utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('formatAccountToCaipAccountId', () => {
+    describe('valid inputs', () => {
+      it('should format a valid lowercase hex address to CAIP-10 account ID', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1'; // Ethereum mainnet
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format a valid checksummed address to CAIP-10 account ID', () => {
+        const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Polygon mainnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x89'; // Polygon mainnet (137)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:137:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Arbitrum One', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xa4b1'; // Arbitrum One (42161)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:42161:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Optimism', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xa'; // Optimism (10)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:10:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Base', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x2105'; // Base (8453)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:8453:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Linea mainnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xe708'; // Linea (59144)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:59144:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for BNB Smart Chain', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x38'; // BSC (56)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:56:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Goerli testnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x5'; // Goerli (5)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:5:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Sepolia testnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xaa36a7'; // Sepolia (11155111)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:11155111:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+    });
+
+    describe('hardware wallet account addresses', () => {
+      // Hardware wallet accounts use the same address format as software wallets,
+      // but we test them explicitly to ensure they work correctly.
+
+      it('should format Ledger hardware wallet address', () => {
+        // Ledger addresses are standard Ethereum addresses
+        const ledgerAddress = '0x71c7656ec7ab88b098defb751b7401b5f6d8976f';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(ledgerAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+        );
+      });
+
+      it('should format Trezor hardware wallet address', () => {
+        // Trezor addresses are also standard Ethereum addresses
+        const trezorAddress = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(trezorAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+        );
+      });
+
+      it('should format QR hardware wallet (Keystone) address', () => {
+        // QR-based hardware wallet addresses are also standard Ethereum addresses
+        const keystoneAddress = '0x4e83362442b8d1bec281594cea3050c8eb01311c';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(keystoneAddress, chainId);
+
+        // The checksum is determined by the keccak256 hash of the lowercase address
+        expect(result).toBe(
+          'eip155:1:0x4E83362442B8d1beC281594cEa3050c8EB01311C',
+        );
+      });
+
+      it('should format hardware wallet address on Polygon', () => {
+        const hardwareAddress = '0x71c7656ec7ab88b098defb751b7401b5f6d8976f';
+        const chainId = '0x89'; // Polygon
+
+        const result = formatAccountToCaipAccountId(hardwareAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:137:0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+        );
+      });
+
+      it('should format hardware wallet address on Arbitrum', () => {
+        const hardwareAddress = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
+        const chainId = '0xa4b1'; // Arbitrum
+
+        const result = formatAccountToCaipAccountId(hardwareAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:42161:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+        );
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle address with mixed case (converts to checksum)', () => {
+        // Input is mixed case but not correct checksum - gets converted to proper checksum
+        const mixedCaseAddress = '0xD8Da6BF26964AF9D7eed9e03e53415D37Aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(mixedCaseAddress, chainId);
+
+        // The checksum conversion normalizes the case
+        expect(result).toBe(
+          'eip155:1:0xD8Da6BF26964AF9D7eed9e03e53415D37Aa96045',
+        );
+      });
+
+      it('should handle all lowercase address', () => {
+        const lowercaseAddress = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(lowercaseAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should handle all uppercase address (except prefix)', () => {
+        // When input is all uppercase (except prefix), it gets converted to checksum
+        // The toChecksumHexAddress preserves the input case for non-checksum addresses
+        const uppercaseAddress = '0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(uppercaseAddress, chainId);
+
+        // All uppercase input gets preserved as toChecksumHexAddress sees it as checksum
+        expect(result).toBe(
+          'eip155:1:0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045',
+        );
+      });
+
+      it('should handle zero address', () => {
+        const zeroAddress = '0x0000000000000000000000000000000000000000';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(zeroAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x0000000000000000000000000000000000000000',
+        );
+      });
+
+      it('should handle dead address', () => {
+        const deadAddress = '0x000000000000000000000000000000000000dead';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(deadAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x000000000000000000000000000000000000dEaD',
+        );
+      });
+
+      it('should handle empty chain ID (converts to 0)', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const emptyChainId = '';
+
+        const result = formatAccountToCaipAccountId(address, emptyChainId);
+
+        // Empty string converts to 0x0 which is chain ID 0
+        expect(result).toBe(
+          'eip155:0:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should pass through non-hex address without checksum conversion', () => {
+        const invalidAddress = 'not-a-valid-address';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(invalidAddress, chainId);
+
+        // For non-hex addresses, isValidHexAddress returns false so the address
+        // is used as-is without checksum conversion
+        expect(result).toBe('eip155:1:not-a-valid-address');
+      });
+
+      it('should return null and log error for invalid chain ID', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const invalidChainId = 'invalid-chain-id';
+
+        const result = formatAccountToCaipAccountId(address, invalidChainId);
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+
+      it('should return null when formatChainIdToCaip throws', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+        jest
+          .spyOn(bridgeControllerUtils, 'formatChainIdToCaip')
+          .mockImplementationOnce(() => {
+            throw new Error('Invalid chain ID format');
+          });
+
+        const result = formatAccountToCaipAccountId(address, '0x1');
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+
+      it('should return null when internal processing throws an error', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+        // Mock formatChainIdToCaip to return invalid data that will cause parseCaipChainId to fail
+        jest
+          .spyOn(bridgeControllerUtils, 'formatChainIdToCaip')
+          .mockImplementationOnce(() => 'invalid:caip:format:with:extra:parts');
+
+        const result = formatAccountToCaipAccountId(address, '0x1');
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+    });
+
+    describe('non-hex address handling', () => {
+      // When isValidHexAddress returns false, the address is used as-is
+      // without checksum conversion
+
+      it('should pass through non-hex address unchanged', () => {
+        const nonHexAddress = 'some-identifier-123';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(nonHexAddress, chainId);
+
+        // The function doesn't validate the address format, it just passes it through
+        expect(result).toBe('eip155:1:some-identifier-123');
+      });
+
+      it('should pass through address without 0x prefix', () => {
+        const addressWithoutPrefix = 'd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(
+          addressWithoutPrefix,
+          chainId,
+        );
+
+        // isValidHexAddress from @metamask/utils checks for 0x prefix
+        expect(result).toBe(
+          'eip155:1:d8da6bf26964af9d7eed9e03e53415d37aa96045',
+        );
+      });
+
+      it('should return null for empty address', () => {
+        const emptyAddress = '';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(emptyAddress, chainId);
+
+        // Empty address causes toCaipAccountId to throw, returns null
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+    });
+
+    describe('checksum address conversion', () => {
+      it('should convert lowercase hex address to checksum format', () => {
+        // These test vectors are from EIP-55
+        const testCases = [
+          {
+            input: '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed',
+            expected: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+          },
+          {
+            input: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
+            expected: '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+          },
+          {
+            input: '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
+            expected: '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
+          },
+          {
+            input: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb',
+            expected: '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+          },
+        ];
+
+        for (const { input, expected } of testCases) {
+          const result = formatAccountToCaipAccountId(input, '0x1');
+          expect(result).toBe(`eip155:1:${expected}`);
+        }
+      });
+    });
+
+    describe('return type', () => {
+      it('should return CaipAccountId type for valid inputs', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        // CaipAccountId is a branded string type
+        expect(typeof result).toBe('string');
+        expect(result).toMatch(/^eip155:\d+:0x[a-fA-F0-9]{40}$/u);
+      });
+
+      it('should return null for errors', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const invalidChainId = 'not-a-valid-chain-id';
+
+        const result = formatAccountToCaipAccountId(address, invalidChainId);
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/ui/helpers/utils/rewards-utils.ts
+++ b/ui/helpers/utils/rewards-utils.ts
@@ -1,0 +1,35 @@
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import {
+  toCaipAccountId,
+  parseCaipChainId,
+  type CaipAccountId,
+  isValidHexAddress,
+  Hex,
+} from '@metamask/utils';
+import log from 'loglevel';
+import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+
+/**
+ * Formats an address to CAIP-10 account ID
+ *
+ * @param address - The address to format
+ * @param chainId - The chain ID to use for the CAIP-10 account ID
+ * @returns The CAIP-10 account ID or null if formatting fails
+ */
+export const formatAccountToCaipAccountId = (
+  address: string,
+  chainId: string,
+): CaipAccountId | null => {
+  try {
+    const caipChainId = formatChainIdToCaip(chainId);
+    const { namespace, reference } = parseCaipChainId(caipChainId);
+    const coercedAddress = isValidHexAddress(address as Hex)
+      ? toChecksumHexAddress(address)
+      : address;
+    return toCaipAccountId(namespace, reference, coercedAddress);
+  } catch (error) {
+    log.error('[rewards-utils] Error formatting account to CAIP-10:', error);
+    return null;
+  }
+};
+

--- a/ui/helpers/utils/rewards-utils.ts
+++ b/ui/helpers/utils/rewards-utils.ts
@@ -32,4 +32,3 @@ export const formatAccountToCaipAccountId = (
     return null;
   }
 };
-

--- a/ui/hooks/bridge/useRewards.ts
+++ b/ui/hooks/bridge/useRewards.ts
@@ -7,9 +7,7 @@ import {
   formatChainIdToCaip,
   selectBridgeQuotes,
 } from '@metamask/bridge-controller';
-import {
-  type CaipAccountId,
-} from '@metamask/utils';
+import { type CaipAccountId } from '@metamask/utils';
 import log from 'loglevel';
 import { debounce } from 'lodash';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -33,9 +31,7 @@ import {
   EstimatedPointsDto,
 } from '../../../shared/types/rewards';
 import { formatAccountToCaipAccountId } from '../../helpers/utils/rewards-utils';
-import {
-  getInternalAccountBySelectedAccountGroupAndCaip,
-} from '../../selectors/multichain-accounts/account-tree';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
 import {
   selectRewardsAccountLinkedTimestamp,
   selectRewardsEnabled,
@@ -251,9 +247,7 @@ export const useRewardsWithQuote = ({
       try {
         // Check if there's a subscription first
         const candidateSubscriptionId = (await dispatch(
-          getRewardsCandidateSubscriptionId(
-            primaryWalletGroupAccounts,
-          ),
+          getRewardsCandidateSubscriptionId(primaryWalletGroupAccounts),
         )) as unknown as string | null;
 
         if (!candidateSubscriptionId) {

--- a/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
@@ -1,7 +1,10 @@
 import { act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import log from 'loglevel';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
 import { useCandidateSubscriptionId } from './useCandidateSubscriptionId';
 
 // Mock store actions used by the hook
@@ -14,14 +17,60 @@ jest.mock('loglevel', () => ({
   setLevel: jest.fn(),
 }));
 
+// Mock usePrimaryWalletGroupAccounts hook - use mutable ref pattern for test-level changes
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accountGroupId: 'account-group-1',
+    accounts: [] as InternalAccount[],
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
+
 const { getRewardsCandidateSubscriptionId } = jest.requireMock(
   '../../store/actions',
 ) as { getRewardsCandidateSubscriptionId: jest.Mock };
 const mockLogError = log.error as jest.MockedFunction<typeof log.error>;
 
+// Helper to create software wallet account
+const createSoftwareAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Software Account',
+  });
+
+// Helper to create hardware wallet accounts
+const createLedgerAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Ledger Account',
+    keyringType: HardwareKeyringType.ledger,
+  });
+
+const createTrezorAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Trezor Account',
+    keyringType: HardwareKeyringType.trezor,
+  });
+
+const createQrAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'QR Hardware Account',
+    keyringType: HardwareKeyringType.qr,
+  });
+
 describe('useCandidateSubscriptionId', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mock to default empty state
+    mockPrimaryWalletGroupAccounts.current = {
+      accountGroupId: 'account-group-1',
+      accounts: [],
+    };
   });
 
   describe('Initial State', () => {
@@ -202,6 +251,7 @@ describe('useCandidateSubscriptionId', () => {
       const rewardsState = store?.getState().rewards;
       expect(rewardsState?.candidateSubscriptionId).toBe('abc-id');
     });
+
     it('uses rewardsActiveAccountSubscriptionId when available and does not fetch', async () => {
       const { result, store } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
@@ -313,6 +363,566 @@ describe('useCandidateSubscriptionId', () => {
         '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
         mockError,
       );
+    });
+  });
+
+  describe('Hardware wallet subscription ID resolution', () => {
+    it('passes primary wallet group accounts including Ledger hardware wallet to action', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'hardware-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        ledgerAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('hardware-sub-id');
+    });
+
+    it('passes primary wallet group accounts including Trezor hardware wallet to action', async () => {
+      const trezorAccount = createTrezorAccount('0xTrezorAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [trezorAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'trezor-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        trezorAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('trezor-sub-id');
+    });
+
+    it('passes primary wallet group accounts including QR hardware wallet to action', async () => {
+      const qrAccount = createQrAccount('0xQrAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [qrAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'qr-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        qrAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('qr-sub-id');
+    });
+
+    it('passes mixed software and hardware wallet accounts to action', async () => {
+      const softwareAccount = createSoftwareAccount('0xSoftwareAddress');
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      const trezorAccount = createTrezorAccount('0xTrezorAddress');
+
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [softwareAccount, ledgerAccount, trezorAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'mixed-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        softwareAccount,
+        ledgerAccount,
+        trezorAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('mixed-sub-id');
+    });
+
+    it('sets special error sentinel when hardware wallet needs explicit authentication', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const hardwareWalletError = new Error(
+        'Primary wallet account group has opted in but is not authenticated yet',
+      );
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw hardwareWalletError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        ledgerAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe(
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+      );
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        hardwareWalletError,
+      );
+    });
+
+    it('sets generic error sentinel for non-hardware-wallet-specific errors', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const genericError = new Error('Network error');
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw genericError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        genericError,
+      );
+    });
+  });
+
+  describe('Edge cases with no valid subscription', () => {
+    it('handles null subscription ID response', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => null,
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+
+    it('handles empty string subscription ID response', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => '',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('');
+    });
+
+    it('handles empty primary wallet group accounts', async () => {
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => null,
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+
+    it('handles non-Error thrown object', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'string error';
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Non-Error objects should fall through to generic error handling
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        'string error',
+      );
+    });
+
+    it('handles rewards disabled with rewardsEnabled flag false', async () => {
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: false },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+  });
+
+  describe('Concurrent fetch prevention (isLoading ref)', () => {
+    it('prevents multiple concurrent fetches', async () => {
+      let resolvePromise: (value: string) => void;
+      const slowPromise = new Promise<string>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => () => slowPromise,
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // Start first fetch (won't complete immediately)
+      act(() => {
+        result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Try to start second fetch while first is pending
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Should only be called once because isLoading prevents second call
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Resolve the promise
+      await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        resolvePromise?.('delayed-sub-id');
+      });
+    });
+
+    it('resets isLoading after successful fetch allowing subsequent fetches', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'first-sub-id',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // First fetch
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Second fetch should be allowed after first completes
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'second-sub-id',
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets isLoading after failed fetch allowing subsequent fetches', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('First fetch failed');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // First fetch (will fail)
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Second fetch should be allowed after first completes (even with failure)
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'second-sub-id',
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('rewardsActiveAccountSubscriptionId takes precedence', () => {
+    it('uses active account subscription ID even with hardware wallet in group', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: {
+              account: 'eip155:1:0xLedgerAddress',
+              subscriptionId: 'active-hw-sub-id',
+            },
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Should not fetch because active account subscription ID is available
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('active-hw-sub-id');
+    });
+
+    it('skips fetch and resets isLoading when active account subscription ID becomes available', async () => {
+      // This tests the early return path at line 43-48
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: {
+              account: 'eip155:1:0xabc',
+              subscriptionId: 'existing-sub-id',
+            },
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('existing-sub-id');
     });
   });
 });

--- a/ui/hooks/rewards/useCandidateSubscriptionId.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.ts
@@ -30,7 +30,8 @@ export const useCandidateSubscriptionId =
     );
 
     // Get accounts for the primary account group
-    const { accounts: primaryWalletGroupAccounts } = usePrimaryWalletGroupAccounts();
+    const { accounts: primaryWalletGroupAccounts } =
+      usePrimaryWalletGroupAccounts();
 
     const isLoading = useRef(false);
 
@@ -53,9 +54,7 @@ export const useCandidateSubscriptionId =
         isLoading.current = true;
 
         const candidateId = (await dispatch(
-          getRewardsCandidateSubscriptionId(
-            primaryWalletGroupAccounts,
-          ),
+          getRewardsCandidateSubscriptionId(primaryWalletGroupAccounts),
         )) as unknown as string | null;
         dispatch(setCandidateSubscriptionId(candidateId));
       } catch (error) {
@@ -67,9 +66,13 @@ export const useCandidateSubscriptionId =
         if (
           error instanceof Error &&
           error.message ===
-          'Primary wallet account group has opted in but is not authenticated yet'
+            'Primary wallet account group has opted in but is not authenticated yet'
         ) {
-          dispatch(setCandidateSubscriptionId('error-existing-subscription-hardware-wallet-explicit-sign'));
+          dispatch(
+            setCandidateSubscriptionId(
+              'error-existing-subscription-hardware-wallet-explicit-sign',
+            ),
+          );
         } else {
           dispatch(setCandidateSubscriptionId('error'));
         }

--- a/ui/hooks/rewards/useLinkAccountAddress.test.tsx
+++ b/ui/hooks/rewards/useLinkAccountAddress.test.tsx
@@ -9,7 +9,36 @@ import {
   MetaMetricsEventCategory,
 } from '../../../shared/constants/metametrics';
 import { OptInStatusDto } from '../../../shared/types/rewards';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
 import { useLinkAccountAddress } from './useLinkAccountAddress';
+
+// Mock useMultichainSelector hook
+jest.mock('../useMultichainSelector', () => ({
+  useMultichainSelector: jest.fn(() => '0x1'), // Return mainnet chain ID
+}));
+
+// Mock useRequestHardwareWalletAccess hook
+const mockRequestHardwareWalletAccess = jest.fn();
+const mockIsHardwareWalletAccount = { current: false };
+
+jest.mock('./useRequestHardwareWalletAccess', () => ({
+  useRequestHardwareWalletAccess: () => ({
+    requestHardwareWalletAccess: mockRequestHardwareWalletAccess,
+    isHardwareWalletAccount: mockIsHardwareWalletAccount.current,
+  }),
+}));
+
+// Mock usePrimaryWalletGroupAccounts hook
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accounts: [] as InternalAccount[],
+    accountGroupId: undefined as string | undefined,
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
 
 // Mock store actions used by the hook
 jest.mock('../../store/actions', () => ({
@@ -24,6 +53,7 @@ jest.mock('../../store/actions', () => ({
         success: boolean;
       }[],
   ),
+  getRewardsHasAccountOptedIn: jest.fn(() => async () => false),
 }));
 
 jest.mock('../../ducks/rewards', () => ({
@@ -40,20 +70,34 @@ jest.mock(
   }),
 );
 
+jest.mock('../../helpers/utils/rewards-utils', () => ({
+  formatAccountToCaipAccountId: jest.fn(
+    (address: string, chainId: string) => `eip155:${chainId}:${address}`,
+  ),
+}));
+
 const {
   rewardsIsOptInSupported,
   rewardsGetOptInStatus,
   rewardsLinkAccountsToSubscriptionCandidate,
+  getRewardsHasAccountOptedIn,
 } = jest.requireMock('../../store/actions') as {
   rewardsIsOptInSupported: jest.Mock;
   rewardsGetOptInStatus: jest.Mock;
   rewardsLinkAccountsToSubscriptionCandidate: jest.Mock;
+  getRewardsHasAccountOptedIn: jest.Mock;
 };
 
 const { setRewardsAccountLinkedTimestamp } = jest.requireMock(
   '../../ducks/rewards',
 ) as {
   setRewardsAccountLinkedTimestamp: jest.Mock;
+};
+
+const { getAccountTypeCategory } = jest.requireMock(
+  '../../pages/multichain-accounts/account-details/account-type-utils',
+) as {
+  getAccountTypeCategory: jest.Mock;
 };
 
 // MetaMetrics provider container
@@ -63,6 +107,51 @@ const Container = ({ children }: { children: React.ReactNode }) => (
     {children}
   </MetaMetricsContext.Provider>
 );
+
+// Test account fixtures
+const createMockLedgerAccount = (): InternalAccount => ({
+  id: 'ledger-acc-1',
+  address: '0xLedger111',
+  metadata: {
+    name: 'Ledger Account 1',
+    keyring: { type: HardwareKeyringType.ledger },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockQRAccount = (): InternalAccount => ({
+  id: 'qr-acc-1',
+  address: '0xQR111',
+  metadata: {
+    name: 'QR Account 1',
+    keyring: { type: HardwareKeyringType.qr },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const mockSoftwareAccounts: InternalAccount[] = [
+  {
+    id: 'acc-1',
+    address: '0x111',
+    metadata: {
+      name: 'Account 1',
+      keyring: { type: 'HD Key Tree' },
+      importTime: Date.now(),
+    },
+    options: {},
+    methods: [],
+    type: 'eip155:eoa',
+    scopes: ['eip155:1'],
+  },
+];
 
 describe('useLinkAccountAddress', () => {
   let mockAccount: InternalAccount;
@@ -75,9 +164,20 @@ describe('useLinkAccountAddress', () => {
       name: 'Test Account',
     });
 
+    // Reset mutable mock values
+    mockIsHardwareWalletAccount.current = false;
+    mockRequestHardwareWalletAccess.mockResolvedValue(true);
+    mockPrimaryWalletGroupAccounts.current = {
+      accounts: mockSoftwareAccounts,
+      accountGroupId: 'entropy:test/0',
+    };
+
     (rewardsIsOptInSupported as jest.Mock).mockImplementation(() => () => true);
     (rewardsGetOptInStatus as jest.Mock).mockImplementation(
       () => async () => ({ ois: [false], sids: [null] }) as OptInStatusDto,
+    );
+    (getRewardsHasAccountOptedIn as jest.Mock).mockImplementation(
+      () => async () => false,
     );
     (
       rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
@@ -88,6 +188,7 @@ describe('useLinkAccountAddress', () => {
           success: boolean;
         }[],
     );
+    (getAccountTypeCategory as jest.Mock).mockReturnValue('evm');
   });
 
   describe('Initial State', () => {
@@ -130,9 +231,10 @@ describe('useLinkAccountAddress', () => {
       expect(rewardsGetOptInStatus).toHaveBeenCalledWith({
         addresses: [mockAccount.address],
       });
-      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith([
-        mockAccount,
-      ]);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [mockAccount],
+        mockSoftwareAccounts,
+      );
 
       // Verify events were tracked
       const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
@@ -208,9 +310,8 @@ describe('useLinkAccountAddress', () => {
 
   describe('Account already opted in', () => {
     it('returns success immediately when account is already opted in', async () => {
-      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
-        () => async () =>
-          ({ ois: [true], sids: ['sub-123'] }) as OptInStatusDto,
+      (getRewardsHasAccountOptedIn as jest.Mock).mockImplementation(
+        () => async () => true,
       );
 
       const { result } = renderHookWithProvider(
@@ -232,6 +333,7 @@ describe('useLinkAccountAddress', () => {
       // Should check opt-in status but not link
       expect(rewardsIsOptInSupported).toHaveBeenCalled();
       expect(rewardsGetOptInStatus).toHaveBeenCalled();
+      expect(getRewardsHasAccountOptedIn).toHaveBeenCalled();
       expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
 
       // Should not track linking events
@@ -486,6 +588,578 @@ describe('useLinkAccountAddress', () => {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         account_type: 'evm',
       });
+    });
+  });
+
+  describe('Hardware wallet linking - Ledger account', () => {
+    let mockLedgerAccount: InternalAccount;
+
+    beforeEach(() => {
+      mockLedgerAccount = createMockLedgerAccount();
+      mockIsHardwareWalletAccount.current = true;
+      mockRequestHardwareWalletAccess.mockResolvedValue(true);
+      (getAccountTypeCategory as jest.Mock).mockReturnValue('hardware');
+    });
+
+    it('requests hardware wallet access before linking a Ledger account', async () => {
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(mockRequestHardwareWalletAccess).toHaveBeenCalledTimes(1);
+      expect(linkResult).toBe(true);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [mockLedgerAccount],
+        mockSoftwareAccounts,
+      );
+    });
+
+    it('successfully links Ledger account and tracks events with hardware account type', async () => {
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      // Verify events were tracked with hardware account type
+      const startedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      );
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent[0].properties).toEqual({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        account_type: 'hardware',
+      });
+
+      const completedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent[0].properties).toEqual({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        account_type: 'hardware',
+      });
+
+      // Verify timestamp was set
+      expect(setRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+    });
+
+    it('fails linking when hardware wallet access is denied for Ledger', async () => {
+      mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+
+      // Verify failure event was tracked
+      const failedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+      expect(failedEvent).toBeDefined();
+      expect(failedEvent[0].properties).toEqual({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        account_type: 'hardware',
+      });
+    });
+  });
+
+  describe('Hardware wallet linking - QR-based wallet', () => {
+    let mockQRAccount: InternalAccount;
+
+    beforeEach(() => {
+      mockQRAccount = createMockQRAccount();
+      mockIsHardwareWalletAccount.current = true;
+      mockRequestHardwareWalletAccess.mockResolvedValue(true);
+      (getAccountTypeCategory as jest.Mock).mockReturnValue('hardware');
+    });
+
+    it('requests hardware wallet access before linking a QR wallet account', async () => {
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockQRAccount);
+      });
+
+      expect(mockRequestHardwareWalletAccess).toHaveBeenCalledTimes(1);
+      expect(linkResult).toBe(true);
+    });
+
+    it('successfully links QR wallet account and tracks events', async () => {
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockQRAccount);
+      });
+
+      // Verify linking was called
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [mockQRAccount],
+        mockSoftwareAccounts,
+      );
+
+      // Verify events were tracked
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingStarted,
+      );
+      expect(events).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+    });
+
+    it('fails linking when QR wallet access is denied', async () => {
+      mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockQRAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+
+      // Verify failure event was tracked
+      const failedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+      expect(failedEvent).toBeDefined();
+    });
+  });
+
+  describe('SIWE signing for address linking with hardware wallet', () => {
+    let mockLedgerAccount: InternalAccount;
+
+    beforeEach(() => {
+      mockLedgerAccount = createMockLedgerAccount();
+      mockIsHardwareWalletAccount.current = true;
+      mockRequestHardwareWalletAccess.mockResolvedValue(true);
+      (getAccountTypeCategory as jest.Mock).mockReturnValue('hardware');
+    });
+
+    it('sets loading state during SIWE signing process', async () => {
+      let resolveLinking: (
+        value: { account: InternalAccount; success: boolean }[],
+      ) => void;
+      const linkingPromise = new Promise<
+        { account: InternalAccount; success: boolean }[]
+      >((resolve) => {
+        resolveLinking = resolve;
+      });
+
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => () => linkingPromise);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkPromise: Promise<boolean> | undefined;
+      await act(async () => {
+        linkPromise = result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      // Resolve the linking promise
+      await act(async () => {
+        resolveLinking([{ account: mockLedgerAccount, success: true }]);
+        await linkPromise;
+      });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('handles SIWE signing failure during hardware wallet linking', async () => {
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('SIWE signing failed - user rejected');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+
+      // Verify failure event was tracked
+      const failedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+      expect(failedEvent).toBeDefined();
+    });
+
+    it('successfully completes SIWE signing for hardware wallet address linking', async () => {
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(true);
+      expect(result.current.isError).toBe(false);
+
+      // Verify the full flow was executed
+      expect(rewardsIsOptInSupported).toHaveBeenCalled();
+      expect(rewardsGetOptInStatus).toHaveBeenCalled();
+      expect(mockRequestHardwareWalletAccess).toHaveBeenCalled();
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalled();
+      expect(setRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error handling for hardware wallet signing failures', () => {
+    let mockLedgerAccount: InternalAccount;
+
+    beforeEach(() => {
+      mockLedgerAccount = createMockLedgerAccount();
+      mockIsHardwareWalletAccount.current = true;
+      mockRequestHardwareWalletAccess.mockResolvedValue(true);
+      (getAccountTypeCategory as jest.Mock).mockReturnValue('hardware');
+    });
+
+    it('handles user rejection during hardware wallet signing', async () => {
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('User rejected the request');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('handles hardware wallet connection timeout', async () => {
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('Connection timeout');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+
+      // Verify failure event was tracked
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+    });
+
+    it('handles Ethereum app not open error on Ledger', async () => {
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('Ethereum app not open');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+    });
+
+    it('handles locked hardware wallet error', async () => {
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('Device is locked');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('resets error state on successful retry after failure', async () => {
+      // First attempt fails
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementationOnce(() => async () => {
+        throw new Error('First attempt failed');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(result.current.isError).toBe(true);
+
+      // Second attempt succeeds
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(
+        () => async () =>
+          [{ account: mockLedgerAccount, success: true }] as {
+            account: InternalAccount;
+            success: boolean;
+          }[],
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockLedgerAccount);
+      });
+
+      expect(result.current.isError).toBe(false);
+      expect(setRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+    });
+  });
+
+  describe('Invalid CAIP account ID handling', () => {
+    it('returns false and sets error when caipAccountId is invalid', async () => {
+      const { formatAccountToCaipAccountId } = jest.requireMock(
+        '../../helpers/utils/rewards-utils',
+      ) as { formatAccountToCaipAccountId: jest.Mock };
+
+      formatAccountToCaipAccountId.mockReturnValueOnce(null);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockAccount);
+      });
+
+      expect(linkResult).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Software wallet linking (non-hardware)', () => {
+    it('does not request hardware wallet access for software wallets', async () => {
+      mockIsHardwareWalletAccount.current = false;
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockAccount);
+      });
+
+      // Hardware wallet access should still be called (the hook always calls it)
+      // but it should return true immediately for non-hardware wallets
+      expect(mockRequestHardwareWalletAccess).toHaveBeenCalled();
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalled();
+    });
+
+    it('successfully links software wallet account', async () => {
+      mockIsHardwareWalletAccount.current = false;
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      let linkResult: boolean | undefined;
+      await act(async () => {
+        linkResult = await result.current.linkAccountAddress(mockAccount);
+      });
+
+      expect(linkResult).toBe(true);
+      expect(result.current.isError).toBe(false);
+
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+    });
+  });
+
+  describe('Primary wallet group accounts', () => {
+    it('passes primary wallet group accounts to linking function', async () => {
+      const primaryAccounts: InternalAccount[] = [
+        {
+          id: 'primary-acc-1',
+          address: '0xPrimary111',
+          metadata: {
+            name: 'Primary Account 1',
+            keyring: { type: 'HD Key Tree' },
+            importTime: Date.now(),
+          },
+          options: {},
+          methods: [],
+          type: 'eip155:eoa',
+          scopes: ['eip155:1'],
+        },
+      ];
+
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: primaryAccounts,
+        accountGroupId: 'entropy:primary/0',
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockAccount);
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [mockAccount],
+        primaryAccounts,
+      );
+    });
+
+    it('handles empty primary wallet group accounts', async () => {
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: [],
+        accountGroupId: undefined,
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountAddress(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountAddress(mockAccount);
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [mockAccount],
+        [],
+      );
     });
   });
 });

--- a/ui/hooks/rewards/useLinkAccountAddress.ts
+++ b/ui/hooks/rewards/useLinkAccountAddress.ts
@@ -15,11 +15,11 @@ import {
 } from '../../../shared/constants/metametrics';
 import { getAccountTypeCategory } from '../../pages/multichain-accounts/account-details/account-type-utils';
 import { setRewardsAccountLinkedTimestamp } from '../../ducks/rewards';
-import { useRequestHardwareWalletAccess } from './useRequestHardwareWalletAccess';
 import { useMultichainSelector } from '../useMultichainSelector';
 import { getMultichainCurrentChainId } from '../../selectors/multichain';
-import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
 import { formatAccountToCaipAccountId } from '../../helpers/utils/rewards-utils';
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
+import { useRequestHardwareWalletAccess } from './useRequestHardwareWalletAccess';
 
 type UseLinkAccountAddressResult = {
   linkAccountAddress: (account: InternalAccount) => Promise<boolean>;
@@ -37,7 +37,8 @@ export const useLinkAccountAddress = (): UseLinkAccountAddressResult => {
   const { requestHardwareWalletAccess } = useRequestHardwareWalletAccess();
 
   // Get accounts for the primary account group
-  const { accounts: primaryWalletGroupAccounts } = usePrimaryWalletGroupAccounts();
+  const { accounts: primaryWalletGroupAccounts } =
+    usePrimaryWalletGroupAccounts();
 
   useEffect(() => {
     isMountedRef.current = true;

--- a/ui/hooks/rewards/useLinkAccountGroup.test.tsx
+++ b/ui/hooks/rewards/useLinkAccountGroup.test.tsx
@@ -14,6 +14,7 @@ import { createMockInternalAccount } from '../../../test/jest/mocks';
 import { createMockMultichainAccountsState } from '../../selectors/multichain-accounts/test-utils';
 import { AccountTreeWallets } from '../../selectors/multichain-accounts/account-tree.types';
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
 import { useLinkAccountGroup } from './useLinkAccountGroup';
 
 // Mock store actions used by the hook
@@ -36,6 +37,18 @@ jest.mock('../../ducks/rewards', () => {
     })),
   };
 });
+
+// Mock usePrimaryWalletGroupAccounts to avoid selector chain issues
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accounts: [] as InternalAccount[],
+    accountGroupId: undefined as string | undefined,
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
 
 const {
   rewardsIsOptInSupported,
@@ -107,9 +120,79 @@ const buildStateWithAccounts = (accounts: InternalAccount[]) => {
   );
 };
 
+// Helper to create hardware wallet accounts
+const createMockLedgerAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Ledger Account ${id}`,
+    keyring: { type: HardwareKeyringType.ledger },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockTrezorAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Trezor Account ${id}`,
+    keyring: { type: HardwareKeyringType.trezor },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockQRAccount = (id: string, address: string): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `QR Account ${id}`,
+    keyring: { type: HardwareKeyringType.qr },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockSoftwareAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Software Account ${id}`,
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
 describe('useLinkAccountGroup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPrimaryWalletGroupAccounts.current = {
+      accounts: [],
+      accountGroupId: undefined,
+    };
   });
 
   describe('Initial State', () => {
@@ -127,6 +210,23 @@ describe('useLinkAccountGroup', () => {
       expect(typeof result.current.linkAccountGroup).toBe('function');
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isError).toBe(false);
+    });
+
+    it('returns failure when no accountGroupId is provided', async () => {
+      const state = buildStateWithAccounts([]);
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(undefined),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(report).toEqual({ success: false, byAddress: {} });
     });
   });
 
@@ -299,13 +399,13 @@ describe('useLinkAccountGroup', () => {
         (c: { event: MetaMetricsEventName }) => c.event,
       );
       const startedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_STARTED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingStarted,
       ).length;
       const completedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_COMPLETED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingCompleted,
       ).length;
       const failedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_FAILED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
       ).length;
 
       expect(startedCount).toBe(2);
@@ -426,6 +526,796 @@ describe('useLinkAccountGroup', () => {
         success: false,
         byAddress: {},
       });
+    });
+  });
+
+  describe('Hardware wallet account group linking', () => {
+    it('links a group containing only Ledger hardware wallet accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const ledger2 = createMockLedgerAccount('ledger-2', '0xLedger222');
+      const state = buildStateWithAccounts([ledger1, ledger2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+        { account: ledger2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1, ledger2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xLedger111': true, '0xLedger222': true },
+      });
+    });
+
+    it('links a group containing only Trezor hardware wallet accounts', async () => {
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const trezor2 = createMockTrezorAccount('trezor-2', '0xTrezor222');
+      const state = buildStateWithAccounts([trezor1, trezor2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: trezor1, success: true },
+        { account: trezor2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [trezor1, trezor2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xTrezor111': true, '0xTrezor222': true },
+      });
+    });
+
+    it('links a group containing only QR hardware wallet accounts', async () => {
+      const qr1 = createMockQRAccount('qr-1', '0xQR111');
+      const qr2 = createMockQRAccount('qr-2', '0xQR222');
+      const state = buildStateWithAccounts([qr1, qr2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: qr1, success: true },
+        { account: qr2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [qr1, qr2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xQR111': true, '0xQR222': true },
+      });
+    });
+
+    it('tracks account_type in events for hardware wallet accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      // Verify events were tracked with account_type property
+      const startedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      );
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent[0].properties).toHaveProperty('account_type');
+
+      const completedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent[0].properties).toHaveProperty('account_type');
+    });
+  });
+
+  describe('Mixed groups (software + hardware wallets)', () => {
+    it('links a mixed group with software and Ledger hardware wallet accounts', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1, ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true, '0xLedger111': true },
+      });
+    });
+
+    it('links a mixed group with software, Ledger, and Trezor accounts', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const state = buildStateWithAccounts([software1, ledger1, trezor1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: true },
+        { account: trezor1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1, ledger1, trezor1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: {
+          '0xSoftware111': true,
+          '0xLedger111': true,
+          '0xTrezor111': true,
+        },
+      });
+    });
+
+    it('handles mixed group where only hardware wallet accounts are supported', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      // Software account not supported, hardware account supported
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        ({ account }) =>
+          () => {
+            return account.metadata.keyring.type === HardwareKeyringType.ledger;
+          },
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only ledger1 should be linked
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xLedger111': true },
+      });
+    });
+
+    it('handles mixed group where only software wallet accounts are supported', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      // Software account supported, hardware account not supported
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        ({ account }) =>
+          () => {
+            return account.metadata.keyring.type === 'HD Key Tree';
+          },
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only software1 should be linked
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true },
+      });
+    });
+
+    it('handles mixed group where some accounts are already opted-in', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      // Software already opted in, hardware not
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [true, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only ledger1 should be linked (software1 already opted in)
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true, '0xLedger111': true },
+      });
+    });
+  });
+
+  describe('Error handling for partial group linking failures', () => {
+    it('handles partial failure where software account succeeds and hardware account fails', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: false },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Verify partial success/failure
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': true, '0xLedger111': false },
+      });
+
+      // Verify timestamp is set when at least one account succeeds
+      expect(mockSetRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+
+      // Verify metrics
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(eventNames).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+      expect(eventNames).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+    });
+
+    it('handles partial failure where hardware account succeeds and software account fails', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: false },
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Verify partial success/failure
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': true },
+      });
+
+      // Verify timestamp is set when at least one account succeeds
+      expect(mockSetRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+    });
+
+    it('handles multiple hardware wallets with partial failures', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const qr1 = createMockQRAccount('qr-1', '0xQR111');
+      const state = buildStateWithAccounts([ledger1, trezor1, qr1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+        { account: trezor1, success: false },
+        { account: qr1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: {
+          '0xLedger111': true,
+          '0xTrezor111': false,
+          '0xQR111': true,
+        },
+      });
+
+      // Verify correct count of started/completed/failed events
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      const startedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      ).length;
+      const completedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      ).length;
+      const failedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      ).length;
+
+      expect(startedCount).toBe(3);
+      expect(completedCount).toBe(2);
+      expect(failedCount).toBe(1);
+    });
+
+    it('handles complete failure of all accounts in a mixed group', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: false },
+        { account: ledger1, success: false },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': false },
+      });
+
+      // Verify timestamp is NOT set when all accounts fail
+      expect(mockSetRewardsAccountLinkedTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('handles exception during linking and marks all accounts as failed', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('Hardware wallet connection failed');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': false },
+      });
+
+      // Verify all failure events are tracked
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      const failedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      ).length;
+      expect(failedCount).toBe(2);
+
+      // Verify timestamp is NOT set
+      expect(mockSetRewardsAccountLinkedTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('handles exception during opt-in status check', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('Network error');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: {},
+      });
+
+      // Linking should not be called
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Primary wallet group accounts', () => {
+    it('passes primary wallet group accounts to the linking function', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      const primaryAccounts = [software1];
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: primaryAccounts,
+        accountGroupId: 'entropy:primary/0',
+      };
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        primaryAccounts,
+      );
+    });
+
+    it('handles empty primary wallet group accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: [],
+        accountGroupId: undefined,
+      };
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+    });
+  });
+
+  describe('Loading state', () => {
+    it('sets loading to true during linking and false after completion', async () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const state = buildStateWithAccounts([a1]);
+
+      let resolveLinking: (
+        value: { account: InternalAccount; success: boolean }[],
+      ) => void;
+      const linkingPromise = new Promise<
+        { account: InternalAccount; success: boolean }[]
+      >((resolve) => {
+        resolveLinking = resolve;
+      });
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => () => linkingPromise);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let linkPromise: Promise<unknown>;
+      await act(async () => {
+        linkPromise = result.current.linkAccountGroup();
+      });
+
+      // Resolve the linking promise
+      await act(async () => {
+        resolveLinking([{ account: a1, success: true }]);
+        await linkPromise;
+      });
+
+      expect(result.current.isLoading).toBe(false);
     });
   });
 });

--- a/ui/hooks/rewards/useLinkAccountGroup.ts
+++ b/ui/hooks/rewards/useLinkAccountGroup.ts
@@ -3,9 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { MetaMetricsContext } from '../../contexts/metametrics';
-import {
-  getInternalAccountsFromGroupById,
-} from '../../selectors/multichain-accounts/account-tree';
+import { getInternalAccountsFromGroupById } from '../../selectors/multichain-accounts/account-tree';
 import {
   rewardsGetOptInStatus,
   rewardsIsOptInSupported,
@@ -46,7 +44,8 @@ export const useLinkAccountGroup = (
   const trackEvent = useContext(MetaMetricsContext);
 
   // Get accounts for the primary account group
-  const { accounts: primaryWalletGroupAccounts } = usePrimaryWalletGroupAccounts();
+  const { accounts: primaryWalletGroupAccounts } =
+    usePrimaryWalletGroupAccounts();
 
   const triggerAccountLinkingEvent = useCallback(
     (event: MetaMetricsEventName, account: InternalAccount) => {

--- a/ui/hooks/rewards/useLinkAccountGroup.ts
+++ b/ui/hooks/rewards/useLinkAccountGroup.ts
@@ -3,7 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { MetaMetricsContext } from '../../contexts/metametrics';
-import { getInternalAccountsFromGroupById } from '../../selectors/multichain-accounts/account-tree';
+import {
+  getInternalAccountsFromGroupById,
+} from '../../selectors/multichain-accounts/account-tree';
 import {
   rewardsGetOptInStatus,
   rewardsIsOptInSupported,
@@ -16,6 +18,7 @@ import {
 } from '../../../shared/constants/metametrics';
 import { getAccountTypeCategory } from '../../pages/multichain-accounts/account-details/account-type-utils';
 import { setRewardsAccountLinkedTimestamp } from '../../ducks/rewards';
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
 
 type LinkStatusReport = {
   success: boolean;
@@ -41,6 +44,9 @@ export const useLinkAccountGroup = (
   );
 
   const trackEvent = useContext(MetaMetricsContext);
+
+  // Get accounts for the primary account group
+  const { accounts: primaryWalletGroupAccounts } = usePrimaryWalletGroupAccounts();
 
   const triggerAccountLinkingEvent = useCallback(
     (event: MetaMetricsEventName, account: InternalAccount) => {
@@ -128,7 +134,10 @@ export const useLinkAccountGroup = (
 
       try {
         const results = (await dispatch(
-          rewardsLinkAccountsToSubscriptionCandidate(accountsToLink),
+          rewardsLinkAccountsToSubscriptionCandidate(
+            accountsToLink,
+            primaryWalletGroupAccounts,
+          ),
         )) as unknown as { account: InternalAccount; success: boolean }[];
 
         // Process results and emit completion/failure events
@@ -174,7 +183,12 @@ export const useLinkAccountGroup = (
     } finally {
       setIsLoading(false);
     }
-  }, [dispatch, internalAccountsForGroup, triggerAccountLinkingEvent]);
+  }, [
+    dispatch,
+    internalAccountsForGroup,
+    triggerAccountLinkingEvent,
+    primaryWalletGroupAccounts,
+  ]);
 
   return {
     linkAccountGroup,

--- a/ui/hooks/rewards/useOptIn.test.tsx
+++ b/ui/hooks/rewards/useOptIn.test.tsx
@@ -7,7 +7,31 @@ import {
   MetaMetricsEventName,
   MetaMetricsUserTrait,
 } from '../../../shared/constants/metametrics';
+import { HardwareKeyringNames } from '../../../shared/constants/hardware-wallets';
 import { useOptIn } from './useOptIn';
+
+// Mock useRequestHardwareWalletAccess hook
+const mockRequestHardwareWalletAccess = jest.fn();
+const mockIsHardwareWalletAccount = { current: false };
+
+jest.mock('./useRequestHardwareWalletAccess', () => ({
+  useRequestHardwareWalletAccess: () => ({
+    requestHardwareWalletAccess: mockRequestHardwareWalletAccess,
+    isHardwareWalletAccount: mockIsHardwareWalletAccount.current,
+  }),
+}));
+
+// Mock usePrimaryWalletGroupAccounts hook
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accounts: [] as InternalAccount[],
+    accountGroupId: undefined as string | undefined,
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
 
 // Mocks
 jest.mock('../../store/actions', () => ({
@@ -16,6 +40,9 @@ jest.mock('../../store/actions', () => ({
     { account: {} as InternalAccount, success: true },
   ]),
   updateMetaMetricsTraits: jest.fn(() => async () => {
+    // noop
+  }),
+  linkRewardToShieldSubscription: jest.fn(() => async () => {
     // noop
   }),
 }));
@@ -27,6 +54,10 @@ jest.mock('../../selectors', () => {
     getSelectedAccount: jest.fn(() => ({ address: '0x111' })),
   };
 });
+
+jest.mock('../../ducks/bridge/selectors', () => ({
+  getHardwareWalletName: jest.fn(() => undefined),
+}));
 
 const mockSideEffectAccounts: InternalAccount[] = [
   {
@@ -59,6 +90,34 @@ const mockActiveGroupAccounts: InternalAccount[] = [
     scopes: [],
   },
 ];
+
+const mockLedgerAccount: InternalAccount = {
+  id: 'ledger-acc-1',
+  address: '0xLedger111',
+  metadata: {
+    name: 'Ledger Account 1',
+    keyring: { type: 'Ledger Hardware' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+};
+
+const mockQRAccount: InternalAccount = {
+  id: 'qr-acc-1',
+  address: '0xQR111',
+  metadata: {
+    name: 'QR Account 1',
+    keyring: { type: 'QR Hardware Wallet Device' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+};
 
 jest.mock('../../selectors/multichain-accounts/account-tree', () => {
   const actual = jest.requireActual(
@@ -130,6 +189,9 @@ const { rewardsLinkAccountsToSubscriptionCandidate } = jest.requireMock(
 const { updateMetaMetricsTraits } = jest.requireMock('../../store/actions') as {
   updateMetaMetricsTraits: jest.Mock;
 };
+const { linkRewardToShieldSubscription } = jest.requireMock(
+  '../../store/actions',
+) as { linkRewardToShieldSubscription: jest.Mock };
 const { setCandidateSubscriptionId } = jest.requireMock(
   '../../ducks/rewards',
 ) as { setCandidateSubscriptionId: jest.Mock };
@@ -139,6 +201,9 @@ const { getSelectedAccountGroup } = jest.requireMock(
 const { getInternalAccountsFromGroupById } = jest.requireMock(
   '../../selectors/multichain-accounts/account-tree',
 ) as { getInternalAccountsFromGroupById: jest.Mock };
+const { getHardwareWalletName } = jest.requireMock(
+  '../../ducks/bridge/selectors',
+) as { getHardwareWalletName: jest.Mock };
 
 // MetaMetrics provider container
 const mockTrackEvent = jest.fn();
@@ -151,6 +216,15 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 describe('useOptIn', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mutable mock values
+    mockIsHardwareWalletAccount.current = false;
+    mockRequestHardwareWalletAccess.mockResolvedValue(true);
+    mockPrimaryWalletGroupAccounts.current = {
+      accounts: mockSideEffectAccounts,
+      accountGroupId: 'entropy:test/1',
+    };
+    getHardwareWalletName.mockReturnValue(undefined);
+
     (rewardsOptIn as jest.Mock).mockImplementation(() => async () => 'sub-123');
     (
       rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
@@ -158,6 +232,11 @@ describe('useOptIn', () => {
       { account: {} as InternalAccount, success: true },
     ]);
     (updateMetaMetricsTraits as jest.Mock).mockImplementation(
+      () => async () => {
+        // noop
+      },
+    );
+    (linkRewardToShieldSubscription as jest.Mock).mockImplementation(
       () => async () => {
         // noop
       },
@@ -253,7 +332,7 @@ describe('useOptIn', () => {
       });
     });
 
-    it('uses side effect accounts for opt-in when available and links active group accounts', async () => {
+    it('uses primary wallet group accounts for opt-in when available and links active group accounts', async () => {
       (rewardsOptIn as jest.Mock).mockImplementation(
         () => async () => 'sub-side-effect',
       );
@@ -269,7 +348,7 @@ describe('useOptIn', () => {
         await result.current.optin();
       });
 
-      // Should opt-in with side effect accounts (entropy:test/1)
+      // Should opt-in with primary wallet group accounts
       expect(rewardsOptIn).toHaveBeenCalledWith({
         accounts: mockSideEffectAccounts,
         referralCode: undefined,
@@ -278,22 +357,16 @@ describe('useOptIn', () => {
       // Should link active group accounts after opt-in
       expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
         mockActiveGroupAccounts,
+        mockSideEffectAccounts,
       );
     });
 
-    it('uses active group accounts for opt-in when no side effect accounts available', async () => {
-      // Mock to return empty array for side effect accounts
-      (getInternalAccountsFromGroupById as jest.Mock).mockImplementation(
-        (_state, groupId: string) => {
-          if (groupId === 'entropy:test/1') {
-            return [];
-          }
-          if (groupId === 'entropy:test/0') {
-            return mockActiveGroupAccounts;
-          }
-          return [];
-        },
-      );
+    it('uses active group accounts for opt-in when no primary wallet group accounts available', async () => {
+      // Mock to return empty array for primary wallet group accounts
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: [],
+        accountGroupId: undefined,
+      };
 
       (rewardsOptIn as jest.Mock).mockImplementation(
         () => async () => 'sub-active',
@@ -316,7 +389,7 @@ describe('useOptIn', () => {
         referralCode: undefined,
       });
 
-      // Should not link accounts when there are no accounts to link
+      // Should link primary wallet group accounts (empty in this case)
       expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
     });
 
@@ -455,6 +528,648 @@ describe('useOptIn', () => {
       expect(updateMetaMetricsTraits).not.toHaveBeenCalled();
       const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
       expect(events).not.toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+  });
+
+  describe('Hardware wallet opt-in flow', () => {
+    describe('Ledger account opt-in', () => {
+      beforeEach(() => {
+        mockIsHardwareWalletAccount.current = true;
+        getHardwareWalletName.mockReturnValue(HardwareKeyringNames.ledger);
+        mockPrimaryWalletGroupAccounts.current = {
+          accounts: [mockLedgerAccount],
+          accountGroupId: 'ledger:test/0',
+        };
+      });
+
+      it('requests hardware wallet access before opt-in for Ledger accounts', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-ledger',
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(mockRequestHardwareWalletAccess).toHaveBeenCalledTimes(1);
+        expect(rewardsOptIn).toHaveBeenCalledWith({
+          accounts: [mockLedgerAccount],
+          referralCode: undefined,
+        });
+        expect(setCandidateSubscriptionId).toHaveBeenCalledWith('sub-ledger');
+      });
+
+      it('tracks is_hardware_wallet property in metrics for Ledger accounts', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-ledger-metrics',
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+        const started = calls.find(
+          (c: { event: MetaMetricsEventName }) =>
+            c.event === MetaMetricsEventName.RewardsOptInStarted,
+        );
+        expect(started?.properties?.is_hardware_wallet).toBe(true);
+
+        const completed = calls.find(
+          (c: { event: MetaMetricsEventName }) =>
+            c.event === MetaMetricsEventName.RewardsOptInCompleted,
+        );
+        expect(completed).toBeDefined();
+      });
+
+      it('does not link additional accounts for hardware wallets to prevent multiple signing requests', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-ledger-no-link',
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        // For hardware wallets, linking should be skipped to prevent multiple signing requests
+        expect(
+          rewardsLinkAccountsToSubscriptionCandidate,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('fails opt-in when hardware wallet access is denied', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(rewardsOptIn).not.toHaveBeenCalled();
+        expect(result.current.optinLoading).toBe(false);
+        expect(result.current.optinError).not.toBeNull();
+
+        // Verify failure event was tracked with hardware wallet access denied reason
+        const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+        const failedEvent = calls.find(
+          (c: { event: MetaMetricsEventName }) =>
+            c.event === MetaMetricsEventName.RewardsOptInFailed,
+        );
+        expect(failedEvent).toBeDefined();
+        expect(failedEvent?.properties?.failure_reason).toBe(
+          'hardware_wallet_access_denied',
+        );
+      });
+
+      it('uses hardware wallet name in error message when access is denied', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        // Error should be set (the actual error message depends on t() translation function)
+        expect(result.current.optinError).not.toBeNull();
+        expect(result.current.optinLoading).toBe(false);
+      });
+    });
+
+    describe('QR-based wallet opt-in', () => {
+      beforeEach(() => {
+        mockIsHardwareWalletAccount.current = true;
+        getHardwareWalletName.mockReturnValue(HardwareKeyringNames.qr);
+        mockPrimaryWalletGroupAccounts.current = {
+          accounts: [mockQRAccount],
+          accountGroupId: 'qr:test/0',
+        };
+      });
+
+      it('requests hardware wallet access before opt-in for QR accounts', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-qr',
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(mockRequestHardwareWalletAccess).toHaveBeenCalledTimes(1);
+        expect(rewardsOptIn).toHaveBeenCalledWith({
+          accounts: [mockQRAccount],
+          referralCode: undefined,
+        });
+        expect(setCandidateSubscriptionId).toHaveBeenCalledWith('sub-qr');
+      });
+
+      it('does not link additional accounts for QR wallets', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-qr-no-link',
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        // For hardware wallets, linking should be skipped
+        expect(
+          rewardsLinkAccountsToSubscriptionCandidate,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('fails opt-in when QR wallet access is denied', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(rewardsOptIn).not.toHaveBeenCalled();
+        expect(result.current.optinError).not.toBeNull();
+
+        const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+        const failedEvent = calls.find(
+          (c: { event: MetaMetricsEventName }) =>
+            c.event === MetaMetricsEventName.RewardsOptInFailed,
+        );
+        expect(failedEvent?.properties?.failure_reason).toBe(
+          'hardware_wallet_access_denied',
+        );
+      });
+    });
+
+    describe('Hardware wallet SIWE signing state management', () => {
+      beforeEach(() => {
+        mockIsHardwareWalletAccount.current = true;
+        getHardwareWalletName.mockReturnValue(HardwareKeyringNames.ledger);
+        mockPrimaryWalletGroupAccounts.current = {
+          accounts: [mockLedgerAccount],
+          accountGroupId: 'ledger:test/0',
+        };
+      });
+
+      it('sets loading state during hardware wallet opt-in process', async () => {
+        let resolveOptIn: (value: string) => void;
+        const optInPromise = new Promise<string>((resolve) => {
+          resolveOptIn = resolve;
+        });
+
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => () => optInPromise,
+        );
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        let optinPromise: Promise<void> | undefined;
+        await act(async () => {
+          optinPromise = result.current.optin();
+        });
+
+        // Loading should be true during opt-in
+        // Note: Due to async nature, we resolve and check final state
+        await act(async () => {
+          resolveOptIn('sub-loading-test');
+          await optinPromise;
+        });
+
+        expect(result.current.optinLoading).toBe(false);
+      });
+
+      it('properly resets loading state when hardware wallet signing fails', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(() => async () => {
+          throw new Error('SIWE signing failed');
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinLoading).toBe(false);
+        expect(result.current.optinError).toBe('mock error');
+      });
+
+      it('clears error state on successful retry after failure', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+
+        // First attempt fails
+        (rewardsOptIn as jest.Mock).mockImplementationOnce(() => async () => {
+          throw new Error('First attempt failed');
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).toBe('mock error');
+
+        // Second attempt succeeds
+        (rewardsOptIn as jest.Mock).mockImplementation(
+          () => async () => 'sub-retry-success',
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).toBeNull();
+        expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
+          'sub-retry-success',
+        );
+      });
+    });
+
+    describe('Hardware wallet error states', () => {
+      beforeEach(() => {
+        mockIsHardwareWalletAccount.current = true;
+        getHardwareWalletName.mockReturnValue(HardwareKeyringNames.ledger);
+        mockPrimaryWalletGroupAccounts.current = {
+          accounts: [mockLedgerAccount],
+          accountGroupId: 'ledger:test/0',
+        };
+      });
+
+      it('handles hardware wallet signing rejection gracefully', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(() => async () => {
+          throw new Error('User rejected signing');
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).toBe('mock error');
+        expect(result.current.optinLoading).toBe(false);
+        expect(setCandidateSubscriptionId).not.toHaveBeenCalled();
+      });
+
+      it('handles hardware wallet connection timeout', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(() => async () => {
+          throw new Error('Connection timeout');
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).toBe('mock error');
+        expect(result.current.optinLoading).toBe(false);
+
+        const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+        const failedEvent = calls.find(
+          (c: { event: MetaMetricsEventName }) =>
+            c.event === MetaMetricsEventName.RewardsOptInFailed,
+        );
+        expect(failedEvent).toBeDefined();
+      });
+
+      it('handles hardware wallet app not open error', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(true);
+        (rewardsOptIn as jest.Mock).mockImplementation(() => async () => {
+          throw new Error('Ethereum app not open');
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).toBe('mock error');
+        expect(result.current.optinLoading).toBe(false);
+      });
+
+      it('clearOptinError clears hardware wallet error state', async () => {
+        mockRequestHardwareWalletAccess.mockResolvedValue(false);
+
+        const { result } = renderHookWithProvider(
+          () => useOptIn(),
+          {},
+          undefined,
+          Container,
+        );
+
+        await act(async () => {
+          await result.current.optin();
+        });
+
+        expect(result.current.optinError).not.toBeNull();
+
+        act(() => {
+          result.current.clearOptinError();
+        });
+
+        expect(result.current.optinError).toBeNull();
+      });
+    });
+  });
+
+  describe('Shield subscription linking', () => {
+    it('links reward to shield subscription when options are provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-123',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).toHaveBeenCalledWith(
+        'shield-sub-123',
+        100,
+      );
+    });
+
+    it('does not link to shield subscription when options are not provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-no-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('does not link when only rewardPoints is provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-partial-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn({ rewardPoints: 100 }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('does not link when only shieldSubscriptionId is provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-partial-shield-2',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn({ shieldSubscriptionId: 'shield-sub-456' }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('swallows shield subscription linking errors without affecting opt-in success', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-shield-error',
+      );
+      (linkRewardToShieldSubscription as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('Shield linking failed');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-error',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Opt-in should still succeed despite shield linking failure
+      expect(result.current.optinError).toBeNull();
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
+        'sub-shield-error',
+      );
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+
+    it('does not link to shield subscription when subscriptionId is null', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(() => async () => null);
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-null',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Non-hardware wallet opt-in (software wallet)', () => {
+    it('does not request hardware wallet access for software wallets', async () => {
+      mockIsHardwareWalletAccount.current = false;
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-software',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(mockRequestHardwareWalletAccess).not.toHaveBeenCalled();
+      expect(rewardsOptIn).toHaveBeenCalled();
+    });
+
+    it('links additional accounts for software wallets', async () => {
+      mockIsHardwareWalletAccount.current = false;
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-software-link',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Software wallets should link additional accounts
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalled();
+    });
+
+    it('tracks is_hardware_wallet as false for software wallets', async () => {
+      mockIsHardwareWalletAccount.current = false;
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-software-metrics',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      const calls = mockTrackEvent.mock.calls.map((args) => args[0]);
+      const started = calls.find(
+        (c: { event: MetaMetricsEventName }) =>
+          c.event === MetaMetricsEventName.RewardsOptInStarted,
+      );
+      expect(started?.properties?.is_hardware_wallet).toBe(false);
     });
   });
 });

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -63,7 +63,6 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
   const { requestHardwareWalletAccess, isHardwareWalletAccount } =
     useRequestHardwareWalletAccess();
 
-
   // Get accounts for active (selected) account group
   const activeGroupAccounts = useSelector((state) =>
     selectedAccountGroupId
@@ -75,7 +74,10 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
   );
 
   // Get accounts for the primary account group
-  const { accounts: primaryWalletGroupAccounts, accountGroupId: primaryWalletAccountGroupId } = usePrimaryWalletGroupAccounts();
+  const {
+    accounts: primaryWalletGroupAccounts,
+    accountGroupId: primaryWalletAccountGroupId,
+  } = usePrimaryWalletGroupAccounts();
 
   const handleOptIn = useCallback(
     async (referralCode?: string) => {

--- a/ui/hooks/rewards/usePrimaryWalletGroupAccounts.test.ts
+++ b/ui/hooks/rewards/usePrimaryWalletGroupAccounts.test.ts
@@ -1,0 +1,696 @@
+import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { renderHook } from '@testing-library/react-hooks';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
+
+// Import after mocks
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
+
+// Mock the selectors module
+const mockGetSelectedAccount = jest.fn();
+const mockGetWalletIdAndNameByAccountAddress = jest.fn();
+const mockGetMultichainAccountsByWalletId = jest.fn();
+const mockGetInternalAccountsFromGroupById = jest.fn();
+
+jest.mock('../../selectors', () => ({
+  getSelectedAccount: (...args: unknown[]) => mockGetSelectedAccount(...args),
+}));
+
+jest.mock('../../selectors/multichain-accounts/account-tree', () => ({
+  getWalletIdAndNameByAccountAddress: (...args: unknown[]) =>
+    mockGetWalletIdAndNameByAccountAddress(...args),
+  getMultichainAccountsByWalletId: (...args: unknown[]) =>
+    mockGetMultichainAccountsByWalletId(...args),
+  getInternalAccountsFromGroupById: (...args: unknown[]) =>
+    mockGetInternalAccountsFromGroupById(...args),
+}));
+
+// Mock react-redux useSelector to call our mocked selectors
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector) => {
+    // Call the selector with a minimal state object
+    return selector({});
+  }),
+}));
+
+// Constants
+const PRIMARY_GROUP_ID = 'entropy:test-wallet/0' as AccountGroupId;
+const SECONDARY_GROUP_ID = 'entropy:test-wallet/1' as AccountGroupId;
+const WALLET_ID = 'entropy:test-wallet' as AccountWalletId;
+
+// Helper functions to create mock accounts
+const createMockLedgerAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Ledger Account ${id}`,
+    keyring: { type: HardwareKeyringType.ledger },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockTrezorAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Trezor Account ${id}`,
+    keyring: { type: HardwareKeyringType.trezor },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockQRAccount = (id: string, address: string): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `QR Account ${id}`,
+    keyring: { type: HardwareKeyringType.qr },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockSoftwareAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Software Account ${id}`,
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+/**
+ * Helper to set up all mocks for a typical test scenario
+ *
+ * @param options0
+ * @param options0.selectedAddress
+ * @param options0.walletId
+ * @param options0.accountGroupsByWallet
+ * @param options0.primaryGroupAccounts
+ */
+const setupMocks = ({
+  selectedAddress = '0xAccount111',
+  walletId = WALLET_ID,
+  accountGroupsByWallet = {} as Record<AccountGroupId, unknown>,
+  primaryGroupAccounts = [] as InternalAccount[],
+}: {
+  selectedAddress?: string;
+  walletId?: AccountWalletId | undefined;
+  accountGroupsByWallet?: Record<AccountGroupId, unknown>;
+  primaryGroupAccounts?: InternalAccount[];
+} = {}) => {
+  mockGetSelectedAccount.mockReturnValue({ address: selectedAddress });
+  mockGetWalletIdAndNameByAccountAddress.mockReturnValue(
+    walletId ? { id: walletId, name: 'Test Wallet' } : null,
+  );
+  mockGetMultichainAccountsByWalletId.mockReturnValue(accountGroupsByWallet);
+  mockGetInternalAccountsFromGroupById.mockReturnValue(primaryGroupAccounts);
+};
+
+describe('usePrimaryWalletGroupAccounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Filtering accounts by primary wallet group', () => {
+    it('returns accounts from the primary (first) group when wallet has multiple groups', () => {
+      const primaryAccounts = [
+        createMockSoftwareAccount('sw-1', '0xPrimary111'),
+        createMockSoftwareAccount('sw-2', '0xPrimary222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xPrimary111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+          [SECONDARY_GROUP_ID]: { id: SECONDARY_GROUP_ID },
+        },
+        primaryGroupAccounts: primaryAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(2);
+      expect(result.current.accounts.map((a) => a.address)).toEqual([
+        '0xPrimary111',
+        '0xPrimary222',
+      ]);
+    });
+
+    it('returns accounts from the single group when wallet has only one group', () => {
+      const accounts = [
+        createMockSoftwareAccount('sw-1', '0xAccount111'),
+        createMockSoftwareAccount('sw-2', '0xAccount222'),
+        createMockSoftwareAccount('sw-3', '0xAccount333'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(3);
+    });
+
+    it('returns the correct primary group for the selected account wallet', () => {
+      const wallet1Accounts = [
+        createMockSoftwareAccount('w1-acc-1', '0xWallet1Account111'),
+      ];
+
+      const wallet1GroupId = 'entropy:wallet-1/0' as AccountGroupId;
+
+      setupMocks({
+        selectedAddress: '0xWallet1Account111',
+        walletId: 'entropy:wallet-1' as AccountWalletId,
+        accountGroupsByWallet: {
+          [wallet1GroupId]: { id: wallet1GroupId },
+        },
+        primaryGroupAccounts: wallet1Accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(wallet1GroupId);
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0].address).toBe('0xWallet1Account111');
+    });
+  });
+
+  describe('Mixed account types (software, Ledger, QR, Trezor)', () => {
+    it('returns all accounts in primary group including mixed hardware types', () => {
+      const mixedAccounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+        createMockTrezorAccount('trezor-1', '0xTrezor111'),
+        createMockQRAccount('qr-1', '0xQR111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: mixedAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(4);
+      expect(result.current.accounts.map((a) => a.address)).toEqual([
+        '0xSoftware111',
+        '0xLedger111',
+        '0xTrezor111',
+        '0xQR111',
+      ]);
+    });
+
+    it('returns only Ledger accounts when primary group has only Ledger accounts', () => {
+      const ledgerAccounts = [
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+        createMockLedgerAccount('ledger-2', '0xLedger222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xLedger111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: ledgerAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.ledger);
+      });
+    });
+
+    it('returns only QR accounts when primary group has only QR accounts', () => {
+      const qrAccounts = [
+        createMockQRAccount('qr-1', '0xQR111'),
+        createMockQRAccount('qr-2', '0xQR222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xQR111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: qrAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.qr);
+      });
+    });
+
+    it('returns only Trezor accounts when primary group has only Trezor accounts', () => {
+      const trezorAccounts = [
+        createMockTrezorAccount('trezor-1', '0xTrezor111'),
+        createMockTrezorAccount('trezor-2', '0xTrezor222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xTrezor111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: trezorAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.trezor);
+      });
+    });
+
+    it('correctly identifies account types in a mixed primary group', () => {
+      const mixedAccounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: mixedAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      const softwareAccount = result.current.accounts.find(
+        (a) => a.address === '0xSoftware111',
+      );
+      const ledgerAccount = result.current.accounts.find(
+        (a) => a.address === '0xLedger111',
+      );
+
+      expect(softwareAccount?.metadata.keyring.type).toBe('HD Key Tree');
+      expect(ledgerAccount?.metadata.keyring.type).toBe(
+        HardwareKeyringType.ledger,
+      );
+    });
+  });
+
+  describe('Empty/null wallet group scenarios', () => {
+    it('returns empty accounts array when primary group has no accounts', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns empty accounts when wallet has no groups', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('handles undefined walletId gracefully (null return from getWalletIdAndNameByAccountAddress)', () => {
+      // When getWalletIdAndNameByAccountAddress returns null, the fallback { walletId: undefined } is used
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue(null);
+      mockGetMultichainAccountsByWalletId.mockReturnValue({});
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('uses fallback when getWalletIdAndNameByAccountAddress returns undefined', () => {
+      // Test the || { walletId: undefined } fallback explicitly
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue(undefined);
+      mockGetMultichainAccountsByWalletId.mockReturnValue({});
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns undefined accountGroupId when wallet groups are empty object', () => {
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns empty array when accountGroupsByWallet is undefined', () => {
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue({
+        id: WALLET_ID,
+        name: 'Test Wallet',
+      });
+      mockGetMultichainAccountsByWalletId.mockReturnValue(undefined);
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+  });
+
+  describe('Memoization behavior', () => {
+    it('returns the same reference when state does not change', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePrimaryWalletGroupAccounts(),
+      );
+
+      const firstResult = result.current;
+      rerender();
+      const secondResult = result.current;
+
+      // The hook uses useMemo for primaryAccountGroupId, so the reference should be stable
+      expect(firstResult.accountGroupId).toBe(secondResult.accountGroupId);
+    });
+
+    it('returns stable accounts array reference when accounts do not change', () => {
+      const accounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePrimaryWalletGroupAccounts(),
+      );
+
+      const firstAccounts = result.current.accounts;
+      rerender();
+      const secondAccounts = result.current.accounts;
+
+      // Both renders should return the same account data
+      expect(firstAccounts).toEqual(secondAccounts);
+      expect(firstAccounts.length).toBe(secondAccounts.length);
+    });
+
+    it('useMemo recalculates primaryAccountGroupId only when accountGroupsByWallet changes', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      // First render should have calculated the primary group ID
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('returns first group as primary when groups are added in non-sequential order', () => {
+      const accounts1 = [createMockSoftwareAccount('sw-1', '0xFirst111')];
+      const groupId5 = 'entropy:test-wallet/5' as AccountGroupId;
+
+      // Create groups with IDs that might not be in expected order
+      // Object.keys order is based on insertion order in modern JS
+      setupMocks({
+        selectedAddress: '0xFirst111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+          [groupId5]: { id: groupId5 },
+        },
+        primaryGroupAccounts: accounts1,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      // Should return the first group in the object
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts[0].address).toBe('0xFirst111');
+    });
+
+    it('handles wallet with single account correctly', () => {
+      const singleAccount = createMockLedgerAccount(
+        'ledger-1',
+        '0xSingleLedger',
+      );
+
+      setupMocks({
+        selectedAddress: '0xSingleLedger',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [singleAccount],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0].address).toBe('0xSingleLedger');
+      expect(result.current.accounts[0].metadata.keyring.type).toBe(
+        HardwareKeyringType.ledger,
+      );
+    });
+
+    it('handles large number of accounts in a group', () => {
+      const manyAccounts: InternalAccount[] = [];
+      for (let i = 0; i < 100; i++) {
+        manyAccounts.push(
+          createMockSoftwareAccount(
+            `sw-${i}`,
+            `0xAccount${i.toString().padStart(4, '0')}`,
+          ),
+        );
+      }
+
+      setupMocks({
+        selectedAddress: '0xAccount0000',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: manyAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(100);
+    });
+  });
+
+  describe('Return type structure', () => {
+    it('returns correct shape with accountGroupId and accounts', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current).toHaveProperty('accountGroupId');
+      expect(result.current).toHaveProperty('accounts');
+      expect(typeof result.current.accountGroupId).toBe('string');
+      expect(Array.isArray(result.current.accounts)).toBe(true);
+    });
+
+    it('accounts array contains InternalAccount objects with expected properties', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      const account = result.current.accounts[0];
+      expect(account).toHaveProperty('id');
+      expect(account).toHaveProperty('address');
+      expect(account).toHaveProperty('metadata');
+      expect(account.metadata).toHaveProperty('name');
+      expect(account.metadata).toHaveProperty('keyring');
+      expect(account.metadata.keyring).toHaveProperty('type');
+    });
+
+    it('accountGroupId is undefined when no groups exist', () => {
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+    });
+  });
+
+  describe('Selector integration', () => {
+    it('calls getSelectedAccount selector', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetSelectedAccount).toHaveBeenCalled();
+    });
+
+    it('calls getWalletIdAndNameByAccountAddress with selected account address', () => {
+      setupMocks({
+        selectedAddress: '0xSelectedAddress',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetWalletIdAndNameByAccountAddress).toHaveBeenCalled();
+    });
+
+    it('calls getMultichainAccountsByWalletId when walletId is available', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetMultichainAccountsByWalletId).toHaveBeenCalled();
+    });
+
+    it('calls getInternalAccountsFromGroupById when primary group ID is determined', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetInternalAccountsFromGroupById).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
+++ b/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
@@ -53,4 +53,3 @@ export const usePrimaryWalletGroupAccounts = (): {
     accounts: primaryWalletGroupAccounts,
   };
 };
-

--- a/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
+++ b/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { getSelectedAccount } from '../../selectors';
+import {
+  getMultichainAccountsByWalletId,
+  getWalletIdAndNameByAccountAddress,
+  getInternalAccountsFromGroupById,
+} from '../../selectors/multichain-accounts/account-tree';
+import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
+
+/**
+ * Hook to get accounts for the primary (first) account group in the wallet
+ * of the currently selected account.
+ *
+ * @returns Object containing the accountGroupId and accounts array for the primary wallet group
+ */
+export const usePrimaryWalletGroupAccounts = (): {
+  accountGroupId: AccountGroupId | undefined;
+  accounts: InternalAccount[];
+} => {
+  const selectedAccount = useSelector(getSelectedAccount);
+  const { id: walletId } = useSelector((state) =>
+    getWalletIdAndNameByAccountAddress(state, selectedAccount.address),
+  ) || { walletId: undefined };
+
+  const accountGroupsByWallet = useSelector((state: MultichainAccountsState) =>
+    walletId
+      ? getMultichainAccountsByWalletId(state, walletId as AccountWalletId)
+      : {},
+  );
+
+  // Get the first account group ID from the wallet (primary account group)
+  const primaryAccountGroupId = useMemo(
+    () =>
+      accountGroupsByWallet ? Object.keys(accountGroupsByWallet)[0] : undefined,
+    [accountGroupsByWallet],
+  );
+
+  // Get accounts for the primary account group
+  const primaryWalletGroupAccounts = useSelector((state) =>
+    primaryAccountGroupId
+      ? getInternalAccountsFromGroupById(
+          state,
+          primaryAccountGroupId as AccountGroupId,
+        )
+      : [],
+  );
+
+  return {
+    accountGroupId: primaryAccountGroupId as AccountGroupId | undefined,
+    accounts: primaryWalletGroupAccounts,
+  };
+};
+

--- a/ui/hooks/rewards/useRequestHardwareWalletAccess.test.ts
+++ b/ui/hooks/rewards/useRequestHardwareWalletAccess.test.ts
@@ -1,0 +1,456 @@
+import { renderHook } from '@testing-library/react-hooks';
+import log from 'loglevel';
+import {
+  HardwareKeyringType,
+  LEDGER_USB_VENDOR_ID,
+  LedgerTransportTypes,
+} from '../../../shared/constants/hardware-wallets';
+
+// Import after mocks
+import { useRequestHardwareWalletAccess } from './useRequestHardwareWalletAccess';
+
+// Mock the selectors
+const mockIsHardwareWallet = jest.fn();
+const mockGetHardwareWalletType = jest.fn();
+const mockGetLedgerTransportType = jest.fn();
+
+jest.mock('../../selectors', () => ({
+  isHardwareWallet: (...args: unknown[]) => mockIsHardwareWallet(...args),
+  getHardwareWalletType: (...args: unknown[]) =>
+    mockGetHardwareWalletType(...args),
+}));
+
+jest.mock('../../ducks/metamask/metamask', () => ({
+  getLedgerTransportType: (...args: unknown[]) =>
+    mockGetLedgerTransportType(...args),
+}));
+
+// Mock loglevel
+jest.mock('loglevel', () => ({
+  error: jest.fn(),
+}));
+
+// Mock react-redux useSelector to call our mocked selectors
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector) => {
+    // Call the selector with a minimal state object
+    return selector({});
+  }),
+}));
+
+describe('useRequestHardwareWalletAccess', () => {
+  let originalNavigatorHid: HID | undefined;
+  let originalNavigatorUsb: USB | undefined;
+  let mockRequestDeviceHid: jest.Mock;
+  let mockRequestDeviceUsb: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Save original navigator properties
+    originalNavigatorHid = window.navigator.hid;
+    originalNavigatorUsb = window.navigator.usb;
+
+    // Setup mock HID
+    mockRequestDeviceHid = jest.fn();
+    Object.defineProperty(window.navigator, 'hid', {
+      value: {
+        requestDevice: mockRequestDeviceHid,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Setup mock USB
+    mockRequestDeviceUsb = jest.fn();
+    Object.defineProperty(window.navigator, 'usb', {
+      value: {
+        requestDevice: mockRequestDeviceUsb,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore original navigator properties
+    Object.defineProperty(window.navigator, 'hid', {
+      value: originalNavigatorHid,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window.navigator, 'usb', {
+      value: originalNavigatorUsb,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('isHardwareWalletAccount flag', () => {
+    it('returns false when account is not a hardware wallet', () => {
+      mockIsHardwareWallet.mockReturnValue(false);
+      mockGetHardwareWalletType.mockReturnValue(null);
+      mockGetLedgerTransportType.mockReturnValue(null);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      expect(result.current.isHardwareWalletAccount).toBe(false);
+    });
+
+    it('returns true when account is a hardware wallet', () => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      expect(result.current.isHardwareWalletAccount).toBe(true);
+    });
+  });
+
+  describe('requestHardwareWalletAccess - non-hardware wallet', () => {
+    it('returns true immediately when account is not a hardware wallet', async () => {
+      mockIsHardwareWallet.mockReturnValue(false);
+      mockGetHardwareWalletType.mockReturnValue(null);
+      mockGetLedgerTransportType.mockReturnValue(null);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+      expect(mockRequestDeviceHid).not.toHaveBeenCalled();
+      expect(mockRequestDeviceUsb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestHardwareWalletAccess - Ledger with WebHID', () => {
+    beforeEach(() => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+    });
+
+    it('returns true when Ledger device is connected with correct vendor ID', async () => {
+      const mockDevice = {
+        vendorId: Number(LEDGER_USB_VENDOR_ID),
+        productId: 0x0001,
+      } as HIDDevice;
+
+      mockRequestDeviceHid.mockResolvedValue([mockDevice]);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+      expect(mockRequestDeviceHid).toHaveBeenCalledWith({
+        filters: [{ vendorId: Number(LEDGER_USB_VENDOR_ID) }],
+      });
+    });
+
+    it('returns false when no Ledger device is found', async () => {
+      mockRequestDeviceHid.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(mockRequestDeviceHid).toHaveBeenCalled();
+    });
+
+    it('returns false when connected device has wrong vendor ID', async () => {
+      const mockDevice = {
+        vendorId: 0x1234, // Wrong vendor ID
+        productId: 0x0001,
+      } as HIDDevice;
+
+      mockRequestDeviceHid.mockResolvedValue([mockDevice]);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+    });
+
+    it('returns true when multiple devices are returned and at least one has correct vendor ID', async () => {
+      const mockDevice1 = {
+        vendorId: 0x1234, // Wrong vendor ID
+        productId: 0x0001,
+      } as HIDDevice;
+      const mockDevice2 = {
+        vendorId: Number(LEDGER_USB_VENDOR_ID), // Correct vendor ID
+        productId: 0x0001,
+      } as HIDDevice;
+
+      mockRequestDeviceHid.mockResolvedValue([mockDevice1, mockDevice2]);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+    });
+
+    it('returns false when user cancels device selection', async () => {
+      const error = new Error('No device selected');
+      mockRequestDeviceHid.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(log.error).not.toHaveBeenCalled();
+    });
+
+    it('returns false and logs error when requestDevice throws non-cancellation error', async () => {
+      const error = new Error('Permission denied');
+      mockRequestDeviceHid.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(log.error).toHaveBeenCalledWith(
+        'Hardware wallet access request failed:',
+        error,
+      );
+    });
+
+    it('handles string error messages', async () => {
+      const error = 'Some string error';
+      mockRequestDeviceHid.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(log.error).toHaveBeenCalledWith(
+        'Hardware wallet access request failed:',
+        error,
+      );
+    });
+  });
+
+  describe('requestHardwareWalletAccess - Trezor with WebUSB', () => {
+    beforeEach(() => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.trezor);
+      mockGetLedgerTransportType.mockReturnValue(null);
+    });
+
+    it('returns true when Trezor device access is granted', async () => {
+      mockRequestDeviceUsb.mockResolvedValue({});
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+      expect(mockRequestDeviceUsb).toHaveBeenCalledWith({
+        filters: [
+          { vendorId: 0x534c, productId: 0x0001 }, // Trezor One
+          { vendorId: 0x1209, productId: 0x53c0 }, // Trezor Model T
+          { vendorId: 0x1209, productId: 0x53c1 }, // Trezor Safe 3
+        ],
+      });
+    });
+
+    it('returns false when user cancels device selection', async () => {
+      const error = new Error('No device selected');
+      mockRequestDeviceUsb.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(log.error).not.toHaveBeenCalled();
+    });
+
+    it('returns false and logs error when requestDevice throws non-cancellation error', async () => {
+      const error = new Error('Permission denied');
+      mockRequestDeviceUsb.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(log.error).toHaveBeenCalledWith(
+        'Hardware wallet access request failed:',
+        error,
+      );
+    });
+
+    it('returns false when WebUSB is not available', async () => {
+      Object.defineProperty(window.navigator, 'usb', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(mockRequestDeviceUsb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestHardwareWalletAccess - Lattice', () => {
+    beforeEach(() => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.lattice);
+      mockGetLedgerTransportType.mockReturnValue(null);
+    });
+
+    it('returns true without requesting device access', async () => {
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+      expect(mockRequestDeviceHid).not.toHaveBeenCalled();
+      expect(mockRequestDeviceUsb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestHardwareWalletAccess - QR hardware wallet', () => {
+    beforeEach(() => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.qr);
+      mockGetLedgerTransportType.mockReturnValue(null);
+    });
+
+    it('returns true without requesting device access', async () => {
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(true);
+      expect(mockRequestDeviceHid).not.toHaveBeenCalled();
+      expect(mockRequestDeviceUsb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestHardwareWalletAccess - Ledger with non-WebHID transport', () => {
+    beforeEach(() => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.u2f);
+    });
+
+    it('returns false when Ledger uses U2F transport (not WebHID)', async () => {
+      // When ledgerTransportType is not webhid, the hook should fall through
+      // to the Lattice/QR check, which will return false since hardwareWalletType is ledger
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      const accessGranted = await result.current.requestHardwareWalletAccess();
+
+      expect(accessGranted).toBe(false);
+      expect(mockRequestDeviceHid).not.toHaveBeenCalled();
+      expect(mockRequestDeviceUsb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestHardwareWalletAccess - callback memoization', () => {
+    it('returns stable function reference when dependencies do not change', () => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+
+      const { result, rerender } = renderHook(() =>
+        useRequestHardwareWalletAccess(),
+      );
+
+      const firstFunction = result.current.requestHardwareWalletAccess;
+      rerender();
+      const secondFunction = result.current.requestHardwareWalletAccess;
+
+      expect(firstFunction).toBe(secondFunction);
+    });
+
+    it('returns new function reference when isHardwareWalletAccount changes', () => {
+      mockIsHardwareWallet.mockReturnValue(false);
+      mockGetHardwareWalletType.mockReturnValue(null);
+      mockGetLedgerTransportType.mockReturnValue(null);
+
+      const { result, rerender } = renderHook(() =>
+        useRequestHardwareWalletAccess(),
+      );
+
+      const firstFunction = result.current.requestHardwareWalletAccess;
+
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+      rerender();
+
+      const secondFunction = result.current.requestHardwareWalletAccess;
+
+      expect(firstFunction).not.toBe(secondFunction);
+    });
+
+    it('returns new function reference when hardwareWalletType changes', () => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+
+      const { result, rerender } = renderHook(() =>
+        useRequestHardwareWalletAccess(),
+      );
+
+      const firstFunction = result.current.requestHardwareWalletAccess;
+
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.trezor);
+      rerender();
+
+      const secondFunction = result.current.requestHardwareWalletAccess;
+
+      expect(firstFunction).not.toBe(secondFunction);
+    });
+
+    it('returns new function reference when ledgerTransportType changes', () => {
+      mockIsHardwareWallet.mockReturnValue(true);
+      mockGetHardwareWalletType.mockReturnValue(HardwareKeyringType.ledger);
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.webhid);
+
+      const { result, rerender } = renderHook(() =>
+        useRequestHardwareWalletAccess(),
+      );
+
+      const firstFunction = result.current.requestHardwareWalletAccess;
+
+      mockGetLedgerTransportType.mockReturnValue(LedgerTransportTypes.u2f);
+      rerender();
+
+      const secondFunction = result.current.requestHardwareWalletAccess;
+
+      expect(firstFunction).not.toBe(secondFunction);
+    });
+  });
+
+  describe('requestHardwareWalletAccess - return type structure', () => {
+    it('returns correct shape with requestHardwareWalletAccess and isHardwareWalletAccount', () => {
+      mockIsHardwareWallet.mockReturnValue(false);
+      mockGetHardwareWalletType.mockReturnValue(null);
+      mockGetLedgerTransportType.mockReturnValue(null);
+
+      const { result } = renderHook(() => useRequestHardwareWalletAccess());
+
+      expect(result.current).toHaveProperty('requestHardwareWalletAccess');
+      expect(result.current).toHaveProperty('isHardwareWalletAccount');
+      expect(typeof result.current.requestHardwareWalletAccess).toBe('function');
+      expect(typeof result.current.isHardwareWalletAccount).toBe('boolean');
+    });
+  });
+});
+

--- a/ui/hooks/rewards/useRequestHardwareWalletAccess.test.ts
+++ b/ui/hooks/rewards/useRequestHardwareWalletAccess.test.ts
@@ -448,9 +448,10 @@ describe('useRequestHardwareWalletAccess', () => {
 
       expect(result.current).toHaveProperty('requestHardwareWalletAccess');
       expect(result.current).toHaveProperty('isHardwareWalletAccount');
-      expect(typeof result.current.requestHardwareWalletAccess).toBe('function');
+      expect(typeof result.current.requestHardwareWalletAccess).toBe(
+        'function',
+      );
       expect(typeof result.current.isHardwareWalletAccount).toBe('boolean');
     });
   });
 });
-

--- a/ui/hooks/rewards/useRequestHardwareWalletAccess.ts
+++ b/ui/hooks/rewards/useRequestHardwareWalletAccess.ts
@@ -1,0 +1,93 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import log from 'loglevel';
+import { isHardwareWallet, getHardwareWalletType } from '../../selectors';
+import {
+  HardwareKeyringType,
+  LEDGER_USB_VENDOR_ID,
+  LedgerTransportTypes,
+} from '../../../shared/constants/hardware-wallets';
+import { getLedgerTransportType } from '../../ducks/metamask/metamask';
+
+export type UseRequestHardwareWalletAccessResult = {
+  /**
+   * Request USB/HID device access for certain types of hardware wallets.
+   * This must be called in a user gesture context (onClick handler).
+   * Returns true if device access was granted or not needed, false otherwise.
+   */
+  requestHardwareWalletAccess: () => Promise<boolean>;
+  /**
+   * Whether the current account is a hardware wallet account.
+   */
+  isHardwareWalletAccount: boolean;
+};
+
+/**
+ * Hook that provides a function to request hardware wallet USB/HID device access.
+ * Encapsulates all hardware wallet detection and access request logic.
+ *
+ * @returns An object containing the requestHardwareWalletAccess function and isHardwareWalletAccount flag.
+ */
+export const useRequestHardwareWalletAccess =
+  (): UseRequestHardwareWalletAccessResult => {
+    const isHardwareWalletAccount = useSelector(isHardwareWallet);
+    const hardwareWalletType = useSelector(getHardwareWalletType);
+    const ledgerTransportType = useSelector(getLedgerTransportType);
+
+    const requestHardwareWalletAccess =
+      useCallback(async (): Promise<boolean> => {
+        if (!isHardwareWalletAccount) {
+          return true; // Not a hardware wallet, proceed normally
+        }
+
+        try {
+          // Handle Ledger with WebHID
+          if (
+            hardwareWalletType === HardwareKeyringType.ledger &&
+            ledgerTransportType === LedgerTransportTypes.webhid
+          ) {
+            const connectedDevices = await window.navigator.hid.requestDevice({
+              filters: [{ vendorId: Number(LEDGER_USB_VENDOR_ID) }],
+            });
+            return connectedDevices.some(
+              (device) => device.vendorId === Number(LEDGER_USB_VENDOR_ID),
+            );
+          }
+
+          // Handle Trezor with WebUSB
+          if (
+            hardwareWalletType === HardwareKeyringType.trezor &&
+            window.navigator.usb
+          ) {
+            await window.navigator.usb.requestDevice({
+              filters: [
+                { vendorId: 0x534c, productId: 0x0001 }, // Trezor One
+                { vendorId: 0x1209, productId: 0x53c0 }, // Trezor Model T
+                { vendorId: 0x1209, productId: 0x53c1 }, // Trezor Safe 3
+              ],
+            });
+            return true;
+          }
+
+          // Lattice uses HTTP/WebSocket to communicate with the device.
+          // QR code hardware wallets use a popover signing modal, so we don't need to request device access.
+          return (
+            hardwareWalletType === HardwareKeyringType.lattice ||
+            hardwareWalletType === HardwareKeyringType.qr
+          );
+        } catch (error) {
+          // User cancelled the device selection or no device found
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          if (!errorMessage.includes('No device selected')) {
+            log.error('Hardware wallet access request failed:', error);
+          }
+          return false;
+        }
+      }, [isHardwareWalletAccount, hardwareWalletType, ledgerTransportType]);
+
+    return {
+      requestHardwareWalletAccess,
+      isHardwareWalletAccount,
+    };
+  };

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -6908,18 +6908,11 @@ export function getRewardsHasAccountOptedIn(
 
 export function getRewardsCandidateSubscriptionId(
   primaryWalletGroupAccounts?: InternalAccount[],
-): ThunkAction<
-  Promise<string | null>,
-  MetaMaskReduxState,
-  unknown,
-  AnyAction
-> {
+): ThunkAction<Promise<string | null>, MetaMaskReduxState, unknown, AnyAction> {
   return async () => {
     return await submitRequestToBackground<string | null>(
       'getRewardsCandidateSubscriptionId',
-      primaryWalletGroupAccounts
-        ? [primaryWalletGroupAccounts]
-        : undefined,
+      primaryWalletGroupAccounts ? [primaryWalletGroupAccounts] : undefined,
     );
   };
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -61,6 +61,7 @@ import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-s
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SerializedUR } from '@metamask/eth-qr-keyring';
 import {
   BillingPortalResponse,
@@ -6905,7 +6906,9 @@ export function getRewardsHasAccountOptedIn(
   };
 }
 
-export function getRewardsCandidateSubscriptionId(): ThunkAction<
+export function getRewardsCandidateSubscriptionId(
+  primaryWalletGroupAccounts?: InternalAccount[],
+): ThunkAction<
   Promise<string | null>,
   MetaMaskReduxState,
   unknown,
@@ -6914,6 +6917,9 @@ export function getRewardsCandidateSubscriptionId(): ThunkAction<
   return async () => {
     return await submitRequestToBackground<string | null>(
       'getRewardsCandidateSubscriptionId',
+      primaryWalletGroupAccounts
+        ? [primaryWalletGroupAccounts]
+        : undefined,
     );
   };
 }
@@ -7041,6 +7047,7 @@ export function rewardsGetOptInStatus(
 
 export function rewardsLinkAccountsToSubscriptionCandidate(
   accounts: InternalAccount[],
+  primaryWalletGroupAccounts?: InternalAccount[],
 ): ThunkAction<
   Promise<{ account: InternalAccount; success: boolean }[]>,
   MetaMaskReduxState,
@@ -7050,7 +7057,12 @@ export function rewardsLinkAccountsToSubscriptionCandidate(
   return async () => {
     return await submitRequestToBackground<
       { account: InternalAccount; success: boolean }[]
-    >('rewardsLinkAccountsToSubscriptionCandidate', [accounts]);
+    >(
+      'rewardsLinkAccountsToSubscriptionCandidate',
+      primaryWalletGroupAccounts
+        ? [accounts, primaryWalletGroupAccounts]
+        : [accounts],
+    );
   };
 }
 


### PR DESCRIPTION
## **Description**

This PR is a WIP, the changes in it make it so that users can opt into and/or link accounts from a hardware wallet. Unfortunately right now it's unpredictable to use because when asking the KeyringController to sign a SIWE personal message via:

 
```
    const messageHex =  Buffer.from(challenge.message, 'utf8').toString('hex')
    const siwe = detectSIWE({ data: messageHex });
    const signature = await this.messenger.call(
      'KeyringController:signPersonalMessage',
      {
        data: messageHex,
        from: account.address,
        siwe,
      },
    );
```

The following error is thrown:

`error failed to execute requestdevice on USB, must be handling a user gesture to show a permission request`

This is thrown intermittently, even if we previously made the connection with the USB device via `useRequestHardwareWalletAccess`. (which was scraped together by looking at legacy code that handles hardware wallet connections) 

However, if we use `useRequestHardwareWalletAccess` and just ask the KeyringController to sign a personal message not in SIWE format (like we do for hot wallets) then it sometimes does work.. although we intermittently also experience the same error I listed above.

---

Ideally, before this can be merged in:

- There's some kind of fix to the repo so that we have a better and reliable way of connecting to the usb device. We shouldn't have to define/use `useRequestHardwareWalletAccess`. We shouldn't be hitting `error failed to execute requestdevice on USB, must be handling a user gesture to show a permission request` at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Hardware wallet support for Rewards via SIWE**
> 
> - Add SIWE flows: new `RewardsDataService` actions `generateChallenge`, `siweLogin`, `siweJoin`; wire through messenger; implement `ChallengeDto`, `SiweLoginDto`, `SiweJoinDto`
> - Controller updates: sign SIWE messages (`signSiweEvmMessage`), support hardware accounts in opt-in, login, and join; adjust silent auth to skip HW without pre-signed result; reauth logic avoids HW; refine opt-in support checks and subscription ID selection
> - UI/UX: `RewardsPointsBalance` shows "Sign in to view points" and triggers opt-in for HW; onboarding removes HW block, tweaks modal z-index/behavior; add onboarding styles
> - Caching/threshold tweaks: shorter season metadata cache; ensure opted-in state requires subscription token
> - Tests: extensive new/updated unit tests across controller, data service, utils, hooks, and components
> - i18n: add `rewardsSignInToViewPoints` string; remove unused HW title copy
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cae01933100420e4bbaa8572002ec8ee7baff995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->