### PR TITLE
chore: update copy icon on network avatars to size sm

### DIFF
--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -212,7 +212,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                 </div>
               </div>
               <svg
-                class="inline-block w-3 h-3 text-icon-alternative"
+                class="inline-block w-4 h-4 text-icon-alternative"
                 fill="currentColor"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -287,7 +287,7 @@ export const AppHeaderUnlockedContent = ({
               />
               <Icon
                 name={IconName.Copy}
-                size={IconSize.Xs}
+                size={IconSize.Sm}
                 color={IconColor.IconAlternative}
               />
             </MultichainHoveredAddressRowsList>


### PR DESCRIPTION
## **Description**

The network avatars copy icon was introduced last week. Design feedback is that they wanted it a bit bigger, so now it's `IconSize.Sm` instead of `IconSize.Xs`.

## **Changelog**

CHANGELOG entry: Increased network avatars copy icon to size small

## **Related issues**

Fixes:

## **Manual testing steps**

On home screen verify that icon is size small:

<img width="489" height="251" alt="image" src="https://github.com/user-attachments/assets/7d0636de-93f1-4c33-b1bb-645df31c439b" />


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="489" height="255" alt="image" src="https://github.com/user-attachments/assets/a909446a-6a24-4a8e-950e-5e9560e45979" />


### **After**

<img width="489" height="251" alt="image" src="https://github.com/user-attachments/assets/9a134076-7b95-47de-b9a4-7c33534e09f8" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increases the copy icon size in the multichain app header UI.
> 
> - Updates `Icon` in `app-header-unlocked-content.tsx` from `IconSize.Xs` to `IconSize.Sm` within `MultichainHoveredAddressRowsList`
> - Adjusts corresponding snapshot to reflect larger icon (`w-3 h-3` → `w-4 h-4`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97c8eb3658d3b91fae8428f345f5daa76146a9e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->