### PR TITLE
chore: Remove restriction for success Main on the `update-onboarding-fixture`

### DIFF
--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -106,6 +106,13 @@ jobs:
             # Poll until the build-dist-browserify job completes
             while true; do
               JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
+
+              # Check if job exists
+              if [ -z "$JOB_INFO" ]; then
+                echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped or the job name may have changed."
+                exit 1
+              fi
+
               JOB_STATUS=$(echo "$JOB_INFO" | jq -r '.status')
               JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
 
@@ -121,6 +128,13 @@ jobs:
           else
             # Run is completed, get the job conclusion
             JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
+
+            # Check if job exists
+            if [ -z "$JOB_INFO" ]; then
+              echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped or the job name may have changed."
+              exit 1
+            fi
+
             JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
           fi
 

--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -85,32 +85,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
-      - name: Find and download dist artifact
+      - name: Download dist artifact
         run: |
           # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion --limit 1 --jq 'first')
+          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status --limit 1 --jq 'first')
 
           if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
-            echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
+            echo "::error::No 'Main' workflow run found for branch ${BRANCH}. Please push your changes to trigger a build first."
             exit 1
           fi
 
           RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
           RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
-          RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
 
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
+          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}"
 
-          # If the run is still in progress, wait for it to complete
+          # If the run is still in progress, wait up to 10 minutes
           if [ "$RUN_STATUS" != "completed" ]; then
-            echo "Run ${RUN_ID} is still in progress. Waiting for it to complete..."
-            gh run watch "${RUN_ID}"
-            # Re-fetch the conclusion after waiting
-            RUN_CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion')
-            echo "Run completed with conclusion: ${RUN_CONCLUSION}"
+            echo "Run ${RUN_ID} is still in progress. Waiting up to 10 minutes for it to complete..."
+            WAIT_COUNT=0
+            while [ "$RUN_STATUS" != "completed" ]; do
+              WAIT_COUNT=$((WAIT_COUNT + 1))
+              if [ $WAIT_COUNT -gt 20 ]; then
+                echo "::error::The Main workflow run (${RUN_ID}) is still in progress after 10 minutes. Please wait for it to complete and try again."
+                exit 1
+              fi
+              echo "Waiting 30 seconds... (attempt ${WAIT_COUNT}/20)"
+              sleep 30
+              RUN_STATUS=$(gh run view "${RUN_ID}" --json status --jq '.status')
+            done
+            echo "Run ${RUN_ID} completed."
           fi
 
-          echo "Downloading artifacts from run ${RUN_ID}..."
+          # Check if the build-dist-browserify job succeeded
+          JOB_CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | .conclusion')
+
+          if [ -z "$JOB_CONCLUSION" ]; then
+            echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped."
+            exit 1
+          fi
+
+          if [ "$JOB_CONCLUSION" != "success" ]; then
+            echo "::error::The 'build-dist-browserify' job failed (conclusion: ${JOB_CONCLUSION}). Please fix the build and try again."
+            exit 1
+          fi
+
+          echo "Downloading build-dist-browserify artifact from run ${RUN_ID}..."
           gh run download "${RUN_ID}" -n build-dist-browserify -D build-dist-browserify
         env:
           BRANCH: ${{ steps.branch.outputs.BRANCH }}

--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Find and download dist artifact
         run: |
           # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status --limit 1 --jq 'first')
+          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion --limit 1 --jq 'first')
 
           if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
             echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
@@ -97,53 +97,17 @@ jobs:
 
           RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
           RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
+          RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
 
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}"
+          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
 
-          # If the run is still in progress, wait for the build-dist-browserify job to complete
+          # If the run is still in progress, wait for it to complete
           if [ "$RUN_STATUS" != "completed" ]; then
