### PR TITLE
chore: Minor readability improvements to the UI initialization

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -29,7 +29,8 @@ import { StreamProvider } from '@metamask/providers';
 import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
 import log from 'loglevel';
 import { ExtensionPortStream } from 'extension-port-stream';
-import launchMetaMaskUi, {
+import {
+  launchMetamaskUi,
   CriticalStartupErrorHandler,
   connectToBackground,
   displayCriticalErrorMessage,
@@ -235,19 +236,20 @@ async function loadPhishingWarningPage() {
 }
 
 async function initializeUiWithTab(
-  tab,
-  connectionStream,
+  activeTab,
+  backgroundConnection,
   windowType,
   traceContext,
   initialState,
 ) {
   try {
-    const store = await initializeUi(
-      tab,
-      connectionStream,
+    const store = await launchMetamaskUi({
+      activeTab,
+      container,
+      backgroundConnection,
       traceContext,
       initialState,
-    );
+    });
 
     endTrace({ name: TraceName.UIStartup });
 
@@ -313,21 +315,6 @@ async function queryCurrentActiveTab(windowType) {
   }
 
   return { id, title, origin, protocol, url };
-}
-
-async function initializeUi(
-  activeTab,
-  backgroundConnection,
-  traceContext,
-  initialState,
-) {
-  return await launchMetaMaskUi({
-    activeTab,
-    container,
-    backgroundConnection,
-    traceContext,
-    initialState,
-  });
 }
 
 /**

--- a/ui/index.js
+++ b/ui/index.js
@@ -89,7 +89,7 @@ export const connectToBackground = (
   });
 };
 
-export default async function launchMetamaskUi(opts) {
+export async function launchMetamaskUi(opts) {
   const { backgroundConnection, initialState } = opts;
 
   const store = await startApp(initialState, opts);


### PR DESCRIPTION
## **Description**

The UI initialization has been simplified to make it easier to read.

Changes include:
 * Remove redundant `initializeUi` wrapper function
 * Normalize `activeTab` and `backgroundConnection` parameter names
 * Normalize `launchMetamaskUi` function name and make it a named export

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39682?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity refactor, but it touches the UI boot path and changes `launchMetamaskUi` from a default export to a named export, which could break any remaining default importers at startup.
> 
> **Overview**
> Simplifies UI startup by calling `launchMetamaskUi` directly from `app/scripts/ui.js`, removing the redundant `initializeUi` wrapper and normalizing the `activeTab`/`backgroundConnection` naming.
> 
> Updates `ui/index.js` to export `launchMetamaskUi` as a **named** export (and standardizes the function name casing), requiring callers to use a named import instead of the previous default import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3ef34a68f314f0f4b2a81abcc6c65ef2fcc4fea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->