### PR TITLE
fix: known bots list again

### DIFF
--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -33,8 +33,8 @@ const knownBots = [
   'sentry-io',
   'devin-ai-integration',
   'runway-github',
-  'cursoragent',
-  'Copilot',
+  'app/cursor',
+  'app/copilot-swe-agent',
 ];
 
 main().catch((error: Error): void => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39595?quickstart=1)

This PR fixes the known bots list again. I accidentally added the names of the bots that commit under the PRs, but we actually needs the names of the bots that open the PR. These are different.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no changelog

## **Related issues**

Fixes: null

## **Manual testing steps**

1. After merging this PR, opening a PR with a known bot shouldn't assign the external contributor label to the PR.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts bot detection in `check-template-and-add-labels.ts`.
> 
> - Replaces `cursoragent` and `Copilot` with `app/cursor` and `app/copilot-swe-agent` in `knownBots`
> - Ensures PRs opened by these bots are exempt from template checks and not labeled as external contributors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ac647fec3a00ef6fcc3097649d50a4b565ff9cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->