### PR TITLE
chore: don't require the complete Main job to be finalized if `update-onboarding-fixture` is triggered

### DIFF
--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -100,18 +100,14 @@ jobs:
           RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
 
           echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
+          echo "Attempting to download latest dist artifact..."
 
-          # If the run is still in progress, wait for it to complete
-          if [ "$RUN_STATUS" != "completed" ]; then
-            echo "Run ${RUN_ID} is still in progress. Waiting for it to complete..."
-            gh run watch "${RUN_ID}"
-            # Re-fetch the conclusion after waiting
-            RUN_CONCLUSION=$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion')
-            echo "Run completed with conclusion: ${RUN_CONCLUSION}"
+          if ! gh run download "${RUN_ID}" -n build-dist-browserify -D build-dist-browserify; then
+            echo "::error::Failed to download the 'build-dist-browserify' artifact. The build job may not have completed yet, may have failed. Please ensure the build-dist-browserify job has completed successfully."
+            exit 1
           fi
 
-          echo "Downloading artifacts from run ${RUN_ID}..."
-          gh run download "${RUN_ID}" -n build-dist-browserify -D build-dist-browserify
+          echo "Successfully downloaded dist artifact."
         env:
           BRANCH: ${{ steps.branch.outputs.BRANCH }}
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This bug has been discovered while testing the `update-onboarding-fixture` command by adding a PR comment.
Whenever we trigger this flow from the comment, we will wait until Main job is fully completed in order to proceed grabbing the dist artifact.
This waiting is unnecessary, as we don't need that all e2e finish running, as the dist artifact will already be there.
Furthermore, whenever someone triggers the job by a comment, it's (assumption) because the dist e2e job has failed and they want to fix it. So at this point, we already have a dist build.

The solution is to take a simple approach:
- whenever we add the PR comment, we'll get the latest dist from the latest Main job
  - if the dist is not there or the job has failed, we simply fail the job with an error message to try again, ensuring the latest dist job is there and green
  - if it's there we proceed

See the bug discovered performed in [this branch.](https://github.com/MetaMask/metamask-extension/pull/39555) At the moment, a way to skip the waiting until Main has finished, is to Cancel all running jobs, in order to not have to wait


<img width="992" height="492" alt="image" src="https://github.com/user-attachments/assets/9f1bc29c-b7dd-438d-ad24-e172bd90ade5" />

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39596?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1332

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines `update-onboarding-fixture` by downloading the `build-dist-browserify` artifact immediately from the latest `Main` workflow run on the PR branch.
> 
> - Removes waiting for `Main` run completion; attempts direct `gh run download` of `build-dist-browserify`
> - Adds clear error and early exit if the artifact is unavailable, with logs indicating the run ID/status/conclusion
> - Caches the downloaded artifact as before; no other workflow behavior changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51ca0fada8be0f11caec03b20db1357c8c9b44f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->