### PR TITLE
feat: Allow queueing of Snap dialogs

### DIFF
--- a/app/scripts/controller-init/confirmations/approval-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/approval-controller-init.ts
@@ -3,6 +3,7 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { ControllerInitFunction } from '../types';
 import { ApprovalControllerMessenger } from '../messengers';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 
 /**
  * Initialize the approval controller.
@@ -30,6 +31,8 @@ export const ApprovalControllerInit: ControllerInitFunction<
       // Exclude Smart TX Status Page from rate limiting to allow sequential
       // transactions.
       SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+
+      ...Object.values(DIALOG_APPROVAL_TYPES),
     ],
   });
 

--- a/app/scripts/controller-init/confirmations/approval-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/approval-controller-init.ts
@@ -1,9 +1,9 @@
 import { ApprovalController } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 import { ControllerInitFunction } from '../types';
 import { ApprovalControllerMessenger } from '../messengers';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
-import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 
 /**
  * Initialize the approval controller.
@@ -32,7 +32,8 @@ export const ApprovalControllerInit: ControllerInitFunction<
       // transactions.
       SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
 
-      ...Object.values(DIALOG_APPROVAL_TYPES),
+      // Allow one flavor of snap_dialog to be queued.
+      DIALOG_APPROVAL_TYPES.default,
     ],
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Allow queueing of `snap_dialog` (the non-legacy type) by adding it to the `ApprovalController` configuration.

This allows Snaps to queue multiple dialogs in the same way that EVM flows do. This also impacts Solana, Bitcoin and Tron.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39599?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for queueing non-EVM confirmations

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-36

## **Manual testing steps**

1. Go to https://metamask.github.io/test-dapp-multichain/latest/
2. Connect with Solana
3. Select "signMessage" below and click "Invoke Method" a couple of times
4. Multiple confirmations should now be queued

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows `snap_dialog` (non-legacy) confirmations to be queued like other flows.
> 
> - Adds `DIALOG_APPROVAL_TYPES.default` to `typesExcludedFromRateLimiting` in `approval-controller-init.ts`
> - Imports `DIALOG_APPROVAL_TYPES` to support the new exclusion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bcbbe96032aeeaaac04a428e5b40c8d2dab74b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->