### PR TITLE
feat(rewards): add points estimate history for CS diagnostics

### DIFF
--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -283,6 +283,7 @@ export const SENTRY_BACKGROUND_STATE = {
     rewardsSeasons: false,
     rewardsSeasonStatuses: false,
     rewardsSubscriptionTokens: false,
+    rewardsPointsEstimateHistory: false,
   },
   NotificationServicesPushController: {
     fcmToken: false,

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1193,8 +1193,46 @@ describe('RewardsController', () => {
           // History should now have one entry
           expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
           const historyEntry = controller.state.rewardsPointsEstimateHistory[0];
-          expect(historyEntry.request).toEqual(request);
-          expect(historyEntry.response).toEqual(mockEstimatedPoints);
+          // Verify flattened request fields
+          expect(historyEntry.requestActivityType).toBe(request.activityType);
+          expect(historyEntry.requestAccount).toBe(request.account);
+          // Verify flattened swap source asset fields
+          expect(historyEntry.requestSwapSrcAssetId).toBe(
+            request.activityContext.swapContext?.srcAsset.id,
+          );
+          expect(historyEntry.requestSwapSrcAssetAmount).toBe(
+            request.activityContext.swapContext?.srcAsset.amount,
+          );
+          expect(historyEntry.requestSwapSrcAssetUsdPrice).toBe(
+            request.activityContext.swapContext?.srcAsset.usdPrice,
+          );
+          // Verify flattened swap destination asset fields
+          expect(historyEntry.requestSwapDestAssetId).toBe(
+            request.activityContext.swapContext?.destAsset.id,
+          );
+          expect(historyEntry.requestSwapDestAssetAmount).toBe(
+            request.activityContext.swapContext?.destAsset.amount,
+          );
+          expect(historyEntry.requestSwapDestAssetUsdPrice).toBe(
+            request.activityContext.swapContext?.destAsset.usdPrice,
+          );
+          // Verify flattened swap fee asset fields
+          expect(historyEntry.requestSwapFeeAssetId).toBe(
+            request.activityContext.swapContext?.feeAsset.id,
+          );
+          expect(historyEntry.requestSwapFeeAssetAmount).toBe(
+            request.activityContext.swapContext?.feeAsset.amount,
+          );
+          expect(historyEntry.requestSwapFeeAssetUsdPrice).toBe(
+            request.activityContext.swapContext?.feeAsset.usdPrice,
+          );
+          // Verify flattened response fields
+          expect(historyEntry.responsePointsEstimate).toBe(
+            mockEstimatedPoints.pointsEstimate,
+          );
+          expect(historyEntry.responseBonusBips).toBe(
+            mockEstimatedPoints.bonusBips,
+          );
           expect(historyEntry.timestamp).toBeGreaterThan(0);
         },
       );
@@ -1317,16 +1355,16 @@ describe('RewardsController', () => {
 
           // Most recent (300 points) should be first
           expect(
-            controller.state.rewardsPointsEstimateHistory[0].response
-              .pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[0]
+              .responsePointsEstimate,
           ).toBe(300);
           expect(
-            controller.state.rewardsPointsEstimateHistory[1].response
-              .pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[1]
+              .responsePointsEstimate,
           ).toBe(200);
           expect(
-            controller.state.rewardsPointsEstimateHistory[2].response
-              .pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[2]
+              .responsePointsEstimate,
           ).toBe(100);
         },
       );

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1446,7 +1446,7 @@ describe('RewardsController', () => {
               srcAsset: {
                 id: 'eip155:1/slip44:60',
                 amount: '1000000000000000000',
-                usdPrice: '2500'  ,
+                usdPrice: '2500',
               },
               destAsset: {
                 id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -1633,13 +1633,16 @@ describe('RewardsController', () => {
 
         // Most recent (300 points) should be first
         expect(
-          controller.state.rewardsPointsEstimateHistory[0].responsePointsEstimate,
+          controller.state.rewardsPointsEstimateHistory[0]
+            .responsePointsEstimate,
         ).toBe(300);
         expect(
-          controller.state.rewardsPointsEstimateHistory[1].responsePointsEstimate,
+          controller.state.rewardsPointsEstimateHistory[1]
+            .responsePointsEstimate,
         ).toBe(200);
         expect(
-          controller.state.rewardsPointsEstimateHistory[2].responsePointsEstimate,
+          controller.state.rewardsPointsEstimateHistory[2]
+            .responsePointsEstimate,
         ).toBe(100);
       });
     });

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1193,12 +1193,8 @@ describe('RewardsController', () => {
           // History should now have one entry
           expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
           const historyEntry = controller.state.rewardsPointsEstimateHistory[0];
-          expect(historyEntry).toMatchObject({
-            activityType: 'SWAP',
-            account: MOCK_CAIP_ACCOUNT,
-            pointsEstimate: 150,
-            bonusBips: 300,
-          });
+          expect(historyEntry.request).toEqual(request);
+          expect(historyEntry.response).toEqual(mockEstimatedPoints);
           expect(historyEntry.timestamp).toBeGreaterThan(0);
         },
       );
@@ -1321,13 +1317,16 @@ describe('RewardsController', () => {
 
           // Most recent (300 points) should be first
           expect(
-            controller.state.rewardsPointsEstimateHistory[0].pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[0].response
+              .pointsEstimate,
           ).toBe(300);
           expect(
-            controller.state.rewardsPointsEstimateHistory[1].pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[1].response
+              .pointsEstimate,
           ).toBe(200);
           expect(
-            controller.state.rewardsPointsEstimateHistory[2].pointsEstimate,
+            controller.state.rewardsPointsEstimateHistory[2].response
+              .pointsEstimate,
           ).toBe(100);
         },
       );

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1371,6 +1371,267 @@ describe('RewardsController', () => {
     });
   });
 
