### PR TITLE
fix: incorrect enum usage

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -26,7 +26,7 @@ import {
   RECURRING_INTERVALS,
   RecurringInterval,
 } from '@metamask/subscription-controller';
-import { HardwareDeviceNames } from '../../../../shared/constants/hardware-wallets';
+import { HardwareKeyringType } from '../../../../shared/constants/hardware-wallets';
 import {
   RewardsControllerActions,
   RewardsControllerEvents,
@@ -536,7 +536,7 @@ describe('RewardsController', () => {
           metadata: {
             ...MOCK_INTERNAL_ACCOUNT.metadata,
             keyring: {
-              type: HardwareDeviceNames.ledger,
+              type: HardwareKeyringType.ledger,
             },
           },
         };
@@ -2363,7 +2363,7 @@ describe('RewardsController', () => {
           metadata: {
             ...MOCK_INTERNAL_ACCOUNT.metadata,
             keyring: {
-              type: HardwareDeviceNames.ledger,
+              type: HardwareKeyringType.ledger,
             },
           },
         };

--- a/shared/lib/accounts/accounts.test.ts
+++ b/shared/lib/accounts/accounts.test.ts
@@ -74,16 +74,20 @@ describe('accounts', () => {
         },
       }) as InternalAccount;
 
+    // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
       ['Ledger', HardwareKeyringType.ledger],
       ['Trezor', HardwareKeyringType.trezor],
       ['OneKey', HardwareKeyringType.oneKey],
       ['Lattice', HardwareKeyringType.lattice],
       ['QR', HardwareKeyringType.qr],
-    ])('returns true for %s hardware wallet', (_name, keyringType) => {
-      const account = createMockAccount(keyringType);
-      expect(isHardwareAccount(account)).toBe(true);
-    });
+    ])(
+      'returns true for %s hardware wallet',
+      (_name: string, keyringType: HardwareKeyringType) => {
+        const account = createMockAccount(keyringType);
+        expect(isHardwareAccount(account)).toBe(true);
+      },
+    );
 
     it('returns false for non-hardware keyring type', () => {
       const account = createMockAccount('HD Key Tree');

--- a/shared/lib/accounts/accounts.test.ts
+++ b/shared/lib/accounts/accounts.test.ts
@@ -15,8 +15,11 @@ import {
 } from '@metamask/messenger';
 import { AccountsControllerActions } from '@metamask/accounts-controller';
 import { SnapControllerActions } from '@metamask/snaps-controllers';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { HardwareKeyringType } from '../../constants/hardware-wallets';
 import {
   getNextAvailableSnapAccountName,
+  isHardwareAccount,
   MultichainWalletSnapClient,
   SnapAccountNameOptions,
   CreateAccountSnapOptions,
@@ -56,6 +59,83 @@ describe('accounts', () => {
       expect(await get('npm:not-known' as SnapId)).toStrictEqual(
         `Snap Account ${index}`,
       );
+    });
+  });
+
+  describe('isHardwareAccount', () => {
+    const createMockAccount = (keyringType: string): InternalAccount =>
+      ({
+        id: 'test-account-id',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        metadata: {
+          keyring: {
+            type: keyringType,
+          },
+        },
+      }) as InternalAccount;
+
+    it.each([
+      ['Ledger', HardwareKeyringType.ledger],
+      ['Trezor', HardwareKeyringType.trezor],
+      ['OneKey', HardwareKeyringType.oneKey],
+      ['Lattice', HardwareKeyringType.lattice],
+      ['QR', HardwareKeyringType.qr],
+    ])('returns true for %s hardware wallet', (_name, keyringType) => {
+      const account = createMockAccount(keyringType);
+      expect(isHardwareAccount(account)).toBe(true);
+    });
+
+    it('returns false for non-hardware keyring type', () => {
+      const account = createMockAccount('HD Key Tree');
+      expect(isHardwareAccount(account)).toBe(false);
+    });
+
+    it('returns false for snap keyring type', () => {
+      const account = createMockAccount('Snap Keyring');
+      expect(isHardwareAccount(account)).toBe(false);
+    });
+
+    it('returns false for simple keyring type', () => {
+      const account = createMockAccount('Simple Key Pair');
+      expect(isHardwareAccount(account)).toBe(false);
+    });
+
+    it('returns false when account is null', () => {
+      expect(isHardwareAccount(null as unknown as InternalAccount)).toBe(false);
+    });
+
+    it('returns false when account is undefined', () => {
+      expect(isHardwareAccount(undefined as unknown as InternalAccount)).toBe(
+        false,
+      );
+    });
+
+    it('returns false when metadata is missing', () => {
+      const account = {
+        id: 'test-account-id',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+      } as InternalAccount;
+      expect(isHardwareAccount(account)).toBe(false);
+    });
+
+    it('returns false when keyring is missing', () => {
+      const account = {
+        id: 'test-account-id',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        metadata: {},
+      } as InternalAccount;
+      expect(isHardwareAccount(account)).toBe(false);
+    });
+
+    it('returns false when keyring type is missing', () => {
+      const account = {
+        id: 'test-account-id',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        metadata: {
+          keyring: {},
+        },
+      } as InternalAccount;
+      expect(isHardwareAccount(account)).toBe(false);
     });
   });
 

--- a/shared/lib/accounts/accounts.ts
+++ b/shared/lib/accounts/accounts.ts
@@ -18,7 +18,7 @@ import { AccountsControllerGetNextAvailableAccountNameAction } from '@metamask/a
 ///: END:ONLY_INCLUDE_IF
 import { MultichainNetworks } from '../../constants/multichain/networks';
 import { captureException } from '../sentry';
-import { HardwareDeviceNames } from '../../constants/hardware-wallets';
+import { HardwareKeyringType } from '../../constants/hardware-wallets';
 import { BITCOIN_WALLET_SNAP_ID } from './bitcoin-wallet-snap';
 import { SOLANA_WALLET_SNAP_ID } from './solana-wallet-snap';
 import { TRON_WALLET_SNAP_ID } from './tron-wallet-snap';
@@ -83,8 +83,8 @@ export async function getNextAvailableSnapAccountName(
 export function isHardwareAccount(account: InternalAccount): boolean {
   try {
     const keyringType = account?.metadata?.keyring?.type;
-    return Object.values(HardwareDeviceNames).includes(
-      keyringType as HardwareDeviceNames,
+    return Object.values(HardwareKeyringType).includes(
+      keyringType as HardwareKeyringType,
     );
   } catch {
     return false;

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
@@ -11,7 +11,7 @@ import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
-import { HardwareDeviceNames } from '../../../../../../shared/constants/hardware-wallets';
+import { HardwareKeyringType } from '../../../../../../shared/constants/hardware-wallets';
 import { usePayHardwareAccountAlert } from './usePayHardwareAccountAlert';
 
 const HARDWARE_ACCOUNT_ID = 'hardware-account-id';
@@ -77,7 +77,7 @@ function runHookWithoutTransaction() {
 
 describe('usePayHardwareAccountAlert', () => {
   it('returns alert if from address is a Ledger hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.ledger);
+    const { result } = runHookWithTransaction(HardwareKeyringType.ledger);
 
     expect(result.current).toStrictEqual([
       {
@@ -93,7 +93,7 @@ describe('usePayHardwareAccountAlert', () => {
   });
 
   it('returns alert if from address is a Trezor hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.trezor);
+    const { result } = runHookWithTransaction(HardwareKeyringType.trezor);
 
     expect(result.current).toStrictEqual([
       {
@@ -109,7 +109,7 @@ describe('usePayHardwareAccountAlert', () => {
   });
 
   it('returns alert if from address is a Lattice hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.lattice);
+    const { result } = runHookWithTransaction(HardwareKeyringType.lattice);
 
     expect(result.current).toStrictEqual([
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes the incorrect enum being used in the isHardwareAccount.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39549?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches hardware wallet enum usage to the correct `HardwareKeyringType` and strengthens hardware account detection tests.
> 
> - Updates `isHardwareAccount` in `shared/lib/accounts/accounts.ts` to check against `HardwareKeyringType`
> - Adds comprehensive `isHardwareAccount` test cases in `shared/lib/accounts/accounts.test.ts`
> - Refactors tests to use `HardwareKeyringType` in `rewards-controller.test.ts` and `usePayHardwareAccountAlert.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53ce02aa3f78accd9e0c1db85c70cb5fce6213fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->