### PR TITLE
fix: Wait for unlock before using `SnapKeyring`

### DIFF
--- a/app/scripts/controller-init/snaps/multichain-router-init.ts
+++ b/app/scripts/controller-init/snaps/multichain-router-init.ts
@@ -20,8 +20,12 @@ export const MultichainRouterInit: ControllerInitFunction<
   MultichainRouterMessenger
 > = ({ controllerMessenger, getController }) => {
   const keyringController = getController('KeyringController');
+  const appStateController = getController('AppStateController');
 
   const getSnapKeyring = async (): Promise<SnapKeyring> => {
+    // Ensure the client is unlocked before attempting to access keyrings.
+    await appStateController.getUnlockPromise(true);
+
     // TODO: Use `withKeyring` instead
     let [snapKeyring] = keyringController.getKeyringsByType(KeyringType.snap);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ensure the `MultichainRouter` does not throw because the `SnapKeyring` is unavailable by waiting for the app to unlock.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39592?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where multichain requests would fail when the wallet is locked

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-356
https://consensyssoftware.atlassian.net/browse/WAPI-1034

## **Manual testing steps**

1. Go to https://metamask.github.io/test-dapp-multichain/latest/
2. Create a Solana session
3. Lock the wallet
4. Select "signMessage" in the dropdown and click "Invoke Method"
5. A popup should display to unlock the wallet
6. A popup should display to sign the message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `MultichainRouter` defers keyring access until the wallet is unlocked to avoid missing `SnapKeyring` errors.
> 
> - In `app/scripts/controller-init/snaps/multichain-router-init.ts`, adds `AppStateController` usage and awaits `appStateController.getUnlockPromise(true)` before retrieving/creating the `SnapKeyring`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c871a0fd060c4951462066bdec62dab4b093a2a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->