### PR TITLE
fix: Don't use subject metadata controller for Snaps install origin

### DIFF
--- a/ui/components/app/permission-connect-header/permission-connect-header.js
+++ b/ui/components/app/permission-connect-header/permission-connect-header.js
@@ -18,18 +18,13 @@ import {
   AvatarFavicon,
   AvatarBase,
 } from '../../component-library';
-import { getAvatarFallbackLetter } from '../../../helpers/utils/util';
+import {
+  getAvatarFallbackLetter,
+  transformOriginToTitle,
+} from '../../../helpers/utils/util';
 import { Nav } from '../../../pages/confirmations/components/confirm/nav';
 
 const PermissionConnectHeader = ({ requestId, origin, iconUrl }) => {
-  const transformOriginToTitle = (rawOrigin) => {
-    try {
-      const url = new URL(rawOrigin);
-      return url.hostname;
-    } catch (e) {
-      return 'Unknown Origin';
-    }
-  };
   const title = transformOriginToTitle(origin);
 
   return (

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -19,10 +19,7 @@ import {
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import {
-  formatDate,
-  transformOriginToTitle,
-} from '../../../../helpers/utils/util';
+import { formatDate } from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getSnapRegistryData } from '../../../../selectors';
 import { disableSnap, enableSnap } from '../../../../store/actions';
@@ -31,6 +28,7 @@ import ToggleButton from '../../../ui/toggle-button';
 import Tooltip from '../../../ui/tooltip/tooltip';
 import SnapExternalPill from '../snap-version/snap-external-pill';
 import { useSafeWebsite } from '../../../../hooks/snaps/useSafeWebsite';
+import { useOriginTitle } from '../../../../hooks/snaps/useOriginTitle';
 
 const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
   const t = useI18nContext();
@@ -60,7 +58,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
   const installInfo = versionHistory.length
     ? versionHistory[versionHistory.length - 1]
     : undefined;
-  const installOrigin = transformOriginToTitle(installInfo?.origin);
+  const installOrigin = useOriginTitle(installInfo?.origin);
 
   const onToggle = () => {
     if (snap?.enabled) {

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -19,9 +19,11 @@ import {
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { formatDate } from '../../../../helpers/utils/util';
+import {
+  formatDate,
+  transformOriginToTitle,
+} from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { getSnapRegistryData } from '../../../../selectors';
 import { disableSnap, enableSnap } from '../../../../store/actions';
 import { Box, ButtonLink, Text } from '../../../component-library';
@@ -58,7 +60,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
   const installInfo = versionHistory.length
     ? versionHistory[versionHistory.length - 1]
     : undefined;
-  const installOrigin = useOriginMetadata(installInfo?.origin);
+  const installOrigin = transformOriginToTitle(installInfo?.origin);
 
   const onToggle = () => {
     if (snap?.enabled) {
@@ -144,7 +146,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
               flexDirection={FlexDirection.Column}
               alignItems={AlignItems.flexEnd}
             >
-              <Text textAlign={TextAlign.End}>{installOrigin.host}</Text>
+              <Text textAlign={TextAlign.End}>{installOrigin}</Text>
               <Text color={Color.textMuted}>
                 {t('installedOn', [
                   formatDate(installInfo.date, 'dd MMM yyyy'),

--- a/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
+++ b/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
@@ -36,16 +36,14 @@ import {
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import {
-  formatDate,
-  transformOriginToTitle,
-} from '../../../../helpers/utils/util';
+import { formatDate } from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { ShowMore } from '../show-more';
 import SnapExternalPill from '../snap-version/snap-external-pill';
 import { useSafeWebsite } from '../../../../hooks/snaps/useSafeWebsite';
 import Tooltip from '../../../ui/tooltip';
 import { SnapIcon } from '../snap-icon';
+import { useOriginTitle } from '../../../../hooks/snaps/useOriginTitle';
 
 export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {
   const t = useI18nContext();
@@ -65,7 +63,7 @@ export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {
     ? versionHistory[versionHistory.length - 1]
     : undefined;
 
-  const installOrigin = transformOriginToTitle(installInfo?.origin);
+  const installOrigin = useOriginTitle(installInfo?.origin);
   const isSnapRequesting = isSnapId(installInfo?.origin);
 
   const snapPrefix = getSnapPrefix(snapId);

--- a/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
+++ b/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
@@ -36,7 +36,10 @@ import {
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { formatDate } from '../../../../helpers/utils/util';
+import {
+  formatDate,
+  transformOriginToTitle,
+} from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { ShowMore } from '../show-more';
@@ -63,7 +66,7 @@ export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {
     ? versionHistory[versionHistory.length - 1]
     : undefined;
 
-  const installOrigin = useOriginMetadata(installInfo?.origin);
+  const installOrigin = transformOriginToTitle(installInfo?.origin);
   const isSnapRequesting = isSnapId(installInfo?.origin);
 
   const snapPrefix = getSnapPrefix(snapId);
@@ -169,7 +172,7 @@ export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {
               <Text ellipsis>
                 {isSnapRequesting
                   ? stripSnapPrefix(installInfo.origin)
-                  : installOrigin.host}
+                  : installOrigin}
               </Text>
             </Box>
           )}

--- a/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
+++ b/ui/components/app/snaps/snap-metadata-modal/snap-metadata-modal.js
@@ -41,7 +41,6 @@ import {
   transformOriginToTitle,
 } from '../../../../helpers/utils/util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { ShowMore } from '../show-more';
 import SnapExternalPill from '../snap-version/snap-external-pill';
 import { useSafeWebsite } from '../../../../hooks/snaps/useSafeWebsite';
@@ -137,7 +136,7 @@ export const SnapMetadataModal = ({ snapId, isOpen, onClose }) => {
               </ButtonLink>
             </Box>
           )}
-          {installOrigin && (
+          {installOrigin && installInfo && (
             <Box
               display={Display.Flex}
               flexDirection={FlexDirection.Row}

--- a/ui/hooks/snaps/useOriginTitle.test.ts
+++ b/ui/hooks/snaps/useOriginTitle.test.ts
@@ -1,0 +1,51 @@
+import mockState from '../../../test/data/mock-state.json';
+import { createElement, ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import configureStore from '../../store/store';
+import { renderHook } from '@testing-library/react-hooks';
+import { useOriginTitle } from './useOriginTitle';
+
+const createMockState = (overrides = {}) => ({
+  ...mockState,
+  metamask: {
+    ...mockState.metamask,
+    ...overrides,
+  },
+});
+
+const renderHookWithStore = (
+  origin?: string,
+  stateOverrides = {},
+) => {
+  const state = createMockState(stateOverrides);
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(Provider, { store: configureStore(state) }, children);
+
+  return renderHook(
+    () =>
+      useOriginTitle(origin),
+    { wrapper },
+  );
+};
+
+describe('useOriginTitle', () => {
+  it('returns the origin title for a Snap ID', () => {
+    const { result } = renderHookWithStore('npm:@metamask/test-snap-bip44');
+    expect(result.current).toBe('BIP-44 Test Snap');
+  });
+
+  it('returns the origin title for a website origin', () => {
+    const { result } = renderHookWithStore('https://example.com');
+    expect(result.current).toBe('example.com');
+  });
+
+  it('returns "Unknown Origin" for undefined origin', () => {
+    const { result } = renderHookWithStore(undefined);
+    expect(result.current).toBe('Unknown Origin');
+  });
+
+  it('returns "Unknown Origin" for an invalid origin', () => {
+    const { result } = renderHookWithStore('invalid-origin');
+    expect(result.current).toBe('Unknown Origin');
+  });
+});

--- a/ui/hooks/snaps/useOriginTitle.test.ts
+++ b/ui/hooks/snaps/useOriginTitle.test.ts
@@ -1,8 +1,8 @@
-import mockState from '../../../test/data/mock-state.json';
 import { createElement, ReactNode } from 'react';
 import { Provider } from 'react-redux';
-import configureStore from '../../store/store';
 import { renderHook } from '@testing-library/react-hooks';
+import configureStore from '../../store/store';
+import mockState from '../../../test/data/mock-state.json';
 import { useOriginTitle } from './useOriginTitle';
 
 const createMockState = (overrides = {}) => ({
@@ -13,19 +13,12 @@ const createMockState = (overrides = {}) => ({
   },
 });
 
-const renderHookWithStore = (
-  origin?: string,
-  stateOverrides = {},
-) => {
+const renderHookWithStore = (origin?: string, stateOverrides = {}) => {
   const state = createMockState(stateOverrides);
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(Provider, { store: configureStore(state) }, children);
 
-  return renderHook(
-    () =>
-      useOriginTitle(origin),
-    { wrapper },
-  );
+  return renderHook(() => useOriginTitle(origin), { wrapper });
 };
 
 describe('useOriginTitle', () => {

--- a/ui/hooks/snaps/useOriginTitle.ts
+++ b/ui/hooks/snaps/useOriginTitle.ts
@@ -1,6 +1,6 @@
 import { isSnapId } from '@metamask/snaps-utils';
-import { getSnapMetadata } from '../../selectors';
 import { useSelector } from 'react-redux';
+import { getSnapMetadata } from '../../selectors';
 import { transformOriginToTitle } from '../../helpers/utils/util';
 
 /**

--- a/ui/hooks/snaps/useOriginTitle.ts
+++ b/ui/hooks/snaps/useOriginTitle.ts
@@ -1,0 +1,33 @@
+import { isSnapId } from '@metamask/snaps-utils';
+import { getSnapMetadata } from '../../selectors';
+import { useSelector } from 'react-redux';
+import { transformOriginToTitle } from '../../helpers/utils/util';
+
+/**
+ * A hook to get the title of a Snap or website origin.
+ *
+ * @param origin - The origin of the Snap or website.
+ * @returns The title of the Snap or website.
+ * @example
+ * const title = useOriginTitle('npm:example-snap');
+ * // "Example Snap"
+ * @example
+ * const title = useOriginTitle('https://example.com');
+ * // "example.com"
+ */
+export function useOriginTitle(origin?: string) {
+  const { name } = useSelector((state) =>
+    // Hack around the selector throwing.
+    getSnapMetadata(state, isSnapId(origin) ? origin : `npm:${origin}`),
+  );
+
+  if (!origin) {
+    return 'Unknown Origin';
+  }
+
+  if (isSnapId(origin)) {
+    return name;
+  }
+
+  return transformOriginToTitle(origin);
+}

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -44,8 +44,7 @@ export default function SnapInstall({
   targetSubjectMetadata,
 }) {
   const t = useI18nContext();
-  const siteMetadata = useOriginMetadata(request?.metadata?.dappOrigin) || {};
-  const { origin, iconUrl } = siteMetadata;
+  const { iconUrl } = useOriginMetadata(request?.metadata?.dappOrigin) || {};
   const [isShowingWarning, setIsShowingWarning] = useState(false);
   const snapsMetadata = useSelector(getSnapsMetadata);
   const [showAllPermissions, setShowAllPermissions] = useState(false);
@@ -116,7 +115,10 @@ export default function SnapInstall({
       backgroundColor={BackgroundColor.backgroundAlternative}
     >
       {(isLoading || hasError) && !isOriginSnap ? (
-        <PermissionConnectHeader origin={origin} iconUrl={iconUrl} />
+        <PermissionConnectHeader
+          origin={request?.metadata?.dappOrigin}
+          iconUrl={iconUrl}
+        />
       ) : (
         <SnapAuthorshipHeader
           snapId={

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -18,7 +18,10 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import SnapConnectCell from '../../../../components/app/snaps/snap-connect-cell/snap-connect-cell';
-import { getDedupedSnaps } from '../../../../helpers/utils/util';
+import {
+  getDedupedSnaps,
+  transformOriginToTitle,
+} from '../../../../helpers/utils/util';
 import PulseLoader from '../../../../components/ui/pulse-loader/pulse-loader';
 import SnapPrivacyWarning from '../../../../components/app/snaps/snap-privacy-warning/snap-privacy-warning';
 import {
@@ -26,7 +29,6 @@ import {
   getPreinstalledSnaps,
   getSnapMetadata,
 } from '../../../../selectors';
-import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { SnapIcon } from '../../../../components/app/snaps/snap-icon';
 
 export default function SnapsConnect({
@@ -71,7 +73,7 @@ export default function SnapsConnect({
   }, [request, approveConnection]);
 
   const SnapsConnectContent = () => {
-    let trimmedOrigin = (useOriginMetadata(origin) || {})?.hostname;
+    let trimmedOrigin = transformOriginToTitle(origin);
     const { name } = useSelector((state) =>
       // hack around the selector throwing
       getSnapMetadata(state, isSnapId(origin) ? origin : `npm:${origin}`),

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isSnapId } from '@metamask/snaps-utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { Box, IconSize, Text } from '../../../../components/component-library';
 import {
@@ -18,10 +17,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import SnapConnectCell from '../../../../components/app/snaps/snap-connect-cell/snap-connect-cell';
-import {
-  getDedupedSnaps,
-  transformOriginToTitle,
-} from '../../../../helpers/utils/util';
+import { getDedupedSnaps } from '../../../../helpers/utils/util';
 import PulseLoader from '../../../../components/ui/pulse-loader/pulse-loader';
 import SnapPrivacyWarning from '../../../../components/app/snaps/snap-privacy-warning/snap-privacy-warning';
 import {
@@ -30,6 +26,7 @@ import {
   getSnapMetadata,
 } from '../../../../selectors';
 import { SnapIcon } from '../../../../components/app/snaps/snap-icon';
+import { useOriginTitle } from '../../../../hooks/snaps/useOriginTitle';
 
 export default function SnapsConnect({
   request,
@@ -73,15 +70,7 @@ export default function SnapsConnect({
   }, [request, approveConnection]);
 
   const SnapsConnectContent = () => {
-    let trimmedOrigin = transformOriginToTitle(origin);
-    const { name } = useSelector((state) =>
-      // hack around the selector throwing
-      getSnapMetadata(state, isSnapId(origin) ? origin : `npm:${origin}`),
-    );
-
-    if (isSnapId(origin)) {
-      trimmedOrigin = name;
-    }
+    const trimmedOrigin = useOriginTitle(origin);
 
     if (isLoading) {
       return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This replaces `useOriginMetadata` with `transformOriginToTitle`.

Related to https://consensyssoftware.atlassian.net/browse/WPC-348.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39634?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Don't use subject metadata controller for Snaps install origin

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX refactoring around how origins are displayed, plus a small new hook with unit tests; minimal behavioral risk outside potential edge cases in origin parsing/title fallback.
> 
> **Overview**
> Introduces `useOriginTitle` (with tests) to derive a display title for either a Snap ID (via `getSnapMetadata`) or a website origin (via `transformOriginToTitle`), with an `Unknown Origin` fallback.
> 
> Updates Snap-related UI (`SnapAuthorshipExpanded`, `SnapMetadataModal`, `SnapsConnect`) to use this hook and treat install origin as a simple string (and adds an `installInfo` guard), and updates `PermissionConnectHeader`/`SnapInstall` to use `transformOriginToTitle` and pass the raw `dappOrigin` rather than relying on subject metadata-derived origin fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de92e8c4d9fe6844229588976de599e0116c58b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->