-            echo "Run ${RUN_ID} is still in progress. Checking build-dist-browserify job status..."
-            # Poll until the build-dist-browserify job completes
-            while true; do
-              JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
-
-              # Check if job exists
-              if [ -z "$JOB_INFO" ]; then
-                echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped or the job name may have changed."
-                exit 1
-              fi
-
-              JOB_STATUS=$(echo "$JOB_INFO" | jq -r '.status')
-              JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
-
-              echo "build-dist-browserify job status: ${JOB_STATUS}, conclusion: ${JOB_CONCLUSION}"
-
-              if [ "$JOB_STATUS" == "completed" ]; then
-                break
-              fi
-
-              echo "Job still in progress, waiting 30 seconds..."
-              sleep 30
-            done
-          else
-            # Run is completed, get the job conclusion
-            JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
-
-            # Check if job exists
-            if [ -z "$JOB_INFO" ]; then
-              echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped or the job name may have changed."
-              exit 1
-            fi
-
-            JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
-          fi
-
-          echo "build-dist-browserify job conclusion: ${JOB_CONCLUSION}"
-
-          # Check if the build-dist-browserify job was successful
-          if [ "$JOB_CONCLUSION" != "success" ]; then
-            echo "::error::The 'build-dist-browserify' job in run ${RUN_ID} did not succeed (conclusion: ${JOB_CONCLUSION}). Please fix the build and try again."
-            exit 1
+            echo "Run ${RUN_ID} is still in progress. Waiting for it to complete..."
+            gh run watch "${RUN_ID}"
+            # Re-fetch the conclusion after waiting
+            RUN_CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion')
+            echo "Run completed with conclusion: ${RUN_CONCLUSION}"
           fi
 
           echo "Downloading artifacts from run ${RUN_ID}..."

--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Find and download dist artifact
         run: |
           # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion --limit 1 --jq 'first')
+          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status --limit 1 --jq 'first')
 
           if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
             echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
@@ -97,22 +97,38 @@ jobs:
 
           RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
           RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
-          RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
 
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
+          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}"
 
-          # If the run is still in progress, wait for it to complete
+          # If the run is still in progress, wait for the build-dist-browserify job to complete
           if [ "$RUN_STATUS" != "completed" ]; then
-            echo "Run ${RUN_ID} is still in progress. Waiting for it to complete..."
-            gh run watch "${RUN_ID}"
-            # Re-fetch the conclusion after waiting
-            RUN_CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion')
-            echo "Run completed with conclusion: ${RUN_CONCLUSION}"
+            echo "Run ${RUN_ID} is still in progress. Checking build-dist-browserify job status..."
+            # Poll until the build-dist-browserify job completes
+            while true; do
+              JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
+              JOB_STATUS=$(echo "$JOB_INFO" | jq -r '.status')
+              JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
+
+              echo "build-dist-browserify job status: ${JOB_STATUS}, conclusion: ${JOB_CONCLUSION}"
+
+              if [ "$JOB_STATUS" == "completed" ]; then
+                break
+              fi
+
+              echo "Job still in progress, waiting 30 seconds..."
+              sleep 30
+            done
+          else
+            # Run is completed, get the job conclusion
+            JOB_INFO=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | {status: .status, conclusion: .conclusion}')
+            JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
           fi
 
-          # Check if the run was successful
-          if [ "$RUN_CONCLUSION" != "success" ]; then
-            echo "::error::The most recent 'Main' workflow run (${RUN_ID}) did not succeed (conclusion: ${RUN_CONCLUSION}). Please fix the build and try again."
+          echo "build-dist-browserify job conclusion: ${JOB_CONCLUSION}"
+
+          # Check if the build-dist-browserify job was successful
+          if [ "$JOB_CONCLUSION" != "success" ]; then
+            echo "::error::The 'build-dist-browserify' job in run ${RUN_ID} did not succeed (conclusion: ${JOB_CONCLUSION}). Please fix the build and try again."
             exit 1
           fi
 

--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -85,52 +85,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
-      - name: Download dist artifact
+      - name: Find and download dist artifact
         run: |
           # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status --limit 1 --jq 'first')
+          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion --limit 1 --jq 'first')
 
           if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
-            echo "::error::No 'Main' workflow run found for branch ${BRANCH}. Please push your changes to trigger a build first."
+            echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
             exit 1
           fi
 
           RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
           RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
+          RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
 
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}"
+          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
 
