### PR TITLE
test: suspense test

### DIFF
--- a/test/integration/helpers.tsx
+++ b/test/integration/helpers.tsx
@@ -4,6 +4,10 @@ import { parseAccountGroupId } from '@metamask/account-api';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { AccountTreeControllerState } from '@metamask/account-tree-controller';
 
+const flushPromises = async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+};
+
 // Used to "relax" (widen) types that are too strict. This can be useful when using mocked data from JSON
 // files. As some of the literal strings are being interpreted as general strings, this can cause some
 // type mismatches. (This could be moved to `@metamask/utils`)
@@ -109,6 +113,7 @@ export const getSelectedAccountGroupAccounts = <
 export const clickElementById = async (testId: string) => {
   await act(async () => {
     fireEvent.click(await screen.findByTestId(testId));
+    await flushPromises();
   });
 };
 
@@ -170,5 +175,6 @@ export const waitForElementByTextToNotBePresent = async (text: string) => {
 export const clickElementByText = async (text: string) => {
   await act(async () => {
     fireEvent.click(await screen.findByText(text));
+    await flushPromises();
   });
 };

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -43,15 +43,19 @@ import { AccountOverviewCommonProps } from './common';
 import { AssetListTokenDetection } from './asset-list-token-detection';
 
 // eslint-disable-next-line import/extensions
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
 const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab'));
 // eslint-disable-next-line import/extensions
-const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab.js'));
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
+const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab'));
 // eslint-disable-next-line import/extensions
+// @ts-expect-error -- Bundler resolves TS/TSX without extensions.
 const TransactionList = lazy(() => import('../../app/transaction-list'));
 const UnifiedTransactionList = lazy(
   () =>
     // eslint-disable-next-line import/extensions
-    import('../../app/transaction-list/unified-transaction-list.component.js'),
+    // @ts-expect-error -- Bundler resolves TS/JS without extensions.
+    import('../../app/transaction-list/unified-transaction-list.component'),
 );
 
 export type AccountOverviewTabsProps = AccountOverviewCommonProps & {

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -43,7 +43,7 @@ import { AccountOverviewCommonProps } from './common';
 import { AssetListTokenDetection } from './asset-list-token-detection';
 
 // eslint-disable-next-line import/extensions
-const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab.js'));
+const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab'));
 // eslint-disable-next-line import/extensions
 const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab.js'));
 // eslint-disable-next-line import/extensions

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -42,11 +42,16 @@ import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { AccountOverviewCommonProps } from './common';
 import { AssetListTokenDetection } from './asset-list-token-detection';
 
-const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab'));
-const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab'));
+// eslint-disable-next-line import/extensions
+const NftsTab = lazy(() => import('../../app/assets/nfts/nfts-tab.js'));
+// eslint-disable-next-line import/extensions
+const DeFiTab = lazy(() => import('../../app/assets/defi-list/defi-tab.js'));
+// eslint-disable-next-line import/extensions
 const TransactionList = lazy(() => import('../../app/transaction-list'));
 const UnifiedTransactionList = lazy(
-  () => import('../../app/transaction-list/unified-transaction-list.component'),
+  () =>
+    // eslint-disable-next-line import/extensions
+    import('../../app/transaction-list/unified-transaction-list.component.js'),
 );
 
 export type AccountOverviewTabsProps = AccountOverviewCommonProps & {


### PR DESCRIPTION
Update integration test click helpers to flush async updates, resolving `act` warnings, and apply lint autofixes.

Adding Suspense boundaries introduced `act` warnings in integration tests. These warnings occur when state updates (like those triggered by Suspense/lazy components) happen outside of an `act` block, or when an `act` block finishes before all asynchronous updates have been processed. By adding `flushPromises` after `fireEvent.click` within the `act` blocks, we ensure that all pending microtasks (including those from Suspense) are resolved before the `act` block completes, thus preventing these warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8e06ee4-9bf0-4e25-b191-77252e3e5893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8e06ee4-9bf0-4e25-b191-77252e3e5893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

