### PR TITLE
fix: flaky test `Settings Redirects to ENS domains when user inputs ENS into address bar`

### DIFF
--- a/test/e2e/page-objects/pages/login-page.ts
+++ b/test/e2e/page-objects/pages/login-page.ts
@@ -4,51 +4,46 @@ import { WALLET_PASSWORD } from '../../constants';
 class LoginPage {
   private driver: Driver;
 
-  private passwordInput: string;
+  private readonly connectionsRemovedModal = {
+    testId: 'connections-removed-modal',
+  };
 
-  private unlockButton: string;
+  private readonly connectionsRemovedModalButton = {
+    testId: 'connections-removed-modal-button',
+  };
 
-  private welcomeBackMessage: object;
+  private readonly forgotPasswordButton = {
+    testId: 'unlock-forgot-password-button',
+  };
 
-  private forgotPasswordButton: string;
+  private readonly incorrectPasswordMessage = {
+    testId: 'unlock-page-help-text',
+    text: 'Password is incorrect. Please try again.',
+  };
 
-  private resetPasswordModalButton: string;
+  private readonly metamaskAnimation = {
+    css: 'riv-animation__canvas',
+  };
 
-  private resetWalletButton: string;
+  private readonly passwordInput = { testId: 'unlock-password' };
 
-  private connectionsRemovedModal: string;
+  private readonly resetPasswordModalButton = {
+    testId: 'reset-password-modal-button',
+  };
 
-  private connectionsRemovedModalButton: string;
+  private readonly resetWalletButton = { testId: 'login-error-modal-button' };
 
-  private incorrectPasswordMessage: { css: string; text: string };
+  private readonly unlockButton = { testId: 'unlock-submit' };
 
   constructor(driver: Driver) {
     this.driver = driver;
-    this.passwordInput = '[data-testid="unlock-password"]';
-    this.unlockButton = '[data-testid="unlock-submit"]';
-    this.welcomeBackMessage = {
-      css: '[data-testid="unlock-page-title"]',
-      text: 'Welcome back',
-    };
-    this.forgotPasswordButton = '[data-testid="unlock-forgot-password-button"]';
-
-    this.resetPasswordModalButton =
-      '[data-testid="reset-password-modal-button"]';
-
-    this.incorrectPasswordMessage = {
-      css: '[data-testid="unlock-page-help-text"]',
-      text: 'Password is incorrect. Please try again.',
-    };
-
-    this.resetWalletButton = '[data-testid="login-error-modal-button"]';
-    this.connectionsRemovedModal = '[data-testid="connections-removed-modal"]';
-    this.connectionsRemovedModalButton =
-      '[data-testid="connections-removed-modal-button"]';
   }
 
   async checkPageIsLoaded(): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
+        this.forgotPasswordButton,
+        this.metamaskAnimation,
         this.passwordInput,
         this.unlockButton,
       ]);

--- a/test/e2e/page-objects/pages/login-page.ts
+++ b/test/e2e/page-objects/pages/login-page.ts
@@ -29,7 +29,9 @@ class LoginPage {
     testId: 'reset-password-modal-button',
   };
 
-  private readonly resetWalletButton: object = { testId: 'login-error-modal-button' };
+  private readonly resetWalletButton: object = {
+    testId: 'login-error-modal-button',
+  };
 
   private readonly unlockButton: object = { testId: 'unlock-submit' };
 

