### PR TITLE
chore: sort fixture entries alphabetically

### DIFF
--- a/test/e2e/fixtures/fixture-validation.ts
+++ b/test/e2e/fixtures/fixture-validation.ts
@@ -216,6 +216,32 @@ const getLeafKeyPath = (keyPath: string): string => {
 };
 
 /**
+ * Recursively sorts all object keys alphabetically.
+ * Arrays are preserved as-is (their elements are sorted if they are objects).
+ *
+ * @param value - The value to sort (object, array, or primitive)
+ * @returns The value with all object keys sorted alphabetically
+ */
+const sortObjectKeysDeep = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sortObjectKeysDeep);
+  }
+
+  const sortedKeys = Object.keys(value as Record<string, unknown>).sort();
+  const sorted: Record<string, unknown> = {};
+
+  for (const key of sortedKeys) {
+    sorted[key] = sortObjectKeysDeep((value as Record<string, unknown>)[key]);
+  }
+
+  return sorted;
+};
+
+/**
  * Merge changes from the new state into the existing fixture.
  * Only updates the specific keys that have actually changed (new, missing, or type mismatch),
  * preserving all other values including timestamps.
@@ -343,7 +369,8 @@ export const mergeFixtureChanges = (
     }
   }
 
-  return merged;
+  // Sort all keys alphabetically to ensure consistent ordering in output
+  return sortObjectKeysDeep(merged) as JsonLike;
 };
 
 /**

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -64,8 +64,10 @@
       "onboardingDate": 1764061390455,
       "outdatedBrowserWarningLastShown": null,
       "pendingShieldCohortTxType": null,
+      "pna25Acknowledged": false,
       "productTour": "accountIcon",
       "recoveryPhraseReminderHasBeenShown": false,
+      "recoveryPhraseReminderLastShown": 7952515200000,
       "shieldEndingToastLastClickedOrClosed": null,
       "shieldPausedToastLastClickedOrClosed": null,
       "showAccountBanner": true,
@@ -79,9 +81,7 @@
       "surveyLinkLastClickedOrClosed": null,
       "timeoutMinutes": 0,
       "trezorModel": null,
-      "updateModalLastDismissedAt": null,
-      "pna25Acknowledged": false,
-      "recoveryPhraseReminderLastShown": 7952515200000
+      "updateModalLastDismissedAt": null
     },
     "AuthenticationController": {
       "isSignedIn": false
@@ -168,6 +168,7 @@
       "gatorPermissionsMapSerialized": "{\"erc20-token-revocation\":{},\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
       "isGatorPermissionsEnabled": true
     },
+    "KeyringController": {},
     "LoggingController": {
       "logs": {}
     },
@@ -2002,9 +2003,9 @@
         "npm:@metamask/gator-permissions-snap": "mainnet",
         "npm:@metamask/institutional-wallet-snap": "mainnet",
         "npm:@metamask/message-signing-snap": "mainnet",
+        "npm:@metamask/permissions-kernel-snap": "mainnet",
         "npm:@metamask/solana-wallet-snap": "mainnet",
-        "npm:@metamask/tron-wallet-snap": "mainnet",
-        "npm:@metamask/permissions-kernel-snap": "mainnet"
+        "npm:@metamask/tron-wallet-snap": "mainnet"
       }
     },
     "ShieldController": {
@@ -2131,11 +2132,10 @@
       "isBackupAndSyncEnabled": true,
       "isContactSyncingEnabled": true
     },
-    "config": {},
-    "KeyringController": {}
+    "config": {}
   },
   "meta": {
-    "version": 189,
-    "storageKind": "split"
+    "storageKind": "split",
+    "version": 189
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

One more tweak on the fixture validation and fixture export flow. I've found that whenever there's a change in the fixture (removal/addition of key), that is not sorted alphabetically.
For keeping the fixture file ordered, I've added an extra validation which now orders the entries alphabetically. This caused to have to update a couple of entries from the fixture file too.

See how I found the bug here: https://github.com/MetaMask/metamask-extension/pull/39555#issuecomment-3809522200

1. I changed the fixture file by removing a key and editing a key
2. The dist test failed as expected
3. I added a comment to update the fixture
4. The job was triggered successfully and the fixture was exported
5. Changes were commited by MetaMask bot
6. The fixture file was not like the original one as now the key is disordered

Comment to trigger the job
<img width="1022" height="420" alt="image" src="https://github.com/user-attachments/assets/e4b50c69-a1f4-4760-aecd-a3cd4c4ed3d6" />

Addition from the bot:
<img width="1263" height="377" alt="image" src="https://github.com/user-attachments/assets/1502c76e-db19-4e85-8a03-db93d7b65341" />

Resulting file change is disordered (We should expect no changes to the fixture now, as it should be left as the original one)

<img width="1263" height="476" alt="image" src="https://github.com/user-attachments/assets/3559509f-2a2b-4625-a693-87d8ce22c32b" />







[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39590?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
8. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1331

## **Manual testing steps**

1. Remove this key `"accountGroupsMetadata": {},` from the onboarding fixture file
2. Run `yarn test:e2e:single test/e2e/dist/wallet-fixture-export.spec.ts --leave-running=true --browser=chrome``
3. Run `yarn lint:prettier:fix`
4. See the key is added back without causing any diff (BEFORE: a diff would be generated as the key is added disordered)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures stable, alphabetized ordering of fixture output and updates the onboarding fixture accordingly.
> 
> - Adds `sortObjectKeysDeep` and applies it in `mergeFixtureChanges` so merged fixtures have recursively sorted keys
> - Regenerates `onboarding-fixture.json` with alphabetized object keys/sections (e.g., moves `KeyringController` into sorted position, normalizes `SelectedNetworkController.domains`, reorders `meta` fields); removes duplicate/unsorted entries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ff0772468b56d83076a82cde0110bd6d16351d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->