+  describe('addPointsEstimateToHistory', () => {
+    it('adds a swap activity entry to history', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            swapContext: {
+              srcAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '1000000000000000000',
+                usdPrice: '2500'  ,
+              },
+              destAsset: {
+                id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                amount: '4500000000',
+                usdPrice: '1',
+              },
+              feeAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '5000000000000000',
+                usdPrice: '2500',
+              },
+            },
+          },
+        };
+
+        const response: EstimatedPointsDto = {
+          pointsEstimate: 250,
+          bonusBips: 100,
+        };
+
+        controller.addPointsEstimateToHistory(request, response);
+
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+        const entry = controller.state.rewardsPointsEstimateHistory[0];
+
+        expect(entry.requestActivityType).toBe('SWAP');
+        expect(entry.requestAccount).toBe(MOCK_CAIP_ACCOUNT);
+        expect(entry.requestSwapSrcAssetId).toBe('eip155:1/slip44:60');
+        expect(entry.requestSwapSrcAssetAmount).toBe('1000000000000000000');
+        expect(entry.requestSwapSrcAssetUsdPrice).toBe('2500');
+        expect(entry.requestSwapDestAssetId).toBe(
+          'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        );
+        expect(entry.requestSwapDestAssetAmount).toBe('4500000000');
+        expect(entry.requestSwapDestAssetUsdPrice).toBe('1');
+        expect(entry.requestSwapFeeAssetId).toBe('eip155:1/slip44:60');
+        expect(entry.requestSwapFeeAssetAmount).toBe('5000000000000000');
+        expect(entry.requestSwapFeeAssetUsdPrice).toBe('2500');
+        expect(entry.responsePointsEstimate).toBe(250);
+        expect(entry.responseBonusBips).toBe(100);
+        expect(entry.timestamp).toBeGreaterThan(0);
+      });
+    });
+
+    it('adds a perps activity entry to history', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'PERPS',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            perpsContext: {
+              type: 'OPEN_POSITION',
+              usdFeeValue: '25.5',
+              coin: 'ETH',
+            },
+          },
+        };
+
+        const response: EstimatedPointsDto = {
+          pointsEstimate: 500,
+          bonusBips: 200,
+        };
+
+        controller.addPointsEstimateToHistory(request, response);
+
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+        const entry = controller.state.rewardsPointsEstimateHistory[0];
+
+        expect(entry.requestActivityType).toBe('PERPS');
+        expect(entry.requestAccount).toBe(MOCK_CAIP_ACCOUNT);
+        expect(entry.requestPerpsType).toBe('OPEN_POSITION');
+        expect(entry.requestPerpsUsdFeeValue).toBe('25.5');
+        expect(entry.requestPerpsCoin).toBe('ETH');
+        expect(entry.responsePointsEstimate).toBe(500);
+        expect(entry.responseBonusBips).toBe(200);
+        // Swap fields should be undefined for perps
+        expect(entry.requestSwapSrcAssetId).toBeUndefined();
+      });
+    });
+
+    it('adds a shield activity entry to history', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SHIELD',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            shieldContext: {
+              recurringInterval: 'month',
+            },
+          },
+        };
+
+        const response: EstimatedPointsDto = {
+          pointsEstimate: 1000,
+          bonusBips: 0,
+        };
+
+        controller.addPointsEstimateToHistory(request, response);
+
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+        const entry = controller.state.rewardsPointsEstimateHistory[0];
+
+        expect(entry.requestActivityType).toBe('SHIELD');
+        expect(entry.requestAccount).toBe(MOCK_CAIP_ACCOUNT);
+        expect(entry.requestShieldRecurringInterval).toBe('month');
+        expect(entry.responsePointsEstimate).toBe(1000);
+        expect(entry.responseBonusBips).toBe(0);
+        // Swap and perps fields should be undefined
+        expect(entry.requestSwapSrcAssetId).toBeUndefined();
+        expect(entry.requestPerpsType).toBeUndefined();
+      });
+    });
+
+    it('limits history to 50 entries', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            swapContext: {
+              srcAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '1000000000000000000',
+              },
+              destAsset: {
+                id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                amount: '4500000000',
+              },
+              feeAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '5000000000000000',
+              },
+            },
+          },
+        };
+
+        // Add 55 entries directly
+        for (let i = 0; i < 55; i++) {
+          controller.addPointsEstimateToHistory(request, {
+            pointsEstimate: i * 10,
+            bonusBips: 0,
+          });
+        }
+
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(50);
+      });
+    });
+
+    it('stores most recent entries first', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            swapContext: {
+              srcAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '1000000000000000000',
+              },
+              destAsset: {
+                id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                amount: '4500000000',
+              },
+              feeAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '5000000000000000',
+              },
+            },
+          },
+        };
+
+        controller.addPointsEstimateToHistory(request, {
+          pointsEstimate: 100,
+          bonusBips: 0,
+        });
+        controller.addPointsEstimateToHistory(request, {
+          pointsEstimate: 200,
+          bonusBips: 0,
+        });
+        controller.addPointsEstimateToHistory(request, {
+          pointsEstimate: 300,
+          bonusBips: 0,
+        });
+
+        // Most recent (300 points) should be first
+        expect(
+          controller.state.rewardsPointsEstimateHistory[0].responsePointsEstimate,
+        ).toBe(300);
+        expect(
+          controller.state.rewardsPointsEstimateHistory[1].responsePointsEstimate,
+        ).toBe(200);
+        expect(
+          controller.state.rewardsPointsEstimateHistory[2].responsePointsEstimate,
+        ).toBe(100);
+      });
+    });
+
+    it('handles activity with empty context gracefully', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {},
+        };
+
+        const response: EstimatedPointsDto = {
+          pointsEstimate: 50,
+          bonusBips: 0,
+        };
+
+        controller.addPointsEstimateToHistory(request, response);
+
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+        const entry = controller.state.rewardsPointsEstimateHistory[0];
+
+        expect(entry.requestActivityType).toBe('SWAP');
+        expect(entry.requestAccount).toBe(MOCK_CAIP_ACCOUNT);
+        expect(entry.responsePointsEstimate).toBe(50);
+        // All context-specific fields should be undefined
+        expect(entry.requestSwapSrcAssetId).toBeUndefined();
+        expect(entry.requestPerpsType).toBeUndefined();
+        expect(entry.requestShieldRecurringInterval).toBeUndefined();
+      });
+    });
+
+    it('records timestamp at the time of adding entry', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const beforeTimestamp = Date.now();
+
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {},
+        };
+
+        controller.addPointsEstimateToHistory(request, {
+          pointsEstimate: 100,
+          bonusBips: 0,
+        });
+
+        const afterTimestamp = Date.now();
+        const entry = controller.state.rewardsPointsEstimateHistory[0];
+
+        expect(entry.timestamp).toBeGreaterThanOrEqual(beforeTimestamp);
+        expect(entry.timestamp).toBeLessThanOrEqual(afterTimestamp);
+      });
+    });
+  });
+
   describe('getSeasonMetadata', () => {
     it('should fetch current season metadata', async () => {
       await withController(

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1369,6 +1369,70 @@ describe('RewardsController', () => {
         },
       );
     });
+
+    it('returns estimated points even when history tracking fails', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const mockEstimatedPoints: EstimatedPointsDto = {
+            pointsEstimate: 250,
+            bonusBips: 100,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:estimatePoints') {
+              return Promise.resolve(mockEstimatedPoints);
+            }
+            return undefined;
+          });
+
+          // Mock addPointsEstimateToHistory to throw an error
+          const originalAddToHistory =
+            controller.addPointsEstimateToHistory.bind(controller);
+          jest
+            .spyOn(controller, 'addPointsEstimateToHistory')
+            .mockImplementation(() => {
+              throw new Error('State update failed');
+            });
+
+          const request: EstimatePointsDto = {
+            activityType: 'SWAP',
+            account: MOCK_CAIP_ACCOUNT,
+            activityContext: {
+              swapContext: {
+                srcAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '1000000000000000000',
+                },
+                destAsset: {
+                  id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                  amount: '4500000000',
+                },
+                feeAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '5000000000000000',
+                },
+              },
+            },
+          };
+
+          // Should still return successful estimate despite history tracking failure
+          const result = await controller.estimatePoints(request);
+
+          expect(result).toEqual(mockEstimatedPoints);
+
+          // Restore original implementation
+          jest.restoreAllMocks();
+
+          // Verify history was not updated (since it threw)
+          expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(0);
+
+          // Call again with working history to verify it works after restore
+          originalAddToHistory(request, mockEstimatedPoints);
+          expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+        },
+      );
+    });
   });
 
   describe('addPointsEstimateToHistory', () => {

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -343,6 +343,7 @@ describe('RewardsController', () => {
         rewardsSeasons: {},
         rewardsSeasonStatuses: {},
         rewardsSubscriptionTokens: {},
+        rewardsPointsEstimateHistory: [],
       });
     });
   });
