### PR TITLE
chore: Fix misleading comment in workflow

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -88,7 +88,7 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-dist:
-    # This if statement is equivalent to IS_FORK
+    # This if statement is equivalent to !IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -68,7 +68,7 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-firefox-dist:
-    # This if statement is equivalent to IS_FORK
+    # This if statement is equivalent to !IS_FORK
     if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:


### PR DESCRIPTION
## **Description**

These two comments were updated to better reflect the purpose of the condition.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39649?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes in GitHub Actions workflows; no job conditions or commands were modified.
> 
> **Overview**
> Updates the inline comment above the `if:` guard for the `*-dist` E2E jobs in `e2e-chrome.yml` and `e2e-firefox.yml` to correctly state that the condition is equivalent to `!IS_FORK` (not `IS_FORK`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3ca04dc4e95950a93da0f606aa0a831f869f844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->