### PR TITLE
fix: Remove black backgrounds on fees and migrate edit-gas-fee-popover to Modal

### DIFF
--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -9,6 +9,8 @@ import {
   BoxFlexDirection,
   FontWeight,
   TextColor,
+  BoxBorderColor,
+  TextAlign,
 } from '@metamask/design-system-react';
 import {
   EditGasModes,
@@ -74,10 +76,13 @@ const EditGasFeePopoverWrapped = () => {
               <BannerAlert
                 severity={BannerAlertSeverity.Danger}
                 description={t(INSUFFICIENT_FUNDS_ERROR_KEY)}
-                className="mb-1"
+                marginBottom={1}
               />
             )}
-            <Box className="flex gap-0 mx-3 mb-0">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              marginHorizontal={3}
+            >
               <Text
                 variant={TextVariant.BodyXs}
                 fontWeight={FontWeight.Bold}
@@ -112,18 +117,23 @@ const EditGasFeePopoverWrapped = () => {
             )}
             <EditGasItem priorityLevel={PriorityLevels.medium} />
             <EditGasItem priorityLevel={PriorityLevels.high} />
-            <Box className="border-t border-default my-2 mx-3" />
+            <Box
+              className="border-t"
+              borderColor={BoxBorderColor.BorderDefault}
+              marginVertical={2}
+              marginHorizontal={3}
+            />
             {editGasMode === EditGasModes.modifyInPlace && (
               <EditGasItem priorityLevel={PriorityLevels.dAppSuggested} />
             )}
             <EditGasItem priorityLevel={PriorityLevels.custom} />
           </Box>
-          <Box flexDirection={BoxFlexDirection.Column} className="mt-9">
+          <Box flexDirection={BoxFlexDirection.Column} marginTop={9}>
             <NetworkStatistics />
             <Text
               variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
