### PR TITLE
fix: cp-13.17.0 add support for CAIP in useRefreshSmartTransactionsLiveness

### DIFF
--- a/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.ts
+++ b/ui/pages/bridge/hooks/useRefreshSmartTransactionsLiveness.ts
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { isCaipChainId, Hex, CaipChainId } from '@metamask/utils';
 import { getAllowedSmartTransactionsChainIds } from '../../../../shared/constants/smartTransactions';
 import { getSmartTransactionsPreferenceEnabled } from '../../../../shared/modules/selectors';
 import { fetchSmartTransactionsLiveness } from '../../../store/actions';
 import { isNonEvmChain } from '../../../ducks/bridge/utils';
+import { convertCaipToHexChainId } from '../../../../shared/modules/network.utils';
 
 /**
  * Hook that fetches smart transactions liveness for a given chain.
@@ -13,7 +15,7 @@ import { isNonEvmChain } from '../../../ducks/bridge/utils';
  * @param chainId - The chain ID to check for STX support (string or null/undefined).
  */
 export function useRefreshSmartTransactionsLiveness(
-  chainId: string | null | undefined,
+  chainId: Hex | CaipChainId | null | undefined,
 ): void {
   const smartTransactionsOptInStatus = useSelector(
     getSmartTransactionsPreferenceEnabled,
@@ -28,9 +30,13 @@ export function useRefreshSmartTransactionsLiveness(
       return;
     }
 
+    const chainIdHex = isCaipChainId(chainId)
+      ? convertCaipToHexChainId(chainId)
+      : chainId;
+
     // TODO: will be replaced with feature flags once we have them.
     const allowedChainId = getAllowedSmartTransactionsChainIds().find(
-      (id) => id === chainId,
+      (id) => id === chainIdHex,
     );
 
     if (allowedChainId) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `getFromChain` now returns CAIP formatted chains which were not supported by the `useRefreshSmartTransactionsLiveness` hook. Liveness was not fetched, disabling STX/sendBundle gasless swaps. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39686?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39712

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that normalizes CAIP `eip155:*` chain IDs to hex before checking allowed networks and fetching liveness, with accompanying unit test coverage.
> 
> **Overview**
> Fixes Smart Transactions liveness refresh on the Bridge page when the source chain ID is provided in CAIP format.
> 
> `useRefreshSmartTransactionsLiveness` now accepts `Hex | CaipChainId` and converts CAIP `eip155:*` IDs to hex via `convertCaipToHexChainId` before comparing against the allowed chain list and calling `fetchSmartTransactionsLiveness`. Tests were updated to cover CAIP input and adjust mocks/types accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6367c5959b357db547be28322a528e1022d27e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->