### PR TITLE
perf: defer TokenListController.initialize() to reduce backgroundConnect contention

### DIFF
--- a/app/scripts/controller-init/token-list-controller-init.ts
+++ b/app/scripts/controller-init/token-list-controller-init.ts
@@ -22,12 +22,22 @@ export const TokenListControllerInit: ControllerInitFunction<
   // Initialize the controller to load cached token lists from storage.
   // This is a fire-and-forget operation - if it fails, the controller will
   // self-heal by fetching token lists on demand when needed.
-  controller.initialize().catch((error: Error) => {
-    console.error(
-      'TokenListController: Failed to initialize from storage:',
-      error,
-    );
-  });
+  // Deferred to avoid competing with critical startup path (backgroundConnect).
+  const deferredInit = () => {
+    controller.initialize().catch((error: Error) => {
+      console.error(
+        'TokenListController: Failed to initialize from storage:',
+        error,
+      );
+    });
+  };
+
+  // Use requestIdleCallback if available, otherwise setTimeout
+  if (typeof globalThis.requestIdleCallback === 'function') {
+    globalThis.requestIdleCallback(deferredInit, { timeout: 2000 });
+  } else {
+    setTimeout(deferredInit, 0);
+  }
 
   return {
     controller,


### PR DESCRIPTION
## Summary

Defer `TokenListController.initialize()` to run after the critical startup path completes, reducing I/O contention during `backgroundConnect`.

**Parent Epic:** [MetaMask-planning#6669](https://github.com/MetaMask/MetaMask-planning/issues/6669) — Break Global Re-render Cascade

## Problem

Benchmarking revealed a **10% regression in backgroundConnect** (~12.6ms) caused by `TokenListController.initialize()` running synchronously during controller initialization. This call loads cached token lists from IndexedDB, competing with the critical startup handshake.

**Benchmark Results (100 samples each):**
| Metric | Main | Branch | Change |
|--------|------|--------|--------|
| backgroundConnect | 123.1ms | 135.7ms | +10.2% ⚠ |
| uiStartup | 812.7ms | 757.1ms | -6.8% ✓ |
| load | 547.7ms | 511.2ms | -6.7% ✓ |

## Solution

Defer the initialization using `requestIdleCallback` (with `setTimeout` fallback):

```typescript
const deferredInit = () => {
  controller.initialize().catch((error: Error) => {
    console.error(
      'TokenListController: Failed to initialize from storage:',
      error,
    );
  });
};

if (typeof globalThis.requestIdleCallback === 'function') {
  globalThis.requestIdleCallback(deferredInit, { timeout: 2000 });
} else {
  setTimeout(deferredInit, 0);
}
```

## Why This Works

- `requestIdleCallback` runs when the browser is idle (after critical work)
- 2s timeout ensures it eventually runs even if never idle
- Falls back to `setTimeout(0)` for service workers/non-browser environments
- Token list loading is explicitly non-critical ("self-heals" on demand per existing comment)

## Test Plan

- [ ] Extension loads successfully
- [ ] Token list displays correctly after startup
- [ ] Run benchmark to verify backgroundConnect improvement

## Changelog

CHANGELOG entry: null

## Related

- Fixes: https://github.com/MetaMask/metamask-extension/issues/39718
- Epic: https://github.com/MetaMask/MetaMask-planning/issues/6669