### PR TITLE
chore: wrap tab contents in error boundary

### DIFF
--- a/ui/components/app/error-boundary/error-boundary.tsx
+++ b/ui/components/app/error-boundary/error-boundary.tsx
@@ -1,0 +1,35 @@
+import React, { Component, ReactNode, ErrorInfo } from 'react';
+import { captureException } from '../../../../shared/lib/sentry';
+import { I18nContext } from '../../../contexts/i18n';
+
+type ErrorBoundaryProps = { children: ReactNode };
+type ErrorBoundaryState = { hasError: boolean };
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    captureException(error, { extra: { ...errorInfo } });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <I18nContext.Consumer>
+          {(t) => <p className="p-4 text-center">{t('somethingWentWrong')}</p>}
+        </I18nContext.Consumer>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Hex, isStrictHexString } from '@metamask/utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import ErrorBoundary from '../../app/error-boundary/error-boundary';
 import {
   ACCOUNT_OVERVIEW_TAB_KEY_TO_METAMETRICS_EVENT_NAME_MAP,
   ACCOUNT_OVERVIEW_TAB_KEY_TO_TRACE_NAME_MAP,
@@ -33,7 +34,6 @@ import NftsTab from '../../app/assets/nfts/nfts-tab';
 import TransactionList from '../../app/transaction-list';
 import UnifiedTransactionList from '../../app/transaction-list/unified-transaction-list.component';
 import { PerpsTabView } from '../../app/perps';
-import { Box } from '../../component-library';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { AccountOverviewCommonProps } from './common';
@@ -166,13 +166,13 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Tokens}
             data-testid="account-overview__asset-tab"
           >
-            <Box marginBottom={2}>
+            <ErrorBoundary key="tokens">
               <AssetList
                 showTokensLinks={showTokensLinks ?? true}
                 onClickAsset={onClickAsset}
                 safeChains={safeChains}
               />
-            </Box>
+            </ErrorBoundary>
           </Tab>
         )}
 
@@ -182,7 +182,9 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Perps}
             data-testid="account-overview__perps-tab"
           >
-            <PerpsTabView />
+            <ErrorBoundary key="perps">
+              <PerpsTabView />
+            </ErrorBoundary>
           </Tab>
         )}
 
@@ -192,13 +194,13 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.DeFi}
             data-testid="account-overview__defi-tab"
           >
-            <Box>
+            <ErrorBoundary key="defi">
               <DeFiTab
                 showTokensLinks={showTokensLinks ?? true}
                 onClickAsset={onClickDeFi}
                 safeChains={safeChains}
               />
-            </Box>
+            </ErrorBoundary>
           </Tab>
         )}
 
@@ -208,7 +210,9 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Nfts}
             data-testid="account-overview__nfts-tab"
           >
-            <NftsTab />
+            <ErrorBoundary key="nfts">
+              <NftsTab />
+            </ErrorBoundary>
           </Tab>
         )}
 
@@ -218,11 +222,13 @@ export const AccountOverviewTabs = ({
             tabKey={AccountOverviewTabKey.Activity}
             data-testid="account-overview__activity-tab"
           >
-            {showUnifiedTransactionList ? (
-              <UnifiedTransactionList />
-            ) : (
-              <TransactionList />
-            )}
+            <ErrorBoundary key="activity">
+              {showUnifiedTransactionList ? (
+                <UnifiedTransactionList />
+              ) : (
+                <TransactionList />
+              )}
+            </ErrorBoundary>
           </Tab>
         )}
       </Tabs>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Wrap each home screen tab in their own error boundaries

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39685?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

|Before|After|
|---|---|
|<img width="424" height="430" alt="image" src="https://github.com/user-attachments/assets/b839f965-2b8f-454c-b060-0145ed079ea0" />|<img width="426" height="355" alt="image" src="https://github.com/user-attachments/assets/367b34a8-cd78-4f5e-b0bf-0404324fe241" />|

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI resilience change: it mainly adds error isolation and Sentry reporting around tab content. Main concern is masking underlying UI errors behind a generic fallback message in individual tabs.
> 
> **Overview**
> **Adds a new `ErrorBoundary` component** that catches render errors, reports them via `captureException`, and displays a localized `somethingWentWrong` fallback.
> 
> **Wraps each Account Overview tab’s content** (`tokens`, `perps`, `defi`, `nfts`, `activity`) in its own `ErrorBoundary` so a crash in one tab doesn’t take down the entire home screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aaddbad8b9cce7731dc1c3be908412bf7b5bd2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->