### PR TITLE
fix: fixtures app version ignore list

### DIFF
--- a/test/e2e/fixtures/fixture-validation.ts
+++ b/test/e2e/fixtures/fixture-validation.ts
@@ -55,7 +55,7 @@ const getFixtureIgnoredKeys = (): string[] => [
   // Environment-specific values that differ per machine
   'data.AppStateController.browserEnvironment.os',
   // Version that changes on every release
-  'data.AppStateController.currentAppVersion',
+  'data.AppMetadataController.currentAppVersion',
 ];
 
 /**

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -36,6 +36,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
+      "currentAppVersion": "13.17.0",
       "currentMigrationVersion": 190,
       "previousAppVersion": "",
       "previousMigrationVersion": 0

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -36,7 +36,6 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentAppVersion": "13.17.0",
       "currentMigrationVersion": 190,
       "previousAppVersion": "",
       "previousMigrationVersion": 0


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There was a bug in the ignore list for fixture validation, which didn't ignore the currentAppVersion.
This has been fixed.
The entry was as well in the json file, so this has now been removed, to avoid confusion and to avoid having an outdated version. This will now be autogenerated


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39664?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates E2E test fixtures/validation to treat app version as a volatile field, with no production logic changes.
> 
> **Overview**
> Fixes E2E fixture validation to ignore the app version field by updating the ignore list entry from `data.AppStateController.currentAppVersion` to `data.AppMetadataController.currentAppVersion`.
> 
> Removes the hardcoded `currentAppVersion` value from `onboarding-fixture.json` so the fixture no longer becomes stale on each release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d14fd8e9455a5a055ee03199c52efa428ea232cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->