### PR TITLE
docs: Update deprecated component references to point to @metamask/design-system-react

### DIFF
--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -188,12 +188,11 @@ const generateClassNames = memoize(
 );
 
 /**
- * @deprecated The JS version of the <Box /> component has been deprecated in favor of the new TS version from the component-library.
- * Please update your code to use the new <Box> component instead
- * import { Box } from '../../component-library';
- * The component API is the same so you should only have to update the import statement but you can find documentation for the new Box component in the MetaMask Storybook:
- * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-box--docs}
- * If you would like to help with the replacement of the old Button component, please submit a pull request against this GitHub issue:
+ * @deprecated The `<Box />` component has been deprecated in favor of the `Box` component from `@metamask/design-system-react`.
+ * Please update your code to use the `Box` component from `@metamask/design-system-react`.
+ * You can find documentation for the Box component in the MetaMask Design System:
+ * {@link https://metamask.github.io/metamask-design-system/?path=/docs/react-components-box--docs}
+ * If you would like to help with the replacement of the old Box component, please submit a pull request against this GitHub issue:
  * {@link https://github.com/MetaMask/metamask-extension/issues/19526}
  */
 const Box = React.forwardRef(function Box(

--- a/ui/components/ui/icon-border/icon-border.js
+++ b/ui/components/ui/icon-border/icon-border.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
- * @deprecated The `<IconBorder />` component has been deprecated in favor of the `<AvatarBase />` component from the component-library.
- * Please update your code to use the new `<AvatarBase>` component instead, which can be found at ./ui/components/component-library/avatar-base/avatar-base.js.
- * You can find documentation for the new AvatarBase component in the MetaMask Storybook:
- * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-avatarbase--docs}
+ * @deprecated The `<IconBorder />` component has been deprecated in favor of the `AvatarBase` component from `@metamask/design-system-react`.
+ * Please update your code to use the `AvatarBase` component from `@metamask/design-system-react`.
+ * You can find documentation for the AvatarBase component in the MetaMask Design System:
+ * {@link https://metamask.github.io/metamask-design-system/?path=/docs/react-components-avatarbase--docs}
  * If you would like to help with the replacement of the old IconBorder component, please submit a pull request
  */
 

--- a/ui/components/ui/icon/approve-icon.component.js
+++ b/ui/components/ui/icon/approve-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const Approve = ({ className, size, color }) => (

--- a/ui/components/ui/icon/icon-eye-slash.js
+++ b/ui/components/ui/icon/icon-eye-slash.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const IconEyeSlash = ({

--- a/ui/components/ui/icon/icon-eye.js
+++ b/ui/components/ui/icon/icon-eye.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const IconEye = ({

--- a/ui/components/ui/icon/icon-token-search.js
+++ b/ui/components/ui/icon/icon-token-search.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const IconTokenSearch = ({

--- a/ui/components/ui/icon/info-icon-inverted.component.js
+++ b/ui/components/ui/icon/info-icon-inverted.component.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { SEVERITIES } from '../../../helpers/constants/design-system';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 export default function InfoIconInverted({ severity }) {

--- a/ui/components/ui/icon/info-icon.component.js
+++ b/ui/components/ui/icon/info-icon.component.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { SEVERITIES } from '../../../helpers/constants/design-system';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 export default function InfoIcon({ severity }) {

--- a/ui/components/ui/icon/interaction-icon.component.js
+++ b/ui/components/ui/icon/interaction-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const Interaction = ({ className, size, color }) => (

--- a/ui/components/ui/icon/overview-buy-icon.component.js
+++ b/ui/components/ui/icon/overview-buy-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 export default function BuyIcon({

--- a/ui/components/ui/icon/receive-icon.component.js
+++ b/ui/components/ui/icon/receive-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const Receive = ({ className, size, color }) => (

--- a/ui/components/ui/icon/search-icon.js
+++ b/ui/components/ui/icon/search-icon.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const SearchIcon = ({

--- a/ui/components/ui/icon/send-icon.component.js
+++ b/ui/components/ui/icon/send-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const Send = ({ className, size, color }) => (

--- a/ui/components/ui/icon/sign-icon.component.js
+++ b/ui/components/ui/icon/sign-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 export default function Sign({ className, size, color }) {

--- a/ui/components/ui/icon/sun-check-icon.component.js
+++ b/ui/components/ui/icon/sun-check-icon.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 export default function SunCheck({ reverseColors }) {

--- a/ui/components/ui/icon/swap-icon-for-list.component.js
+++ b/ui/components/ui/icon/swap-icon-for-list.component.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- * @deprecated This has been deprecated in favor of the `<Icon />` component in ./ui/components/component-library/icon/icon.js
- * See storybook documentation for Icon here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-icon--default-story#icon
+ * @deprecated This has been deprecated in favor of the `Icon` component from `@metamask/design-system-react`
+ * See documentation for Icon here https://metamask.github.io/metamask-design-system/?path=/docs/react-components-icon--docs
  */
 
 const Swap = ({ className, size, color }) => (


### PR DESCRIPTION
## **Description**

This PR updates deprecation messages for UI components that previously pointed to component-library components which are themselves deprecated. These now point directly to `@metamask/design-system-react` and the new MetaMask Design System documentation.

Previously, deprecated components in `ui/components/ui/` pointed to intermediate deprecated components in `ui/components/component-library/`, creating confusion about the proper migration path. This update provides clearer guidance by pointing directly to the final destination.

### Changes Made:
- Updated 14 icon component deprecation messages to reference `Icon` from `@metamask/design-system-react`
- Updated `IconBorder` deprecation message to reference `AvatarBase` from `@metamask/design-system-react`
- Updated `Box` deprecation message to reference `Box` from `@metamask/design-system-react`
- Updated all documentation links from `metamask-storybook` to `metamask-design-system`

This improves developer experience by providing clearer migration paths and avoiding intermediate deprecated components.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39694?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (documentation improvement)

## **Manual testing steps**

This is a documentation-only change. No manual testing required beyond:
1. Verify deprecation warnings still appear correctly in IDEs
2. Verify links in deprecation messages point to correct documentation

## **Screenshots/Recordings**

N/A - Documentation change only

### **Before**

Deprecated components referenced intermediate deprecated components in component-library with links to metamask-storybook.

### **After**

Deprecated components now reference final components from @metamask/design-system-react with links to metamask-design-system.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation only)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A - documentation only)
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates: only `@deprecated` comments and links were changed, with no runtime behavior or API changes.
> 
> **Overview**
> Updates deprecation guidance on legacy UI components to point directly to the MetaMask Design System (`@metamask/design-system-react`) instead of intermediate deprecated `component-library` components.
> 
> Refreshes the referenced docs links (Storybook → Design System) for `Box`, `IconBorder` (`AvatarBase`), and multiple legacy icon components (`Icon`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b5e1ef3ecba722e18a3284ddec8476ef60fc37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->