-          # If the run is still in progress, wait up to 10 minutes
+          # If the run is still in progress, wait for it to complete
           if [ "$RUN_STATUS" != "completed" ]; then
-            echo "Run ${RUN_ID} is still in progress. Waiting up to 10 minutes for it to complete..."
-            WAIT_COUNT=0
-            while [ "$RUN_STATUS" != "completed" ]; do
-              WAIT_COUNT=$((WAIT_COUNT + 1))
-              if [ $WAIT_COUNT -gt 20 ]; then
-                echo "::error::The Main workflow run (${RUN_ID}) is still in progress after 10 minutes. Please wait for it to complete and try again."
-                exit 1
-              fi
-              echo "Waiting 30 seconds... (attempt ${WAIT_COUNT}/20)"
-              sleep 30
-              RUN_STATUS=$(gh run view "${RUN_ID}" --json status --jq '.status')
-            done
-            echo "Run ${RUN_ID} completed."
+            echo "Run ${RUN_ID} is still in progress. Waiting for it to complete..."
+            gh run watch "${RUN_ID}"
+            # Re-fetch the conclusion after waiting
+            RUN_CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion')
+            echo "Run completed with conclusion: ${RUN_CONCLUSION}"
           fi
 
-          # Check if the build-dist-browserify job succeeded
-          JOB_CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name == "build-dist-browserify") | .conclusion')
-
-          if [ -z "$JOB_CONCLUSION" ]; then
-            echo "::error::The 'build-dist-browserify' job was not found in run ${RUN_ID}. The job may have been skipped."
-            exit 1
-          fi
-
-          if [ "$JOB_CONCLUSION" != "success" ]; then
-            echo "::error::The 'build-dist-browserify' job failed (conclusion: ${JOB_CONCLUSION}). Please fix the build and try again."
-            exit 1
-          fi
-
-          echo "Downloading build-dist-browserify artifact from run ${RUN_ID}..."
+          echo "Downloading artifacts from run ${RUN_ID}..."
           gh run download "${RUN_ID}" -n build-dist-browserify -D build-dist-browserify
         env:
           BRANCH: ${{ steps.branch.outputs.BRANCH }}

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -36,8 +36,8 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentAppVersion": "13.12.0",
-      "currentMigrationVersion": 184,
+      "currentAppVersion": "13.17.0",
+      "currentMigrationVersion": 189,
       "previousAppVersion": "",
       "previousMigrationVersion": 0
     },
@@ -74,19 +74,18 @@
       "showNetworkBanner": true,
       "showPermissionsTour": true,
       "showShieldEntryModalOnce": null,
-      "showStorageErrorToast": false,
       "showTestnetMessageInDropdown": true,
       "slides": [],
       "surveyLinkLastClickedOrClosed": null,
       "timeoutMinutes": 0,
       "trezorModel": null,
-      "updateModalLastDismissedAt": null
+      "updateModalLastDismissedAt": null,
+      "pna25Acknowledged": false,
+      "recoveryPhraseReminderLastShown": 7952515200000
     },
-    "ApprovalController": {},
     "AuthenticationController": {
       "isSignedIn": false
     },
-    "BridgeController": {},
     "BridgeStatusController": {
       "txHistory": {}
     },
@@ -95,7 +94,8 @@
       "claimsConfigurations": {
         "supportedNetworks": ["0x1", "0xe708"],
         "validSubmissionWindowDays": 21
-      }
+      },
+      "drafts": []
     },
     "CurrencyController": {
       "currencyRates": {
@@ -107,12 +107,9 @@
       },
       "currentCurrency": "usd"
     },
-    "DeFiPositionsController": {},
-    "DecryptMessageController": {},
     "DelegationController": {
       "delegations": {}
     },