--- a/test/e2e/page-objects/pages/login-page.ts
+++ b/test/e2e/page-objects/pages/login-page.ts
@@ -4,34 +4,34 @@ import { WALLET_PASSWORD } from '../../constants';
 class LoginPage {
   private driver: Driver;
 
-  private readonly connectionsRemovedModal = {
+  private readonly connectionsRemovedModal: object = {
     testId: 'connections-removed-modal',
   };
 
-  private readonly connectionsRemovedModalButton = {
+  private readonly connectionsRemovedModalButton: object = {
     testId: 'connections-removed-modal-button',
   };
 
-  private readonly forgotPasswordButton = {
+  private readonly forgotPasswordButton: object = {
     testId: 'unlock-forgot-password-button',
   };
 
-  private readonly incorrectPasswordMessage = {
+  private readonly incorrectPasswordMessage: object = {
     testId: 'unlock-page-help-text',
     text: 'Password is incorrect. Please try again.',
   };
 
-  private readonly metamaskAnimation = '.riv-animation__canvas';
+  private readonly metamaskAnimation: string = '.riv-animation__canvas';
 
-  private readonly passwordInput = { testId: 'unlock-password' };
+  private readonly passwordInput: object = { testId: 'unlock-password' };
 
-  private readonly resetPasswordModalButton = {
+  private readonly resetPasswordModalButton: object = {
     testId: 'reset-password-modal-button',
   };
 
-  private readonly resetWalletButton = { testId: 'login-error-modal-button' };
+  private readonly resetWalletButton: object = { testId: 'login-error-modal-button' };
 
-  private readonly unlockButton = { testId: 'unlock-submit' };
+  private readonly unlockButton: object = { testId: 'unlock-submit' };
 
   constructor(driver: Driver) {
     this.driver = driver;

--- a/test/e2e/page-objects/pages/login-page.ts
+++ b/test/e2e/page-objects/pages/login-page.ts
@@ -21,9 +21,7 @@ class LoginPage {
     text: 'Password is incorrect. Please try again.',
   };
 
-  private readonly metamaskAnimation = {
-    css: 'riv-animation__canvas',
-  };
+  private readonly metamaskAnimation = '.riv-animation__canvas';
 
   private readonly passwordInput = { testId: 'unlock-password' };
 

--- a/test/e2e/page-objects/pages/login-page.ts
+++ b/test/e2e/page-objects/pages/login-page.ts
@@ -21,8 +21,6 @@ class LoginPage {
     text: 'Password is incorrect. Please try again.',
   };
 
-  private readonly metamaskAnimation: string = '.riv-animation__canvas';
-
   private readonly passwordInput: object = { testId: 'unlock-password' };
 
   private readonly resetPasswordModalButton: object = {
@@ -43,7 +41,6 @@ class LoginPage {
     try {
       await this.driver.waitForMultipleSelectors([
         this.forgotPasswordButton,
-        this.metamaskAnimation,
         this.passwordInput,
         this.unlockButton,
       ]);

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -42,6 +42,7 @@ describe('Settings', function () {
         await driver.navigate();
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();
+        await driver.delay(5000);
 
         // The setting defaults to "on" so we can simply enter an ENS address
         // into the address bar and listen for address change

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -12,7 +12,7 @@ describe('Settings', function () {
   const ENS_NAME_URL = `https://${ENS_NAME}/`;
   const ENS_DESTINATION_URL = `https://app.ens.domains/name/${ENS_NAME}`;
 
-  it('Redirects to ENS domains when user inputs ENS into address bar', async function () {
+  it('Redirects to ENS domains when user inputs ENS into address bar TEST', async function () {
     async function mockMetaMaskDotEth(mockServer: MockttpServer) {
       return await mockServer.forGet(ENS_NAME_URL).thenResetConnection();
     }
@@ -42,7 +42,6 @@ describe('Settings', function () {
         await driver.navigate();
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();
-        await driver.delay(5000);
 
         // The setting defaults to "on" so we can simply enter an ENS address
         // into the address bar and listen for address change

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -7,7 +7,7 @@ import PrivacySettings from '../../page-objects/pages/settings/privacy-settings'
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
-describe('Settings', function () {
+describe('Settings TEST', function () {
   const ENS_NAME = 'metamask.eth';
   const ENS_NAME_URL = `https://${ENS_NAME}/`;
   const ENS_DESTINATION_URL = `https://app.ens.domains/name/${ENS_NAME}`;

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -7,7 +7,7 @@ import PrivacySettings from '../../page-objects/pages/settings/privacy-settings'
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
-describe('Settings TEST', function () {
+describe('Settings', function () {
   const ENS_NAME = 'metamask.eth';
   const ENS_NAME_URL = `https://${ENS_NAME}/`;
   const ENS_DESTINATION_URL = `https://app.ens.domains/name/${ENS_NAME}`;

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -12,7 +12,7 @@ describe('Settings', function () {
   const ENS_NAME_URL = `https://${ENS_NAME}/`;
   const ENS_DESTINATION_URL = `https://app.ens.domains/name/${ENS_NAME}`;
 
-  it('Redirects to ENS domains when user inputs ENS into address bar TEST', async function () {
+  it('Redirects to ENS domains when user inputs ENS into address bar', async function () {
     async function mockMetaMaskDotEth(mockServer: MockttpServer) {
       return await mockServer.forGet(ENS_NAME_URL).thenResetConnection();
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39738?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E page-object selectors and should only affect test stability, with no production logic impact. Main risk is breaking tests if `Driver` selector APIs don’t accept the updated object-form selectors consistently.
> 
> **Overview**
> Updates the E2E `LoginPage` page-object to use consistent object-based `testId` selectors (instead of CSS strings) and removes selector initialization from the constructor.
> 
> Tightens `checkPageIsLoaded()` to also wait for the *Forgot password* button, aiming to reduce login-related test flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee6cfd86d51493ce995cccd982fd970a59bfba72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->