### PR TITLE
feat: add collapsible wallet sections to Accounts page

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -687,8 +687,8 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx": {
-      "MetaMask: Background connection not initialized": 66,
-      "Reselect: Identity function warnings": 2,
+      "MetaMask: Background connection not initialized": 73,
+      "Reselect: Identity function warnings": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/multichain-accounts/multichain-account-menu-items/multichain-account-menu-items.test.tsx": {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -1195,6 +1195,132 @@ describe('MultichainAccountList', () => {
     });
   });
 
+  describe('Collapsible section headers', () => {
+    it('collapses wallet section when wallet header is clicked', async () => {
+      renderComponent();
+
+      // Both wallet accounts should be visible initially
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+
+      // Click the first wallet header to collapse it
+      const walletHeaders = screen.getAllByTestId(walletHeaderTestId);
+      await act(async () => {
+        fireEvent.click(walletHeaders[0]);
+      });
+
+      // Wallet 1's account should no longer be visible
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).not.toBeInTheDocument();
+
+      // Wallet 2's account should still be visible
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+    });
+
+    it('collapses pinned section when pinned header is clicked', async () => {
+      const walletsWithPinnedAccount = {
+        [walletOneId]: {
+          ...mockWallets[walletOneId],
+          groups: {
+            [walletOneGroupId]: {
+              ...mockWallets[walletOneId].groups[walletOneGroupId],
+              metadata: {
+                ...mockWallets[walletOneId].groups[walletOneGroupId].metadata,
+                pinned: true,
+              },
+            },
+          },
+        },
+        [walletTwoId]: mockWallets[walletTwoId],
+      };
+
+      renderComponent({ wallets: walletsWithPinnedAccount });
+
+      // Pinned account should be visible initially
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).toBeInTheDocument();
+
+      // Click the pinned header to collapse it
+      const pinnedHeader = screen.getByTestId(
+        'multichain-account-tree-pinned-header',
+      );
+      await act(async () => {
+        fireEvent.click(pinnedHeader);
+      });
+
+      // Pinned account should no longer be visible
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).not.toBeInTheDocument();
+
+      // Wallet 2's account should still be visible
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+    });
+
+    it('multiple sections can be collapsed independently', async () => {
+      renderComponent();
+
+      // Both wallet accounts should be visible initially
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+
+      const walletHeaders = screen.getAllByTestId(walletHeaderTestId);
+
+      // Collapse Wallet 1
+      await act(async () => {
+        fireEvent.click(walletHeaders[0]);
+      });
+
+      // Wallet 1 collapsed, Wallet 2 still visible
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).toBeInTheDocument();
+
+      // Collapse Wallet 2
+      await act(async () => {
+        fireEvent.click(walletHeaders[1]);
+      });
+
+      // Both wallets now collapsed
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).not.toBeInTheDocument();
+
+      // Expand Wallet 1 again
+      await act(async () => {
+        fireEvent.click(walletHeaders[0]);
+      });
+
+      // Wallet 1 now visible, Wallet 2 still collapsed
+      expect(
+        screen.getByTestId(`multichain-account-cell-${walletOneGroupId}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`multichain-account-cell-${walletTwoGroupId}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('Trace events', () => {
     it('ends AccountList and ShowAccountList traces on mount', () => {
       renderComponent();

--- a/ui/components/ui/virtualized-list/virtualized-list.tsx
+++ b/ui/components/ui/virtualized-list/virtualized-list.tsx
@@ -29,6 +29,8 @@ export const VirtualizedList = <TItem,>({
     getScrollElement: () =>
       disabled ? null : (scrollContainerRef?.current ?? null),
     estimateSize: () => estimatedItemSize,
+    getItemKey: (index) =>
+      keyExtractor ? keyExtractor(data[index], index) : index,
     overscan,
     initialOffset: scrollContainerRef?.current?.scrollTop,
   });
@@ -68,7 +70,7 @@ export const VirtualizedList = <TItem,>({
           const item = data[virtualItem.index];
           const key = keyExtractor
             ? keyExtractor(item, virtualItem.index)
-            : virtualItem.index.toString();
+            : virtualItem.key.toString();
 
           return (
             <div


### PR DESCRIPTION
## **Description**

This PR adds collapsible wallet sections to the MultichainAccountList component on the Accounts page, allowing users to collapse and expand wallet sections (including pinned accounts) to better organize their accounts view.

Currently, users with multiple wallets and many accounts have limited ability to manage the visual organization of their accounts. This PR extends the existing collapse functionality (previously only available for hidden accounts) to all wallet sections and the pinned accounts section.

**Implementation approach:**
- Added `collapsedSectionKeys` Set to track which sections are collapsed
- Enhanced the `header` ListItem type to support collapsible sections with `sectionKey`, `isCollapsible`, and `isExpanded` properties
- Wallet headers and pinned section header are now clickable buttons with expand/collapse arrow indicators
- All sections are expanded by default and can be independently collapsed
- Improved virtualizer integration using `getItemKey` config to ensure proper React reconciliation during collapse/expand

**Technical details:**
- Sections conditionally include/exclude items from the data array based on collapse state
- Uses `getItemKey` in virtualizer config for stable keys during list changes
- No forced remounting - virtualizer handles height recalculation naturally

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39645?quickstart=1)

## **Changelog**

CHANGELOG entry: Added ability to collapse wallet sections in the Accounts page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-678
Supersedes: #39583

## **Manual testing steps**

1. Open MetaMask extension
2. Navigate to the Accounts page (click account icon)
3. Verify you see multiple wallet sections with headers (e.g., \"Wallet 1\", \"Ledger\")
4. If you have pinned accounts, verify the \"Pinned\" section header is also present
5. Click on any section header (Pinned, Wallet 1, Wallet 2, etc.)
6. Verify the section collapses (accounts hidden, arrow changes from up to down)
7. Click the header again
8. Verify the section expands (accounts shown, arrow changes from down to up)
9. Test collapsing multiple sections independently
10. Verify hidden accounts section still works as expected
11. Add a new account and verify it appears in the correct section
12. Collapse and expand repeatedly to ensure no spacing issues or visual glitches

## **Screenshots/Recordings**

### **Before**

Wallet headers were not interactive - all wallets were always expanded. Only the hidden accounts section could be collapsed.

https://github.com/user-attachments/assets/c0229ede-361b-4ae5-82a2-08a943a07be0

### **After**

All section headers (Pinned, Wallet 1, Wallet 2, etc.) are now clickable buttons with collapse/expand arrows. Each section can be independently collapsed to hide its accounts.

https://github.com/user-attachments/assets/ab16d655-e70a-4715-9275-211d228d611f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes list rendering/state and virtualized keying, which could cause subtle UI/scroll/reconciliation issues when collapsing/expanding sections.
> 
> **Overview**
> Adds **collapsible section headers** to `MultichainAccountList` for both the *Pinned* section and each wallet section, tracking collapsed state via a `collapsedSectionKeys` set and conditionally omitting section items from the list data.
> 
> Updates header rendering to be a clickable button with `aria-expanded` and an up/down arrow indicator, and adds unit tests covering wallet, pinned, and independent multi-section collapse behavior.
> 
> Improves `VirtualizedList` stability by wiring `keyExtractor` into `useVirtualizer` via `getItemKey` and using the virtualizer-provided key when no extractor is given.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e086d46b21d6d4f2a441445cc94d97fb18090c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->