### PR TITLE
chore(permissions): remove permissions popover bottom border

### DIFF
--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -199,7 +199,7 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
           </Box>
         )}
         {isConnected && (
-          <Box padding={4}>
+          <Box padding={4} paddingBottom={0}>
             <ButtonSecondary block onClick={onClick}>
               {t('managePermissions')}
             </ButtonSecondary>

--- a/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
+++ b/ui/components/multichain/connected-site-popover/connected-site-popover.tsx
@@ -105,11 +105,15 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
     >
       <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
         <Box
-          style={{
-            borderBottomWidth: '1px',
-            borderBottomStyle: 'solid',
-            borderBottomColor: '#858B9A33',
-          }}
+          style={
+            isConnected
+              ? undefined
+              : {
+                  borderBottomWidth: '1px',
+                  borderBottomStyle: 'solid',
+                  borderBottomColor: '#858B9A33',
+                }
+          }
           paddingLeft={4}
           paddingRight={4}
           paddingBottom={2}
@@ -195,7 +199,7 @@ export const ConnectedSitePopover: React.FC<ConnectedSitePopoverProps> = ({
           </Box>
         )}
         {isConnected && (
-          <Box paddingTop={4} paddingLeft={4} paddingRight={4}>
+          <Box padding={4}>
             <ButtonSecondary block onClick={onClick}>
               {t('managePermissions')}
             </ButtonSecondary>


### PR DESCRIPTION
## **Description**

Remove the divider above the “Manage permissions” button in the connected app popover and make the button padding uniform on all sides to match design spacing.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39530?quickstart=1)

## **Changelog**

CHANGELOG entry: Removed the divider above the Manage permissions button in the connected app popover.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-662

## **Manual testing steps**

1. Open the extension home while connected to a dapp.
2. Click the connected site icon to open the connected app popover.
3. Verify there is no divider above the “Manage permissions” button and padding is uniform on all sides.

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/a69bb151-3823-470e-bbee-4be4eccf18b7) | ![after](https://github.com/user-attachments/assets/09bba1f3-ca9c-454b-a76e-7f74d56d47b1) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
---
<a href="https://cursor.com/background-agent?bcId=bc-cf96c9c9-ee6f-4987-8924-1624c9b2513a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf96c9c9-ee6f-4987-8924-1624c9b2513a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the connected site popover styling to match design spacing.
> 
> - Conditionally removes the header bottom border in `connected-site-popover.tsx` when `isConnected` is true
> - Updates the Manage permissions section to use `padding={4}` with `paddingBottom={0}` for consistent spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8336324b70dbd466f8136dfde4791a4efe79f0f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->