-    "EncryptionPublicKeyController": {},
     "EnsController": {
       "ensEntries": {
         "0x1": {
@@ -168,10 +165,9 @@
       "nonRPCGasFeeApisDisabled": false
     },
     "GatorPermissionsController": {
-      "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
-      "isGatorPermissionsEnabled": false
+      "gatorPermissionsMapSerialized": "{\"erc20-token-revocation\":{},\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
+      "isGatorPermissionsEnabled": true
     },
-    "KeyringController": {},
     "LoggingController": {
       "logs": {}
     },
@@ -201,7 +197,8 @@
         }
       ],
       "traits": {
-        "install_date_ext": "2025-11-25"
+        "install_date_ext": "2026-01-22",
+        "storage_kind": "split"
       }
     },
     "MetaMetricsDataDeletionController": {
@@ -2006,28 +2003,27 @@
         "npm:@metamask/institutional-wallet-snap": "mainnet",
         "npm:@metamask/message-signing-snap": "mainnet",
         "npm:@metamask/solana-wallet-snap": "mainnet",
-        "npm:@metamask/tron-wallet-snap": "mainnet"
+        "npm:@metamask/tron-wallet-snap": "mainnet",
+        "npm:@metamask/permissions-kernel-snap": "mainnet"
       }
     },
     "ShieldController": {
       "coverageResults": {},
       "orderedTransactionHistory": []
     },
-    "SignatureController": {},
-    "SmartTransactionsController": {},
     "SnapController": {
       "snapStates": {},
       "snaps": {},
       "unencryptedSnapStates": {}
     },
-    "SnapInsightsController": {},
     "SnapInterfaceController": {
       "interfaces": {}
     },
     "SnapsRegistry": {
       "database": null,
       "databaseUnavailable": false,
-      "lastUpdated": null
+      "lastUpdated": null,
+      "signature": null
     },
     "SubjectMetadataController": {
       "subjectMetadata": {
@@ -2105,7 +2101,6 @@
       "subscriptions": [],
       "trialedProducts": []
     },
-    "SwapsController": {},
     "TokenBalancesController": {
       "tokenBalances": {}
     },
@@ -2137,12 +2132,10 @@
       "isContactSyncingEnabled": true
     },
     "config": {},
-    "firstTimeInfo": {
-      "date": 1764061389865,
-      "version": "13.12.0"
-    }
+    "KeyringController": {}
   },
   "meta": {
-    "version": 185
+    "version": 189,
+    "storageKind": "split"
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -36,8 +36,9 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentAppVersion": "13.17.0",
-      "currentMigrationVersion": 189,
+      "currentAppVersion": "13.12.0",
+      "currentMigrationVersion": 184,
+      "previousAppVersion": "",
       "previousMigrationVersion": 0
     },
     "AppStateController": {
@@ -48,7 +49,7 @@
       "canTrackWalletFundsObtained": true,
       "connectedStatusPopoverHasBeenShown": true,
       "defaultHomeActiveTabName": null,
-      "enableEnforcedSimulations": false,
+      "enableEnforcedSimulations": true,
       "enforcedSimulationsSlippage": 10,
       "hadAdvancedGasFeesSetPriorToMigration92_3": false,
       "hasShownMultichainAccountsIntroModal": false,
@@ -73,18 +74,19 @@
       "showNetworkBanner": true,
       "showPermissionsTour": true,
       "showShieldEntryModalOnce": null,
+      "showStorageErrorToast": false,
       "showTestnetMessageInDropdown": true,
       "slides": [],
       "surveyLinkLastClickedOrClosed": null,
       "timeoutMinutes": 0,
       "trezorModel": null,
-      "updateModalLastDismissedAt": null,
-      "pna25Acknowledged": false,
-      "recoveryPhraseReminderLastShown": 7952515200000
+      "updateModalLastDismissedAt": null
     },
+    "ApprovalController": {},
     "AuthenticationController": {
       "isSignedIn": false
     },
+    "BridgeController": {},
     "BridgeStatusController": {
       "txHistory": {}
     },
@@ -93,8 +95,7 @@
       "claimsConfigurations": {
         "supportedNetworks": ["0x1", "0xe708"],
         "validSubmissionWindowDays": 21
-      },
-      "drafts": []
+      }
     },
     "CurrencyController": {
       "currencyRates": {
@@ -106,9 +107,12 @@
       },
       "currentCurrency": "usd"
     },
+    "DeFiPositionsController": {},
+    "DecryptMessageController": {},
     "DelegationController": {
       "delegations": {}
     },
