### PR TITLE
fix: Replace `metamask_sendDomainMetadata` with a no-op

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -111,6 +111,7 @@ if (shouldInjectProvider()) {
     connectionStream: mux.createStream(METAMASK_EIP_1193_PROVIDER),
     logger: log,
     shouldShimWeb3: true,
+    shouldSendMetadata: false,
     providerInfo: {
       uuid: uuid(),
       name: process.env.METAMASK_BUILD_NAME,

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
@@ -22,7 +22,7 @@ describe('SendMetaData', () => {
     mockAddSubjectMetadata = jest.fn();
   });
 
-  it('should call AddSubjectMetadata when the handler is invoked', async () => {
+  it('should do nothing and return true', async () => {
     const req: SendMetadataHandlerRequest<SubjectMetadataToAdd> = {
       origin: 'testOrigin',
       params: paramsData,
@@ -37,11 +37,7 @@ describe('SendMetaData', () => {
       result: true,
     };
 
-    sendMetadata.implementation(req, res, jest.fn(), mockEnd, {
-      addSubjectMetadata: mockAddSubjectMetadata,
-      subjectType: SubjectType.Extension,
-    });
-    expect(mockAddSubjectMetadata).toHaveBeenCalled();
+    sendMetadata.implementation(req, res, jest.fn(), mockEnd);
     expect(res.result).toStrictEqual(true);
     expect(mockEnd).toHaveBeenCalled();
   });

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
@@ -1,6 +1,5 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import { PendingJsonRpcResponse } from '@metamask/utils';
-import { SubjectType } from '@metamask/permission-controller';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import { HandlerRequestType as SendMetadataHandlerRequest } from './types';
 import sendMetadata, { SubjectMetadataToAdd } from './send-metadata';
@@ -27,7 +26,7 @@ describe('SendMetaData', () => {
       result: true,
     };
 
-    const mockEnd = jest.fn();
+    const mockEnd: JsonRpcEngineEndCallback = jest.fn();
     sendMetadata.implementation(req, res, jest.fn(), mockEnd);
     expect(res.result).toStrictEqual(true);
     expect(mockEnd).toHaveBeenCalled();

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.test.ts
@@ -3,24 +3,14 @@ import { PendingJsonRpcResponse } from '@metamask/utils';
 import { SubjectType } from '@metamask/permission-controller';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import { HandlerRequestType as SendMetadataHandlerRequest } from './types';
-import sendMetadata, {
-  AddSubjectMetadata,
-  SubjectMetadataToAdd,
-} from './send-metadata';
+import sendMetadata, { SubjectMetadataToAdd } from './send-metadata';
 
 describe('SendMetaData', () => {
-  let mockEnd: JsonRpcEngineEndCallback;
-  let mockAddSubjectMetadata: AddSubjectMetadata;
   const paramsData = {
     origin: 'testOrigin',
     iconUrl: 'testicon',
     name: 'testname',
   };
-
-  beforeEach(() => {
-    mockEnd = jest.fn();
-    mockAddSubjectMetadata = jest.fn();
-  });
 
   it('should do nothing and return true', async () => {
     const req: SendMetadataHandlerRequest<SubjectMetadataToAdd> = {
@@ -37,6 +27,7 @@ describe('SendMetaData', () => {
       result: true,
     };
 
+    const mockEnd = jest.fn();
     sendMetadata.implementation(req, res, jest.fn(), mockEnd);
     expect(res.result).toStrictEqual(true);
     expect(mockEnd).toHaveBeenCalled();

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
@@ -1,4 +1,3 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import {
   JsonRpcEngineEndCallback,
   JsonRpcEngineNextCallback,

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
@@ -36,6 +36,7 @@ type SendMetadataConstraint<
 const sendMetadata = {
   methodNames: [MESSAGE_TYPE.SEND_METADATA],
   implementation: sendMetadataHandler,
+  hookNames: {},
 } satisfies SendMetadataConstraint;
 export default sendMetadata;
 
@@ -44,10 +45,6 @@ export default sendMetadata;
  * @param res - The JSON-RPC response object.
  * @param _next - The json-rpc-engine 'next' callback.
  * @param end - The json-rpc-engine 'end' callback.
- * @param options
- * @param options.addSubjectMetadata - A function that records subject
- * metadata, bound to the requesting origin.
- * @param options.subjectType - The type of the requesting origin / subject.
  */
 function sendMetadataHandler<
   Params extends SubjectMetadataToAdd = SubjectMetadataToAdd,
@@ -57,7 +54,7 @@ function sendMetadataHandler<
   _next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,
 ): void {
-  const { origin, params } = req;
+  const { params } = req;
   if (!isObject(params)) {
     return end(rpcErrors.invalidParams({ data: params }));
   }

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
@@ -24,11 +24,6 @@ export type SubjectMetadataToAdd = PermissionSubjectMetadata & {
 
 export type AddSubjectMetadata = (metadata: SubjectMetadataToAdd) => void;
 
-type SendMetadataOptions = {
-  addSubjectMetadata: AddSubjectMetadata;
-  subjectType: SubjectType;
-};
-
 type SendMetadataConstraint<
   Params extends SubjectMetadataToAdd = SubjectMetadataToAdd,
 > = {
@@ -36,22 +31,13 @@ type SendMetadataConstraint<
     req: SendMetadataHandlerRequest<Params>,
     res: PendingJsonRpcResponse<true>,
     _next: JsonRpcEngineNextCallback,
-    end: JsonRpcEngineEndCallback,
-    { addSubjectMetadata, subjectType }: SendMetadataOptions,
+    end: JsonRpcEngineEndCallback
   ) => void;
 } & HandlerWrapper;
-/**
- * This internal method is used by our external provider to send metadata about
- * permission subjects so that we can e.g. display a proper name and icon in
- * our UI.
- */
+
 const sendMetadata = {
   methodNames: [MESSAGE_TYPE.SEND_METADATA],
   implementation: sendMetadataHandler,
-  hookNames: {
-    addSubjectMetadata: true,
-    subjectType: true,
-  },
 } satisfies SendMetadataConstraint;
 export default sendMetadata;
 
@@ -72,23 +58,13 @@ function sendMetadataHandler<
   res: PendingJsonRpcResponse<true>,
   _next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,
-  { addSubjectMetadata, subjectType }: SendMetadataOptions,
 ): void {
   const { origin, params } = req;
-  if (isObject(params)) {
-    const { icon = null, name = null, ...remainingParams } = params;
-
-    addSubjectMetadata({
-      ...remainingParams,
-      iconUrl: icon,
-      name,
-      subjectType,
-      origin,
-    });
-  } else {
+  if (!isObject(params)) {
     return end(rpcErrors.invalidParams({ data: params }));
   }
 
+  // This handler is no longer in-use and simply remains as a no-op for backwards compatibility.
   res.result = true;
   return end();
 }

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
@@ -22,8 +22,6 @@ export type SubjectMetadataToAdd = PermissionSubjectMetadata & {
   iconUrl?: string | null;
 };
 
-export type AddSubjectMetadata = (metadata: SubjectMetadataToAdd) => void;
-
 type SendMetadataConstraint<
   Params extends SubjectMetadataToAdd = SubjectMetadataToAdd,
 > = {
@@ -31,7 +29,7 @@ type SendMetadataConstraint<
     req: SendMetadataHandlerRequest<Params>,
     res: PendingJsonRpcResponse<true>,
     _next: JsonRpcEngineNextCallback,
-    end: JsonRpcEngineEndCallback
+    end: JsonRpcEngineEndCallback,
   ) => void;
 } & HandlerWrapper;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/send-metadata.ts
@@ -4,7 +4,6 @@ import {
   JsonRpcEngineNextCallback,
 } from '@metamask/json-rpc-engine';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
-import { isObject } from '@metamask/utils';
 import {
   PermissionSubjectMetadata,
   SubjectType,
@@ -41,7 +40,7 @@ const sendMetadata = {
 export default sendMetadata;
 
 /**
- * @param req - The JSON-RPC request object.
+ * @param _req - The JSON-RPC request object.
  * @param res - The JSON-RPC response object.
  * @param _next - The json-rpc-engine 'next' callback.
  * @param end - The json-rpc-engine 'end' callback.
@@ -49,16 +48,11 @@ export default sendMetadata;
 function sendMetadataHandler<
   Params extends SubjectMetadataToAdd = SubjectMetadataToAdd,
 >(
-  req: SendMetadataHandlerRequest<Params>,
+  _req: SendMetadataHandlerRequest<Params>,
   res: PendingJsonRpcResponse<true>,
   _next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,
 ): void {
-  const { params } = req;
-  if (!isObject(params)) {
-    return end(rpcErrors.invalidParams({ data: params }));
-  }
-
   // This handler is no longer in-use and simply remains as a no-op for backwards compatibility.
   res.result = true;
   return end();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7072,10 +7072,6 @@ export default class MetamaskController extends EventEmitter {
   setupCommonMiddlewareHooks(origin) {
     return {
       // Miscellaneous
-      addSubjectMetadata:
-        this.subjectMetadataController.addSubjectMetadata.bind(
-          this.subjectMetadataController,
-        ),
       getProviderState: this.getProviderState.bind(this),
       handleWatchAssetRequest: this.handleWatchAssetRequest.bind(this),
       requestUserApproval:
@@ -7391,7 +7387,6 @@ export default class MetamaskController extends EventEmitter {
     // They must nevertheless be placed _behind_ the permission middleware.
     engine.push(
       createEip1193MethodMiddleware({
-        subjectType,
         ...this.setupCommonMiddlewareHooks(origin),
 
         // Miscellaneous
@@ -7829,10 +7824,7 @@ export default class MetamaskController extends EventEmitter {
     }
 
     engine.push(
-      createMultichainMethodMiddleware({
-        subjectType,
-        ...this.setupCommonMiddlewareHooks(origin),
-      }),
+      createMultichainMethodMiddleware(this.setupCommonMiddlewareHooks(origin)),
     );
 
     engine.push(this.metamaskMiddleware);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace `metamask_sendDomainMetadata` with a no-op as we no longer need the provider to report metadata for sites. The `SubjectMetadataController` is populated already using the tabs API. The RPC method is kept around for backwards compatibility.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39642?quickstart=1)

## **Changelog**

CHANGELOG entry: Calling the RPC method `metamask_sendDomainMetadata` no longer has any effect.

## **Manual testing steps**

1. Connect to any dapp
2. See that the name and icon for a site is populated in the connection screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables domain-metadata reporting from the inpage provider and removes the backend hook that persisted this metadata, which could affect any flows still relying on `metamask_sendDomainMetadata` for site name/icon display.
> 
> **Overview**
> Stops the inpage provider from sending site metadata by setting `shouldSendMetadata: false` during `initializeProvider`.
> 
> Replaces the `metamask_sendDomainMetadata` (`MESSAGE_TYPE.SEND_METADATA`) RPC handler with a **no-op** that always returns `true`, removing subject-metadata persistence hooks (`addSubjectMetadata`/`subjectType`) from middleware wiring and updating the unit test to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf06db4adbe5044aad8fa9f6b16165c5ead8f93a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->