@@ -1143,6 +1144,191 @@ describe('RewardsController', () => {
           const result = await controller.estimatePoints(request);
 
           expect(result).toEqual(mockEstimatedPoints);
+        },
+      );
+    });
+
+    it('should add successful estimate to history', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const mockEstimatedPoints: EstimatedPointsDto = {
+            pointsEstimate: 150,
+            bonusBips: 300,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:estimatePoints') {
+              return Promise.resolve(mockEstimatedPoints);
+            }
+            return undefined;
+          });
+
+          const request: EstimatePointsDto = {
+            activityType: 'SWAP',
+            account: MOCK_CAIP_ACCOUNT,
+            activityContext: {
+              swapContext: {
+                srcAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '1000000000000000000',
+                },
+                destAsset: {
+                  id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                  amount: '4500000000',
+                },
+                feeAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '5000000000000000',
+                },
+              },
+            },
+          };
+
+          // History should be empty initially
+          expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(0);
+
+          await controller.estimatePoints(request);
+
+          // History should now have one entry
+          expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(1);
+          const historyEntry = controller.state.rewardsPointsEstimateHistory[0];
+          expect(historyEntry).toMatchObject({
+            activityType: 'SWAP',
+            account: MOCK_CAIP_ACCOUNT,
+            pointsEstimate: 150,
+            bonusBips: 300,
+          });
+          expect(historyEntry.timestamp).toBeGreaterThan(0);
+        },
+      );
+    });
+
+    it('should not add to history when rewards are disabled', async () => {
+      await withController({ isDisabled: true }, async ({ controller }) => {
+        const request: EstimatePointsDto = {
+          activityType: 'SWAP',
+          account: MOCK_CAIP_ACCOUNT,
+          activityContext: {
+            swapContext: {
+              srcAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '1000000000000000000',
+              },
+              destAsset: {
+                id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                amount: '4500000000',
+              },
+              feeAsset: {
+                id: 'eip155:1/slip44:60',
+                amount: '5000000000000000',
+              },
+            },
+          },
+        };
+
+        await controller.estimatePoints(request);
+
+        // History should remain empty when disabled
+        expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(0);
+      });
+    });
+
+    it('should limit history to 20 entries', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:estimatePoints') {
+              return Promise.resolve({ pointsEstimate: 100, bonusBips: 0 });
+            }
+            return undefined;
+          });
+
+          const request: EstimatePointsDto = {
+            activityType: 'SWAP',
+            account: MOCK_CAIP_ACCOUNT,
+            activityContext: {
+              swapContext: {
+                srcAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '1000000000000000000',
+                },
+                destAsset: {
+                  id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                  amount: '4500000000',
+                },
+                feeAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '5000000000000000',
+                },
+              },
+            },
+          };
+
+          // Make 25 calls - should only keep last 20
+          for (let i = 0; i < 25; i++) {
+            await controller.estimatePoints(request);
+          }
+
+          expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(
+            20,
+          );
+        },
+      );
+    });
+
+    it('should store most recent estimates first in history', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          let callCount = 0;
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:estimatePoints') {
+              callCount += 1;
+              return Promise.resolve({
+                pointsEstimate: callCount * 100,
+                bonusBips: 0,
+              });
+            }
+            return undefined;
+          });
+
+          const request: EstimatePointsDto = {
+            activityType: 'SWAP',
+            account: MOCK_CAIP_ACCOUNT,
+            activityContext: {
+              swapContext: {
+                srcAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '1000000000000000000',
+                },
+                destAsset: {
+                  id: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                  amount: '4500000000',
+                },
+                feeAsset: {
+                  id: 'eip155:1/slip44:60',
+                  amount: '5000000000000000',
+                },
+              },
+            },
+          };
+
+          await controller.estimatePoints(request);
+          await controller.estimatePoints(request);
+          await controller.estimatePoints(request);
+
+          // Most recent (300 points) should be first
+          expect(
+            controller.state.rewardsPointsEstimateHistory[0].pointsEstimate,
+          ).toBe(300);
+          expect(
+            controller.state.rewardsPointsEstimateHistory[1].pointsEstimate,
+          ).toBe(200);
+          expect(
+            controller.state.rewardsPointsEstimateHistory[2].pointsEstimate,
+          ).toBe(100);
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1230,7 +1230,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should limit history to 20 entries', async () => {
+    it('should limit history to 50 entries', async () => {
       await withController(
         { isDisabled: false },
         async ({ controller, mockMessengerCall }) => {
@@ -1262,13 +1262,13 @@ describe('RewardsController', () => {
             },
           };
 
-          // Make 25 calls - should only keep last 20
-          for (let i = 0; i < 25; i++) {
+          // Make 55 calls - should only keep last 50
+          for (let i = 0; i < 55; i++) {
             await controller.estimatePoints(request);
           }
 
           expect(controller.state.rewardsPointsEstimateHistory).toHaveLength(
-            20,
+            50,
           );
         },
       );

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -1121,7 +1121,7 @@ export class RewardsController extends BaseController<
       );
 
       // Track successful estimate in history for Customer Support diagnostics
-      this.#addPointsEstimateToHistory(request, estimatedPoints);
+      this.addPointsEstimateToHistory(request, estimatedPoints);
 
       return estimatedPoints;
     } catch (error) {
@@ -1140,7 +1140,7 @@ export class RewardsController extends BaseController<
    * @param request - The estimate request containing activity details
    * @param response - The estimated points response
    */
-  #addPointsEstimateToHistory(
+  addPointsEstimateToHistory(
     request: EstimatePointsDto,
     response: EstimatedPointsDto,
   ): void {

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -29,6 +29,7 @@ import {
   type SeasonTierDto,
   type SeasonStatusDto,
   type SubscriptionDto,
+  type PointsEstimateHistoryEntry,
   SeasonStateDto,
   SeasonMetadataDto,
   DiscoverSeasonsDto,
@@ -54,6 +55,9 @@ const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
 
 // Opt-in status stale threshold for not opted-in accounts to force a fresh check (less strict than in mobile for now)
 const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
+
+// Maximum number of points estimate history entries to keep for Customer Support diagnostics
+const MAX_POINTS_ESTIMATE_HISTORY_ENTRIES = 20;
 
 /**
  * State metadata for the RewardsController
@@ -101,6 +105,12 @@ const metadata = {
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
+  rewardsPointsEstimateHistory: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: false,
+  },
 };
 
 /**
@@ -113,6 +123,7 @@ export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
   rewardsSeasons: {},
   rewardsSeasonStatuses: {},
   rewardsSubscriptionTokens: {},
+  rewardsPointsEstimateHistory: [],
 });
 
 export const defaultRewardsControllerState = getRewardsControllerDefaultState();
@@ -1109,6 +1120,9 @@ export class RewardsController extends BaseController<
         request,
       );
 
+      // Track successful estimate in history for Customer Support diagnostics
+      this.#addPointsEstimateToHistory(request, estimatedPoints);
+
       return estimatedPoints;
     } catch (error) {
       log.error(
@@ -1117,6 +1131,43 @@ export class RewardsController extends BaseController<
       );
       throw error;
     }
+  }
+
+  /**
+   * Add a successful points estimate to the history for Customer Support diagnostics.
+   * Maintains a bounded history of the last N estimates.
+   *
+   * @param request - The estimate request containing activity details
+   * @param response - The estimated points response
+   */
+  #addPointsEstimateToHistory(
+    request: EstimatePointsDto,
+    response: EstimatedPointsDto,
+  ): void {
+    const entry: PointsEstimateHistoryEntry = {
+      timestamp: Date.now(),
+      activityType: request.activityType,
+      account: request.account,
+      pointsEstimate: response.pointsEstimate,
+      bonusBips: response.bonusBips,
+    };
+
+    this.update((state: RewardsControllerState) => {
+      // Add new entry at the beginning (most recent first)
+      state.rewardsPointsEstimateHistory.unshift(entry);
+
+      // Keep only the last N entries
+      if (
+        state.rewardsPointsEstimateHistory.length >
+        MAX_POINTS_ESTIMATE_HISTORY_ENTRIES
+      ) {
+        state.rewardsPointsEstimateHistory =
+          state.rewardsPointsEstimateHistory.slice(
+            0,
+            MAX_POINTS_ESTIMATE_HISTORY_ENTRIES,
+          );
+      }
+    });
   }
 
   /**

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -57,7 +57,7 @@ const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
 const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
 
 // Maximum number of points estimate history entries to keep for Customer Support diagnostics
-const MAX_POINTS_ESTIMATE_HISTORY_ENTRIES = 20;
+const MAX_POINTS_ESTIMATE_HISTORY_ENTRIES = 50;
 
 /**
  * State metadata for the RewardsController

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -1146,10 +1146,8 @@ export class RewardsController extends BaseController<
   ): void {
     const entry: PointsEstimateHistoryEntry = {
       timestamp: Date.now(),
-      activityType: request.activityType,
-      account: request.account,
-      pointsEstimate: response.pointsEstimate,
-      bonusBips: response.bonusBips,
+      request,
+      response,
     };
 
     this.update((state: RewardsControllerState) => {

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -1144,10 +1144,43 @@ export class RewardsController extends BaseController<
     request: EstimatePointsDto,
     response: EstimatedPointsDto,
   ): void {
+    const { activityContext } = request;
+
     const entry: PointsEstimateHistoryEntry = {
       timestamp: Date.now(),
-      request,
-      response,
+      requestActivityType: request.activityType,
+      requestAccount: request.account,
+      // Swap context fields (if applicable) - flattened for easier diagnostics
+      ...(activityContext.swapContext && {
+        requestSwapSrcAssetId: activityContext.swapContext.srcAsset.id,
+        requestSwapSrcAssetAmount: activityContext.swapContext.srcAsset.amount,
+        requestSwapSrcAssetUsdPrice:
+          activityContext.swapContext.srcAsset.usdPrice,
+        requestSwapDestAssetId: activityContext.swapContext.destAsset.id,
+        requestSwapDestAssetAmount:
+          activityContext.swapContext.destAsset.amount,
+        requestSwapDestAssetUsdPrice:
+          activityContext.swapContext.destAsset.usdPrice,
+        requestSwapFeeAssetId: activityContext.swapContext.feeAsset.id,
+        requestSwapFeeAssetAmount: activityContext.swapContext.feeAsset.amount,
+        requestSwapFeeAssetUsdPrice:
+          activityContext.swapContext.feeAsset.usdPrice,
+      }),
+      // Perps context fields (if applicable)
+      ...(activityContext.perpsContext &&
+        !Array.isArray(activityContext.perpsContext) && {
+          requestPerpsType: activityContext.perpsContext.type,
+          requestPerpsUsdFeeValue: activityContext.perpsContext.usdFeeValue,
+          requestPerpsCoin: activityContext.perpsContext.coin,
+        }),
+      // Shield context fields (if applicable)
+      ...(activityContext.shieldContext && {
+        requestShieldRecurringInterval:
+          activityContext.shieldContext.recurringInterval,
+      }),
+      // Response fields
+      responsePointsEstimate: response.pointsEstimate,
+      responseBonusBips: response.bonusBips,
     };
 
     this.update((state: RewardsControllerState) => {

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -1121,7 +1121,17 @@ export class RewardsController extends BaseController<
       );
 
       // Track successful estimate in history for Customer Support diagnostics
-      this.addPointsEstimateToHistory(request, estimatedPoints);
+      // Wrapped in its own try-catch so history tracking failures don't affect the main functionality
+      try {
+        this.addPointsEstimateToHistory(request, estimatedPoints);
+      } catch (historyError) {
+        log.error(
+          'RewardsController: Failed to add points estimate to history:',
+          historyError instanceof Error
+            ? historyError.message
+            : String(historyError),
+        );
+      }
 
       return estimatedPoints;
     } catch (error) {

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,10 +1,14 @@
 import { CaipAccountId } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
+  EstimateAssetDto,
   EstimatedPointsDto,
+  EstimatePerpsContextDto,
   EstimatePointsDto,
+  EstimateShieldContextDto,
   OptInStatusDto,
   OptInStatusInputDto,
+  PointsEventEarnType,
   RewardsGeoMetadata,
   SeasonDtoState,
   SeasonRewardType,
@@ -487,6 +491,7 @@ export type RewardsAccountState = {
 /**
  * A single entry in the points estimate history.
  * Used by Customer Support to verify points estimates shown to users.
+ * Structure is intentionally flat to simplify debugging and log analysis.
  */
 export type PointsEstimateHistoryEntry = {
   /**
@@ -495,14 +500,129 @@ export type PointsEstimateHistoryEntry = {
   timestamp: number;
 
   /**
-   * The original request containing activity type, account, and context
+   * Type of point earning activity (from request)
+   *
+   * @example 'SWAP'
    */
-  request: EstimatePointsDto;
+  requestActivityType: PointsEventEarnType;
 
   /**
-   * The response containing estimated points and bonus information
+   * Account address performing the activity in CAIP-10 format (from request)
+   *
+   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
    */
-  response: EstimatedPointsDto;
+  requestAccount: CaipAccountId;
+
+  /**
+   * Source asset ID for swap activity in CAIP-19 format (if applicable)
+   *
+   * @example 'eip155:1/slip44:60'
+   */
+  requestSwapSrcAssetId?: CaipAssetType;
+
+  /**
+   * Source asset amount for swap activity (if applicable)
+   *
+   * @example '1000000000000000000'
+   */
+  requestSwapSrcAssetAmount?: string;
+
+  /**
+   * Source asset USD price for swap activity (if applicable)
+   *
+   * @example '4512.34'
+   */
+  requestSwapSrcAssetUsdPrice?: string;
+
+  /**
+   * Destination asset ID for swap activity in CAIP-19 format (if applicable)
+   *
+   * @example 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+   */
+  requestSwapDestAssetId?: CaipAssetType;
+
+  /**
+   * Destination asset amount for swap activity (if applicable)
+   *
+   * @example '4500000000'
+   */
+  requestSwapDestAssetAmount?: string;
+
+  /**
+   * Destination asset USD price for swap activity (if applicable)
+   *
+   * @example '1.00'
+   */
+  requestSwapDestAssetUsdPrice?: string;
+
+  /**
+   * Fee asset ID for swap activity in CAIP-19 format (if applicable)
+   *
+   * @example 'eip155:1/slip44:60'
+   */
+  requestSwapFeeAssetId?: CaipAssetType;
+
+  /**
+   * Fee asset amount for swap activity (if applicable)
+   *
+   * @example '5000000000000000'
+   */
+  requestSwapFeeAssetAmount?: string;
+
+  /**
+   * Fee asset USD price for swap activity (if applicable)
+   *
+   * @example '4512.34'
+   */
+  requestSwapFeeAssetUsdPrice?: string;
+
+  /**
+   * Type of PERPS action (if applicable)
+   *
+   * @example 'OPEN_POSITION'
+   */
+  requestPerpsType?: EstimatePerpsContextDto['type'];
+
+  /**
+   * USD fee value for PERPS activity (if applicable)
+   *
+   * @example '12.34'
+   */
+  requestPerpsUsdFeeValue?: string;
+
+  /**
+   * Asset symbol for PERPS activity (if applicable)
+   *
+   * @example 'ETH'
+   */
+  requestPerpsCoin?: string;
+
+  /**
+   * Fee asset for predict activity (if applicable)
+   */
+  requestPredictFeeAsset?: EstimateAssetDto;
+
+  /**
+   * Recurring interval for shield activity (if applicable)
+   *
+   * @example 'month'
+   */
+  requestShieldRecurringInterval?: EstimateShieldContextDto['recurringInterval'];
+
+  /**
+   * Estimated points earnable for the activity (from response)
+   *
+   * @example 100
+   */
+  responsePointsEstimate: number;
+
+  /**
+   * Bonus applied to the points estimate, in basis points (from response)
+   * 100 = 1%
+   *
+   * @example 200
+   */
+  responseBonusBips: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -495,32 +495,14 @@ export type PointsEstimateHistoryEntry = {
   timestamp: number;
 
   /**
-   * Type of point earning activity
-   *
-   * @example 'SWAP'
+   * The original request containing activity type, account, and context
    */
-  activityType: string;
+  request: EstimatePointsDto;
 
   /**
-   * Account address in CAIP-10 format
-   *
-   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
+   * The response containing estimated points and bonus information
    */
-  account: CaipAccountId;
-
-  /**
-   * Estimated points for the activity
-   *
-   * @example 100
-   */
-  pointsEstimate: number;
-
-  /**
-   * Bonus applied to the points estimate, in basis points (100 = 1%)
-   *
-   * @example 200
-   */
-  bonusBips: number;
+  response: EstimatedPointsDto;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,4 +1,4 @@
-import { CaipAccountId } from '@metamask/utils';
+import { CaipAccountId, CaipAssetType } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   EstimateAssetDto,

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -598,11 +598,6 @@ export type PointsEstimateHistoryEntry = {
   requestPerpsCoin?: string;
 
   /**
-   * Fee asset for predict activity (if applicable)
-   */
-  requestPredictFeeAsset?: EstimateAssetDto;
-
-  /**
    * Recurring interval for shield activity (if applicable)
    *
    * @example 'month'

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -484,6 +484,45 @@ export type RewardsAccountState = {
   lastFreshOptInStatusCheck?: number | null;
 };
 
+/**
+ * A single entry in the points estimate history.
+ * Used by Customer Support to verify points estimates shown to users.
+ */
+export type PointsEstimateHistoryEntry = {
+  /**
+   * Timestamp when the estimate was made (milliseconds since epoch)
+   */
+  timestamp: number;
+
+  /**
+   * Type of point earning activity
+   *
+   * @example 'SWAP'
+   */
+  activityType: string;
+
+  /**
+   * Account address in CAIP-10 format
+   *
+   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
+   */
+  account: CaipAccountId;
+
+  /**
+   * Estimated points for the activity
+   *
+   * @example 100
+   */
+  pointsEstimate: number;
+
+  /**
+   * Bonus applied to the points estimate, in basis points (100 = 1%)
+   *
+   * @example 200
+   */
+  bonusBips: number;
+};
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RewardsControllerState = {
   rewardsActiveAccount: RewardsAccountState | null;
@@ -492,6 +531,11 @@ export type RewardsControllerState = {
   rewardsSeasons: { [seasonId: string]: SeasonDtoState };
   rewardsSeasonStatuses: { [compositeId: string]: SeasonStatusState };
   rewardsSubscriptionTokens: { [subscriptionId: string]: string };
+  /**
+   * History of points estimates for Customer Support diagnostics.
+   * Stores the last N successful estimates to verify user-reported discrepancies.
+   */
+  rewardsPointsEstimateHistory: PointsEstimateHistoryEntry[];
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,7 +1,6 @@
 import { CaipAccountId, CaipAssetType } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
-  EstimateAssetDto,
   EstimatedPointsDto,
   EstimatePerpsContextDto,
   EstimatePointsDto,

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -329,6 +329,7 @@ export type ControllerStatePropertiesEnumerated = {
   rewardsSeasons: RewardsControllerState['rewardsSeasons'];
   rewardsSeasonStatuses: RewardsControllerState['rewardsSeasonStatuses'];
   rewardsSubscriptionTokens: RewardsControllerState['rewardsSubscriptionTokens'];
+  rewardsPointsEstimateHistory: RewardsControllerState['rewardsPointsEstimateHistory'];
   claims: ClaimsControllerState['claims'];
   claimsConfigurations: ClaimsControllerState['claimsConfigurations'];
   drafts: ClaimsControllerState['drafts'];

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -1970,7 +1970,8 @@
       "rewardsSeasonStatuses": {},
       "rewardsSeasons": {},
       "rewardsSubscriptionTokens": {},
-      "rewardsSubscriptions": {}
+      "rewardsSubscriptions": {},
+      "rewardsPointsEstimateHistory": []
     },
     "SeedlessOnboardingController": {
       "isSeedlessOnboardingUserAuthenticated": false,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -329,11 +329,11 @@
   "RewardsController": {
     "rewardsAccounts": "object",
     "rewardsActiveAccount": null,
+    "rewardsPointsEstimateHistory": "object",
     "rewardsSeasonStatuses": "object",
     "rewardsSeasons": "object",
     "rewardsSubscriptionTokens": "object",
-    "rewardsSubscriptions": "object",
-    "rewardsPointsEstimateHistory": "object"
+    "rewardsSubscriptions": "object"
   },
   "RewardsDataService": "undefined",
   "SeedlessOnboardingController": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -332,7 +332,8 @@
     "rewardsSeasonStatuses": "object",
     "rewardsSeasons": "object",
     "rewardsSubscriptionTokens": "object",
-    "rewardsSubscriptions": "object"
+    "rewardsSubscriptions": "object",
+    "rewardsPointsEstimateHistory": "object"
   },
   "RewardsDataService": "undefined",
   "SeedlessOnboardingController": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -322,6 +322,7 @@
     },
     "rewardsAccounts": "object",
     "rewardsActiveAccount": null,
+    "rewardsPointsEstimateHistory": "object",
     "rewardsSeasonStatuses": "object",
     "rewardsSeasons": "object",
     "rewardsSubscriptionTokens": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -266,7 +266,8 @@
       "rewardsSeasonStatuses": "object",
       "rewardsSeasons": "object",
       "rewardsSubscriptionTokens": "object",
-      "rewardsSubscriptions": "object"
+      "rewardsSubscriptions": "object",
+      "rewardsPointsEstimateHistory": "object"
     },
     "SeedlessOnboardingController": "object",
     "SelectedNetworkController": { "domains": "object" },

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -263,11 +263,11 @@
     "RewardsController": {
       "rewardsAccounts": "object",
       "rewardsActiveAccount": null,
+      "rewardsPointsEstimateHistory": "object",
       "rewardsSeasonStatuses": "object",
       "rewardsSeasons": "object",
       "rewardsSubscriptionTokens": "object",
-      "rewardsSubscriptions": "object",
-      "rewardsPointsEstimateHistory": "object"
+      "rewardsSubscriptions": "object"
     },
     "SeedlessOnboardingController": "object",
     "SelectedNetworkController": { "domains": "object" },

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -905,6 +905,7 @@
     },
     "rewardsAccounts": {},
     "rewardsActiveAccount": "null",
+    "rewardsPointsEstimateHistory": [],
     "rewardsSeasons": {},
     "rewardsSeasonStatuses": {},
     "rewardsSubscriptions": {},


### PR DESCRIPTION
## **Description**

Store the last 50 successful points estimates in state logs to help Customer Support verify user-reported discrepancies between estimated and awarded points.

## **Changelog**

CHANGELOG entry: Added points estimate history tracking to state logs for Customer Support diagnostics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Persists and logs additional rewards-related request/response data (including account and activity details), which increases stored state/log surface area and could affect privacy/perf if misused. Functional risk is contained by bounding history to 50 entries and isolating history-write failures from `estimatePoints()` results.
> 
> **Overview**
> Adds `rewardsPointsEstimateHistory` to `RewardsController` state and defaults, persisting it and including it in state logs for Customer Support diagnostics.
> 
> `estimatePoints()` now records each successful estimate (flattened request context for swap/perps/shield plus response and timestamp) via `addPointsEstimateToHistory`, keeps most-recent-first, and caps history at 50 entries while swallowing/logging history-update errors.
> 
> Wires the new state field through background state typing and test fixtures/state snapshots, and explicitly excludes it from Sentry background state attachment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef76f07fa17c3ef0ab00da9337fd5c8cbbd7df03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->