### PR TITLE
fix: prevent TypeError when canceling transactions on unsupported networks

### DIFF
--- a/ui/pages/confirmations/hooks/useTransactionFunction.test.js
+++ b/ui/pages/confirmations/hooks/useTransactionFunction.test.js
@@ -176,4 +176,46 @@ describe('useMaxPriorityFeePerGasInput', () => {
     result.current.updateTransactionUsingEstimate(GasRecommendations.low);
     expect(mockUpdateTransaction).not.toHaveBeenCalled();
   });
+
+  it('updateTransactionToTenPercentIncreasedGasFee returns early when gasFeeEstimates is undefined and maxPriorityFeePerGas is zero', async () => {
+    const mockUpdateGasFees = jest
+      .spyOn(Actions, 'updateTransactionGasFees')
+      .mockImplementation(() => ({ type: '' }));
+
+    const { result } = renderUseTransactionFunctions({
+      gasFeeEstimates: undefined,
+      transaction: {
+        userFeeLevel: CUSTOM_GAS_ESTIMATE,
+        txParams: { maxFeePerGas: '0x5028', maxPriorityFeePerGas: '0x0' },
+      },
+    });
+    await result.current.updateTransactionToTenPercentIncreasedGasFee();
+    expect(mockUpdateGasFees).not.toHaveBeenCalled();
+  });
+
+  it('updateTransactionToTenPercentIncreasedGasFee still works when gasFeeEstimates is undefined but maxPriorityFeePerGas is non-zero', async () => {
+    const mockUpdateGasFees = jest
+      .spyOn(Actions, 'updateTransactionGasFees')
+      .mockImplementation(() => ({ type: '' }));
+
+    const { result } = renderUseTransactionFunctions({
+      gasFeeEstimates: undefined,
+      transaction: {
+        userFeeLevel: CUSTOM_GAS_ESTIMATE,
+        txParams: { maxFeePerGas: '0x5028', maxPriorityFeePerGas: '0x5028' },
+      },
+    });
+    await result.current.updateTransactionToTenPercentIncreasedGasFee();
+    expect(mockUpdateGasFees).toHaveBeenCalledTimes(1);
+    expect(mockUpdateGasFees).toHaveBeenCalledWith(undefined, {
+      estimateSuggested: 'tenPercentIncreased',
+      estimateUsed: 'tenPercentIncreased',
+      gas: '5208',
+      gasLimit: '5208',
+      maxFeePerGas: '0x582c',
+      maxPriorityFeePerGas: '0x582c',
+      userEditedGasLimit: undefined,
+      userFeeLevel: 'tenPercentIncreased',
+    });
+  });
 });

--- a/ui/pages/confirmations/hooks/useTransactionFunction.test.js
+++ b/ui/pages/confirmations/hooks/useTransactionFunction.test.js
@@ -177,7 +177,7 @@ describe('useMaxPriorityFeePerGasInput', () => {
     expect(mockUpdateTransaction).not.toHaveBeenCalled();
   });
 
