### PR TITLE
fix: flaky test `Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed

### DIFF
--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -60,7 +60,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const switchEthereumChainRequest = JSON.stringify({
           jsonrpc: '2.0',
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: '0x53a' }],
+          params: [{ chainId: '0x53a' }], // chain 1338
         });
 
         // Initiate switchEthereumChain on Dapp one
@@ -79,20 +79,22 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const switchEthereumChainRequestDappOne = JSON.stringify({
           jsonrpc: '2.0',
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: '0x3e8' }],
+          params: [{ chainId: '0x3e8' }], // chain 1000
         });
 
         // Initiate switchEthereumChain on Dapp one
         await driver.executeScript(
           `window.ethereum.request(${switchEthereumChainRequestDappOne})`,
         );
-        await testDappOne.checkNetworkIsConnected('0x3e8');
+        await testDappOne.checkNetworkIsConnected('0x3e8'); // chain 1000 7777
         // Should auto switch without prompt since already approved via connect
 
         await driver.switchToWindowWithUrl(DAPP_URL);
 
         // eth_sendTransaction request
         await testDappOne.clickSimpleSendButton();
+        const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.checkNetworkIsDisplayed('Localhost 7777');
 
         await driver.switchToWindowWithUrl(DAPP_ONE_URL);
 
@@ -102,7 +104,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // Check correct network on the send confirmation.
-        const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.checkNetworkIsDisplayed('Localhost 7777');
 
         await transactionConfirmation.clickFooterConfirmButton();

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -60,7 +60,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const switchEthereumChainRequest = JSON.stringify({
           jsonrpc: '2.0',
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: '0x53a' }], // chain 1338
+          params: [{ chainId: '0x53a' }],
         });
 
         // Initiate switchEthereumChain on Dapp one
@@ -79,14 +79,14 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         const switchEthereumChainRequestDappOne = JSON.stringify({
           jsonrpc: '2.0',
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: '0x3e8' }], // chain 1000
+          params: [{ chainId: '0x3e8' }],
         });
 
         // Initiate switchEthereumChain on Dapp one
         await driver.executeScript(
           `window.ethereum.request(${switchEthereumChainRequestDappOne})`,
         );
-        await testDappOne.checkNetworkIsConnected('0x3e8'); // chain 1000 7777
+        await testDappOne.checkNetworkIsConnected('0x3e8');
         // Should auto switch without prompt since already approved via connect
 
         await driver.switchToWindowWithUrl(DAPP_URL);

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -93,6 +93,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
 
         // eth_sendTransaction request
         await testDappOne.clickSimpleSendButton();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.checkNetworkIsDisplayed('Localhost 7777');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We trigger 1 Send tx in one dapp (in network 8546) and 1 Signature in another dapp (in network 7777). The requests are queued, but sometimes, if this happens fast, they are disordered.

The fix is to add a check for Dialog/UI loaded after the first tx is triggered, so we ensure the next request (signature) is queued behind.

<img width="400" height="619" alt="image" src="https://github.com/user-attachments/assets/ac90b088-236c-46d6-bf4c-818802f66b2a" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39737?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts E2E test sequencing by adding an explicit wait/assertion on the first confirmation dialog, with no production code changes.
> 
> **Overview**
> Stabilizes the request-queuing E2E test by explicitly switching to the confirmation `Dialog` immediately after triggering `eth_sendTransaction` and asserting the transaction confirmation shows the expected network before starting the `signTypedData` request.
> 
> This reduces flakiness caused by the second request being fired before the first confirmation UI is fully loaded, which could reorder queued requests and lead to incorrect network assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee80b459e7c54d1dceebe20615ef5c232eb54df5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->