### PR TITLE
ci: Skip Firefox `dist` tests on forks

### DIFF
--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -68,6 +68,8 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-firefox-dist:
+    # This if statement is equivalent to IS_FORK
+    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-firefox-dist


### PR DESCRIPTION
## **Description**

Firefox `dist` test suite currently relies on secrets, so it has been updated to no longer run on forks (where it currently fails). We skip the `dist` tests for Chrome already.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39532?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Example of this failing on a PR from a fork: https://github.com/MetaMask/metamask-extension/pull/39451#issuecomment-3798971271

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: it just gates the Firefox `dist` E2E job behind a fork check, but could reduce test coverage on forked PRs if the condition is too broad.
> 
> **Overview**
> Updates the Firefox E2E GitHub Actions workflow to **skip the `test-e2e-firefox-dist` job on forked PRs** by adding an `if` condition equivalent to `IS_FORK`.
> 
> This prevents the `dist` suite (which relies on secrets) from running in fork contexts, aligning behavior with existing fork-gated jobs in other workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bd03c5c797d616cf6e1049c182c8da908a73b1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->