### PR TITLE
chore: simplify empty state component

### DIFF
--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.stories.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.stories.tsx
@@ -1,34 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { TransactionActivityEmptyState } from './transaction-activity-empty-state';
-
-const mockAccount: InternalAccount = {
-  id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
-  address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-  type: 'eip155:eoa',
-  options: {},
-  scopes: ['eip155:1'],
-  methods: [
-    'personal_sign',
-    'eth_sign',
-    'eth_signTransaction',
-    'eth_signTypedData_v1',
-    'eth_signTypedData_v3',
-    'eth_signTypedData_v4',
-  ],
-  metadata: {
-    name: 'Account 1',
-    keyring: { type: 'HD Key Tree' },
-    importTime: Date.now(),
-  },
-};
 
 const meta: Meta<typeof TransactionActivityEmptyState> = {
   title: 'Components/App/TransactionActivityEmptyState',
   component: TransactionActivityEmptyState,
-  args: {
-    account: mockAccount,
-  },
 };
 
 export default meta;

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -10,6 +10,7 @@ import { ThemeType } from '../../../../shared/constants/preferences';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import * as useMultichainSelectorHook from '../../../hooks/useMultichainSelector';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   TransactionActivityEmptyState,
   type TransactionActivityEmptyStateProps,
@@ -17,6 +18,7 @@ import {
 
 // Mock the useBridging hook
 jest.mock('../../../hooks/bridge/useBridging');
+jest.mock('../../../selectors/accounts');
 
 const createAccount = (
   overrides: Partial<InternalAccount> = {},
@@ -136,14 +138,18 @@ describe('TransactionActivityEmptyState', () => {
   const renderComponent = (
     props: Partial<TransactionActivityEmptyStateProps> = {},
     stateOverrides = {},
+    account = mockAccount,
   ) => {
+    // Set up the mock for the selected account
+    (getSelectedInternalAccount as jest.Mock).mockReturnValue(account);
+
     const store = configureMockStore(middleware)({
       ...mockState,
       ...stateOverrides,
     });
 
     return renderWithProvider(
-      <TransactionActivityEmptyState account={mockAccount} {...props} />,
+      <TransactionActivityEmptyState {...props} />,
       store,
     );
   };
@@ -201,47 +207,36 @@ describe('TransactionActivityEmptyState', () => {
     (describe as unknown as jest.Describe).each<
       [
         string,
-        Partial<TransactionActivityEmptyStateProps>,
+        InternalAccount,
         ReturnType<typeof createStateOverrides> | Record<string, never>,
       ]
     >([
-      [
-        'not a swaps chain',
-        { account: accountWithSigning },
-        createTestnetState(),
-      ],
+      ['not a swaps chain', accountWithSigning, createTestnetState()],
       [
         'external services are disabled',
-        { account: accountWithSigning },
+        accountWithSigning,
         createStateWithoutExternalServices(),
       ],
-      [
-        'account cannot sign transactions',
-        { account: accountWithoutSigning },
-        {},
-      ],
+      ['account cannot sign transactions', accountWithoutSigning, {}],
     ])(
       'disables swap button when %s',
       (
         _condition: string,
-        props: Partial<TransactionActivityEmptyStateProps>,
+        account: InternalAccount,
         stateOverrides:
           | ReturnType<typeof createStateOverrides>
           | Record<string, never>,
       ) => {
         it(`should disable swap button`, () => {
-          renderComponent(props, stateOverrides);
+          renderComponent({}, stateOverrides, account);
           expectSwapButtonState(false);
         });
       },
     );
 
     it('enables swap button when all conditions are met', () => {
-      const props: Partial<TransactionActivityEmptyStateProps> = {
-        account: accountWithSigning,
-      };
       const stateOverrides = createValidSwapState();
-      renderComponent(props, stateOverrides);
+      renderComponent({}, stateOverrides, accountWithSigning);
       expectSwapButtonState(true);
     });
 
@@ -252,20 +247,14 @@ describe('TransactionActivityEmptyState', () => {
           chainId: MultichainNetworks.SOLANA,
           isEvmNetwork: false,
         });
-      const props: Partial<TransactionActivityEmptyStateProps> = {
-        account: accountWithSigning,
-      };
       const stateOverrides = createTestnetState();
-      renderComponent(props, stateOverrides);
+      renderComponent({}, stateOverrides, accountWithSigning);
       expectSwapButtonState(true); // Should be enabled due to Solana logic
     });
 
     it('calls openBridgeExperience when swap button is clicked', () => {
-      const props: Partial<TransactionActivityEmptyStateProps> = {
-        account: accountWithSigning,
-      };
       const stateOverrides = createValidSwapState();
-      renderComponent(props, stateOverrides);
+      renderComponent({}, stateOverrides, accountWithSigning);
       const swapButton = expectSwapButtonState(true);
 
       fireEvent.click(swapButton);

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -135,28 +135,29 @@ describe('TransactionActivityEmptyState', () => {
 
   const renderComponent = (
     props: Partial<TransactionActivityEmptyStateProps> = {},
-    stateOverrides = {},
+    stateOverrides: Record<string, unknown> = {},
     account = mockAccount,
   ) => {
-    // Set up Redux state with the account properly configured
-    const stateWithAccount = {
+    const state = {
       ...mockState,
       ...stateOverrides,
       metamask: {
         ...mockState.metamask,
-        ...(stateOverrides as any).metamask,
+        ...(('metamask' in stateOverrides
+          ? stateOverrides.metamask
+          : {}) as Record<string, unknown>),
         internalAccounts: {
-          ...(mockState.metamask as any).internalAccounts,
+          ...mockState.metamask.internalAccounts,
           selectedAccount: account.id,
           accounts: {
-            ...((mockState.metamask as any).internalAccounts?.accounts || {}),
+            ...mockState.metamask.internalAccounts.accounts,
             [account.id]: account,
           },
         },
       },
     };
 
-    const store = configureMockStore(middleware)(stateWithAccount);
+    const store = configureMockStore(middleware)(state);
 
     return renderWithProvider(
       <TransactionActivityEmptyState {...props} />,

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -47,10 +47,7 @@ const mockAccount = createAccount();
 const createStateOverrides = (
   metamaskOverrides: Record<string, unknown> = {},
 ) => ({
-  metamask: {
-    ...mockState.metamask,
-    ...metamaskOverrides,
-  },
+  metamask: metamaskOverrides,
 });
 
 const createTestnetState = (): ReturnType<typeof createStateOverrides> =>

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -10,7 +10,6 @@ import { ThemeType } from '../../../../shared/constants/preferences';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import * as useMultichainSelectorHook from '../../../hooks/useMultichainSelector';
-import { getSelectedInternalAccount } from '../../../selectors/accounts';
 import {
   TransactionActivityEmptyState,
   type TransactionActivityEmptyStateProps,
@@ -18,7 +17,6 @@ import {
 
 // Mock the useBridging hook
 jest.mock('../../../hooks/bridge/useBridging');
-jest.mock('../../../selectors/accounts');
 
 const createAccount = (
   overrides: Partial<InternalAccount> = {},
@@ -140,13 +138,25 @@ describe('TransactionActivityEmptyState', () => {
     stateOverrides = {},
     account = mockAccount,
   ) => {
-    // Set up the mock for the selected account
-    (getSelectedInternalAccount as jest.Mock).mockReturnValue(account);
-
-    const store = configureMockStore(middleware)({
+    // Set up Redux state with the account properly configured
+    const stateWithAccount = {
       ...mockState,
       ...stateOverrides,
-    });
+      metamask: {
+        ...mockState.metamask,
+        ...(stateOverrides as any).metamask,
+        internalAccounts: {
+          ...(mockState.metamask as any).internalAccounts,
+          selectedAccount: account.id,
+          accounts: {
+            ...((mockState.metamask as any).internalAccounts?.accounts || {}),
+            [account.id]: account,
+          },
+        },
+      },
+    };
+
+    const store = configureMockStore(middleware)(stateWithAccount);
 
     return renderWithProvider(
       <TransactionActivityEmptyState {...props} />,

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { twMerge } from '@metamask/design-system-react';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { EthMethod } from '@metamask/keyring-api';
 import { TabEmptyState } from '../../ui/tab-empty-state';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -14,21 +13,19 @@ import { ThemeType } from '../../../../shared/constants/preferences';
 import { getMultichainNetwork } from '../../../selectors/multichain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 
 export type TransactionActivityEmptyStateProps = {
   /**
    * Additional className to apply to the component
    */
   className?: string;
-  /**
-   * The account to use for swap logic
-   */
-  account: InternalAccount;
 };
 
 export const TransactionActivityEmptyState: React.FC<
   TransactionActivityEmptyStateProps
-> = ({ className, account }) => {
+> = ({ className }) => {
+  const account = useSelector(getSelectedInternalAccount);
   const t = useI18nContext();
   const theme = useTheme();
   const isSigningEnabled =

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -577,10 +577,7 @@ export default function TransactionList({
                 )}
               </Box>
             ) : (
-              <TransactionActivityEmptyState
-                className="mx-auto mt-5 mb-6"
-                account={selectedAccount}
-              />
+              <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
             )}
           </Box>
         </Box>
@@ -594,10 +591,7 @@ export default function TransactionList({
       <Box className="transaction-list" {...boxProps}>
         {groupedPendingTransactions.length === 0 &&
         groupedCompletedTransactions.length === 0 ? (
-          <TransactionActivityEmptyState
-            className="mx-auto mt-5 mb-6"
-            account={selectedAccount}
-          />
+          <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
         ) : (
           <Box className="transaction-list__transactions">
             {groupedPendingTransactions.length > 0 && (

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -845,10 +845,7 @@ export default function UnifiedTransactionList({
 
       <Box className="transaction-list" {...boxProps}>
         {processedUnifiedActivityItems.length === 0 ? (
-          <TransactionActivityEmptyState
-            className="mx-auto mt-5 mb-6"
-            account={selectedAccount}
-          />
+          <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
         ) : (
           <div
             className="transaction-list__transactions relative w-full"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reduce selector based re-render by encapsulating the useSelector usage into the component

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39637?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that removes a prop and relies on an existing selector for the selected internal account; primary risk is runtime issues if state shape differs in edge cases or tests/stories not providing required Redux state.
> 
> **Overview**
> `TransactionActivityEmptyState` no longer accepts an `account` prop and instead selects the active internal account via `getSelectedInternalAccount`, encapsulating the swap-enable logic inside the component.
> 
> All call sites in `transaction-list` and `unified-transaction-list` are updated to render the empty state without passing `selectedAccount`, and Storybook/tests are adjusted to remove the mock account prop and to set up `internalAccounts.selectedAccount`/`accounts` in mocked Redux state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7801794816747297c071a99ca07f3904f92c53b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->