### PR TITLE
chore: reduce eip155 magic strings

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -17,6 +17,7 @@ import {
   isBtcTestnetAddress,
   isTronAddress,
 } from '../../../../shared/lib/multichain/accounts';
+import { toMultiChainAccountId } from '../../../../shared/lib/asset-utils';
 import {
   EstimatedPointsDto,
   EstimatePointsDto,
@@ -452,10 +453,10 @@ export class RewardsController extends BaseController<
   #getAccountState(account: CaipAccountId): RewardsAccountState | null {
     let accState = null;
     if (account?.startsWith('eip155')) {
+      const address = account.split(':')[2];
       accState =
-        this.state.rewardsAccounts[
-          `eip155:0:${account.split(':')[2]?.toLowerCase()}`
-        ] || this.state.rewardsAccounts[`eip155:0:${account.split(':')[2]}`];
+        this.state.rewardsAccounts[toMultiChainAccountId(address)] ||
+        this.state.rewardsAccounts[toMultiChainAccountId(address)];
     }
     if (!accState) {
       accState = this.state.rewardsAccounts[account];

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -17,7 +17,7 @@ import {
   isBtcTestnetAddress,
   isTronAddress,
 } from '../../../../shared/lib/multichain/accounts';
-import { toMultiChainAccountId } from '../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../shared/lib/multichain/scope-utils';
 import {
   EstimatedPointsDto,
   EstimatePointsDto,
@@ -454,7 +454,10 @@ export class RewardsController extends BaseController<
     let accState = null;
     if (account?.startsWith('eip155')) {
       const address = account.split(':')[2];
-      accState = this.state.rewardsAccounts[toMultiChainAccountId(address)];
+      accState =
+        this.state.rewardsAccounts[
+          toEvmCaipAccountId(address?.toLowerCase())
+        ] || this.state.rewardsAccounts[toEvmCaipAccountId(address)];
     }
     if (!accState) {
       accState = this.state.rewardsAccounts[account];

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -454,9 +454,7 @@ export class RewardsController extends BaseController<
     let accState = null;
     if (account?.startsWith('eip155')) {
       const address = account.split(':')[2];
-      accState =
-        this.state.rewardsAccounts[toMultiChainAccountId(address)] ||
-        this.state.rewardsAccounts[toMultiChainAccountId(address)];
+      accState = this.state.rewardsAccounts[toMultiChainAccountId(address)];
     }
     if (!accState) {
       accState = this.state.rewardsAccounts[account];

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -9,6 +9,7 @@ import {
   isStrictHexString,
   parseCaipAssetType,
   KnownCaipNamespace,
+  CaipAccountId,
 } from '@metamask/utils';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -250,3 +251,14 @@ export const isTronResource = (asset: Asset): boolean => {
     asset.symbol?.toLowerCase() as TronResourceSymbol,
   );
 };
+
+/**
+ * Converts an Ethereum account address to a multi-chain CAIP account reference.
+ * Uses the special chain ID 0 to represent "all EVM chains" for API compatibility.
+ *
+ * @param accountAddress - The Ethereum account address
+ * @returns The multi-chain CAIP account reference in format "eip155:0:address"
+ */
+export function toMultiChainAccountId(accountAddress: string) {
+  return `eip155:0:${accountAddress}` as CaipAccountId;
+}

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -9,7 +9,6 @@ import {
   isStrictHexString,
   parseCaipAssetType,
   KnownCaipNamespace,
-  CaipAccountId,
 } from '@metamask/utils';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -251,14 +250,3 @@ export const isTronResource = (asset: Asset): boolean => {
     asset.symbol?.toLowerCase() as TronResourceSymbol,
   );
 };
-
-/**
- * Converts an Ethereum account address to a multi-chain CAIP account reference.
- * Uses the special chain ID 0 to represent "all EVM chains" for API compatibility.
- *
- * @param accountAddress - The Ethereum account address
- * @returns The multi-chain CAIP account reference in format "eip155:0:address"
- */
-export function toMultiChainAccountId(accountAddress: string) {
-  return `eip155:0:${accountAddress}` as CaipAccountId;
-}

--- a/shared/lib/multichain/scope-utils.ts
+++ b/shared/lib/multichain/scope-utils.ts
@@ -4,6 +4,7 @@ import {
   CaipChainId,
   CaipNamespace,
   CaipAccountId,
+  toCaipAccountId,
 } from '@metamask/utils';
 import { EthScope } from '@metamask/keyring-api';
 // eslint-disable-next-line import/no-restricted-paths
@@ -185,3 +186,14 @@ export const getCaip25AccountIdsFromAccountGroupAndScope = (
 
   return Array.from(updatedSelectedCaipAccountAddresses);
 };
+
+/**
+ * Converts an Ethereum account address to an EVM wildcard CAIP account ID.
+ * Uses the special chain reference "0" to represent "all EVM chains" for API compatibility.
+ *
+ * @param accountAddress - The Ethereum account address
+ * @returns The EVM wildcard CAIP account ID in format "eip155:0:address"
+ */
+export function toEvmCaipAccountId(accountAddress: string): CaipAccountId {
+  return toCaipAccountId(KnownCaipNamespace.Eip155, '0', accountAddress);
+}

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -3,7 +3,7 @@ import { isObject } from 'lodash';
 import { ACCOUNT_1, ACCOUNT_2, WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
-import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../shared/lib/multichain/scope-utils';
 import ConnectAccountConfirmation from '../../../page-objects/pages/confirmations/connect-account-confirmation';
 import EditConnectedAccountsModal from '../../../page-objects/pages/dialog/edit-connected-accounts-modal';
 import HomePage from '../../../page-objects/pages/home/homepage';
@@ -468,7 +468,7 @@ describe('Multichain API', function () {
               await driver.clickElement(`input[name="${scope}"]`),
           );
           await testDapp.initCreateSessionScopes(NEW_SCOPES, [
-            toMultiChainAccountId(TREZOR_ACCOUNT),
+            toEvmCaipAccountId(TREZOR_ACCOUNT),
           ]);
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(

--- a/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_createSession.spec.ts
@@ -3,6 +3,7 @@ import { isObject } from 'lodash';
 import { ACCOUNT_1, ACCOUNT_2, WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
+import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
 import ConnectAccountConfirmation from '../../../page-objects/pages/confirmations/connect-account-confirmation';
 import EditConnectedAccountsModal from '../../../page-objects/pages/dialog/edit-connected-accounts-modal';
 import HomePage from '../../../page-objects/pages/home/homepage';
@@ -467,7 +468,7 @@ describe('Multichain API', function () {
               await driver.clickElement(`input[name="${scope}"]`),
           );
           await testDapp.initCreateSessionScopes(NEW_SCOPES, [
-            `eip155:0:${TREZOR_ACCOUNT}`,
+            toMultiChainAccountId(TREZOR_ACCOUNT),
           ]);
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC,
   WINDOW_TITLES,
 } from '../../../constants';
+import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
 import { convertETHToHexGwei, withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
 import TestDappMultichain from '../../../page-objects/pages/test-dapp-multichain';
@@ -24,7 +25,10 @@ import {
 
 describe('Multichain API', function () {
   const GANACHE_SCOPES = ['eip155:1337', 'eip155:1338', 'eip155:1000'];
-  const CAIP_ACCOUNT_IDS = [`eip155:0:${ACCOUNT_1}`, `eip155:0:${ACCOUNT_2}`];
+  const CAIP_ACCOUNT_IDS = [
+    toMultiChainAccountId(ACCOUNT_1),
+    toMultiChainAccountId(ACCOUNT_2),
+  ];
   const DEFAULT_INITIAL_BALANCE_HEX = convertETHToHexGwei(
     DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC,
   );

--- a/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_invokeMethod.spec.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC,
   WINDOW_TITLES,
 } from '../../../constants';
-import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../shared/lib/multichain/scope-utils';
 import { convertETHToHexGwei, withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
 import TestDappMultichain from '../../../page-objects/pages/test-dapp-multichain';
@@ -26,8 +26,8 @@ import {
 describe('Multichain API', function () {
   const GANACHE_SCOPES = ['eip155:1337', 'eip155:1338', 'eip155:1000'];
   const CAIP_ACCOUNT_IDS = [
-    toMultiChainAccountId(ACCOUNT_1),
-    toMultiChainAccountId(ACCOUNT_2),
+    toEvmCaipAccountId(ACCOUNT_1),
+    toEvmCaipAccountId(ACCOUNT_2),
   ];
   const DEFAULT_INITIAL_BALANCE_HEX = convertETHToHexGwei(
     DEFAULT_LOCAL_NODE_ETH_BALANCE_DEC,

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert';
 import { pick } from 'lodash';
 import { ACCOUNT_1, ACCOUNT_2, WINDOW_TITLES } from '../../../constants';
+import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
 import { largeDelayMs, withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
 import ConnectAccountConfirmation from '../../../page-objects/pages/confirmations/connect-account-confirmation';
@@ -15,7 +16,10 @@ import {
 
 describe('Initializing a session w/ several scopes and accounts, then calling `wallet_revokeSession`', function () {
   const GANACHE_SCOPES = ['eip155:1337', 'eip155:1338', 'eip155:1000'];
-  const CAIP_ACCOUNT_IDS = [`eip155:0:${ACCOUNT_1}`, `eip155:0:${ACCOUNT_2}`];
+  const CAIP_ACCOUNT_IDS = [
+    toMultiChainAccountId(ACCOUNT_1),
+    toMultiChainAccountId(ACCOUNT_2),
+  ];
   it('Should return empty object from `wallet_getSession` call', async function () {
     await withFixtures(
       {

--- a/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_revokeSession.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { pick } from 'lodash';
 import { ACCOUNT_1, ACCOUNT_2, WINDOW_TITLES } from '../../../constants';
-import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../shared/lib/multichain/scope-utils';
 import { largeDelayMs, withFixtures } from '../../../helpers';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
 import ConnectAccountConfirmation from '../../../page-objects/pages/confirmations/connect-account-confirmation';
@@ -17,8 +17,8 @@ import {
 describe('Initializing a session w/ several scopes and accounts, then calling `wallet_revokeSession`', function () {
   const GANACHE_SCOPES = ['eip155:1337', 'eip155:1338', 'eip155:1000'];
   const CAIP_ACCOUNT_IDS = [
-    toMultiChainAccountId(ACCOUNT_1),
-    toMultiChainAccountId(ACCOUNT_2),
+    toEvmCaipAccountId(ACCOUNT_1),
+    toEvmCaipAccountId(ACCOUNT_2),
   ];
   it('Should return empty object from `wallet_getSession` call', async function () {
     await withFixtures(

--- a/test/e2e/flask/multichain-api/evm/wallet_sessionChanged.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_sessionChanged.spec.ts
@@ -5,7 +5,7 @@ import {
   DAPP_HOST_ADDRESS,
   WINDOW_TITLES,
 } from '../../../constants';
-import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../shared/lib/multichain/scope-utils';
 import { withFixtures } from '../../../helpers';
 import { Driver } from '../../../webdriver/driver';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
@@ -27,8 +27,8 @@ describe('Call `wallet_createSession`, then update the accounts and/or scopes in
   const UPDATED_SCOPE = INITIAL_SCOPES[1];
 
   const CAIP_ACCOUNT_IDS = [
-    toMultiChainAccountId(ACCOUNT_1),
-    toMultiChainAccountId(ACCOUNT_2),
+    toEvmCaipAccountId(ACCOUNT_1),
+    toEvmCaipAccountId(ACCOUNT_2),
   ];
   const UPDATED_ACCOUNT = ACCOUNT_2;
   it('should receive a `wallet_sessionChanged` event with the full new session scopes', async function () {

--- a/test/e2e/flask/multichain-api/evm/wallet_sessionChanged.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_sessionChanged.spec.ts
@@ -5,6 +5,7 @@ import {
   DAPP_HOST_ADDRESS,
   WINDOW_TITLES,
 } from '../../../constants';
+import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
 import { withFixtures } from '../../../helpers';
 import { Driver } from '../../../webdriver/driver';
 import FixtureBuilder from '../../../fixtures/fixture-builder';
@@ -25,7 +26,10 @@ describe('Call `wallet_createSession`, then update the accounts and/or scopes in
   const REMOVED_SCOPE = INITIAL_SCOPES[0];
   const UPDATED_SCOPE = INITIAL_SCOPES[1];
 
-  const CAIP_ACCOUNT_IDS = [`eip155:0:${ACCOUNT_1}`, `eip155:0:${ACCOUNT_2}`];
+  const CAIP_ACCOUNT_IDS = [
+    toMultiChainAccountId(ACCOUNT_1),
+    toMultiChainAccountId(ACCOUNT_2),
+  ];
   const UPDATED_ACCOUNT = ACCOUNT_2;
   it('should receive a `wallet_sessionChanged` event with the full new session scopes', async function () {
     await withFixtures(

--- a/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
@@ -1,7 +1,7 @@
 import { Box, AddressInput, Field } from '@metamask/snaps-sdk/jsx';
 import { fireEvent } from '@testing-library/react';
 import { renderInterface } from '../test-utils';
-import { toMultiChainAccountId } from '../../../../../../../shared/lib/asset-utils';
+import { toMultiChainAccountId } from '../../../../../../shared/lib/asset-utils';
 
 const MOCK_ACCOUNT_NAME = 'Account 1';
 

--- a/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
@@ -1,6 +1,7 @@
 import { Box, AddressInput, Field } from '@metamask/snaps-sdk/jsx';
 import { fireEvent } from '@testing-library/react';
 import { renderInterface } from '../test-utils';
+import { toMultiChainAccountId } from '../../../../../../../shared/lib/asset-utils';
 
 const MOCK_ACCOUNT_NAME = 'Account 1';
 
@@ -135,7 +136,7 @@ describe('SnapUIAddressInput', () => {
           displayAvatar: true,
         }),
       }),
-      { state: { input: `eip155:0:${testAddress}` } },
+      { state: { input: toMultiChainAccountId(testAddress) } },
     );
 
     const matchedAddress = getByDisplayValue(testAddress);
@@ -156,7 +157,7 @@ describe('SnapUIAddressInput', () => {
           displayAvatar: false,
         }),
       }),
-      { state: { input: `eip155:0:${testAddress}` } },
+      { state: { input: toMultiChainAccountId(testAddress) } },
     );
 
     const matchedAddress = getByDisplayValue(testAddress);

--- a/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts
@@ -1,7 +1,7 @@
 import { Box, AddressInput, Field } from '@metamask/snaps-sdk/jsx';
 import { fireEvent } from '@testing-library/react';
 import { renderInterface } from '../test-utils';
-import { toMultiChainAccountId } from '../../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../../shared/lib/multichain/scope-utils';
 
 const MOCK_ACCOUNT_NAME = 'Account 1';
 
@@ -136,7 +136,7 @@ describe('SnapUIAddressInput', () => {
           displayAvatar: true,
         }),
       }),
-      { state: { input: toMultiChainAccountId(testAddress) } },
+      { state: { input: toEvmCaipAccountId(testAddress) } },
     );
 
     const matchedAddress = getByDisplayValue(testAddress);
@@ -157,7 +157,7 @@ describe('SnapUIAddressInput', () => {
           displayAvatar: false,
         }),
       }),
-      { state: { input: toMultiChainAccountId(testAddress) } },
+      { state: { input: toEvmCaipAccountId(testAddress) } },
     );
 
     const matchedAddress = getByDisplayValue(testAddress);

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getAllNetworkConfigurationsByCaipChainId } from '../../../../../shared/modules/selectors/networks';
+import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
 import {
   getAllPermittedAccountsForSelectedTab,
   getAllPermittedChainsForSelectedTab,
@@ -181,8 +182,7 @@ export const ReviewPermissions = () => {
         chain: { namespace },
       } = parseCaipAccountId(caipAccountId);
       if (namespace === KnownCaipNamespace.Eip155) {
-        // this is very hacky, but it works for now
-        return `eip155:0:${address}` as CaipAccountId;
+        return toMultiChainAccountId(address);
       }
       return caipAccountId;
     }),

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getAllNetworkConfigurationsByCaipChainId } from '../../../../../shared/modules/selectors/networks';
-import { toMultiChainAccountId } from '../../../../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../../../../shared/lib/multichain/scope-utils';
 import {
   getAllPermittedAccountsForSelectedTab,
   getAllPermittedChainsForSelectedTab,
@@ -182,7 +182,7 @@ export const ReviewPermissions = () => {
         chain: { namespace },
       } = parseCaipAccountId(caipAccountId);
       if (namespace === KnownCaipNamespace.Eip155) {
-        return toMultiChainAccountId(address);
+        return toEvmCaipAccountId(address);
       }
       return caipAccountId;
     }),

--- a/ui/hooks/useAccountGroupForPermissions.test.ts
+++ b/ui/hooks/useAccountGroupForPermissions.test.ts
@@ -5,7 +5,7 @@ import { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 import { CaipAccountId, CaipChainId, CaipNamespace } from '@metamask/utils';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
-import { toMultiChainAccountId } from '../../../shared/lib/asset-utils';
+import { toMultiChainAccountId } from '../../shared/lib/asset-utils';
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import { createMockInternalAccount } from '../../test/jest/mocks';

--- a/ui/hooks/useAccountGroupForPermissions.test.ts
+++ b/ui/hooks/useAccountGroupForPermissions.test.ts
@@ -5,7 +5,7 @@ import { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 import { CaipAccountId, CaipChainId, CaipNamespace } from '@metamask/utils';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
-import { toMultiChainAccountId } from '../../shared/lib/asset-utils';
+import { toEvmCaipAccountId } from '../../shared/lib/multichain/scope-utils';
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import { createMockInternalAccount } from '../../test/jest/mocks';
@@ -584,7 +584,7 @@ describe('useAccountGroupsForPermissions', () => {
     it('shows second group first when it has higher priority', () => {
       const emptyPermission = createEmptyPermission();
       const requestedCaipAccountIds: CaipAccountId[] = [
-        toMultiChainAccountId(mockEvmAccount2.address), // Group 2 account
+        toEvmCaipAccountId(mockEvmAccount2.address), // Group 2 account
       ];
       const requestedChainIds: CaipChainId[] = ['eip155:0' as CaipChainId];
       const requestedNamespaces: CaipNamespace[] = [];

--- a/ui/hooks/useAccountGroupForPermissions.test.ts
+++ b/ui/hooks/useAccountGroupForPermissions.test.ts
@@ -5,6 +5,7 @@ import { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 import { CaipAccountId, CaipChainId, CaipNamespace } from '@metamask/utils';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import { toMultiChainAccountId } from '../../../shared/lib/asset-utils';
 import mockState from '../../test/data/mock-state.json';
 import configureStore from '../store/store';
 import { createMockInternalAccount } from '../../test/jest/mocks';
@@ -583,7 +584,7 @@ describe('useAccountGroupsForPermissions', () => {
     it('shows second group first when it has higher priority', () => {
       const emptyPermission = createEmptyPermission();
       const requestedCaipAccountIds: CaipAccountId[] = [
-        `eip155:0:${mockEvmAccount2.address}` as CaipAccountId, // Group 2 account
+        toMultiChainAccountId(mockEvmAccount2.address), // Group 2 account
       ];
       const requestedChainIds: CaipChainId[] = ['eip155:0' as CaipChainId];
       const requestedNamespaces: CaipNamespace[] = [];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reduce repeated magic strings: `eip155:0`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39688?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/a

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes construction of `eip155:0:*` CAIP-10 account IDs; behavior should be equivalent but could affect lookups where callers relied on ad-hoc string casing/formatting.
> 
> **Overview**
> Introduces `toEvmCaipAccountId` to generate the EVM wildcard CAIP account ID (`eip155:0:<address>`) and replaces repeated string interpolation across the codebase.
> 
> Updates `RewardsController` account-state lookup and several UI/e2e/unit tests to use the shared helper, improving consistency (including explicit lower/upper-case fallback) and reducing hard-coded `eip155:0` “magic strings”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d03339e8cb99cf9573811fe6b71457c42cf73ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->