### PR TITLE
fix: add collision detection to migration 149 chainId normalization

### DIFF
--- a/app/scripts/migrations/149.ts
+++ b/app/scripts/migrations/149.ts
@@ -76,9 +76,19 @@ function transformState(state: Record<string, unknown>) {
       );
     }
 
+    // Always normalize the chainId value inside the configuration
     networkConfiguration.chainId = chainIdAsHex;
 
     if (chainIdAsHex !== chainId) {
+      // Check for collision: if the normalized hex key already exists,
+      // preserve the existing hex-keyed entry and discard the decimal duplicate.
+      // This prevents a malicious decimal-keyed entry from overwriting a
+      // legitimate hex-keyed configuration (e.g., '1' overwriting '0x1').
+      if (hasProperty(networkConfigurationsByChainId, chainIdAsHex)) {
+        delete networkConfigurationsByChainId[chainId];
+        continue;
+      }
+
       delete networkConfigurationsByChainId[chainId];
       networkConfigurationsByChainId[chainIdAsHex] = networkConfiguration;
     }


### PR DESCRIPTION
## **Description**

This PR adds collision detection to Migration 149's chainId key normalization logic to prevent a potential security vulnerability.

**Problem:**
Migration 149 normalizes decimal chainId keys to hex format (e.g., `'1'` → `'0x1'`). However, when both decimal and hex representations of the same chain ID exist (e.g., both `'1'` and `'0x1'` keys), the migration would overwrite entries without collision detection.

Due to JavaScript's object key enumeration order (numeric-like keys are processed first), a decimal-keyed entry processes before its hex equivalent. This means a malicious decimal-keyed network configuration could silently overwrite the legitimate hex-keyed configuration.

**Solution:**
Before normalizing a decimal key to hex, check if the target hex key already exists. If a collision is detected, preserve the canonical hex-keyed entry and discard the decimal duplicate.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39540?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/pm-security/issues/603

## **Manual testing steps**

1. This is a migration fix - manual testing requires a specific pre-migration state
2. Unit tests cover the collision detection scenarios
3. Run `yarn test:unit app/scripts/migrations/149.test.ts` to verify

## **Screenshots/Recordings**

N/A - No UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.