### PR TITLE
fix: metamask pay network picker

### DIFF
--- a/ui/components/app/transaction-status-label/transaction-status-label.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.js
@@ -22,6 +22,7 @@ const SIGNING_PSUEDO_STATUS = 'signing';
 const pendingStatusHash = {
   [TransactionStatus.submitted]: TransactionGroupStatus.pending,
   [TransactionStatus.approved]: TransactionGroupStatus.pending,
+  [TransactionStatus.signed]: TransactionGroupStatus.pending,
 };
 
 const statusToClassNameHash = {

--- a/ui/components/app/transaction-status-label/transaction-status-label.test.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.test.js
@@ -110,6 +110,28 @@ describe('TransactionStatusLabel Component', () => {
     expect(screen.getByText('queued')).toBeInTheDocument();
   });
 
+  it('should map signed status to pending when isEarliestNonce is true', () => {
+    const props = {
+      status: TransactionStatus.signed,
+      isEarliestNonce: true,
+    };
+
+    render(<TransactionStatusLabel {...props} />);
+    expect(
+      screen.getByText(TransactionGroupStatus.pending),
+    ).toBeInTheDocument();
+  });
+
+  it('should map signed status to queued when isEarliestNonce is false', () => {
+    const props = {
+      status: TransactionStatus.signed,
+      isEarliestNonce: false,
+    };
+
+    render(<TransactionStatusLabel {...props} />);
+    expect(screen.getByText('queued')).toBeInTheDocument();
+  });
+
   it('should display date for confirmed transactions when not statusOnly', () => {
     const props = {
       status: TransactionStatus.confirmed,

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -56,7 +56,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose}>
+    <Modal isOpen={isOpen} onClose={handleClose} isClosedOnOutsideClick={false}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader onClose={handleClose}>


### PR DESCRIPTION
## **Description**

- Disable outside click on PayWithModal to prevent nested modal conflicts with NetworkFilter
- Show "Pending" label for signed transaction status (same as submitted)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: [#6499](https://github.com/MetaMask/MetaMask-planning/issues/6499)

## **Manual testing steps**

1. Initiate a MetaMask Pay transaction
2. Click "Pay with" to open the modal
3. Click the network filter dropdown
4. Verify the modal doesn't close unexpectedly

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior tweaks: status-label mapping is expanded and covered by tests, and the modal change only affects close behavior (potentially impacting expected dismissal UX).
> 
> **Overview**
> Updates `TransactionStatusLabel` to treat `TransactionStatus.signed` the same as other transient states, mapping it to *pending* (or *queued* when `isEarliestNonce` is false), and adds Jest coverage for the new signed-status behavior.
> 
> Adjusts the MetaMask Pay `PayWithModal` to **not close on outside click** (`isClosedOnOutsideClick={false}`) to avoid nested modal conflicts when using the network filter dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52dd427644a5058413e9df70f7b3cee769f67347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->