### PR TITLE
feat: metamask pay skeletons

### DIFF
--- a/test/integration/config/setupAfter.js
+++ b/test/integration/config/setupAfter.js
@@ -23,3 +23,11 @@ jest.mock(
     MusdConversionInfo: () => null,
   }),
 );
+
+jest.mock(
+  '../../../ui/pages/confirmations/components/info/custom-amount-info',
+  () => ({
+    CustomAmountInfo: () => null,
+    CustomAmountInfoSkeleton: () => null,
+  }),
+);

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -15,6 +15,7 @@ import { renderWithConfirmContextProvider } from '../../../../../../test/lib/con
 import { useAssetDetails } from '../../../hooks/useAssetDetails';
 import { getEnabledAdvancedPermissions } from '../../../../../../shared/modules/environment';
 import { DEFAULT_ROUTE } from '../../../../../helpers/constants/routes';
+import { ConfirmationLoader } from '../../../hooks/useConfirmationNavigation';
 import Info from './info';
 
 jest.mock('../../simulation-details/useBalanceChanges', () => ({
@@ -65,6 +66,30 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(),
 }));
 
+const mockUseConfirmationNavigationOptions = jest.fn();
+jest.mock('../../../hooks/useConfirmationNavigation', () => ({
+  ...jest.requireActual('../../../hooks/useConfirmationNavigation'),
+  useConfirmationNavigationOptions: () =>
+    mockUseConfirmationNavigationOptions(),
+}));
+
+let mockConfirmContextValue: ReturnType<
+  typeof import('../../../context/confirm').useConfirmContext
+> | null = null;
+
+jest.mock('../../../context/confirm', () => {
+  const actual = jest.requireActual('../../../context/confirm');
+  return {
+    ...actual,
+    useConfirmContext: () => {
+      if (mockConfirmContextValue !== null) {
+        return mockConfirmContextValue;
+      }
+      return actual.useConfirmContext();
+    },
+  };
+});
+
 describe('Info', () => {
   const mockedAssetDetails = jest.mocked(useAssetDetails);
   const mockedUseParams = jest.mocked(useParams);
@@ -77,6 +102,7 @@ describe('Info', () => {
       decimals: '4' as any,
     }));
     mockedUseParams.mockReturnValue({});
+    mockUseConfirmationNavigationOptions.mockReturnValue({ loader: null });
   });
 
   it('renders info section for personal sign request', () => {
@@ -157,5 +183,45 @@ describe('Info', () => {
     expect(screen.getByText('example.com')).toBeInTheDocument();
     expect(screen.getByText('rpc.example.com')).toBeInTheDocument();
     expect(screen.getByText('RPC')).toBeInTheDocument();
+  });
+
+  describe('when no confirmation type exists', () => {
+    beforeEach(() => {
+      mockConfirmContextValue = {
+        currentConfirmation: undefined as never,
+        isScrollToBottomCompleted: true,
+        setIsScrollToBottomCompleted: jest.fn(),
+      };
+    });
+
+    afterEach(() => {
+      mockConfirmContextValue = null;
+    });
+
+    it('renders InfoSkeleton when loader is not set', () => {
+      mockUseConfirmationNavigationOptions.mockReturnValue({ loader: null });
+
+      const state = getMockPersonalSignConfirmState();
+      const mockStore = configureMockStore([])(state);
+      renderWithConfirmContextProvider(<Info />, mockStore);
+
+      expect(
+        screen.getByTestId('confirmation__info_skeleton'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders CustomAmountInfoSkeleton when loader is CustomAmount', () => {
+      mockUseConfirmationNavigationOptions.mockReturnValue({
+        loader: ConfirmationLoader.CustomAmount,
+      });
+
+      const state = getMockPersonalSignConfirmState();
+      const mockStore = configureMockStore([])(state);
+      renderWithConfirmContextProvider(<Info />, mockStore);
+
+      expect(
+        screen.getByTestId('custom-amount-info-skeleton'),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -10,6 +10,11 @@ import { SignatureRequestType } from '../../../types/confirm';
 import { AddEthereumChain } from '../../../external/add-ethereum-chain/add-ethereum-chain';
 import { ConfirmInfoSection } from '../../../../../components/app/confirm/info/row/section';
 import { Skeleton } from '../../../../../components/component-library/skeleton';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigationOptions,
+} from '../../../hooks/useConfirmationNavigation';
+import { CustomAmountInfoSkeleton } from '../../info/custom-amount-info';
 import { MusdConversionInfo } from './musd-conversion-info';
 import { PerpsDepositInfo } from './perps-deposit-info';
 import ApproveInfo from './approve/approve';
@@ -35,8 +40,8 @@ export const InfoSkeleton = () => (
 
 const Info = () => {
   const { currentConfirmation } = useConfirmContext();
+  const { loader } = useConfirmationNavigationOptions();
 
-  // TODO: Create TransactionInfo and SignatureInfo components.
   useSmartTransactionFeatureFlags();
   useTransactionFocusEffect();
 
@@ -85,6 +90,10 @@ const Info = () => {
   );
 
   if (!currentConfirmation?.type) {
+    if (loader === ConfirmationLoader.CustomAmount) {
+      return <CustomAmountInfoSkeleton />;
+    }
+
     return <InfoSkeleton />;
   }
 

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -32,6 +32,10 @@ import { useTransactionEventFragment } from '../../../hooks/useTransactionEventF
 import { NestedTransactionTag } from '../../transactions/nested-transaction-tag';
 import { useIsUpgradeTransaction } from '../info/hooks/useIsUpgradeTransaction';
 import { getPermissionDescription } from '../info/typed-sign/typed-sign-permission/typed-sign-permission-util';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigationOptions,
+} from '../../../hooks/useConfirmationNavigation';
 import { useCurrentSpendingCap } from './hooks/useCurrentSpendingCap';
 
 const TRANSACTION_TYPES_HIDE_BANNER: string[] = [
@@ -267,6 +271,7 @@ const ConfirmTitle: React.FC = memo(() => {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
   const { isUpgradeOnly } = useIsUpgradeTransaction();
+  const { loader } = useConfirmationNavigationOptions();
 
   const { isNFT } = useIsNFT(currentConfirmation as TransactionMeta);
 
@@ -337,6 +342,10 @@ const ConfirmTitle: React.FC = memo(() => {
   );
 
   if (!currentConfirmation) {
+    if (loader && loader !== ConfirmationLoader.Default) {
+      return null;
+    }
+
     return <TitleSkeleton />;
   }
 

--- a/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
+++ b/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import type { Hex } from '@metamask/utils';
 import { Interface } from '@ethersproject/abi';
 import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { CONFIRM_TRANSACTION_ROUTE } from '../../../../../helpers/constants/routes';
 import {
   addTransaction,
   findNetworkClientIdByChainId,
@@ -14,6 +12,10 @@ import {
 import { getSelectedInternalAccount } from '../../../../../selectors';
 import { DeveloperButton } from '../developer-button';
 import { MAINNET_MUSD } from '../../../constants/musd';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigation,
+} from '../../../hooks/useConfirmationNavigation';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 const erc20Interface = new Interface(ERC20_ABI);
@@ -33,7 +35,7 @@ const generateERC20TransferData = (
 };
 
 export const MusdConversionButton = () => {
-  const navigate = useNavigate();
+  const { navigateToTransaction } = useConfirmationNavigation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const [hasTriggered, setHasTriggered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -72,13 +74,15 @@ export const MusdConversionButton = () => {
 
       setHasTriggered(true);
 
-      navigate(`${CONFIRM_TRANSACTION_ROUTE}/${txMeta.id}`);
+      navigateToTransaction(txMeta.id, {
+        loader: ConfirmationLoader.CustomAmount,
+      });
     } catch (error) {
       console.error('Failed to create MUSD conversion transaction', error);
     } finally {
       setIsLoading(false);
     }
-  }, [navigate, selectedAccount?.address]);
+  }, [navigateToTransaction, selectedAccount?.address]);
 
   return (
     <DeveloperButton

--- a/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import type { Hex } from '@metamask/utils';
 import { Interface } from '@ethersproject/abi';
 import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { CONFIRM_TRANSACTION_ROUTE } from '../../../../../helpers/constants/routes';
 import {
   addTransaction,
   findNetworkClientIdByChainId,
@@ -18,6 +16,10 @@ import {
   ARBITRUM_USDC,
   HYPERLIQUID_BRIDGE_ADDRESS,
 } from '../../../constants/perps';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigation,
+} from '../../../hooks/useConfirmationNavigation';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 const erc20Interface = new Interface(ERC20_ABI);
@@ -37,7 +39,7 @@ const generateERC20TransferData = (
 };
 
 export const PerpsDepositButton = () => {
-  const navigate = useNavigate();
+  const { navigateToTransaction } = useConfirmationNavigation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const [hasTriggered, setHasTriggered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -76,13 +78,15 @@ export const PerpsDepositButton = () => {
 
       setHasTriggered(true);
 
-      navigate(`${CONFIRM_TRANSACTION_ROUTE}/${txMeta.id}`);
+      navigateToTransaction(txMeta.id, {
+        loader: ConfirmationLoader.CustomAmount,
+      });
     } catch (error) {
       console.error('Failed to create perps deposit transaction', error);
     } finally {
       setIsLoading(false);
     }
-  }, [navigate, selectedAccount?.address]);
+  }, [navigateToTransaction, selectedAccount?.address]);
 
   return (
     <DeveloperButton

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { ApprovalType } from '@metamask/controller-utils';
 import { isEqual } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
@@ -23,12 +23,21 @@ import {
   selectPendingApprovalsForNavigation,
 } from '../../../selectors';
 
+export enum ConfirmationLoader {
+  Default = 'default',
+  CustomAmount = 'customAmount',
+}
+
 const CONNECT_APPROVAL_TYPES = [
   ApprovalType.WalletRequestPermissions,
   'wallet_installSnap',
   'wallet_updateSnap',
   'wallet_installSnapResult',
 ];
+
+export type ConfirmationNavigationOptions = {
+  loader?: ConfirmationLoader;
+};
 
 export function useConfirmationNavigation() {
   const confirmations = useSelector(selectPendingApprovalsForNavigation);
@@ -85,13 +94,28 @@ export function useConfirmationNavigation() {
     [confirmations, getIndex, navigateToIndex],
   );
 
+  const navigateToTransaction = useCallback(
+    (transactionId: string, options: ConfirmationNavigationOptions = {}) => {
+      const loader = options.loader ?? ConfirmationLoader.Default;
+
+      navigate({
+        pathname: `${CONFIRM_TRANSACTION_ROUTE}/${transactionId}`,
+        search: options.loader
+          ? new URLSearchParams({ loader }).toString()
+          : '',
+      });
+    },
+    [navigate],
+  );
+
   return {
     confirmations,
     count,
     getIndex,
+    navigateNext,
     navigateToId,
     navigateToIndex,
-    navigateNext,
+    navigateToTransaction,
   };
 }
 
@@ -165,4 +189,13 @@ export function getConfirmationRoute(
   }
 
   return '';
+}
+
+export function useConfirmationNavigationOptions(): ConfirmationNavigationOptions {
+  const [searchParams] = useSearchParams();
+  const loader = searchParams.get('loader') as ConfirmationLoader;
+
+  return {
+    loader,
+  };
 }

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -193,7 +193,10 @@ export function getConfirmationRoute(
 
 export function useConfirmationNavigationOptions(): ConfirmationNavigationOptions {
   const [searchParams] = useSearchParams();
-  const loader = searchParams.get('loader') as ConfirmationLoader;
+
+  const loader =
+    (searchParams.get('loader') as ConfirmationLoader) ??
+    ConfirmationLoader.Default;
 
   return {
     loader,


### PR DESCRIPTION
## **Description**

Add loader query parameter support to confirmation navigation, allowing different skeleton loaders to be shown while confirmations are loading.

- Add `ConfirmationLoader` enum and `navigateToTransaction` method to `useConfirmationNavigation` hook
- Add `useConfirmationNavigationOptions` hook to read loader param from URL
- Show `CustomAmountInfoSkeleton` for perps/mUSD confirmations while loading
- Hide title skeleton when custom loader is active

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39578?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: [#6499](https://github.com/MetaMask/MetaMask-planning/issues/6499)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="290" height="272" alt="Skeleton" src="https://github.com/user-attachments/assets/5561c36f-6d90-493d-a36a-2a04c5ae14dc" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes confirmation navigation URL generation and alters what renders while `currentConfirmation` is undefined, which could impact confirmation UX if the loader param is mis-set or persists unexpectedly.
> 
> **Overview**
> Adds `ConfirmationLoader` support to confirmations by introducing `useConfirmationNavigationOptions()` (reads `loader` from URL search params) and `navigateToTransaction()` (writes the param when navigating).
> 
> Updates confirmation UI loading states so `Info` can render `CustomAmountInfoSkeleton` when `loader=customAmount`, and `ConfirmTitle` suppresses the default title skeleton when a non-default loader is active.
> 
> Adjusts developer trigger buttons (perps/mUSD) to navigate via `navigateToTransaction` with the custom loader, and extends unit/integration test mocks/coverage for the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 457487a853a416e08ac0f5137f8d3c5dce30a4ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->