### PR TITLE
ci: Skip `check-status` step when workflow was not run

### DIFF
--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -252,8 +252,9 @@ jobs:
     name: Check whether the fixture update succeeded
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: always()
+    if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     needs:
+      - is-fork-pull-request
       - commit-updated-fixture
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}


### PR DESCRIPTION
## **Description**

The `update-onboarding-fixture` workflow was running the `check-status` step every single time it was triggered (i.e. for all comments). This was wasting resources, and made it difficult to tell in the UI which runs were the "real" ones.

The workflow has been updated to skip the `check-status` step if the workflow was not actually run, or if it was cancelled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39684?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions job gating/`needs` for the fixture update workflow, with no product code changes. Main risk is misconfigured conditions causing `check-status`/downstream notifications to be skipped unexpectedly.
> 
> **Overview**
> Avoids running the `check-status` job in `update-onboarding-fixture.yml` when the workflow is cancelled or the comment is on a fork PR.
> 
> This updates `check-status` to depend on `is-fork-pull-request` and adds a stricter `if` condition (`!cancelled()` and non-fork), reducing noisy runs and wasted CI resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900c834d7aa7e7f28575653aaf075c6771e9ab1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->