+    "EncryptionPublicKeyController": {},
     "EnsController": {
       "ensEntries": {
         "0x1": {
@@ -164,9 +168,10 @@
       "nonRPCGasFeeApisDisabled": false
     },
     "GatorPermissionsController": {
-      "gatorPermissionsMapSerialized": "{\"erc20-token-revocation\":{},\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
-      "isGatorPermissionsEnabled": true
+      "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
+      "isGatorPermissionsEnabled": false
     },
+    "KeyringController": {},
     "LoggingController": {
       "logs": {}
     },
@@ -196,8 +201,7 @@
         }
       ],
       "traits": {
-        "install_date_ext": "2026-01-22",
-        "storage_kind": "split"
+        "install_date_ext": "2025-11-25"
       }
     },
     "MetaMetricsDataDeletionController": {
@@ -2002,27 +2006,28 @@
         "npm:@metamask/institutional-wallet-snap": "mainnet",
         "npm:@metamask/message-signing-snap": "mainnet",
         "npm:@metamask/solana-wallet-snap": "mainnet",
-        "npm:@metamask/tron-wallet-snap": "mainnet",
-        "npm:@metamask/permissions-kernel-snap": "mainnet"
+        "npm:@metamask/tron-wallet-snap": "mainnet"
       }
     },
     "ShieldController": {
       "coverageResults": {},
       "orderedTransactionHistory": []
     },
+    "SignatureController": {},
+    "SmartTransactionsController": {},
     "SnapController": {
       "snapStates": {},
       "snaps": {},
       "unencryptedSnapStates": {}
     },
+    "SnapInsightsController": {},
     "SnapInterfaceController": {
       "interfaces": {}
     },
     "SnapsRegistry": {
       "database": null,
       "databaseUnavailable": false,
-      "lastUpdated": null,
-      "signature": null
+      "lastUpdated": null
     },
     "SubjectMetadataController": {
       "subjectMetadata": {
@@ -2100,6 +2105,7 @@
       "subscriptions": [],
       "trialedProducts": []
     },
+    "SwapsController": {},
     "TokenBalancesController": {
       "tokenBalances": {}
     },
@@ -2131,10 +2137,12 @@
       "isContactSyncingEnabled": true
     },
     "config": {},
-    "KeyringController": {}
+    "firstTimeInfo": {
+      "date": 1764061389865,
+      "version": "13.12.0"
+    }
   },
   "meta": {
-    "version": 189,
-    "storageKind": "split"
+    "version": 185
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -38,7 +38,6 @@
     "AppMetadataController": {
       "currentAppVersion": "13.17.0",
       "currentMigrationVersion": 189,
-      "previousAppVersion": "",
       "previousMigrationVersion": 0
     },
     "AppStateController": {
@@ -49,7 +48,7 @@
       "canTrackWalletFundsObtained": true,
       "connectedStatusPopoverHasBeenShown": true,
       "defaultHomeActiveTabName": null,
-      "enableEnforcedSimulations": true,
+      "enableEnforcedSimulations": false,
       "enforcedSimulationsSlippage": 10,
       "hadAdvancedGasFeesSetPriorToMigration92_3": false,
       "hasShownMultichainAccountsIntroModal": false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There's a bug on the `update-onboarding-fixture` script, which it waits for a Successful Main job to be completed in the PR. This will not be the case, as when we will likely use the bugbot comment to update the fixture is precisely when the dist e2e failed (which fails Main job), so we don't want this check to be a requirement.


<img width="1532" height="654" alt="image" src="https://github.com/user-attachments/assets/abddb28a-cd49-4a07-a74f-68fceafbdf54" />

https://github.com/MetaMask/metamask-extension/actions/runs/21389224910/job/61571921550


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39544?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1330

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows the onboarding fixture updater to proceed even if the most recent `Main` run did not succeed.
> 
> - Removes the requirement that `Main` conclude with `success` before downloading `build-dist-browserify` artifacts; still waits for run completion and downloads artifacts
> - CI-only change; no application code modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a6a8e0d9333ea6c36579db4851de238564fd28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->