### PR TITLE
refactor: wrap tabs in suspense POC

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, {
+  lazy,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Hex, isStrictHexString } from '@metamask/utils';
@@ -28,16 +35,19 @@ import {
   setDefaultHomeActiveTabName,
 } from '../../../store/actions';
 import AssetList from '../../app/assets/asset-list';
-import DeFiTab from '../../app/assets/defi-list/defi-tab';
-import NftsTab from '../../app/assets/nfts/nfts-tab';
-import TransactionList from '../../app/transaction-list';
-import UnifiedTransactionList from '../../app/transaction-list/unified-transaction-list.component';
 import { PerpsTabView } from '../../app/perps';
 import { Box } from '../../component-library';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { AccountOverviewCommonProps } from './common';
 import { AssetListTokenDetection } from './asset-list-token-detection';
+
+const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab'));
+const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab'));
+const TransactionList = lazy(() => import('../../app/transaction-list'));
+const UnifiedTransactionList = lazy(
+  () => import('../../app/transaction-list/unified-transaction-list.component'),
+);
 
 export type AccountOverviewTabsProps = AccountOverviewCommonProps & {
   showTokens: boolean;
@@ -192,13 +202,13 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.DeFi}
             data-testid="account-overview__defi-tab"
           >
-            <Box>
+            <Suspense fallback={null}>
               <DeFiTab
                 showTokensLinks={showTokensLinks ?? true}
                 onClickAsset={onClickDeFi}
                 safeChains={safeChains}
               />
-            </Box>
+            </Suspense>
           </Tab>
         )}
 
@@ -208,7 +218,9 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Nfts}
             data-testid="account-overview__nfts-tab"
           >
-            <NftsTab />
+            <Suspense fallback={null}>
+              <NftsTab />
+            </Suspense>
           </Tab>
         )}
 
@@ -218,11 +230,13 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Activity}
             data-testid="account-overview__activity-tab"
           >
-            {showUnifiedTransactionList ? (
-              <UnifiedTransactionList />
-            ) : (
-              <TransactionList />
-            )}
+            <Suspense fallback={null}>
+              {showUnifiedTransactionList ? (
+                <UnifiedTransactionList />
+              ) : (
+                <TransactionList />
+              )}
+            </Suspense>
           </Tab>
         )}
       </Tabs>

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -42,10 +42,14 @@ import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { AccountOverviewCommonProps } from './common';
 import { AssetListTokenDetection } from './asset-list-token-detection';
 
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
 const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab'));
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
 const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab'));
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
 const TransactionList = lazy(() => import('../../app/transaction-list'));
 const UnifiedTransactionList = lazy(
+  // @ts-expect-error -- Bundler resolves TS/TSX without extensions.
   () => import('../../app/transaction-list/unified-transaction-list.component'),
 );
 


### PR DESCRIPTION
## **Description**

Wrap tab contents in Suspense

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39618?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6654

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that changes how several tab views are loaded; main risk is transient blank content or timing issues while lazy modules resolve.
> 
> **Overview**
> Defers loading of heavier Account Overview tabs by converting `DeFiTab`, `NftsTab`, `TransactionList`, and `UnifiedTransactionList` to `React.lazy` imports.
> 
> Wraps the DeFi/NFT/Activity tab bodies in `Suspense` (with `fallback={null}`), so these views render only after their modules load, while Tokens/Perps remain eagerly rendered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d095b64bc559dfe112d465b34c034b41b1b77643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->