### PR TITLE
fix: cp-13.14.2 Guard against invalid controller state

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -43,6 +43,7 @@ import {
   OffscreenCommunicationTarget,
   OffscreenCommunicationEvents,
 } from '../../shared/constants/offscreen-communication';
+import { captureException } from '../../shared/lib/sentry';
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { createCaipStream } from '../../shared/modules/caip-stream';
 import getFetchWithTimeout from '../../shared/modules/fetch-with-timeout';
@@ -1341,6 +1342,14 @@ export function setupController(
   for (const key of Object.keys(currentState)) {
     const initialControllerState = initState[key] || {};
     const newControllerState = currentState[key];
+    if (newControllerState === null || typeof newControllerState !== 'object') {
+      captureException(
+        new Error(
+          `Invalid controller state for '${key}' of type '${typeof newControllerState}'`,
+        ),
+      );
+      continue;
+    }
     const newControllerStateKeys = Object.keys(newControllerState);
 
     // if the number of keys has changed, we need to persist the new state

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1345,7 +1345,7 @@ export function setupController(
     if (newControllerState === null || typeof newControllerState !== 'object') {
       captureException(
         new Error(
-          `Invalid controller state for '${key}' of type '${typeof newControllerState}'`,
+          `Invalid controller state for '${key}' of type '${newControllerState === null ? 'null' : typeof newControllerState}'`,
         ),
       );
       continue;


### PR DESCRIPTION
## **Description**

During the `setupController` method in `background.js`, it will throw an error during initialization if any "controllers with persisted state" have something other than an object as their state (e.g. `undefined` or `null` or a primitive). This should be impossible due to type checks, but we're seeing it happen anyway.

This code has been updated to report the error and continue initialization without interruption. There is still a root cause here to fix, but we can address that in a follow-up PR (it may take more time to learn what the root cause is).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39465?quickstart=1)

## **Changelog**

CHANGELOG entry: Prevent crash during initialization when some controller has invalid state.

## **Related issues**

Fixes #39464

## **Manual testing steps**

* Fresh install, proceed through onboarding
* After onboarding, open the `loading.html` page
* In the dev console, run this:
  ```
  const old = await chrome.storage.local.get()
  await chrome.storage.local.set({ meta: old.meta, data: {...old.data, foo: 'foo', bar: null }})
  ```
* Reload the extension, confirm that it still seems to work
  * I also used a breakpoint to confirm that the Sentry error was sent. You could confirm with the network tab instead (ensure you opt into metrics, otherwise it won't send)
* Navigate to `loading.html` again, and run `await chrome.storage.local.get()` to confirm that the state was set correctly (`foo` and `bar` should be present). If not, try again.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents initialization from crashing when a controller has invalid (non-object) state by reporting and skipping it.
> 
> - Adds Sentry `captureException` import
> - In `setupController` (in `background.js`), guards each controller state: if `null` or not an object, report via `captureException` and continue; otherwise proceed with change detection/persistence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217ff83f73462bb265aa46508615b509377c160c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->