### PR TITLE
fix: flaky test `Ledger Hardware unlocks multiple accounts at once and removes one`

### DIFF
--- a/test/e2e/page-objects/flows/account-list.flow.ts
+++ b/test/e2e/page-objects/flows/account-list.flow.ts
@@ -3,8 +3,8 @@ import {
   KNOWN_PUBLIC_KEY_ADDRESSES,
   KNOWN_QR_ACCOUNTS,
 } from '../../../stub/keyring-bridge';
-import AccountListPage from '../../page-objects/pages/account-list-page';
-import AddressListModal from '../../page-objects/pages/multichain/address-list-modal';
+import AccountListPage from '../pages/account-list-page';
+import AddressListModal from '../pages/multichain/address-list-modal';
 import { shortenAddress } from '../../../../ui/helpers/utils/util';
 
 export async function checkAccountAddressDisplayedInAccountList(
@@ -23,6 +23,7 @@ export async function checkAccountAddressDisplayedInAccountList(
     await accountListPage.openMultichainAccountMenu({
       accountLabel: accountName,
     });
+    await accountListPage.checkMultiChainAccountMenuIsDisplayed();
     await accountListPage.clickMultichainAccountMenuItem('Addresses');
     await addressListModal.checkNetworkAddressIsDisplayed(
       shortenAddress(addresses[index].address),

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -141,6 +141,31 @@ class AccountListPage {
   private readonly importAccountJsonPasswordInput =
     'input[id="json-password-box"]';
 
+  private readonly multichainAccountMenuDetails = {
+    tag: 'p',
+    text: 'Account details',
+  };
+
+  private readonly multichainAccountMenuRename = {
+    tag: 'p',
+    text: 'Rename',
+  };
+
+  private readonly multichainAccountMenuAddresses = {
+    tag: 'p',
+    text: 'Addresses',
+  };
+
+  private readonly multichainAccountMenuPin = {
+    tag: 'p',
+    text: 'Pin to top',
+  };
+
+  private readonly multichainAccountMenuHide = {
+    tag: 'p',
+    text: 'Hide account',
+  };
+
   private readonly pinUnpinAccountButton =
     '[data-testid="account-list-menu-pin"]';
 
@@ -951,6 +976,16 @@ class AccountListPage {
   async checkHiddenAccountsListExists(): Promise<void> {
     console.log(`Check that hidden accounts list is displayed in account list`);
     await this.driver.waitForSelector(this.hiddenAccountsList);
+  }
+
+  async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
+    console.log(`Check that multichain account menu is displayed`);
+    await this.driver.waitForMultipleSelectors([
+      this.multichainAccountMenuAddresses,
+      this.multichainAccountMenuDetails,
+      this.multichainAccountMenuHide,
+      this.multichainAccountMenuPin,
+    ]);
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -141,19 +141,19 @@ class AccountListPage {
   private readonly importAccountJsonPasswordInput =
     'input[id="json-password-box"]';
 
+  private readonly multichainAccountMenuAddresses = {
+    tag: 'p',
+    text: 'Addresses',
+  };
+
   private readonly multichainAccountMenuDetails = {
     tag: 'p',
     text: 'Account details',
   };
 
-  private readonly multichainAccountMenuRename = {
+  private readonly multichainAccountMenuHide = {
     tag: 'p',
-    text: 'Rename',
-  };
-
-  private readonly multichainAccountMenuAddresses = {
-    tag: 'p',
-    text: 'Addresses',
+    text: 'Hide account',
   };
 
   private readonly multichainAccountMenuPin = {
@@ -161,9 +161,9 @@ class AccountListPage {
     text: 'Pin to top',
   };
 
-  private readonly multichainAccountMenuHide = {
+  private readonly multichainAccountMenuRename = {
     tag: 'p',
-    text: 'Hide account',
+    text: 'Rename',
   };
 
   private readonly pinUnpinAccountButton =
@@ -984,6 +984,7 @@ class AccountListPage {
       this.multichainAccountMenuAddresses,
       this.multichainAccountMenuDetails,
       this.multichainAccountMenuHide,
+      this.multichainAccountMenuRename,
       this.multichainAccountMenuPin,
     ]);
   }

--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -88,7 +88,7 @@ class AddressListModal {
   }
 
   async goBack(): Promise<void> {
-    await this.driver.clickElement(this.backButton);
+    await this.driver.clickElementAndWaitToDisappear(this.backButton);
   }
 }
 

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-account.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-account.spec.ts
@@ -72,7 +72,7 @@ describe('Ledger Hardware', function () {
     );
   });
 
-  it.only('unlocks multiple accounts at once and removes one', async function () {
+  it('unlocks multiple accounts at once and removes one', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-account.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-account.spec.ts
@@ -9,7 +9,7 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import SelectHardwareWalletAccountPage from '../../../page-objects/pages/hardware-wallet/select-hardware-wallet-account-page';
 import MultichainAccountDetailsPage from '../../../page-objects/pages/multichain/multichain-account-details-page';
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
-import { checkAccountAddressDisplayedInAccountList } from '../common';
+import { checkAccountAddressDisplayedInAccountList } from '../../../page-objects/flows/account-list.flow';
 
 describe('Ledger Hardware', function () {
   it('derives the correct accounts and unlocks the first account', async function () {
@@ -72,7 +72,7 @@ describe('Ledger Hardware', function () {
     );
   });
 
-  it('unlocks multiple accounts at once and removes one', async function () {
+  it.only('unlocks multiple accounts at once and removes one', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/hardware-wallets/qr-account.spec.ts
+++ b/test/e2e/tests/hardware-wallets/qr-account.spec.ts
@@ -8,7 +8,7 @@ import HomePage from '../../page-objects/pages/home/homepage';
 import SelectHardwareWalletAccountPage from '../../page-objects/pages/hardware-wallet/select-hardware-wallet-account-page';
 import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/multichain-account-details-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import { checkAccountAddressDisplayedInAccountList } from './common';
+import { checkAccountAddressDisplayedInAccountList } from '../../page-objects/flows/account-list.flow';
 
 // BUG: Add funds banner doesn't clear
 // eslint-disable-next-line

--- a/test/e2e/tests/hardware-wallets/trezor/trezor-account.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-account.spec.ts
@@ -8,7 +8,7 @@ import HomePage from '../../../page-objects/pages/home/homepage';
 import SelectHardwareWalletAccountPage from '../../../page-objects/pages/hardware-wallet/select-hardware-wallet-account-page';
 import MultichainAccountDetailsPage from '../../../page-objects/pages/multichain/multichain-account-details-page';
 import { loginWithBalanceValidation } from '../../../page-objects/flows/login.flow';
-import { checkAccountAddressDisplayedInAccountList } from '../common';
+import { checkAccountAddressDisplayedInAccountList } from '../../../page-objects/flows/account-list.flow';
 
 describe('Trezor Hardware', function () {
   it('derives the correct accounts and unlocks the first account', async function () {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39489?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of hardware-wallet e2e tests by introducing a shared flow and stronger UI waits.
> 
> - Adds `test/e2e/page-objects/flows/account-list.flow.ts` with `checkAccountAddressDisplayedInAccountList` and updates Ledger/Trezor/QR tests to use it
> - Extends `AccountListPage` with menu item selectors and `checkMultiChainAccountMenuIsDisplayed()`; flow now waits for menu before clicking `Addresses`
> - Changes `AddressListModal.goBack()` to `clickElementAndWaitToDisappear` to avoid timing issues
> - Fixes/normalizes relative import paths in affected tests and page-objects
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aef63b6e6cd441643d8c6283eec57bdfdc5e5366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->