### PR TITLE
chore: Add Yarn plugin for using preview builds

### DIFF
--- a/.yarn/plugins/@yarnpkg/plugin-preview-builds.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-preview-builds.cjs
@@ -1,0 +1,555 @@
+/**
+ * This plugin makes it easier for engineers to use preview builds (prereleases
+ * published under `@metamask-previews` or a custom NPM scope). It hooks into
+ * Yarn's resolution workflow to alias `@metamask` dependencies to specific
+ * versions of preview packages.
+ *
+ * It assumes that preview builds have been specified using a `previewBuilds`
+ * key in `package.json`, for example, this would alias whatever version of
+ * `@metamask/network-controller` is being used to
+ * `@metamask-previews/network-controller@29.0.0-preview-3ec2a74`.
+ *
+ *     "previewBuilds": {
+ *       "@metamask/network-controller": {
+ *         "type": "non-breaking",
+ *         "previewVersion": "29.0.0-preview-3ec2a74"
+ *       }
+ *     }
+ *
+ * If a dependency is patched, the patch is preserved.
+ *
+ * There are two ways to specify the `type` within a preview build
+ * configuration. If an engineer wants to test breaking changes, they would
+ * specify `"breaking"`; otherwise they would specify `"non-breaking"`.
+ *
+ * To use a custom scope instead of `@metamask-previews`, an optional
+ * `previewScope` is supported, e.g.:
+ *
+ *     "previewBuilds": {
+ *       "@metamask/network-controller": {
+ *         "type": "non-breaking",
+ *         "previewScope": "my-custom-scope"
+ *         "previewVersion": "29.0.0-preview-3ec2a74",
+ *       }
+ *     }
+ */
+
+/**
+ * @typedef {'breaking' | 'non-breaking'} PreviewBuildType
+ *
+ * The nature of the changes in the preview build.
+
+ * For breaking changes, only the dependency at the top level will be resolved
+ * to the preview build.
+ *
+ * For non-breaking changes, all instances of the dependency that match the
+ * major part of the version range specified in `package.json` will be resolved
+ * to the preview build.
+ */
+
+/**
+ * @typedef {object} PreviewBuildConfiguration
+ * @property {PreviewBuildType} type - The nature of the changes in the preview
+ * build.
+ * @property {string} previewScope - The scope for the preview build (defaults
+ * @property {string} previewVersion - The preview version string.
+ * to "metamask-previews").
+ * @property {string} previewVersion - The preview version string.
+ */
+
+/**
+ * @typedef {Record<string, PreviewBuildConfiguration>} PreviewBuildConfigurations
+ */
+
+/**
+ * @typedef {object} ValidatedPreviewBuild
+ * @property {PreviewBuildConfiguration} configuration - The validated preview
+ * build configuration.
+ * @property {YarnDescriptor} originalDependencyDescriptor - The descriptor for
+ * the original dependency in `package.json`.
+ */
+
+/**
+ * @typedef {import('@yarnpkg/core').Configuration} YarnConfiguration
+ */
+
+/**
+ * @typedef {import('@yarnpkg/core').Descriptor} YarnDescriptor
+ */
+
+/**
+ * @typedef {import('@yarnpkg/core').Locator} YarnLocator
+ */
+
+/**
+ * @typedef {import('@yarnpkg/core').Project} YarnProject
+ */
+
+module.exports = {
+  name: '@yarnpkg/plugin-preview-builds',
+  factory: (require) => {
+    const { structUtils } = require('@yarnpkg/core');
+
+    /**
+     * The scope that all MetaMask packages are published under.
+     */
+    const METAMASK_NPM_SCOPE = 'metamask';
+
+    /**
+     * The default scope for preview builds.
+     */
+    const DEFAULT_PREVIEW_SCOPE = 'metamask-previews';
+
+    /**
+     * Stores validated preview build configurations after `validateProject` runs.
+     *
+     * @type {Map<string, ValidatedPreviewBuild>}
+     */
+    const validatedPreviewBuilds = new Map();
+
+    /**
+     * Stores resolutions for preview builds that have been created in the
+     * `reduceDependency` hook. Used to print a summary in `afterAllInstalled`.
+     *
+     * @type {Map<string, { sourceDescriptor: YarnDescriptor, targetDescriptor: YarnDescriptor, type: PreviewBuildType }>}
+     */
+    const resolutions = new Map();
+
+    /**
+     * Stores unique error messages to display after installation.
+     *
+     * @type {Set<string>}
+     */
+    const errors = new Set();
+
+    /**
+     * Extracts the major version from a SemVer-compatible version range.
+     *
+     * @param {string} semVerVersionRange - The version range (e.g., "^10.0.0",
+     * "10.2.3", ">=10.0.0").
+     * @returns {number|null} The major version number, or `null` if it can't be
+     * determined.
+     */
+    function getMajorVersion(semVerVersionRange) {
+      const cleaned = semVerVersionRange.replace(/^[\^~>=<]+/, '');
+      const match = cleaned.match(/^(\d+)/);
+      return match ? parseInt(match[1], 10) : null;
+    }
+
+    /**
+     * Checks if a Yarn descriptor represents a patched dependency.
+     *
+     * @param {string} rawDescriptorRange - The descriptor range string.
+     * @returns {boolean} True if the descriptor is a patch.
+     */
+    function isPatchedDescriptor(rawDescriptorRange) {
+      return rawDescriptorRange.startsWith('patch:');
+    }
+
+    /**
+     * Formats a Yarn descriptor range or locator reference, colorizing it like
+     * Yarn would.
+     *
+     * @param {YarnConfiguration} configuration - The Yarn configuration (used
+     * for color support detection).
+     * @param {string} rawRange - The range to format.
+     * @returns {string} The formatted range.
+     */
+    function formatRangeForDisplay(configuration, rawRange) {
+      return structUtils.prettyRange(configuration, rawRange);
+    }
+
+    /**
+     * Formats a descriptor for a dependency, colorizing it like Yarn would.
+     *
+     * @param {YarnConfiguration} configuration - The Yarn configuration (used
+     * for color support detection).
+     * @param {YarnDescriptor} descriptor - The source descriptor.
+     * @returns {string} The formatted descriptor.
+     */
+    function formatSourceForDisplay(configuration, descriptor) {
+      const locator = structUtils.makeLocator(descriptor, descriptor.range);
+      return structUtils.prettyLocator(configuration, locator);
+    }
+
+    /**
+     * Extracts the patch path from a Yarn descriptor range that represents a
+     * patched dependency.
+     *
+     * @param {string} rawDescriptorRange - The patched descriptor range, e.g.
+     * `patch:@scope/package@npm%3Aversion#path/to/patch`.
+     * @returns {string|null} The patch file path, or null if not found.
+     */
+    function extractPatchPath(rawDescriptorRange) {
+      const hashIndex = rawDescriptorRange.indexOf('#');
+      if (hashIndex === -1) {
+        return null;
+      }
+      return rawDescriptorRange.slice(hashIndex + 1);
+    }
+
+    /**
+     * Reads the preview builds configuration from the project's package.json,
+     * adding default values for optional properties.
+     *
+     * @param {YarnProject} project - The Yarn project object.
+     * @returns {PreviewBuildConfigurations} The value of the `previewBuilds`
+     * key in `package.json`, or an empty object if it isn't present.
+     */
+    function getPreviewBuildConfigurations(project) {
+      /** @type {{ previewBuilds?: PreviewBuildConfigurations }} */
+      const rawManifest = project.topLevelWorkspace.manifest.raw;
+      const rawPreviewBuilds = rawManifest.previewBuilds ?? {};
+
+      return Object.entries(rawPreviewBuilds).reduce(
+        (previewBuilds, [packageName, config]) => {
+          previewBuilds[packageName] = {
+            ...config,
+            previewScope: config.previewScope ?? DEFAULT_PREVIEW_SCOPE,
+          };
+          return previewBuilds;
+        },
+        /** @type {PreviewBuildConfigurations} */ ({}),
+      );
+    }
+
+    /**
+     * Gets the Yarn descriptor for a dependency from the root manifest.
+     *
+     * @param {YarnProject} project - The Yarn project object.
+     * @param {string} packageName - The package name to look up (e.g.,
+     * "@metamask/foo").
+     * @returns {YarnDescriptor | null} The descriptor, or null if not found.
+     */
+    function getDependencyDescriptorFromManifest(project, packageName) {
+      const ident = structUtils.parseIdent(packageName);
+      const manifest = project.topLevelWorkspace.manifest;
+      return manifest.dependencies.get(ident.identHash) ?? null;
+    }
+
+    /**
+     * Extracts the version range from a Yarn descriptor range.
+     * Handles `patch:` protocol, `npm:` protocol, and plain version ranges.
+     *
+     * @param {string} rawDescriptorRange - The descriptor range string.
+     * @returns {string} The extracted version range.
+     */
+    function extractVersionFromRange(rawDescriptorRange) {
+      // `patch:<source>#<patchPath>::<params>`
+      if (isPatchedDescriptor(rawDescriptorRange)) {
+        const parsed = structUtils.parseRange(rawDescriptorRange);
+        // `source` contains the original descriptor like "@<scope>/<name>@npm:<version>"
+        if (!parsed.source) {
+          throw new Error(
+            `Could not extract source from patch range: ${rawDescriptorRange}`,
+          );
+        }
+        return extractVersionFromRange(parsed.source);
+      }
+
+      // `npm:<version>` or `npm:@<scope>/<name>@<version>`
+      if (rawDescriptorRange.startsWith('npm:')) {
+        const { selector } = structUtils.parseRange(rawDescriptorRange);
+        // Try to parse as a descriptor (for aliased packages like
+        // `@<scope>/<name>@<version>`)
+        const descriptor = structUtils.tryParseDescriptor(selector, true);
+        if (descriptor) {
+          return descriptor.range;
+        }
+        // It's just a version range
+        return selector;
+      }
+
+      // Plain version range (e.g., `^10.0.0`)
+      return rawDescriptorRange;
+    }
+
+    /**
+     * Ensures that a preview build configuration object has the correct keys
+     * and that the `type` has a valid value.
+     *
+     * @param {PreviewBuildConfiguration} previewBuildConfiguration - The
+     * preview build configuration to validate.
+     * @param {string} packageName - The package name for error messages.
+     * @returns {string | null} Error message if validation fails, otherwise
+     * `null`.
+     */
+    function validatePreviewBuildConfiguration(
+      previewBuildConfiguration,
+      packageName,
+    ) {
+      if (
+        typeof previewBuildConfiguration !== 'object' ||
+        previewBuildConfiguration === null ||
+        Array.isArray(previewBuildConfiguration)
+      ) {
+        return `Invalid preview build configuration for \`${packageName}\`: Expected an object`;
+      }
+
+      const { type, previewVersion } = previewBuildConfiguration;
+      const subErrors = [];
+
+      if (!type) {
+        subErrors.push('Missing \`type\`');
+      }
+
+      if (!previewVersion) {
+        subErrors.push('Missing \`previewVersion\`');
+      }
+
+      if (type && type !== 'breaking' && type !== 'non-breaking') {
+        subErrors.push(
+          `Invalid \`type\` "${type}" (must be "breaking" or "non-breaking")`,
+        );
+      }
+
+      if (subErrors.length > 0) {
+        return `Invalid preview build configuration for \`${packageName}\`: ${subErrors.join('; ')}`;
+      }
+
+      return null;
+    }
+
+    /**
+     * Determines what effect a configured preview build has on instances of the
+     * dependency in the dependency tree.
+     *
+     * For breaking changes, only the dependency at the top level will be
+     * resolved to the preview build.
+     *
+     * For non-breaking changes, all instances of the dependency that match the
+     * major part of the version range specified in `package.json` will be
+     * resolved to the preview build.
+     *
+     * @param {YarnDescriptor} dependency - The Yarn descriptor for a dependency
+     * in the dependency tree.
+     * @param {YarnLocator} locator - The Yarn locator for a dependency in the
+     * dependency tree.
+     * @param {ValidatedPreviewBuild} validatedPreviewBuild - Information about
+     * the preview build that corresponds to the dependency.
+     * @returns {boolean} True if the dependency should be resolved to the
+     * preview build, false otherwise.
+     */
+    function shouldResolveDependencyToPreviewBuild(
+      dependency,
+      locator,
+      validatedPreviewBuild,
+    ) {
+      const {
+        configuration: { type },
+        originalDependencyDescriptor,
+      } = validatedPreviewBuild;
+
+      if (type === 'breaking') {
+        return locator.reference === 'workspace:.';
+      }
+
+      const rootDependencyMajorVersion = getMajorVersion(
+        extractVersionFromRange(originalDependencyDescriptor.range),
+      );
+      const dependencyMajorVersion = getMajorVersion(
+        extractVersionFromRange(dependency.range),
+      );
+      return (
+        rootDependencyMajorVersion !== null &&
+        dependencyMajorVersion !== null &&
+        rootDependencyMajorVersion === dependencyMajorVersion
+      );
+    }
+
+    /**
+     * Constructs a Yarn descriptor for a dependency that will be used to
+     * resolve it to a preview build.
+     *
+     * @param {YarnDescriptor} dependency - The Yarn descriptor for a
+     * dependency in the dependency tree.
+     * @param {ValidatedPreviewBuild} validatedPreviewBuild - The validated
+     * preview build configuration.
+     * @returns {YarnDescriptor} A new descriptor pointing to the preview build.
+     */
+    function createPreviewBuildDescriptor(dependency, validatedPreviewBuild) {
+      const {
+        configuration: { previewScope, previewVersion },
+        originalDependencyDescriptor,
+      } = validatedPreviewBuild;
+
+      const previewPackageName = `@${previewScope}/${dependency.name}`;
+      const dependencyRange = originalDependencyDescriptor.range;
+
+      let newRange;
+      if (isPatchedDescriptor(dependencyRange)) {
+        const patchPath = extractPatchPath(dependencyRange);
+        if (patchPath) {
+          newRange = `patch:${previewPackageName}@npm%3A${previewVersion}#${patchPath}`;
+        } else {
+          newRange = `npm:${previewPackageName}@${previewVersion}`;
+        }
+      } else {
+        newRange = `npm:${previewPackageName}@${previewVersion}`;
+      }
+
+      return structUtils.makeDescriptor(
+        structUtils.makeIdent(dependency.scope, dependency.name),
+        newRange,
+      );
+    }
+
+    return {
+      hooks: {
+        /**
+         * Validates the `previewBuilds` key in `package.json` before resolution
+         * starts, ensuring all packages specified there correspond to an entry
+         * in `dependencies`, and that the configuration objects are valid.
+         *
+         * @param {YarnProject} project - The Yarn project.
+         */
+        validateProject: async (project) => {
+          const previewBuildConfigurations =
+            getPreviewBuildConfigurations(project);
+          const packageNames = Object.keys(previewBuildConfigurations);
+
+          if (packageNames.length === 0) {
+            return;
+          }
+
+          for (const packageName of packageNames) {
+            const previewBuildConfiguration =
+              previewBuildConfigurations[packageName];
+
+            const error = validatePreviewBuildConfiguration(
+              previewBuildConfiguration,
+              packageName,
+            );
+            if (error) {
+              errors.add(error);
+              continue;
+            }
+
+            const originalDependencyDescriptor =
+              getDependencyDescriptorFromManifest(project, packageName);
+            if (!originalDependencyDescriptor) {
+              errors.add(
+                `\`${packageName}\` is configured in \`previewBuilds\`, but not found in \`dependencies\``,
+              );
+              continue;
+            }
+
+            validatedPreviewBuilds.set(packageName, {
+              configuration: previewBuildConfiguration,
+              originalDependencyDescriptor,
+            });
+          }
+        },
+
+        /**
+         * Yarn calls this during the resolution phase for each dependency in
+         * the dependency tree.
+         *
+         * This hook allows us to resolve `@metamask` packages to associated
+         * preview builds.
+         *
+         * @param {YarnDescriptor} dependency - The dependency being resolved.
+         * @param {YarnProject} project - The Yarn project.
+         * @param {YarnLocator} locator - The parent package locator.
+         * @returns {Promise<YarnDescriptor>} The resolved descriptor.
+         */
+        reduceDependency: async (dependency, _project, locator) => {
+          if (dependency.scope !== METAMASK_NPM_SCOPE) {
+            return dependency;
+          }
+
+          const packageName = `@${dependency.scope}/${dependency.name}`;
+
+          const validatedPreviewBuild = validatedPreviewBuilds.get(packageName);
+          if (!validatedPreviewBuild) {
+            return dependency;
+          }
+
+          if (
+            !shouldResolveDependencyToPreviewBuild(
+              dependency,
+              locator,
+              validatedPreviewBuild,
+            )
+          ) {
+            return dependency;
+          }
+
+          const previewBuildDescriptor = createPreviewBuildDescriptor(
+            dependency,
+            validatedPreviewBuild,
+          );
+
+          const resolutionKey = dependency.descriptorHash;
+          resolutions.set(resolutionKey, {
+            sourceDescriptor: dependency,
+            targetDescriptor: previewBuildDescriptor,
+            type: validatedPreviewBuild.configuration.type,
+          });
+
+          return previewBuildDescriptor;
+        },
+
+        /**
+         * Yarn calls this hook after all packages have been installed.
+         *
+         * This hook is used to print summary information and clear caches.
+         *
+         * @param {YarnProject} project - The Yarn project.
+         */
+        afterAllInstalled: (project) => {
+          const { configuration } = project;
+
+          if (errors.size > 0) {
+            console.log('');
+            console.error(
+              `[plugin-preview-builds] Preview build configurations were not processed due to the following errors:`,
+            );
+            errors.forEach((error) => {
+              console.error(`  - ${error}`);
+            });
+            console.log('');
+          }
+
+          if (resolutions.size > 0) {
+            const workspaceLocator = project.topLevelWorkspace.anchoredLocator;
+            console.log('');
+            console.log(
+              `[plugin-preview-builds] The following dependencies were mapped to preview builds:`,
+            );
+            for (const {
+              sourceDescriptor,
+              targetDescriptor,
+              type,
+            } of resolutions.values()) {
+              const source = formatSourceForDisplay(
+                configuration,
+                sourceDescriptor,
+              );
+              const target = formatRangeForDisplay(
+                configuration,
+                targetDescriptor.range,
+              );
+              const isPatched = isPatchedDescriptor(targetDescriptor.range);
+              const arrow = isPatched ? '\n  -> ' : ' -> ';
+              if (type === 'breaking') {
+                const prettyWorkspace = structUtils.prettyLocator(
+                  configuration,
+                  workspaceLocator,
+                );
+                console.log(`- ${prettyWorkspace}/${source}${arrow}${target}`);
+              } else {
+                console.log(`- ${source}${arrow}${target}`);
+              }
+            }
+            console.log('');
+          }
+
+          validatedPreviewBuilds.clear();
+          resolutions.clear();
+          errors.clear();
+        },
+      },
+    };
+  },
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -68,6 +68,7 @@ plugins:
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
     spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
+  - path: .yarn/plugins/@yarnpkg/plugin-preview-builds.cjs
 
 # Configure the NPM minimal age gate to 3 days, meaning packages must be at
 # least 3 days old to be installed.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some MetaMask repos (e.g. `core`) allow upcoming package changes to be tested in Extension and/or Mobile prior to release by publishing "preview builds".

However, using a preview build can be complicated, as care must be taken to accurately simulate what the dependency tree of a project will look like when a new production version is released.

To make this process easier, this commit adds a Yarn plugin. The plugin works like this:

1. First, you must tell the plugin which preview builds you want to use for which dependencies. You do this by adding an entry to a `previewBuilds` section in `package.json`. For instance, to specify that version `29.0.0-preview-3ec2a74` should be used to test non-breaking changes to `@metamask/network-controller`, you would add:

        "previewBuilds": {
          "@metamask/network-controller": {
            "type": "non-breaking",
            "previewVersion": "29.0.0-preview-3ec2a74"
          }
        }

    Similarly, you could set `type` to "breaking" to test breaking changes.

    By default the plugin will assume the NPM scope of the preview build to be `metamask-previews`, but you can change this with `previewScope`:

        "previewBuilds": {
          "@metamask/network-controller": {
            "type": "non-breaking",
            "previewScope": "my-custom-scope"
            "previewVersion": "29.0.0-preview-3ec2a74",
          }
        }

2. Next, run `yarn install`. The plugin will read the `previewBuilds` section to determine how the dependencies you've specified should be resolved. If the `type` of an entry is "non-breaking", all version ranges of that dependency in the dependency tree that are major-compatible with the corresponding entry in `dependencies` will resolve to the preview build. If the `type` is "breaking", then only the version range of the corresponding entry in `dependencies` will resolve to the preview build. Finally, if a dependency is patched, the preview build will be patched in the same way.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39680?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-199

## **Manual testing steps**

- Add the following section to `package.json`:
  ```
  "previewBuilds": {
    "@metamask/network-controller": {
      "type": "breaking",
      "previewVersion": "29.0.0-preview-3ec2a74"
    }
  },
  ```
- Run `yarn install`. You should see a message at the end of the installation steps:
  ```
  [plugin-preview-builds] The following dependencies were mapped to preview builds:
  - metamask@workspace:./@metamask/network-controller@npm:^29.0.0 -> npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74
  ```
- Run `yarn why @metamask-previews/network-controller`. You should see only one entry:
  ```
  └─ metamask@workspace:.
     └─ @metamask-previews/network-controller@npm:29.0.0-preview-3ec2a74 (via npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74)
  ```
  This proves that only the root instance of `@metamask/network-controller` was updated to use the preview build.
- Update `previewBuilds` in `package.json` to read:
  ```
  "previewBuilds": {
    "@metamask/network-controller": {
      "type": "non-breaking",
      "previewVersion": "29.0.0-preview-3ec2a74"
    }
  },
  ```
- Run `yarn install`. You should see a message at the end of the installation steps:
  ```
  [plugin-preview-builds] The following dependencies were mapped to preview builds:
  - @metamask/network-controller@npm:^29.0.0 -> npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74
  ```
- Run `yarn why @metamask-previews/network-controller`. You should see a bunch of entries:
   ```
   ├─ @metamask/accounts-controller@npm:35.0.2
   │  └─ @metamask-previews/network-controller@npm:29.0.0-preview-3ec2a74 (via npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74)
   │
   ├─ @metamask/accounts-controller@npm:35.0.2 [2d27a]
   │  └─ @metamask-previews/network-controller@npm:29.0.0-preview-3ec2a74 (via npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74)
   │
   ├─ @metamask/accounts-controller@npm:35.0.2 [30658]
   │  └─ @metamask-previews/network-controller@npm:29.0.0-preview-3ec2a74 (via npm:@metamask-previews/network-controller@29.0.0-preview-3ec2a74)
   ...
   ```
  This proves that all instances of `@metamask/network-controller` matching `^29.0.0` were updated to use the preview build.
- Now take away `previewBuilds` and re-run `yarn install`.
- Now run `yarn patch @metamask/network-controller@npm:29.0.0`. Open the resulting patch directory and make a modification to any file. Run `yarn patch-commit -s <directory>` to generate the patch and update `package.json`, then run `yarn install` to apply the patch.
- Now add the following section back to `package.json`:
  ```
  "previewBuilds": {
    "@metamask/network-controller": {
      "type": "breaking",
      "previewVersion": "29.0.0-preview-3ec2a74"
    }
  },
  ```
- Run `yarn install`. You should see a message at the end of the installation steps:
  ```
  [plugin-preview-builds] The following dependencies were mapped to preview builds:
  - metamask@workspace:./@metamask/network-controller@patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch
    -> patch:@metamask-previews/network-controller@npm%3A29.0.0-preview-3ec2a74#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch
  ```
- Run `yarn why @metamask/network-controller`. You should see a bunch of entries:
  ```
  ├─ @metamask/accounts-controller@npm:35.0.2
  │  └─ @metamask/network-controller@patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch::version=29.0.0&hash=3e054c (via patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch)
  │
  ├─ @metamask/accounts-controller@npm:35.0.2 [2d27a]
  │  └─ @metamask/network-controller@patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch::version=29.0.0&hash=3e054c (via patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch)
  │
  ├─ @metamask/accounts-controller@npm:35.0.2 [30658]
  │  └─ @metamask/network-controller@patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch::version=29.0.0&hash=3e054c (via patch:@metamask/network-controller@npm%3A29.0.0#~/.yarn/patches/@metamask-network-controller-npm-29.0.0-51af044f37.patch)
  │
  ```
  This proves that the preview build is patched.

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a custom Yarn resolution plugin that can rewrite dependency ranges (including `patch:` ranges), which can affect installs across the repo if misconfigured, but is limited to `@metamask/*` packages and opt-in via `previewBuilds`.
> 
> **Overview**
> Adds a new Yarn plugin (`.yarn/plugins/@yarnpkg/plugin-preview-builds.cjs`) that reads a `previewBuilds` config from `package.json` and rewrites matching `@metamask/*` dependency resolutions to `@metamask-previews/*` (or a custom scope), supporting *breaking* (top-level only) vs *non-breaking* (major-compatible across the tree) behavior and preserving `patch:` dependencies.
> 
> Updates `.yarnrc.yml` to load the new plugin so the mapping and end-of-install summary/errors run during `yarn install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fd9d4cfc30fc80a57e5b5b779297ea208c59fa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->