### PR TITLE
feat: add wallet collapse functionality to all wallet types [superseded by #39645]

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -1195,6 +1195,43 @@ describe('MultichainAccountList', () => {
     });
   });
 
+  describe('Wallet collapse functionality', () => {
+    it('shows wallet headers when there are multiple wallets', () => {
+      renderComponent();
+
+      const walletHeaders = screen.getAllByTestId(walletHeaderTestId);
+      expect(walletHeaders).toHaveLength(2);
+
+      // Wallets are expanded by default
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+    });
+
+    it('collapses wallet when wallet header is clicked', async () => {
+      renderComponent();
+
+      // Click the first wallet header to collapse it
+      const walletHeaders = screen.getAllByTestId(walletHeaderTestId);
+      await act(async () => {
+        fireEvent.click(walletHeaders[0]);
+      });
+
+      // Wallet 1's account should no longer be visible
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).not.toBeInTheDocument();
+
+      // Wallet 2's account should still be visible
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('Trace events', () => {
     it('ends AccountList and ShowAccountList traces on mount', () => {
       renderComponent();


### PR DESCRIPTION
## **Description**

This PR explored adding collapsible wallet sections to the MultichainAccountList component. After implementation and testing, we discovered that PR #39645 implements a more robust solution to the same problem.

**Why PR #39645 is preferred:**
- Better handling of virtualized list height recalculation
- More comprehensive collapse functionality (includes pinned section)
- Cleaner integration with the virtualizer without forcing remounts
- Uses `getItemKey` in virtualizer config for better React reconciliation

**This PR is being closed in favor of #39645**, which provides the same end-user functionality with a superior technical implementation.

Original implementation details preserved below for reference:

---

Implemented collapsible wallet sections in the MultichainAccountList component, extending the collapse functionality that was previously only available for hidden accounts to all wallet types (Entropy, Keyring, Snap).

**Changes in this PR:**
- Added `expandedWallets` state to track collapse state per wallet
- Made wallet headers clickable buttons with expand/collapse arrows
- Forced VirtualizedList remount on expand/collapse via key prop
- Added tests for the collapse functionality

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39583?quickstart=1)

## **Changelog**

CHANGELOG entry: null (superseded by #39645)

## **Related issues**

Superseded by: #39645
Related: https://consensyssoftware.atlassian.net/browse/MDP-678

## **Manual testing steps**

See PR #39645 for testing steps.

## **Screenshots/Recordings**

### **Before**

Wallet headers were not interactive - all wallets were always expanded.

https://github.com/user-attachments/assets/c0229ede-361b-4ae5-82a2-08a943a07be0

### **After**

Wallet headers are now clickable buttons with collapse/expand arrows. Each wallet can be independently collapsed to hide its accounts.

https://github.com/user-attachments/assets/6b94f569-9f10-44b3-b859-a693c1af0759

🤖 Generated with [Claude Code](https://claude.com/claude-code)