-              className="text-center"
+              textAlign={TextAlign.Center}
             >
               {t('learnMoreAboutGas', [
                 <TextButton asChild key="learnMoreLink" className="inline">

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -79,10 +79,7 @@ const EditGasFeePopoverWrapped = () => {
                 marginBottom={1}
               />
             )}
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              marginHorizontal={3}
-            >
+            <Box flexDirection={BoxFlexDirection.Row} marginHorizontal={3}>
               <Text
                 variant={TextVariant.BodyXs}
                 fontWeight={FontWeight.Bold}

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -56,7 +56,7 @@ const EditGasFeePopoverWrapped = () => {
   }
 
   return (
-    <Modal isOpen onClose={closeAllModals} className="h-[500px]">
+    <Modal isOpen onClose={closeAllModals}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -2,18 +2,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {
+  Box,
+  Text,
+  TextButton,
+  TextVariant,
+  BoxFlexDirection,
+  FontWeight,
+  TextColor,
+} from '@metamask/design-system-react';
+import {
   EditGasModes,
   PriorityLevels,
 } from '../../../../../shared/constants/gas';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTransactionModalContext } from '../../../../contexts/transaction-modal';
-import Box from '../../../../components/ui/box';
-import Popover from '../../../../components/ui/popover';
 
-import {
-  TextColor,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
 import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/error-keys';
 import {
   GasFeeContextProvider,
@@ -24,7 +27,11 @@ import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import {
   BannerAlert,
   BannerAlertSeverity,
-  Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
 } from '../../../../components/component-library';
 import EditGasItem from './edit-gas-item';
 import NetworkStatistics from './network-statistics';
@@ -47,81 +54,93 @@ const EditGasFeePopoverWrapped = () => {
   }
 
   return (
-    <Popover
-      title={t(popupTitle)}
-      // below logic ensures that back button is visible only if there are other modals open before this.
-      onBack={
-        openModalCount === 1 ? undefined : () => closeModal(['editGasFee'])
-      }
-      onClose={closeAllModals}
-      className="edit-gas-fee-popover"
-    >
-      <>
+    <Modal isOpen onClose={closeAllModals} className="h-[500px]">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader
+          onClose={closeAllModals}
+          // below logic ensures that back button is visible only if there are other modals open before this.
+          onBack={
+            openModalCount === 1 ? undefined : () => closeModal(['editGasFee'])
+          }
+        >
+          {t(popupTitle)}
+        </ModalHeader>
+
         <AppLoadingSpinner />
-        <div className="edit-gas-fee-popover__wrapper">
-          <div className="edit-gas-fee-popover__content">
-            <Box>
-              {balanceError && (
-                <BannerAlert
-                  severity={BannerAlertSeverity.Danger}
-                  description={t(INSUFFICIENT_FUNDS_ERROR_KEY)}
-                  marginBottom={1}
-                />
-              )}
-              <div className="edit-gas-fee-popover__content__header">
-                <span className="edit-gas-fee-popover__content__header-option">
-                  {t('gasOption')}
-                </span>
-                <span className="edit-gas-fee-popover__content__header-time">
-                  {editGasMode !== EditGasModes.swaps && t('time')}
-                </span>
-                <span className="edit-gas-fee-popover__content__header-max-fee">
-                  {t('maxFee')}
-                </span>
-              </div>
-              {(editGasMode === EditGasModes.cancel ||
-                editGasMode === EditGasModes.speedUp) && (
-                <EditGasItem
-                  priorityLevel={PriorityLevels.tenPercentIncreased}
-                />
-              )}
-              {editGasMode === EditGasModes.modifyInPlace && (
-                <EditGasItem priorityLevel={PriorityLevels.low} />
-              )}
-              <EditGasItem priorityLevel={PriorityLevels.medium} />
-              <EditGasItem priorityLevel={PriorityLevels.high} />
-              <div className="edit-gas-fee-popover__content__separator" />
-              {editGasMode === EditGasModes.modifyInPlace && (
-                <EditGasItem priorityLevel={PriorityLevels.dAppSuggested} />
-              )}
-              <EditGasItem priorityLevel={PriorityLevels.custom} />
-            </Box>
-            <Box>
-              <NetworkStatistics />
+        <ModalBody className="flex flex-col justify-between">
+          <Box flexDirection={BoxFlexDirection.Column}>
+            {balanceError && (
+              <BannerAlert
+                severity={BannerAlertSeverity.Danger}
+                description={t(INSUFFICIENT_FUNDS_ERROR_KEY)}
+                className="mb-1"
+              />
+            )}
+            <Box className="flex gap-0 mx-3 mb-0">
               <Text
-                className="edit-gas-fee-popover__know-more"
-                align="center"
-                color={TextColor.textAlternative}
-                tag={TextVariant.bodyMd}
-                variant={TextVariant.bodySm}
-                as="h6"
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextAlternative}
+                className="inline-block w-[36%]"
               >
-                {t('learnMoreAboutGas', [
-                  <a
-                    key="learnMoreLink"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={ZENDESK_URLS.USER_GUIDE_GAS}
-                  >
-                    {t('learnMore')}
-                  </a>,
-                ])}
+                {t('gasOption')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextAlternative}
+                className="inline-block w-[24%]"
+              >
+                {editGasMode !== EditGasModes.swaps && t('time')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextAlternative}
+                className="inline-block w-[30%]"
+              >
+                {t('maxFee')}
               </Text>
             </Box>
-          </div>
-        </div>
-      </>
-    </Popover>
+            {(editGasMode === EditGasModes.cancel ||
+              editGasMode === EditGasModes.speedUp) && (
+              <EditGasItem priorityLevel={PriorityLevels.tenPercentIncreased} />
+            )}
+            {editGasMode === EditGasModes.modifyInPlace && (
+              <EditGasItem priorityLevel={PriorityLevels.low} />
+            )}
+            <EditGasItem priorityLevel={PriorityLevels.medium} />
+            <EditGasItem priorityLevel={PriorityLevels.high} />
+            <Box className="border-t border-default my-2 mx-3" />
+            {editGasMode === EditGasModes.modifyInPlace && (
+              <EditGasItem priorityLevel={PriorityLevels.dAppSuggested} />
+            )}
+            <EditGasItem priorityLevel={PriorityLevels.custom} />
+          </Box>
+          <Box flexDirection={BoxFlexDirection.Column} className="mt-9">
+            <NetworkStatistics />
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              className="text-center"
+            >
+              {t('learnMoreAboutGas', [
+                <TextButton asChild key="learnMoreLink" className="inline">
+                  <a
+                    href={ZENDESK_URLS.USER_GUIDE_GAS}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t('learnMore')}
+                  </a>
+                </TextButton>,
+              ])}
+            </Text>
+          </Box>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
   );
 };
 

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -141,7 +141,7 @@ const EditGasItem = ({ priorityLevel }) => {
             <LoadingHeartBeat
               backgroundColor={
                 priorityLevel === estimateUsed
-                  ? 'var(--color-background-alternative)'
+                  ? 'var(--color-primary-muted)'
                   : 'var(--color-background-default)'
               }
               estimateUsed={priorityLevel}


### PR DESCRIPTION
## **Description**

This PR fixes a UI issue in the edit gas fee popover where black backgrounds appeared behind the fee options, causing the highlighted row to appear broken and awkward.

The edit-gas-fee-popover component had visual issues identified in MDP-496 where black backgrounds were showing behind fee options, breaking up the highlighted row selection and creating an awkward appearance. Additionally, the component was using the deprecated Popover component and needed migration to the current Modal component.

Changes included:
- Migrated from deprecated `Popover` component to `Modal` with `ModalOverlay`, `ModalContent`, `ModalHeader`, and `ModalBody`
- Fixed black background issue by changing `LoadingHeartBeat` background color from `var(--color-background-alternative)` to `var(--color-primary-muted)`
- Migrated from deprecated `Box`, `Text`, and design-system constants to `@metamask/design-system-react` components
- Replaced `ButtonLink` with `TextButton` using the asChild pattern for proper link semantics
- Restructured layout using Box components with proper `flexDirection`, `marginHorizontal`, and `marginVertical` props
- Converted header row from CSS classes to Box/Text components with proper styling
- Updated separator to use Box with border styling instead of CSS class

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39569?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed edit gas fee popover UI by removing black backgrounds and migrating to Modal component

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-496

## **Manual testing steps**

1. Create a transaction (e.g., send ETH)
2. In the confirmation screen, click "Edit" on the gas fee section
3. Verify the modal opens (not a popover)
4. Verify there are no black backgrounds behind the fee options
5. Verify the highlighted/selected fee option has a consistent background color
6. Verify all fee options (Low, Medium, High, Custom) display correctly
7. Verify the Network statistics section displays at the bottom
8. Verify the "Learn more" link works correctly
9. Close the modal and verify it closes properly

## **Screenshots/Recordings**

### **Before**

- Black backgrounds appeared behind fee options
- Used deprecated Popover component
- Highlighted row appeared broken

<img width="351" height="529" alt="Screenshot 2026-02-02 at 5 13 26 PM" src="https://github.com/user-attachments/assets/95222174-258d-4da9-b897-5d90f8351cda" />

### **After**

- Clean backgrounds with proper primary-muted color for selected state
- Uses current Modal component
- Highlighted row displays consistently

https://github.com/user-attachments/assets/4808de94-bf1d-44de-a5f2-feace42bf951

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI refactor in the transaction confirmation flow that changes the container component and layout for the gas fee editor; risk is mainly regressions in modal/back/close behavior and styling across modes.
> 
> **Overview**
> Replaces the deprecated `Popover`-based edit gas fee UI with the component-library `Modal` (`ModalHeader`/`ModalBody`), including updated close/back wiring via the transaction modal context.
> 
> Migrates layout primitives to `@metamask/design-system-react` (`Box`/`Text`/`TextButton`) and adjusts header/separator styling and the “Learn more” link rendering.
> 
> Fixes the selected fee row’s visual highlight by updating `LoadingHeartBeat`’s selected `backgroundColor` from `--color-background-alternative` to `--color-primary-muted`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1543d38ba944660635c39246b349d2ed8d80f102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->