### PR TITLE
fix: cp-13.16.0 dynamic transaction list item height

### DIFF
--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -963,6 +963,8 @@ export default function UnifiedTransactionList({
               return (
                 <div
                   key={item.id}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
                   className="absolute top-0 left-0 w-full"
                   style={{
                     transform: `translateY(${virtualItem.start}px)`,


### PR DESCRIPTION
## **Description**

The fixed 70px transaction list item height meant that dynamic elements (e.g. Cancel, Speed up, Bridge transactions) were getting cut off. This PR fixes it by using the `virtualizer.measureElement` ref to measure the actual dom element height. 

## **Changelog**

CHANGELOG entry: Used dynamic height measurement of transaction list items

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39511

## **Manual testing steps**

1. Test any transaction and see that the 'Cancel' button appears without getting cut off. 
2. Test a bridge transaction and see that the transaction UI shows correctly without getting cut off.
3. Test multiple transactions at once and ensure none get cut off.

## **Screenshots/Recordings**

### **Before**

See issue as well as screenshots below:

<img width="926" height="285" alt="image" src="https://github.com/user-attachments/assets/958c1b82-3540-4560-b2b9-71f39e9c28dc" />

<img width="959" height="514" alt="image" src="https://github.com/user-attachments/assets/ae2f4b14-54a8-4c10-bb19-9c4bd633d773" />

### **After**

<img width="565" height="363" alt="image" src="https://github.com/user-attachments/assets/f295fec1-0b03-469b-838d-ef10cd7a6af9" />

<img width="563" height="259" alt="image" src="https://github.com/user-attachments/assets/174a1763-bc1d-4a08-bdf2-fc014d860064" />

<img width="472" height="367" alt="image" src="https://github.com/user-attachments/assets/39b55efd-4821-4507-b305-99cd0dac2774" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts dynamic height measurement for virtualized transaction rows to avoid clipping variable-height content (e.g., Cancel/Speed up/Bridge actions).
> 
> - Adds `ref={virtualizer.measureElement}` and `data-index` to each transaction row container in `unified-transaction-list.component.js` so the virtualizer can measure actual DOM heights
> - Retains date headers and virtualization logic; only measurement wiring changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86e443ef62d1167481a269846625aa959701facf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->