### PR TITLE
fix: solana requests trigger popup when wallet is locked

### DIFF
--- a/app/scripts/lib/createMultichainUnlockMiddleware.test.ts
+++ b/app/scripts/lib/createMultichainUnlockMiddleware.test.ts
@@ -93,6 +93,7 @@ describe('createMultichainUnlockMiddleware', () => {
       expect(nextCalled).toBe(false);
 
       // Simulate user unlocking the wallet
+      // @ts-expect-error Variable 'unlockResolve' is being assigned above
       unlockResolve();
       await middlewarePromise;
 

--- a/app/scripts/lib/createMultichainUnlockMiddleware.test.ts
+++ b/app/scripts/lib/createMultichainUnlockMiddleware.test.ts
@@ -1,0 +1,168 @@
+import type {
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+  Json,
+} from '@metamask/utils';
+import { MESSAGE_TYPE } from '../../../shared/constants/app';
+import { createMultichainUnlockMiddleware } from './createMultichainUnlockMiddleware';
+
+describe('createMultichainUnlockMiddleware', () => {
+  const createMockRequest = (method: string): JsonRpcRequest => ({
+    id: 1,
+    jsonrpc: '2.0',
+    method,
+    params: {},
+  });
+
+  const createMockResponse = (): PendingJsonRpcResponse<Json> => ({
+    id: 1,
+    jsonrpc: '2.0',
+  });
+
+  // Helper to run middleware with proper async handling
+  const runMiddleware = async (
+    middleware: ReturnType<typeof createMultichainUnlockMiddleware>,
+    request: JsonRpcRequest,
+  ) => {
+    const mockEnd = jest.fn();
+    let nextCalled = false;
+
+    await new Promise<void>((resolve) => {
+      // The middleware from createAsyncMiddleware calls next() which should resolve
+      const mockNext = jest.fn(() => {
+        nextCalled = true;
+        resolve();
+      });
+
+      middleware(request, createMockResponse(), mockNext, mockEnd);
+    });
+
+    return { nextCalled, mockEnd };
+  };
+
+  describe('wallet_invokeMethod', () => {
+    it('waits for unlock before proceeding with wallet_invokeMethod', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      const { nextCalled, mockEnd } = await runMiddleware(
+        middleware,
+        createMockRequest(MESSAGE_TYPE.WALLET_INVOKE_METHOD),
+      );
+
+      expect(getUnlockPromise).toHaveBeenCalledTimes(1);
+      expect(getUnlockPromise).toHaveBeenCalledWith(true);
+      expect(nextCalled).toBe(true);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+
+    it('shows unlock popup when wallet is locked for wallet_invokeMethod', async () => {
+      let unlockResolve: () => void;
+      const unlockPromise = new Promise<void>((resolve) => {
+        unlockResolve = resolve;
+      });
+      const getUnlockPromise = jest.fn().mockReturnValue(unlockPromise);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      let nextCalled = false;
+      const mockEnd = jest.fn();
+      const mockNext = jest.fn(() => {
+        nextCalled = true;
+      });
+
+      // Start the middleware but don't await yet
+      const middlewarePromise = new Promise<void>((resolve) => {
+        middleware(
+          createMockRequest(MESSAGE_TYPE.WALLET_INVOKE_METHOD),
+          createMockResponse(),
+          () => {
+            mockNext();
+            resolve();
+          },
+          mockEnd,
+        );
+      });
+
+      // Give middleware a tick to process
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Verify unlock was requested with shouldShowUnlockRequest = true
+      expect(getUnlockPromise).toHaveBeenCalledWith(true);
+
+      // Middleware should be waiting - next shouldn't be called yet
+      expect(nextCalled).toBe(false);
+
+      // Simulate user unlocking the wallet
+      unlockResolve();
+      await middlewarePromise;
+
+      // Now next should have been called
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('wallet_createSession', () => {
+    it('waits for unlock before proceeding with wallet_createSession', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      const { nextCalled, mockEnd } = await runMiddleware(
+        middleware,
+        createMockRequest(MESSAGE_TYPE.WALLET_CREATE_SESSION),
+      );
+
+      expect(getUnlockPromise).toHaveBeenCalledTimes(1);
+      expect(getUnlockPromise).toHaveBeenCalledWith(true);
+      expect(nextCalled).toBe(true);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('wallet_getSession', () => {
+    it('does not wait for unlock for wallet_getSession (read-only)', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      const { nextCalled, mockEnd } = await runMiddleware(
+        middleware,
+        createMockRequest(MESSAGE_TYPE.WALLET_GET_SESSION),
+      );
+
+      expect(getUnlockPromise).not.toHaveBeenCalled();
+      expect(nextCalled).toBe(true);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('wallet_revokeSession', () => {
+    it('does not wait for unlock for wallet_revokeSession', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      const { nextCalled, mockEnd } = await runMiddleware(
+        middleware,
+        createMockRequest(MESSAGE_TYPE.WALLET_REVOKE_SESSION),
+      );
+
+      expect(getUnlockPromise).not.toHaveBeenCalled();
+      expect(nextCalled).toBe(true);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('other methods', () => {
+    it('does not wait for unlock for unrelated methods', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const middleware = createMultichainUnlockMiddleware({ getUnlockPromise });
+
+      const { nextCalled, mockEnd } = await runMiddleware(
+        middleware,
+        createMockRequest('eth_chainId'),
+      );
+
+      expect(getUnlockPromise).not.toHaveBeenCalled();
+      expect(nextCalled).toBe(true);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/scripts/lib/createMultichainUnlockMiddleware.ts
+++ b/app/scripts/lib/createMultichainUnlockMiddleware.ts
@@ -1,0 +1,60 @@
+import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
+import type {
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+  Json,
+} from '@metamask/utils';
+import { MESSAGE_TYPE } from '../../../shared/constants/app';
+
+export type GetUnlockPromise = (
+  shouldShowUnlockRequest: boolean,
+) => Promise<void>;
+
+/**
+ * Options for creating the multichain unlock middleware.
+ */
+export type CreateMultichainUnlockMiddlewareOptions = {
+  /**
+   * Function that returns a promise that resolves when the wallet is unlocked.
+   * If shouldShowUnlockRequest is true, it will also trigger the unlock popup.
+   */
+  getUnlockPromise: GetUnlockPromise;
+};
+
+/**
+ * Creates middleware that ensures the wallet is unlocked before processing
+ * multichain API requests that require user interaction (wallet_invokeMethod
+ * and wallet_createSession).
+ *
+ * When the wallet is locked and a dapp sends a request that requires
+ * confirmation (like signing a transaction), this middleware will trigger
+ * the unlock popup and wait for the user to unlock before proceeding.
+ *
+ * @param options - The middleware options.
+ * @param options.getUnlockPromise - Function to get a promise that resolves when unlocked.
+ * @returns The multichain unlock middleware.
+ */
+export function createMultichainUnlockMiddleware({
+  getUnlockPromise,
+}: CreateMultichainUnlockMiddlewareOptions) {
+  return createAsyncMiddleware(
+    async (
+      req: JsonRpcRequest,
+      _res: PendingJsonRpcResponse<Json>,
+      next: () => Promise<void>,
+    ) => {
+      // Only require unlock for methods that may need user interaction
+      const methodsRequiringUnlock: string[] = [
+        MESSAGE_TYPE.WALLET_INVOKE_METHOD,
+        MESSAGE_TYPE.WALLET_CREATE_SESSION,
+      ];
+
+      if (methodsRequiringUnlock.includes(req.method)) {
+        // Wait for unlock, showing the unlock popup if needed
+        await getUnlockPromise(true);
+      }
+
+      return next();
+    },
+  );
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -257,6 +257,7 @@ import createRpcBlockingMiddleware from './lib/rpcBlockingMiddleware';
 import createMainFrameOriginMiddleware from './lib/createMainFrameOriginMiddleware';
 import createTabIdMiddleware from './lib/createTabIdMiddleware';
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware';
+import { createMultichainUnlockMiddleware } from './lib/createMultichainUnlockMiddleware';
 import { isStreamWritable, setupMultiplex } from './lib/stream-utils';
 import { ReferralStatus } from './controllers/preferences-controller';
 import Backup from './lib/backup';
@@ -7702,6 +7703,15 @@ export default class MetamaskController extends EventEmitter {
       }
       return next();
     });
+
+    engine.push(
+      createMultichainUnlockMiddleware({
+        getUnlockPromise: this.controllerMessenger.call.bind(
+          this.controllerMessenger,
+          'AppStateController:getUnlockPromise',
+        ),
+      }),
+    );
 
     const snapAndHardwareMessenger = new Messenger({
       namespace: 'SnapAndHardwareMessenger',

--- a/test/e2e/flask/solana-wallet-standard/walletPopUpOnRequest.spec.ts
+++ b/test/e2e/flask/solana-wallet-standard/walletPopUpOnRequest.spec.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from 'assert';
+import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
+import { WINDOW_TITLES } from '../../constants';
+import { veryLargeDelayMs } from '../../helpers';
+import { withSolanaAccountSnap } from '../../tests/solana/common-solana';
+import {
+  connectSolanaTestDapp,
+  DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS,
+} from './testHelpers';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+
+describe('Solana Wallet Standard - Wallet Popup on Request', function () {
+  describe('When wallet is locked and dapp requests confirmation', function () {
+    it('Should show unlock popup when sign message is requested while wallet is locked', async function () {
+      await withSolanaAccountSnap(
+        {
+          ...DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS,
+          title: this.test?.fullTitle(),
+        },
+        async (driver) => {
+          const messageToSign = 'Hello, world!';
+          const testDapp = new TestDappSolana(driver);
+          await testDapp.openTestDappPage();
+          await connectSolanaTestDapp(driver, testDapp);
+          await testDapp.checkPageIsLoaded();
+
+          // Switch to extension and lock the wallet
+          await driver.switchToWindowWithTitle(
+            WINDOW_TITLES.ExtensionInFullScreenView,
+          );
+          const headerNavbar = new HeaderNavbar(driver);
+          await headerNavbar.lockMetaMask();
+
+          // Switch back to test dapp and request a signature
+          await testDapp.switchTo();
+          const signMessageTest = await testDapp.getSignMessageTest();
+          await signMessageTest.setMessage(messageToSign);
+
+          // Request sign message - this should trigger the unlock popup
+          await signMessageTest.signMessage();
+
+          // Wait for the dialog window to appear (the unlock popup)
+          await driver.delay(veryLargeDelayMs);
+
+          // Verify the dialog window appears with the unlock prompt
+          // This confirms the unlock popup was triggered automatically
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+          // Verify the unlock password field is present
+          const unlockPasswordField = await driver.findElement(
+            '[data-testid="unlock-password"]',
+          );
+          const isDisplayed = await unlockPasswordField.isDisplayed();
+          assert.ok(isDisplayed);
+        },
+      );
+    });
+  });
+});

--- a/test/e2e/flask/solana-wallet-standard/walletPopUpOnRequest.spec.ts
+++ b/test/e2e/flask/solana-wallet-standard/walletPopUpOnRequest.spec.ts
@@ -3,11 +3,11 @@ import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
 import { WINDOW_TITLES } from '../../constants';
 import { veryLargeDelayMs } from '../../helpers';
 import { withSolanaAccountSnap } from '../../tests/solana/common-solana';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import {
   connectSolanaTestDapp,
   DEFAULT_SOLANA_TEST_DAPP_FIXTURE_OPTIONS,
 } from './testHelpers';
-import HeaderNavbar from '../../page-objects/pages/header-navbar';
 
 describe('Solana Wallet Standard - Wallet Popup on Request', function () {
   describe('When wallet is locked and dapp requests confirmation', function () {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR makes sure when wallet is locked and a Solana dapp (using the multichain API) triggers a confirmation request, the user is prompted to unlock the wallet. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39522?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes issue where solana requests do not trigger pop when wallet is locked

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1034

## **Manual testing steps**

1. Connect to a [Solana test dapp](https://metamask.github.io/test-dapp-solana/staging/)
2. Lock the MetaMask wallet
3. Trigger a `signMessage` request from the Solana dapp
4. MetaMask should show the unlock prompt

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/d743d3de-05e3-45d8-896c-30d9a61f98db

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures interactive multichain requests trigger an unlock prompt when the wallet is locked, then proceed after unlock.
> 
> - New `createMultichainUnlockMiddleware` that awaits `getUnlockPromise(true)` for `wallet_invokeMethod` and `wallet_createSession`; read-only methods unaffected
> - Integrated middleware into `metamask-controller` JSON-RPC engine
> - Added unit tests for middleware behavior (`createMultichainUnlockMiddleware.test.ts`)
> - Added Solana e2e test verifying unlock popup on `signMessage` request when locked (`walletPopUpOnRequest.spec.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cede0d73c4df620a259df17ccc8acd13697f18ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->