-  it('updateTransactionToTenPercentIncreasedGasFee returns early when gasFeeEstimates is undefined and maxPriorityFeePerGas is zero', async () => {
+  it('updateTransactionToTenPercentIncreasedGasFee uses maxFeePerGas as fallback when gasFeeEstimates is undefined and maxPriorityFeePerGas is zero', async () => {
     const mockUpdateGasFees = jest
       .spyOn(Actions, 'updateTransactionGasFees')
       .mockImplementation(() => ({ type: '' }));
@@ -190,7 +190,18 @@ describe('useMaxPriorityFeePerGasInput', () => {
       },
     });
     await result.current.updateTransactionToTenPercentIncreasedGasFee();
-    expect(mockUpdateGasFees).not.toHaveBeenCalled();
+    expect(mockUpdateGasFees).toHaveBeenCalledTimes(1);
+
+    expect(mockUpdateGasFees).toHaveBeenCalledWith(undefined, {
+      estimateSuggested: 'tenPercentIncreased',
+      estimateUsed: 'custom',
+      gas: '5208',
+      gasLimit: '5208',
+      maxFeePerGas: '0x582c',
+      maxPriorityFeePerGas: '0x582c',
+      userEditedGasLimit: undefined,
+      userFeeLevel: 'custom',
+    });
   });
 
   it('updateTransactionToTenPercentIncreasedGasFee still works when gasFeeEstimates is undefined but maxPriorityFeePerGas is non-zero', async () => {

--- a/ui/pages/confirmations/hooks/useTransactionFunctions.js
+++ b/ui/pages/confirmations/hooks/useTransactionFunctions.js
@@ -169,10 +169,19 @@ export const useTransactionFunctions = ({
         maxPriorityFeePerGas,
       } = transaction.previousGas || transaction.txParams;
 
-      const newMaxPriorityFeePerGas = new BigNumber(
+      const isMaxPriorityFeePerGasZero = new BigNumber(
         maxPriorityFeePerGas,
         16,
-      ).isZero()
+      ).isZero();
+
+      if (
+        isMaxPriorityFeePerGasZero &&
+        !gasFeeEstimates?.[defaultEstimateToUse]?.suggestedMaxPriorityFeePerGas
+      ) {
+        return;
+      }
+
+      const newMaxPriorityFeePerGas = isMaxPriorityFeePerGasZero
         ? decGWEIToHexWEI(
             gasFeeEstimates[defaultEstimateToUse].suggestedMaxPriorityFeePerGas,
           )
@@ -183,9 +192,6 @@ export const useTransactionFunctions = ({
           ? CUSTOM_GAS_ESTIMATE
           : PriorityLevels.tenPercentIncreased;
 
-      if (!gasFeeEstimates) {
-        return;
-      }
       updateTransaction({
         estimateSuggested: initTransaction
           ? defaultEstimateToUse

--- a/ui/pages/confirmations/hooks/useTransactionFunctions.js
+++ b/ui/pages/confirmations/hooks/useTransactionFunctions.js
@@ -174,18 +174,17 @@ export const useTransactionFunctions = ({
         16,
       ).isZero();
 
-      if (
-        isMaxPriorityFeePerGasZero &&
-        !gasFeeEstimates?.[defaultEstimateToUse]?.suggestedMaxPriorityFeePerGas
-      ) {
-        return;
-      }
+      let newMaxPriorityFeePerGas;
+      if (isMaxPriorityFeePerGasZero) {
+        const suggestedFee =
+          gasFeeEstimates?.[defaultEstimateToUse]?.suggestedMaxPriorityFeePerGas;
 
-      const newMaxPriorityFeePerGas = isMaxPriorityFeePerGasZero
-        ? decGWEIToHexWEI(
-            gasFeeEstimates[defaultEstimateToUse].suggestedMaxPriorityFeePerGas,
-          )
-        : maxPriorityFeePerGas;
+        newMaxPriorityFeePerGas = suggestedFee
+          ? decGWEIToHexWEI(suggestedFee)
+          : maxFeePerGas;
+      } else {
+        newMaxPriorityFeePerGas = maxPriorityFeePerGas;
+      }
 
       const estimateUsed =
         maxPriorityFeePerGas === '0x0'


### PR DESCRIPTION
## **Description**

This PR fixes a TypeError that occurs when users attempt to cancel a transaction on networks that support EIP-1559 but are not supported by MetaMask's gas API

**Problem:**
When canceling a transaction on unsupported networks, the code attempted to access `suggestedMaxPriorityFeePerGas` from `gasFeeEstimates[defaultEstimateToUse]`, but since these networks are not supported by MetaMask's gas API, `gasFeeEstimates` is undefined, causing the error:

```
TypeError: Cannot read properties of undefined (reading 'suggestedMaxPriorityFeePerGas')
```

**Solution:**
The fix adds a guard clause that checks if the priority fee is zero AND gas fee estimates are unavailable before attempting to access estimate properties. If both conditions are true, the function returns early. If the transaction already has a non-zero `maxPriorityFeePerGas`, it can still proceed using the existing values without needing gas estimates.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39517?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a crash when canceling transactions on networks not supported by MetaMask's gas API

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38866

## **Manual testing steps**

1. Add a custom network that is not supported by MetaMask's gas API
2. Send a transaction on the unsupported network
3. While the transaction is pending, attempt to cancel it
4. Verify that no error occurs and the cancellation proceeds correctly

## **Screenshots/Recordings**

### **Before**
<img width="1023" height="626" alt="mm-before" src="https://github.com/user-attachments/assets/c2b351c5-b064-4b08-8e55-be9f862ed145" />



<!-- [screenshot showing the error when canceling transaction] -->

### **After**
<img width="1079" height="700" alt="mm-after-1" src="https://github.com/user-attachments/assets/23858ab0-906d-47cd-9dce-8d5cbb010bb5" />
<img width="1066" height="701" alt="mm-after-2" src="https://github.com/user-attachments/assets/c1348766-c030-4ed8-af45-1032a00ab078" />

<!-- [screenshot showing successful cancellation without error] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to gas-fee calculation with added tests; primary risk is minor behavioral change in fallback fee selection on networks without gas estimates.
> 
> **Overview**
> Prevents `updateTransactionToTenPercentIncreasedGasFee` from throwing when `gasFeeEstimates` is missing (e.g., unsupported-by-gas-API networks) by using optional access and falling back to `maxFeePerGas` when `maxPriorityFeePerGas` is `0x0` and no suggested priority fee is available.
> 
> Adds test coverage to ensure the 10% increased gas-fee update still dispatches correctly both when estimates are missing and the priority fee is zero (fallback path) and when it is already non-zero (uses existing value).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02adf2359900d27eed3e6d8799ccca1b7cb69a53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->