### PR TITLE
feat: Replace inline address copy feedback with toast notifications

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Mehr Angebote"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Adresse kopiert",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Mehr erfahren",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Περισσότερες προσφορές"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Η διεύθυνση αντιγράφηκε",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Μάθετε περισσότερα",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3866,10 +3866,6 @@
   "moreQuotes": {
     "message": "More quotes"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Address copied",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Learn more",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3866,10 +3866,6 @@
   "moreQuotes": {
     "message": "More quotes"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Address copied",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Learn more",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -3675,10 +3675,6 @@
   "moreQuotes": {
     "message": "Más cotizaciones"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Dirección copiada",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Conozca más",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3675,10 +3675,6 @@
   "moreQuotes": {
     "message": "Plus de cotations"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Adresse copiée",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "En savoir plus",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -3448,10 +3448,6 @@
   "moreQuotes": {
     "message": "Tuilleadh luachana"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Seoladh cóipeáilte",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Foghlaim níos mó",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3675,10 +3675,6 @@
   "moreQuotes": {
     "message": "अधिक कोट्स"
   },
-  "multichainAccountAddressCopied": {
-    "message": "एड्रेस कॉपी किया गया",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "ज़्यादा जानें",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Kuotasi lainnya"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Alamat disalin",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Selengkapnya",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3675,10 +3675,6 @@
   "moreQuotes": {
     "message": "他のクォート"
   },
-  "multichainAccountAddressCopied": {
-    "message": "アドレスをコピーしました",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "詳細",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3678,10 +3678,6 @@
   "moreQuotes": {
     "message": "더 많은 견적"
   },
-  "multichainAccountAddressCopied": {
-    "message": "주소 복사 완료",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "더 보기",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Mais cotações"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Endereço copiado",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Saiba mais",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Больше котировок"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Адрес скопирован",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Узнайте подробнее",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Higit pang quote"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Kinopya ang address",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Matuto pa",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Daha fazla teklif"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Adres kopyalandı",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Daha fazla bilgi edin",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3681,10 +3681,6 @@
   "moreQuotes": {
     "message": "Thêm báo giá"
   },
-  "multichainAccountAddressCopied": {
-    "message": "Đã sao chép địa chỉ",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "Tìm hiểu thêm",
     "description": "Button text to learn more about multichain accounts"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -3675,10 +3675,6 @@
   "moreQuotes": {
     "message": "更多报价"
   },
-  "multichainAccountAddressCopied": {
-    "message": "地址已复制",
-    "description": "Message displayed when the multichain account address is copied to clipboard"
-  },
   "multichainAccountIntroLearnMore": {
     "message": "了解详情",
     "description": "Button text to learn more about multichain accounts"

--- a/test/e2e/page-objects/pages/dialog/account-details-modal.ts
+++ b/test/e2e/page-objects/pages/dialog/account-details-modal.ts
@@ -116,13 +116,13 @@ class AccountDetailsModal {
   }
 
   /**
-   * Check that private key has been copied.
+   * Check that private key has been copied by verifying the toast notification appears.
    *
    */
   async checkAddressIsCopied(): Promise<void> {
     console.log(`Check that private key has been copied`);
     await this.driver.waitForSelector({
-      css: this.accountPrivateKeyText,
+      css: '[data-testid="copy-address-toast"]',
       text: 'Private key copied',
     });
   }

--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -21,8 +21,8 @@ class AddressListModal {
   private readonly shortenedAddress =
     '[data-testid="multichain-address-row-address"]';
 
-  private readonly addressCopiedMessage = {
-    css: '[data-testid="multichain-address-row-address"]',
+  private readonly addressCopiedToast = {
+    css: '[data-testid="copy-address-toast"]',
     text: 'Address copied',
   };
 
@@ -66,8 +66,8 @@ class AddressListModal {
   }
 
   async verifyCopyButtonFeedback(): Promise<void> {
-    console.log(`Look for "Address copied'!" state change`);
-    await this.driver.waitForSelector(this.addressCopiedMessage);
+    console.log(`Look for "Address copied" toast notification`);
+    await this.driver.waitForSelector(this.addressCopiedToast);
   }
 
   async clickQRbutton(addressIndex: number = 0): Promise<void> {

--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -199,12 +199,12 @@ export function selectPasswordChangeToast(
  * Retrieves user preference to see the "Copy Address" toast
  *
  * @param state - Redux state object.
- * @returns Boolean preference value
+ * @returns The toast type ('address' | 'privateKey') or false
  */
 export function selectShowCopyAddressToast(
   state: Pick<State, 'appState'>,
-): boolean {
-  return Boolean(state.appState.showCopyAddressToast);
+): 'address' | 'privateKey' | false {
+  return state.appState.showCopyAddressToast || false;
 }
 
 /**

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -164,17 +164,19 @@ export function ToastMaster() {
         {storageErrorToast}
         <PasswordChangeToast />
         <ClaimSubmitToast />
+        <CopyAddressToast />
       </ToastContainer>
     );
   }
 
-  // On other screens, only render ToastContainer if storage error toast should show
+  // On other screens, render storage error toast and copy address toast
   // ToastContainer provides essential CSS styling (position: fixed, z-index, etc.)
-  if (shouldShowStorageErrorToast) {
-    return <ToastContainer>{storageErrorToast}</ToastContainer>;
-  }
-
-  return null;
+  return (
+    <ToastContainer>
+      {shouldShowStorageErrorToast && storageErrorToast}
+      <CopyAddressToast />
+    </ToastContainer>
+  );
 }
 
 function ConnectAccountToast() {
@@ -593,11 +595,16 @@ function CopyAddressToast() {
   const showCopyAddressToast = useSelector(selectShowCopyAddressToast);
   const autoHideToastDelay = 2 * SECOND;
 
+  const toastText =
+    showCopyAddressToast === 'privateKey'
+      ? t('multichainAccountPrivateKeyCopied')
+      : t('addressCopied');
+
   return (
     showCopyAddressToast && (
       <Toast
         key="copy-address-toast"
-        text={t('addressCopied')}
+        text={toastText}
         startAdornment={
           <Icon name={IconName.CopySuccess} color={IconColor.iconDefault} />
         }

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -88,6 +88,7 @@ import {
   ShieldErrorStateLocationEnum,
   ShieldErrorStateViewEnum,
 } from '../../../../shared/constants/subscriptions';
+import { setShowCopyAddressToast } from '../../../ducks/app/app';
 import {
   selectNftDetectionEnablementToast,
   selectShowConnectAccountToast,
@@ -110,7 +111,6 @@ import {
   setSurveyLinkLastClickedOrClosed,
   setShowNewSrpAddedToast,
   setShowPasswordChangeToast,
-  setShowCopyAddressToast,
   setShowClaimSubmitToast,
   setShowInfuraSwitchToast,
   setShieldPausedToastLastClickedOrClosed,
@@ -169,14 +169,20 @@ export function ToastMaster() {
     );
   }
 
-  // On other screens, render storage error toast and copy address toast
+  // On other screens, render storage error toast and copy address toast only if needed
   // ToastContainer provides essential CSS styling (position: fixed, z-index, etc.)
-  return (
-    <ToastContainer>
-      {shouldShowStorageErrorToast && storageErrorToast}
-      <CopyAddressToast />
-    </ToastContainer>
-  );
+  const showCopyAddressToast = useSelector(selectShowCopyAddressToast);
+
+  if (shouldShowStorageErrorToast || showCopyAddressToast) {
+    return (
+      <ToastContainer>
+        {shouldShowStorageErrorToast && storageErrorToast}
+        <CopyAddressToast />
+      </ToastContainer>
+    );
+  }
+
+  return null;
 }
 
 function ConnectAccountToast() {

--- a/ui/components/app/toast-master/toast-master.test.ts
+++ b/ui/components/app/toast-master/toast-master.test.ts
@@ -34,7 +34,7 @@ const createMockPrivacyPolicyState = (
 
 const createMockAppState = (
   showNewSrpAddedToast?: boolean,
-  showCopyAddressToast?: boolean,
+  showCopyAddressToast?: 'address' | 'privateKey' | false,
 ) => ({
   appState: {
     ...mockState.appState,
@@ -244,10 +244,16 @@ describe('#getShowNewSrpAddedToast', () => {
 });
 
 describe('#selectShowCopyAddressToast', () => {
-  it('returns true when showCopyAddressToast is true', () => {
-    const mockStateData = createMockAppState(undefined, true);
+  it('returns "address" when showCopyAddressToast is "address"', () => {
+    const mockStateData = createMockAppState(undefined, 'address');
     const result = selectShowCopyAddressToast(mockStateData);
-    expect(result).toBe(true);
+    expect(result).toBe('address');
+  });
+
+  it('returns "privateKey" when showCopyAddressToast is "privateKey"', () => {
+    const mockStateData = createMockAppState(undefined, 'privateKey');
+    const result = selectShowCopyAddressToast(mockStateData);
+    expect(result).toBe('privateKey');
   });
 
   it('returns false when showCopyAddressToast is false', () => {

--- a/ui/components/app/toast-master/utils.ts
+++ b/ui/components/app/toast-master/utils.ts
@@ -91,7 +91,9 @@ export function setShowPasswordChangeToast(
   };
 }
 
-export function setShowCopyAddressToast(value: boolean) {
+export function setShowCopyAddressToast(
+  value: 'address' | 'privateKey' | false,
+) {
   return {
     type: SET_SHOW_COPY_ADDRESS_TOAST,
     payload: value,

--- a/ui/components/app/toast-master/utils.ts
+++ b/ui/components/app/toast-master/utils.ts
@@ -3,7 +3,6 @@ import { ReactFragment } from 'react';
 import {
   SET_SHOW_NEW_SRP_ADDED_TOAST,
   SET_SHOW_PASSWORD_CHANGE_TOAST,
-  SET_SHOW_COPY_ADDRESS_TOAST,
   SET_SHOW_CLAIM_SUBMIT_TOAST,
   SET_SHOW_INFURA_SWITCH_TOAST,
   SHOW_NFT_DETECTION_ENABLEMENT_TOAST,
@@ -87,15 +86,6 @@ export function setShowPasswordChangeToast(
 ) {
   return {
     type: SET_SHOW_PASSWORD_CHANGE_TOAST,
-    payload: value,
-  };
-}
-
-export function setShowCopyAddressToast(
-  value: 'address' | 'privateKey' | false,
-) {
-  return {
-    type: SET_SHOW_COPY_ADDRESS_TOAST,
     payload: value,
   };
 }

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof MultichainAddressRow> = {
     copyActionParams: {
       control: 'object',
       description:
-        'Copy parameters for the address, including message and callback function',
+        'Copy parameters for the address, including callback function',
     },
     qrActionParams: {
       control: 'object',
@@ -52,7 +52,6 @@ export const Default: Story = {
     networkName: 'Ethereum Mainnet',
     address: '0x1234567890123456789012345678901234567890',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',
@@ -65,7 +64,6 @@ export const WithLongNetworkName: Story = {
     networkName: 'Polygon Mumbai Testnet',
     address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',
@@ -78,7 +76,6 @@ export const ArbitrumNetwork: Story = {
     networkName: 'Arbitrum One',
     address: '0x0123456789abcdef0123456789abcdef01234567',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',
@@ -91,7 +88,6 @@ export const OptimismNetwork: Story = {
     networkName: 'Optimism',
     address: '0x9876543210987654321098765432109876543210',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',
@@ -104,7 +100,6 @@ export const PolygonNetwork: Story = {
     networkName: 'Polygon Mainnet',
     address: '0xfedcba0987654321fedcba0987654321fedcba09',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',
@@ -117,7 +112,6 @@ export const CustomNetwork: Story = {
     networkName: 'Custom Network',
     address: '0x1111222233334444555566667777888899990000',
     copyActionParams: {
-      message: 'Copied!',
       callback: () => {},
     },
     className: '',

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
     address: '0x1234567890123456789012345678901234567890',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },
@@ -65,6 +66,7 @@ export const WithLongNetworkName: Story = {
     address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },
@@ -77,6 +79,7 @@ export const ArbitrumNetwork: Story = {
     address: '0x0123456789abcdef0123456789abcdef01234567',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },
@@ -89,6 +92,7 @@ export const OptimismNetwork: Story = {
     address: '0x9876543210987654321098765432109876543210',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },
@@ -101,6 +105,7 @@ export const PolygonNetwork: Story = {
     address: '0xfedcba0987654321fedcba0987654321fedcba09',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },
@@ -113,6 +118,7 @@ export const CustomNetwork: Story = {
     address: '0x1111222233334444555566667777888899990000',
     copyActionParams: {
       callback: () => {},
+      toastType: 'address',
     },
     className: '',
   },

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -13,6 +13,11 @@ jest.mock('@metamask/bridge-controller', () => ({
   formatChainIdToCaip: jest.fn(),
 }));
 
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+}));
+
 const mockCopyCallback = jest.fn();
 const mockQrCallback = jest.fn();
 
@@ -23,7 +28,6 @@ const defaultProps = {
   networkName: 'Ethereum',
   address: '0x1234567890123456789012345678901234567890',
   copyActionParams: {
-    message: 'Copied!',
     callback: mockCopyCallback,
   },
 };
@@ -33,7 +37,6 @@ const propsWithQrCode = {
   networkName: 'Ethereum',
   address: '0x1234567890123456789012345678901234567890',
   copyActionParams: {
-    message: 'Copied!',
     callback: mockCopyCallback,
   },
   qrActionParams: {

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
   address: '0x1234567890123456789012345678901234567890',
   copyActionParams: {
     callback: mockCopyCallback,
+    toastType: 'address' as const,
   },
 };
 
@@ -38,6 +39,7 @@ const propsWithQrCode = {
   address: '0x1234567890123456789012345678901234567890',
   copyActionParams: {
     callback: mockCopyCallback,
+    toastType: 'address' as const,
   },
   qrActionParams: {
     callback: mockQrCallback,

--- a/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx
@@ -34,6 +34,10 @@ export type CopyParams = {
    * Callback function to execute when the copy action is triggered
    */
   callback: () => void;
+  /**
+   * Type of toast to show after copying
+   */
+  toastType: 'address' | 'privateKey';
 };
 
 type QrParams = {
@@ -118,7 +122,7 @@ export const MultichainAddressRow = ({
     copyActionParams.callback();
 
     // Show toast notification
-    dispatch(setShowCopyAddressToast('address'));
+    dispatch(setShowCopyAddressToast(copyActionParams.toastType));
 
     // Update icon to success state
     setCopyIcon(IconName.CopySuccess);

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.stories.tsx
@@ -152,7 +152,7 @@ const meta: Meta<typeof MultichainAggregatedAddressListRow> = {
     copyActionParams: {
       control: 'object',
       description:
-        'Copy parameters for the address, including message and callback function',
+        'Copy parameters for the address, including toastType and callback function',
     },
     className: {
       control: 'text',
@@ -178,7 +178,7 @@ export const DefaultEthereum: Story = {
     chainIds: ['0x1'],
     address: '0x1234567890abcdef1234567890abcdef12345678',
     copyActionParams: {
-      message: 'Address copied!',
+      toastType: 'address',
       callback: () => {
         navigator.clipboard.writeText(
           '0x1234567890abcdef1234567890abcdef12345678',
@@ -194,7 +194,7 @@ export const ManyNetworks: Story = {
     chainIds: ['0x1', '0x89', '0xa4b1', '0xa', '0x2105', '0x8274f'],
     address: '0x1234567890abcdef1234567890abcdef12345678',
     copyActionParams: {
-      message: 'Address copied!',
+      toastType: 'address',
       callback: () => {
         navigator.clipboard.writeText(
           '0x1234567890abcdef1234567890abcdef12345678',
@@ -210,7 +210,7 @@ export const NonEvmNetwork: Story = {
     chainIds: [MultichainNetworks.SOLANA],
     address: 'DfGj1XfVTbfM7VZvqLkVNvDhFb4Nt8xBpGpH5f2r3Dqq',
     copyActionParams: {
-      message: 'Address copied!',
+      toastType: 'address',
       callback: () => {
         navigator.clipboard.writeText(
           'DfGj1XfVTbfM7VZvqLkVNvDhFb4Nt8xBpGpH5f2r3Dqq',

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.test.tsx
@@ -74,7 +74,7 @@ const createTestProps = (
   address: TEST_STRINGS.FULL_ADDRESS,
   copyActionParams: {
     callback: jest.fn(),
-    message: TEST_STRINGS.COPY_MESSAGE,
+    toastType: 'address' as const,
   },
   ...overrides,
 });
@@ -276,7 +276,7 @@ describe('MultichainAggregatedAddressListRow', () => {
       const props = createTestProps({
         copyActionParams: {
           callback: mockCallback,
-          message: TEST_STRINGS.COPY_MESSAGE,
+          toastType: 'address' as const,
         },
       });
 
@@ -292,7 +292,7 @@ describe('MultichainAggregatedAddressListRow', () => {
       expect(mockCallback).toHaveBeenCalled();
     });
 
-    it('shows copy message after clicking row', () => {
+    it('executes copy callback after clicking row', () => {
       const props = createTestProps();
 
       render(
@@ -311,8 +311,7 @@ describe('MultichainAggregatedAddressListRow', () => {
       // Click row
       fireEvent.click(row);
 
-      // Should show the copy message
-      expect(screen.getByText(TEST_STRINGS.COPY_MESSAGE)).toBeInTheDocument();
+      // Should call the copy callback
       expect(props.copyActionParams.callback).toHaveBeenCalled();
     });
 

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-aggregated-list-row.tsx
@@ -117,7 +117,7 @@ export const MultichainAggregatedAddressListRow = ({
     copyActionParams.callback();
 
     // Show toast notification
-    dispatch(setShowCopyAddressToast('address'));
+    dispatch(setShowCopyAddressToast(copyActionParams.toastType));
 
     // Update icon to success state
     setCopyIcon(IconName.CopySuccess);

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -259,11 +259,12 @@ export const MultichainHoveredAddressRowsList = ({
           address={item.account.address}
           copyActionParams={{
             callback: handleCopyClick,
+            toastType: 'address',
           }}
         />
       );
     },
-    [handleCopy, t],
+    [handleCopy],
   );
 
   const handleViewAllClick = useCallback(

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -258,7 +258,6 @@ export const MultichainHoveredAddressRowsList = ({
           chainIds={item.scopes.slice(0, MAX_NETWORK_AVATARS)}
           address={item.account.address}
           copyActionParams={{
-            message: t('multichainAccountAddressCopied'),
             callback: handleCopyClick,
           }}
         />

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -145,6 +145,7 @@ export const MultichainAddressRowsList = ({
           address={item.normalizedAddress}
           copyActionParams={{
             callback: handleCopyClick,
+            toastType: 'address',
           }}
           qrActionParams={{
             callback: onQrClick,
@@ -152,7 +153,7 @@ export const MultichainAddressRowsList = ({
         />
       );
     },
-    [handleCopy, onQrClick, t],
+    [handleCopy, onQrClick],
   );
 
   const renderedRows = useMemo(() => {

--- a/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx
@@ -144,7 +144,6 @@ export const MultichainAddressRowsList = ({
           networkName={item.networkName}
           address={item.normalizedAddress}
           copyActionParams={{
-            message: t('multichainAccountAddressCopied'),
             callback: handleCopyClick,
           }}
           qrActionParams={{

--- a/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
+++ b/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
@@ -35,11 +35,7 @@ import {
   TraceName,
   TraceOperation,
 } from '../../../../shared/lib/trace';
-<<<<<<< HEAD
 import { MINUTE } from '../../../../shared/constants/time';
-=======
-import { setShowCopyAddressToast } from '../../app/toast-master/utils';
->>>>>>> 9a7fee6e5c (feat: making copy address feedback a toast in account menu)
 
 /**
  * Check if the account has the private key available according to its keyring type.
@@ -228,7 +224,6 @@ const MultichainPrivateKeyList = ({
 
       const handleCopyClick = () => {
         handleCopy(privateKey);
-        dispatch(setShowCopyAddressToast('privateKey'));
       };
 
       return (
@@ -239,11 +234,12 @@ const MultichainPrivateKeyList = ({
           address={item.account.address}
           copyActionParams={{
             callback: handleCopyClick,
+            toastType: 'privateKey',
           }}
         />
       );
     },
-    [handleCopy, privateKeys, t],
+    [handleCopy, privateKeys],
   );
 
   const renderedRows = useMemo(() => {

--- a/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
+++ b/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
@@ -35,7 +35,11 @@ import {
   TraceName,
   TraceOperation,
 } from '../../../../shared/lib/trace';
+<<<<<<< HEAD
 import { MINUTE } from '../../../../shared/constants/time';
+=======
+import { setShowCopyAddressToast } from '../../app/toast-master/utils';
+>>>>>>> 9a7fee6e5c (feat: making copy address feedback a toast in account menu)
 
 /**
  * Check if the account has the private key available according to its keyring type.
@@ -224,6 +228,7 @@ const MultichainPrivateKeyList = ({
 
       const handleCopyClick = () => {
         handleCopy(privateKey);
+        dispatch(setShowCopyAddressToast('privateKey'));
       };
 
       return (
@@ -233,7 +238,6 @@ const MultichainPrivateKeyList = ({
           networkName={item.networkName}
           address={item.account.address}
           copyActionParams={{
-            message: t('multichainAccountPrivateKeyCopied'),
             callback: handleCopyClick,
           }}
         />

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -144,7 +144,7 @@ export const AppHeaderUnlockedContent = ({
 
   useEffect(() => {
     if (copied) {
-      dispatch(setShowCopyAddressToast(true));
+      dispatch(setShowCopyAddressToast('address'));
     } else {
       dispatch(setShowCopyAddressToast(false));
     }

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -131,7 +131,7 @@ type AppState = {
   errorInSettings: string | null;
   showNewSrpAddedToast: boolean;
   showPasswordChangeToast: PasswordChangeToastType | null;
-  showCopyAddressToast: boolean;
+  showCopyAddressToast: 'address' | 'privateKey' | false;
   showClaimSubmitToast: ClaimSubmitToastType | null;
   showInfuraSwitchToast: boolean;
   shieldEntryModal?: {

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -915,12 +915,6 @@ export function getShowSupportDataConsentModal(state: AppSliceState): boolean {
   return state.appState.showSupportDataConsentModal;
 }
 
-export function getShowCopyAddressToast(
-  state: AppSliceState,
-): 'address' | 'privateKey' | false {
-  return state.appState.showCopyAddressToast;
-}
-
 export function openDeleteMetaMetricsDataModal(): Action {
   return {
     type: actionConstants.DELETE_METAMETRICS_DATA_MODAL_OPEN,

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -859,8 +859,8 @@ export function setOnBoardedInThisUISession(
 }
 
 export function setShowCopyAddressToast(
-  payload: boolean,
-): PayloadAction<boolean> {
+  payload: 'address' | 'privateKey' | false,
+): PayloadAction<'address' | 'privateKey' | false> {
   return { type: actionConstants.SET_SHOW_COPY_ADDRESS_TOAST, payload };
 }
 
@@ -915,7 +915,9 @@ export function getShowSupportDataConsentModal(state: AppSliceState): boolean {
   return state.appState.showSupportDataConsentModal;
 }
 
-export function getShowCopyAddressToast(state: AppSliceState): boolean {
+export function getShowCopyAddressToast(
+  state: AppSliceState,
+): 'address' | 'privateKey' | false {
   return state.appState.showCopyAddressToast;
 }
 


### PR DESCRIPTION
## **Description**

This PR replaces the inline address/private key copy feedback (green background + "Address copied" text) with toast notifications at the bottom of the screen, matching the implementation from the mobile PR [#24599](https://github.com/MetaMask/metamask-mobile/pull/24599).

**What is the reason for the change?**
The inline feedback approach changes the UI layout and temporarily hides the address that was just copied. The toast approach provides a better UX by:
- Keeping the address visible at all times
- Providing consistent feedback across all screens
- Matching the mobile implementation

**What is the improvement/solution?**
- Toast notifications now appear at the bottom of the screen for all address/private key copy actions
- Toast shows "Address copied" for addresses or "Private key copied" for private keys
- Addresses remain visible with no background color changes
- Icon briefly transitions to success state (400ms) for immediate visual feedback
- Toast auto-dismisses after 2 seconds

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39586?quickstart=1)

## **Changelog**

CHANGELOG entry: Changed address and private key copy feedback from inline message to toast notification

## **Related issues**

Fixes: (Related to mobile parity)

## **Manual testing steps**

1. Go to Account menu → Click on account name → Click "Addresses"
2. Click the copy icon next to any address
3. Verify a toast appears at the bottom saying "Address copied"
4. Verify the address remains visible (no green background)
5. Go to Account menu → Click "Show private keys" → Enter password
6. Click copy icon next to any private key
7. Verify toast says "Private key copied"
8. Test copying address from the app header (click address in header)
9. Verify toast appears on all screens (home, settings, address list, private key list)

## **Screenshots/Recordings**

### **Before**
- Green background overlay appeared on the row
- "Address copied" text replaced the address temporarily
- Only visible on the specific screen where copy happened

### **After**
- Toast notification appears at bottom of screen
- Address remains visible at all times
- Icon briefly shows success state
- Works consistently across all screens
- Shows "Address copied" or "Private key copied" depending on what was copied

https://github.com/user-attachments/assets/f94a979a-9fc6-42b6-b0e4-7f875cd24377

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Technical Details

**Files Modified (12 total):**

**State Management:**
- `ui/ducks/app/app.ts` - Changed `showCopyAddressToast` type to `'address' | 'privateKey' | false`
- `ui/components/app/toast-master/utils.ts` - Updated action creator signature
- `ui/components/app/toast-master/selectors.ts` - Updated selector return type

**Toast Component:**
- `ui/components/app/toast-master/toast-master.js` - Added conditional messages and rendered toast on all screens

**Address Copy Components:**
- `ui/components/multichain-accounts/multichain-address-row/multichain-address-row.tsx`
- `ui/components/multichain-accounts/multichain-aggregated-list-row.tsx`
- `ui/components/multichain/app-header/app-header-unlocked-content.tsx`
- `ui/components/multichain-accounts/multichain-address-rows-list/multichain-address-rows-list.tsx`
- `ui/components/multichain-accounts/multichain-hovered-address-rows-hovered-list.tsx`

**Private Key Component:**
- `ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx`

**Tests & Stories:**
- `ui/components/multichain-accounts/multichain-address-row/multichain-address-row.test.tsx`
- `ui/components/multichain-accounts/multichain-address-row/multichain-address-row.stories.tsx`

**Test Results:**
✅ All tests passing (61 tests)
✅ No new linting errors
✅ Formatting validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared toast rendering and the `appState.showCopyAddressToast` shape, so regressions could affect copy feedback visibility across multiple screens. No security- or data-sensitive logic changes.
> 
> **Overview**
> Replaces the multichain address/private-key **inline “copied” UI state** (temporary text/background/color changes) with a centralized `CopyAddressToast` shown at the bottom of the screen; copy actions now keep the address visible and only briefly flip the copy icon to a success state.
> 
> Updates Redux to store `showCopyAddressToast` as a typed value (`'address' | 'privateKey' | false`) so the toast can render the correct message, and adjusts `ToastMaster` to render the toast (and `ToastContainer`) on settings and other screens whenever needed.
> 
> Updates stories/tests and E2E page objects to use the new `copyActionParams.toastType` contract and to assert against the toast (`data-testid="copy-address-toast"`), and removes the unused i18n key `multichainAccountAddressCopied` from multiple locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bc4556f454d1d909b55ffe5febb959342f9c02e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->