### PR TITLE
fix: update cancel/speedup modal UI and migrate to non-deprecated components

### DIFF
--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
@@ -1,13 +1,15 @@
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import React, { useEffect } from 'react';
-import { EditGasModes, PriorityLevels } from '../../../../shared/constants/gas';
 import {
-  AlignItems,
-  Display,
-  FlexDirection,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Text,
+  TextButton,
   TextVariant,
-} from '../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
+import { EditGasModes, PriorityLevels } from '../../../../shared/constants/gas';
 import { getAppIsLoading } from '../../../selectors';
 import { gasEstimateGreaterThanGasUsedPlusTenPercent } from '../../../helpers/utils/gas';
 import {
@@ -17,18 +19,15 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTransactionModalContext } from '../../../contexts/transaction-modal';
 import GasDetailsItem from '../../../pages/confirmations/components/gas-details-item';
-import Box from '../../ui/box';
 import InfoTooltip from '../../ui/info-tooltip';
 import AppLoadingSpinner from '../app-loading-spinner';
 import {
-  Text,
-  Button,
-  ButtonLink,
   Modal,
   ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
 } from '../../component-library';
-import { ModalContent } from '../../component-library/modal-content/deprecated';
-import { ModalHeader } from '../../component-library/modal-header/deprecated';
 
 const CancelSpeedupPopoverWrapped = () => {
   const {
@@ -103,59 +102,54 @@ const CancelSpeedupPopoverWrapped = () => {
           onClose={() => closeModal(['cancelSpeedUpTransaction'])}
           marginBottom={4}
         >
-          {editGasMode === EditGasModes.cancel
-            ? `❌${t('cancel')}`
-            : `🚀${t('speedUp')}`}
+          {editGasMode === EditGasModes.cancel ? t('cancel') : t('speedUp')}
         </ModalHeader>
 
         <AppLoadingSpinner className="cancel-speedup-popover__spinner" />
         <div className="cancel-speedup-popover__wrapper">
           <Text
-            alignItems={AlignItems.center}
-            display={Display.Flex}
-            variant={TextVariant.bodySm}
-            marginBottom={2}
-            paddingBottom={2}
-            className="cancel-speedup-popover__description"
+            className="cancel-speedup-popover__description flex items-center mb-2 pb-2"
+            variant={TextVariant.BodySm}
           >
-            {t('cancelSpeedUpLabel', [
-              <strong key="cancelSpeedupReplace">{t('replace')}</strong>,
-            ])}
+            {t('cancelSpeedUpLabel', [t('replace')])}
             <InfoTooltip
               position="top"
               contentText={
                 <>
-                  <Text variant={TextVariant.bodySm}>
+                  <Text variant={TextVariant.BodySm}>
                     {t('cancelSpeedUpTransactionTooltip', [
                       editGasMode === EditGasModes.cancel
                         ? t('cancel')
                         : t('speedUp'),
                     ])}
                   </Text>
-                  <ButtonLink
-                    variant={TextVariant.bodySm}
-                    href="https://community.metamask.io/t/how-to-speed-up-or-cancel-transactions-on-metamask/3296"
-                    target="_blank"
-                  >
-                    {t('learnMoreUpperCase')}
-                  </ButtonLink>
+                  <TextButton asChild className="inline">
+                    <a
+                      href="https://community.metamask.io/t/how-to-speed-up-or-cancel-transactions-on-metamask/3296"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {t('learnMoreUpperCase')}
+                    </a>
+                  </TextButton>
                 </>
               }
             />
           </Text>
           <Box
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            flexDirection={FlexDirection.Column}
-            marginTop={2}
-            paddingBottom={4}
+            alignItems={BoxAlignItems.Center}
+            flexDirection={BoxFlexDirection.Column}
+            className="mt-2"
           >
             <div className="cancel-speedup-popover__gas-details">
               <GasDetailsItem />
             </div>
           </Box>
-          <Button onClick={submitTransactionChange}>{t('submit')}</Button>
         </div>
+        <ModalFooter
+          onSubmit={submitTransactionChange}
+          submitButtonProps={{ children: t('submit') }}
+        />
       </ModalContent>
     </Modal>
   );

--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
@@ -126,14 +126,14 @@ describe('CancelSpeedupPopover', () => {
     jest.clearAllMocks();
   });
 
-  it('should have ❌Cancel in header if editGasMode is cancel', async () => {
+  it('should have Cancel in header if editGasMode is cancel', async () => {
     await act(async () => render());
-    expect(screen.queryByText('❌Cancel')).toBeInTheDocument();
+    expect(screen.queryByText('Cancel')).toBeInTheDocument();
   });
 
-  it('should have 🚀Speed up in header if editGasMode is speedup', async () => {
+  it('should have Speed up in header if editGasMode is speedup', async () => {
     await act(async () => render({ editGasMode: EditGasModes.speedUp }));
-    expect(screen.queryByText('🚀Speed up')).toBeInTheDocument();
+    expect(screen.queryByText('Speed up')).toBeInTheDocument();
   });
 
   it('information tooltip should contain the correct text if editGasMode is cancel', async () => {


### PR DESCRIPTION
## **Description**

This PR addresses several UI papercuts in the cancel and speedup transaction modals by removing emojis, updating button styling, removing bold text formatting, and migrating from deprecated Modal components to their current versions.

The modals had several UI issues identified in MDP-485, MDP-486, and MDP-491: emoji decorations felt out of place, the submit button wasn't full-width, and bold text made the description too prominent. Additionally, the component was using deprecated Modal components scheduled for removal.

Changes included:
- Removed emoji decorations from modal header titles (❌, 🚀) for a cleaner, more professional appearance
- Migrated from deprecated `ModalHeader` and `ModalContent` imports to current component library versions
- Replaced deprecated `ButtonLink` with `TextButton` using the asChild pattern for proper link semantics
- Migrated from deprecated `Box` and design-system constants to `@metamask/design-system-react` components
- Replaced standalone submit `Button` with `ModalFooter` component for consistent full-width button styling
- Removed bold `<strong>` tag from description text to match design specs
- Fixed `TextVariant` enum usage to use PascalCase (BodySm) instead of camelCase (bodySm)
- Updated tests to reflect emoji removal and component changes

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39661?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed cancel and speedup modal UI by removing emojis, standardizing button width, and migrating to current component versions

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-485
Fixes: https://consensyssoftware.atlassian.net/browse/MDP-486
Fixes: https://consensyssoftware.atlassian.net/browse/MDP-491

## **Manual testing steps**

1. Create a transaction (e.g., send ETH)
2. Click "Speed up" on the pending transaction
3. Verify the modal header shows "Speed up" (without rocket emoji)
4. Verify the submit button is full width at the bottom
5. Verify the description text is not bold
6. Verify the "Learn more" link works correctly
7. Close the modal
8. Click "Cancel" on the pending transaction
9. Verify the modal header shows "Cancel" (without X emoji)
10. Verify the submit button is full width at the bottom
11. Verify the description text is not bold

## **Screenshots/Recordings**

### **Before**

- Header had emoji decorations (❌Cancel, 🚀Speed up)
- Submit button was not full width
- Description text had bold formatting

https://github.com/user-attachments/assets/0cce49c1-1cec-45ba-88ce-94ad6add26c7

### **After**

- Header has clean text without emojis (Cancel, Speed up)
- Submit button is full width using ModalFooter
- Description text uses normal font weight

https://github.com/user-attachments/assets/a5d3914c-6af1-4798-a3fd-9230c76a592f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.