### PR TITLE
feat: metamask pay in dapp confirmations

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5931,6 +5931,10 @@
   "required": {
     "message": "Required"
   },
+  "requiredToken": {
+    "message": "Required token",
+    "description": "Label for the required token row showing the token and amount needed by the transaction"
+  },
   "reset": {
     "message": "Reset"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5931,6 +5931,10 @@
   "required": {
     "message": "Required"
   },
+  "requiredToken": {
+    "description": "Label for the required token row showing the token and amount needed by the transaction",
+    "message": "Required token"
+  },
   "reset": {
     "message": "Reset"
   },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1011,6 +1011,9 @@ export default class MetamaskController extends EventEmitter {
       wallet_getCapabilities: createAsyncMiddleware(async (req, res) =>
         walletGetCapabilities(req, res, {
           getAccounts,
+          getPermittedAccountsForOrigin: async () => {
+            return getAccounts({ origin: req.origin });
+          },
           getCapabilities: getCapabilities.bind(
             null,
             {
@@ -1035,6 +1038,9 @@ export default class MetamaskController extends EventEmitter {
       wallet_sendCalls: createAsyncMiddleware(async (req, res) => {
         return await walletSendCalls(req, res, {
           getAccounts,
+          getPermittedAccountsForOrigin: async () => {
+            return getAccounts({ origin: req.origin });
+          },
           processSendCalls: processSendCalls.bind(
             null,
             {
@@ -1047,6 +1053,9 @@ export default class MetamaskController extends EventEmitter {
               getDismissSmartAccountSuggestionEnabled: () =>
                 this.preferencesController.state.preferences
                   .dismissSmartAccountSuggestionEnabled,
+              getPermittedAccountsForOrigin: async () => {
+                return getAccounts({ origin: req.origin });
+              },
               isAtomicBatchSupported:
                 this.txController.isAtomicBatchSupported.bind(
                   this.txController,

--- a/builds.yml
+++ b/builds.yml
@@ -465,3 +465,6 @@ env:
 
   # Authentication (Backup & Sync, Profile metrics...)
   - FORCE_AUTH_MATCH_BUILD: false
+
+  # Enable MetaMask Pay in dApp transaction confirmations
+  - MM_PAY_DAPPS_ENABLED: false

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1014,35 +1014,6 @@
         "uuid": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "globals": {
-        "AbortController": true,
-        "TextDecoder": true,
-        "URLSearchParams": true,
-        "console.error": true,
-        "console.log": true,
-        "console.warn": true
-      },
-      "packages": {
-        "ethers>@ethersproject/address": true,
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/constants": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/controller-utils": true,
-        "@metamask/keyring-api": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": true,
-        "@metamask/polling-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "@metamask/transaction-pay-controller>bignumber.js": true,
-        "browserify>buffer": true,
-        "lodash": true,
-        "reselect": true,
-        "uuid": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -1719,19 +1690,6 @@
         "lodash": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/keyring-api": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "lodash": true
-      }
-    },
     "@metamask/network-enablement-controller>@metamask/multichain-network-controller": {
       "globals": {
         "URL": true
@@ -1797,35 +1755,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2636,7 +2565,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1014,35 +1014,6 @@
         "uuid": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "globals": {
-        "AbortController": true,
-        "TextDecoder": true,
-        "URLSearchParams": true,
-        "console.error": true,
-        "console.log": true,
-        "console.warn": true
-      },
-      "packages": {
-        "ethers>@ethersproject/address": true,
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/constants": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/controller-utils": true,
-        "@metamask/keyring-api": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": true,
-        "@metamask/polling-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "@metamask/transaction-pay-controller>bignumber.js": true,
-        "browserify>buffer": true,
-        "lodash": true,
-        "reselect": true,
-        "uuid": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -1719,19 +1690,6 @@
         "lodash": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/keyring-api": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "lodash": true
-      }
-    },
     "@metamask/network-enablement-controller>@metamask/multichain-network-controller": {
       "globals": {
         "URL": true
@@ -1797,35 +1755,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2636,7 +2565,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1014,35 +1014,6 @@
         "uuid": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "globals": {
-        "AbortController": true,
-        "TextDecoder": true,
-        "URLSearchParams": true,
-        "console.error": true,
-        "console.log": true,
-        "console.warn": true
-      },
-      "packages": {
-        "ethers>@ethersproject/address": true,
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/constants": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/controller-utils": true,
-        "@metamask/keyring-api": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": true,
-        "@metamask/polling-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "@metamask/transaction-pay-controller>bignumber.js": true,
-        "browserify>buffer": true,
-        "lodash": true,
-        "reselect": true,
-        "uuid": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -1719,19 +1690,6 @@
         "lodash": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/keyring-api": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "lodash": true
-      }
-    },
     "@metamask/network-enablement-controller>@metamask/multichain-network-controller": {
       "globals": {
         "URL": true
@@ -1797,35 +1755,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2636,7 +2565,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1014,35 +1014,6 @@
         "uuid": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "globals": {
-        "AbortController": true,
-        "TextDecoder": true,
-        "URLSearchParams": true,
-        "console.error": true,
-        "console.log": true,
-        "console.warn": true
-      },
-      "packages": {
-        "ethers>@ethersproject/address": true,
-        "@ethersproject/bignumber": true,
-        "ethers>@ethersproject/constants": true,
-        "@ethersproject/contracts": true,
-        "@ethersproject/providers": true,
-        "@metamask/controller-utils": true,
-        "@metamask/keyring-api": true,
-        "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": true,
-        "@metamask/polling-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "@metamask/transaction-pay-controller>bignumber.js": true,
-        "browserify>buffer": true,
-        "lodash": true,
-        "reselect": true,
-        "uuid": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -1719,19 +1690,6 @@
         "lodash": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller": {
-      "globals": {
-        "URL": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/keyring-api": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true,
-        "lodash": true
-      }
-    },
     "@metamask/network-enablement-controller>@metamask/multichain-network-controller": {
       "globals": {
         "URL": true
@@ -1797,35 +1755,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2636,7 +2565,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1012,13 +1012,6 @@
         "buffer": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -2338,7 +2331,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1012,13 +1012,6 @@
         "buffer": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -2338,7 +2331,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1012,13 +1012,6 @@
         "buffer": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -2338,7 +2331,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1012,13 +1012,6 @@
         "buffer": true
       }
     },
-    "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
-      "packages": {
-        "@metamask/controller-utils": true,
-        "@metamask/superstruct": true,
-        "@metamask/utils": true
-      }
-    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -2338,7 +2331,7 @@
       "packages": {
         "@ethersproject/abi": true,
         "@metamask/base-controller": true,
-        "@metamask/transaction-pay-controller>@metamask/bridge-controller": true,
+        "@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
         "@metamask/transaction-controller": true,

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "@metamask/streams": "^0.4.0",
     "@metamask/subscription-controller": "^6.0.0",
     "@metamask/transaction-controller": "^62.16.0",
-    "@metamask/transaction-pay-controller": "^11.0.1",
+    "@metamask/transaction-pay-controller": "^12.2.0",
     "@metamask/tron-wallet-snap": "^1.21.1",
     "@metamask/user-operation-controller": "^40.0.0",
     "@metamask/utils": "^11.4.2",

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2371,9 +2371,16 @@
     "ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.test.tsx": {
+      "Reselect: Identity function warnings": 3,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/confirmations/components/rows/total-row/total-row.test.tsx": {
       "Reselect: Identity function warnings": 3,
-      "Reselect: Input stability warnings": 2,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx": {
+      "Reselect: Identity function warnings": 3,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx": {

--- a/ui/components/app/confirm/info/row/row.tsx
+++ b/ui/components/app/confirm/info/row/row.tsx
@@ -239,26 +239,44 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
 
 export type ConfirmInfoRowSkeletonProps = {
   'data-testid'?: string;
+  label?: string;
+  rowVariant?: ConfirmInfoRowSize;
 };
 
 export const ConfirmInfoRowSkeleton: React.FC<ConfirmInfoRowSkeletonProps> = ({
   'data-testid': dataTestId,
+  label,
+  rowVariant = ConfirmInfoRowSize.Default,
 }) => {
-  const skeleton = (
-    <Skeleton
-      width={80}
-      height={18}
-      style={{ marginTop: 3, marginBottom: 3 }}
-    />
-  );
+  const isSmall = rowVariant === ConfirmInfoRowSize.Small;
+
+  if (isSmall || !label) {
+    const skeleton = (
+      <Skeleton
+        width={80}
+        height={18}
+        style={{ marginTop: 3, marginBottom: 3 }}
+      />
+    );
+
+    return (
+      <ConfirmInfoRow
+        data-testid={dataTestId}
+        rowVariant={ConfirmInfoRowSize.Small}
+        labelChildren={skeleton}
+      >
+        {skeleton}
+      </ConfirmInfoRow>
+    );
+  }
 
   return (
     <ConfirmInfoRow
       data-testid={dataTestId}
-      rowVariant={ConfirmInfoRowSize.Small}
-      labelChildren={skeleton}
+      label={label}
+      rowVariant={rowVariant}
     >
-      {skeleton}
+      <Skeleton height="16px" width="60px" />
     </ConfirmInfoRow>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.tsx
@@ -1,6 +1,7 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import React from 'react';
 
+import { TransactionPaySection } from '../../../rows/transaction-pay-section/transaction-pay-section';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useDappSwapContext } from '../../../../context/dapp-swap';
 import { DappSwapComparisonBanner } from '../../dapp-swap-comparison-banner/dapp-swap-comparison-banner';
@@ -30,6 +31,7 @@ const BaseTransactionInfo = () => {
           <TransactionDetails />
         </>
       )}
+      <TransactionPaySection />
       <GasFeesSection />
       <AdvancedDetails />
       <EstimatedPointsSection />

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useConfirmContext } from '../../../../context/confirm';
 import { SimulationDetails } from '../../../simulation-details';
+import { TransactionPaySection } from '../../../rows/transaction-pay-section/transaction-pay-section';
 import { AdvancedDetails } from '../shared/advanced-details/advanced-details';
 import { GasFeesSection } from '../shared/gas-fees-section/gas-fees-section';
 import NativeSendHeading from '../shared/native-send-heading/native-send-heading';
@@ -27,6 +28,7 @@ const NativeTransferInfo = () => {
         metricsOnly={isWalletInitiated}
       />
       <TokenDetailsSection />
+      <TransactionPaySection />
       <GasFeesSection />
       <AdvancedDetails />
     </>

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { useTransactionPaySourceAmounts } from '../../../../../hooks/pay/useTransactionPayData';
 import { GasFeesDetails } from '../gas-fees-details/gas-fees-details';
 
 export const GasFeesSection = () => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
+  const sourceAmounts = useTransactionPaySourceAmounts();
 
   if (!transactionMeta?.txParams) {
+    return null;
+  }
+
+  if (sourceAmounts?.length) {
     return null;
   }
 

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
@@ -2,6 +2,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import React from 'react';
 import { useConfirmContext } from '../../../../context/confirm';
 import { SimulationDetails } from '../../../simulation-details';
+import { TransactionPaySection } from '../../../rows/transaction-pay-section/transaction-pay-section';
 import { AdvancedDetails } from '../shared/advanced-details/advanced-details';
 import { GasFeesSection } from '../shared/gas-fees-section/gas-fees-section';
 import SendHeading from '../shared/send-heading/send-heading';
@@ -25,6 +26,7 @@ const TokenTransferInfo = () => {
         metricsOnly={isWalletInitiated}
       />
       <TokenDetailsSection />
+      <TransactionPaySection />
       <GasFeesSection />
       <AdvancedDetails />
     </>

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -25,6 +25,7 @@ import {
 import { BridgeFeeRow } from '../../rows/bridge-fee-row/bridge-fee-row';
 import { BridgeTimeRow } from '../../rows/bridge-time-row/bridge-time-row';
 import { TotalRow } from '../../rows/total-row/total-row';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
 import {
   PercentageButtons,
   PercentageButtonsSkeleton,
@@ -246,9 +247,9 @@ function BottomContainer() {
       gap={2}
       paddingBottom={4}
     >
-      <BridgeFeeRow />
-      <BridgeTimeRow />
-      <TotalRow />
+      <BridgeFeeRow variant={ConfirmInfoRowSize.Small} />
+      <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
+      <TotalRow variant={ConfirmInfoRowSize.Small} />
     </Box>
   );
 }

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -13,16 +13,20 @@ import {
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { BridgeFeeRow } from './bridge-fee-row';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import { BridgeFeeRow, BridgeFeeRowProps } from './bridge-fee-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../../../hooks/useI18nContext');
 
 const mockStore = configureMockStore([]);
 
-function render() {
+function render(props: BridgeFeeRowProps = {}) {
   const state = getMockPersonalSignConfirmState();
-  return renderWithConfirmContextProvider(<BridgeFeeRow />, mockStore(state));
+  return renderWithConfirmContextProvider(
+    <BridgeFeeRow {...props} />,
+    mockStore(state),
+  );
 }
 
 describe('BridgeFeeRow', () => {
@@ -61,26 +65,71 @@ describe('BridgeFeeRow', () => {
     ]);
   });
 
-  it('renders transaction fee', () => {
-    const { getByText } = render();
-    expect(getByText('$1.23')).toBeInTheDocument();
-  });
-
-  it('renders skeletons if quotes loading', () => {
+  it('renders skeleton with label when loading (Default variant)', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
 
-    const { getByTestId } = render();
+    const { getByTestId, queryByTestId, getByText } = render();
+
+    expect(getByTestId('bridge-fee-row-skeleton')).toBeInTheDocument();
+    expect(queryByTestId('metamask-fee-row-skeleton')).not.toBeInTheDocument();
+    expect(getByText('Transaction fee')).toBeInTheDocument();
+  });
+
+  it('renders full skeletons without labels when loading (Small variant)', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId, queryByText } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
 
     expect(getByTestId('bridge-fee-row-skeleton')).toBeInTheDocument();
     expect(getByTestId('metamask-fee-row-skeleton')).toBeInTheDocument();
+    expect(queryByText('Transaction fee')).not.toBeInTheDocument();
+    expect(queryByText('MetaMask fee')).not.toBeInTheDocument();
   });
 
-  it('does not render metamask fee if no quotes', () => {
-    useTransactionPayQuotesMock.mockReturnValue([]);
-
+  it('does not render metamask fee with Default variant', () => {
     const { getByTestId, queryByTestId } = render();
 
     expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
     expect(queryByTestId('metamask-fee-row')).not.toBeInTheDocument();
+  });
+
+  it('renders metamask fee with Small variant when quotes exist', () => {
+    const { getByTestId } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
+    expect(getByTestId('metamask-fee-row')).toBeInTheDocument();
+  });
+
+  it('does not render metamask fee if no quotes (Small variant)', () => {
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { getByTestId, queryByTestId } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
+    expect(queryByTestId('metamask-fee-row')).not.toBeInTheDocument();
+  });
+
+  it('renders fee value with ConfirmInfoRowText for Default variant', () => {
+    const { getByTestId } = render();
+
+    const feeValue = getByTestId('transaction-fee-value');
+    expect(feeValue).toBeInTheDocument();
+    expect(feeValue).toHaveTextContent('$1.23');
+  });
+
+  it('renders fee value with Text component for Small variant', () => {
+    const { getByTestId } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    const feeValue = getByTestId('transaction-fee-value');
+    expect(feeValue).toBeInTheDocument();
+    expect(feeValue).toHaveTextContent('$1.23');
   });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -11,6 +11,7 @@ import {
   ConfirmInfoRowSize,
   ConfirmInfoRowSkeleton,
 } from '../../../../../components/app/confirm/info/row/row';
+import { ConfirmInfoRowText } from '../../../../../components/app/confirm/info/row/text';
 import {
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
@@ -19,8 +20,14 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 
+export type BridgeFeeRowProps = {
+  variant?: ConfirmInfoRowSize;
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function BridgeFeeRow() {
+export function BridgeFeeRow({
+  variant = ConfirmInfoRowSize.Default,
+}: BridgeFeeRowProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
   const isLoading = useIsTransactionPayLoading();
@@ -41,11 +48,24 @@ export function BridgeFeeRow() {
 
   const metamaskFeeUsd = useMemo(() => formatFiat(0), [formatFiat]);
 
+  const isSmall = variant === ConfirmInfoRowSize.Small;
+  const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;
+
   if (isLoading) {
     return (
       <>
-        <ConfirmInfoRowSkeleton data-testid="bridge-fee-row-skeleton" />
-        <ConfirmInfoRowSkeleton data-testid="metamask-fee-row-skeleton" />
+        <ConfirmInfoRowSkeleton
+          data-testid="bridge-fee-row-skeleton"
+          label={t('transactionFee')}
+          rowVariant={variant}
+        />
+        {isSmall && (
+          <ConfirmInfoRowSkeleton
+            data-testid="metamask-fee-row-skeleton"
+            label={t('metamaskFee')}
+            rowVariant={variant}
+          />
+        )}
       </>
     );
   }
@@ -57,28 +77,35 @@ export function BridgeFeeRow() {
       <ConfirmInfoRow
         data-testid="bridge-fee-row"
         label={t('transactionFee')}
-        rowVariant={ConfirmInfoRowSize.Small}
+        rowVariant={variant}
         tooltip={
           hasQuotes && totals
             ? renderTooltipContent(t, totals, formatFiat)
             : undefined
         }
       >
-        <Text
-          variant={TextVariant.bodyMd}
-          color={TextColor.textAlternative}
-          data-testid="transaction-fee-value"
-        >
-          {feeTotalUsd}
-        </Text>
+        {isSmall ? (
+          <Text
+            variant={textVariant}
+            color={TextColor.textAlternative}
+            data-testid="transaction-fee-value"
+          >
+            {feeTotalUsd}
+          </Text>
+        ) : (
+          <ConfirmInfoRowText
+            text={feeTotalUsd}
+            data-testid="transaction-fee-value"
+          />
+        )}
       </ConfirmInfoRow>
-      {hasQuotes && (
+      {hasQuotes && isSmall && (
         <ConfirmInfoRow
           data-testid="metamask-fee-row"
           label={t('metamaskFee')}
-          rowVariant={ConfirmInfoRowSize.Small}
+          rowVariant={variant}
         >
-          <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
+          <Text variant={textVariant} color={TextColor.textAlternative}>
             {metamaskFeeUsd}
           </Text>
         </ConfirmInfoRow>

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -15,7 +15,8 @@ import {
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
-import { BridgeTimeRow } from './bridge-time-row';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import { BridgeTimeRow, BridgeTimeRowProps } from './bridge-time-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPayToken');
@@ -24,9 +25,9 @@ jest.mock('../../../context/confirm');
 
 const mockStore = configureMockStore([]);
 
-function render() {
+function render(props: BridgeTimeRowProps = {}) {
   const state = getMockPersonalSignConfirmState();
-  return renderWithProvider(<BridgeTimeRow />, mockStore(state));
+  return renderWithProvider(<BridgeTimeRow {...props} />, mockStore(state));
 }
 
 describe('BridgeTimeRow', () => {
@@ -123,11 +124,23 @@ describe('BridgeTimeRow', () => {
     expect(getByTestId('bridge-time-value')).toHaveTextContent('< 10 sec');
   });
 
-  it('renders skeleton if quotes loading', () => {
+  it('renders skeleton with label when loading (Default variant)', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
 
-    const { getByTestId } = render();
+    const { getByTestId, getByText } = render();
 
     expect(getByTestId('bridge-time-row-skeleton')).toBeInTheDocument();
+    expect(getByText('Estimated time')).toBeInTheDocument();
+  });
+
+  it('renders full skeleton without label when loading (Small variant)', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId, queryByText } = render({
+      rowVariant: ConfirmInfoRowSize.Small,
+    });
+
+    expect(getByTestId('bridge-time-row-skeleton')).toBeInTheDocument();
+    expect(queryByText('Estimated time')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -27,8 +27,14 @@ const SAME_CHAIN_DURATION_SECONDS = '< 10';
 
 const HIDE_TYPES: TransactionType[] = [];
 
+export type BridgeTimeRowProps = {
+  rowVariant?: ConfirmInfoRowSize;
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function BridgeTimeRow() {
+export function BridgeTimeRow({
+  rowVariant = ConfirmInfoRowSize.Default,
+}: BridgeTimeRowProps) {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const isLoading = useIsTransactionPayLoading();
@@ -41,12 +47,21 @@ export function BridgeTimeRow() {
     !hasTransactionType(currentConfirmation, HIDE_TYPES) &&
     (isLoading || Boolean(quotes?.length));
 
+  const isSmall = rowVariant === ConfirmInfoRowSize.Small;
+  const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;
+
   if (!showEstimate) {
     return null;
   }
 
   if (isLoading) {
-    return <ConfirmInfoRowSkeleton data-testid="bridge-time-row-skeleton" />;
+    return (
+      <ConfirmInfoRowSkeleton
+        data-testid="bridge-time-row-skeleton"
+        label={t('estimatedTime')}
+        rowVariant={rowVariant}
+      />
+    );
   }
 
   const isSameChain = payToken?.chainId === chainId;
@@ -60,10 +75,10 @@ export function BridgeTimeRow() {
     <ConfirmInfoRow
       data-testid="bridge-time-row"
       label={t('estimatedTime')}
-      rowVariant={ConfirmInfoRowSize.Small}
+      rowVariant={rowVariant}
     >
       <Text
-        variant={TextVariant.bodyMd}
+        variant={textVariant}
         color={TextColor.textAlternative}
         data-testid="bridge-time-value"
       >

--- a/ui/pages/confirmations/components/rows/required-tokens-row/index.ts
+++ b/ui/pages/confirmations/components/rows/required-tokens-row/index.ts
@@ -1,0 +1,2 @@
+export { RequiredTokensRow } from './required-tokens-row';
+export type { RequiredTokensRowProps } from './required-tokens-row';

--- a/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import type { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
+import { getMockPersonalSignConfirmState } from '../../../../../../test/data/confirmations/helper';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import {
+  RequiredTokensRow,
+  RequiredTokensRowProps,
+} from './required-tokens-row';
+
+jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../../../hooks/useI18nContext');
+jest.mock('../../../../../hooks/useFiatFormatter');
+jest.mock('../../simulation-details/amount-pill', () => ({
+  AmountPill: ({ amount }: { amount: { toString: () => string } }) => (
+    <div data-testid="simulation-details-amount-pill">{amount.toString()}</div>
+  ),
+}));
+jest.mock('../../simulation-details/asset-pill', () => ({
+  AssetPill: ({ asset }: { asset: { address: string } }) => (
+    <div data-testid="simulation-details-asset-pill">{asset.address}</div>
+  ),
+}));
+
+const mockStore = configureMockStore([]);
+
+function render(props: RequiredTokensRowProps = {}) {
+  const state = getMockPersonalSignConfirmState();
+  return renderWithConfirmContextProvider(
+    <RequiredTokensRow {...props} />,
+    mockStore(state),
+  );
+}
+
+function createMockRequiredToken(
+  overrides: Partial<TransactionPayRequiredToken> = {},
+): TransactionPayRequiredToken {
+  return {
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    allowUnderMinimum: false,
+    amountFiat: '$1.00',
+    amountHuman: '1.00',
+    amountRaw: '1000000',
+    amountUsd: '1.00',
+    balanceFiat: '$100.00',
+    balanceHuman: '100.00',
+    balanceRaw: '100000000',
+    balanceUsd: '100.00',
+    chainId: '0x1',
+    decimals: 6,
+    skipIfBalance: false,
+    symbol: 'USDC',
+    ...overrides,
+  };
+}
+
+describe('RequiredTokensRow', () => {
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+  const useI18nContextMock = jest.mocked(useI18nContext);
+  const useFiatFormatterMock = jest.mocked(useFiatFormatter);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useI18nContextMock.mockReturnValue(((key: string) => {
+      const translations: Record<string, string> = {
+        requiredToken: 'Required token',
+      };
+      return translations[key] ?? key;
+    }) as ReturnType<typeof useI18nContext>);
+
+    useFiatFormatterMock.mockReturnValue(
+      (value: number) => `$${value.toFixed(2)}`,
+    );
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+  });
+
+  it('renders nothing when no required tokens', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when required tokens is undefined', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue(
+      undefined as unknown as TransactionPayRequiredToken[],
+    );
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders required token row with token details', () => {
+    const mockToken = createMockRequiredToken();
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { getByTestId, getByText } = render();
+
+    expect(getByTestId('required-tokens-row')).toBeInTheDocument();
+    expect(getByText('Required token')).toBeInTheDocument();
+    expect(getByTestId('simulation-details-amount-pill')).toHaveTextContent(
+      '-1',
+    );
+    expect(getByTestId('simulation-details-asset-pill')).toBeInTheDocument();
+  });
+
+  it('renders asset pill with correct props', () => {
+    const mockToken = createMockRequiredToken();
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { getByTestId } = render();
+
+    const assetPill = getByTestId('simulation-details-asset-pill');
+    expect(assetPill).toHaveTextContent(
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    );
+  });
+
+  it('renders multiple required tokens', () => {
+    const mockTokens: TransactionPayRequiredToken[] = [
+      createMockRequiredToken(),
+      createMockRequiredToken({
+        chainId: '0x89',
+        address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        amountHuman: '2.00',
+        amountUsd: '2.00',
+      }),
+    ];
+
+    useTransactionPayRequiredTokensMock.mockReturnValue(mockTokens);
+
+    const { getAllByTestId } = render();
+
+    expect(getAllByTestId('required-tokens-row')).toHaveLength(2);
+    expect(getAllByTestId('simulation-details-asset-pill')).toHaveLength(2);
+  });
+
+  it('hides tokens with skipIfBalance true', () => {
+    const mockToken = createMockRequiredToken({
+      skipIfBalance: true,
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('only renders tokens without skipIfBalance', () => {
+    const mockTokens: TransactionPayRequiredToken[] = [
+      createMockRequiredToken({ skipIfBalance: true }),
+      createMockRequiredToken({
+        chainId: '0x89',
+        address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        skipIfBalance: false,
+      }),
+    ];
+
+    useTransactionPayRequiredTokensMock.mockReturnValue(mockTokens);
+
+    const { getAllByTestId } = render();
+
+    expect(getAllByTestId('required-tokens-row')).toHaveLength(1);
+  });
+
+  it('shows fiat amount for Default variant', () => {
+    const mockToken = createMockRequiredToken();
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { getByText } = render();
+
+    expect(getByText('$1.00')).toBeInTheDocument();
+  });
+
+  it('hides fiat amount for Small variant', () => {
+    const mockToken = createMockRequiredToken();
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { queryByText } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    expect(queryByText('$1.00')).not.toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.tsx
+++ b/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import { Hex } from '@metamask/utils';
+import { Box, Text } from '../../../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  TextColor,
+} from '../../../../../helpers/constants/design-system';
+import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import {
+  ConfirmInfoRow,
+  ConfirmInfoRowSize,
+} from '../../../../../components/app/confirm/info/row/row';
+import { TokenStandard } from '../../../../../../shared/constants/transaction';
+import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { AmountPill } from '../../simulation-details/amount-pill';
+import { AssetPill } from '../../simulation-details/asset-pill';
+import type { TokenAssetIdentifier } from '../../simulation-details/types';
+
+export type RequiredTokensRowProps = {
+  variant?: ConfirmInfoRowSize;
+};
+
+export const RequiredTokensRow = ({
+  variant = ConfirmInfoRowSize.Default,
+}: RequiredTokensRowProps) => {
+  const t = useI18nContext();
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const fiatFormatter = useFiatFormatter();
+
+  const visibleTokens = useMemo(
+    () => requiredTokens?.filter((token) => !token.skipIfBalance) ?? [],
+    [requiredTokens],
+  );
+
+  const isDefaultVariant = variant === ConfirmInfoRowSize.Default;
+
+  if (!visibleTokens.length) {
+    return null;
+  }
+
+  return (
+    <>
+      {visibleTokens.map((token) => {
+        const asset: TokenAssetIdentifier = {
+          chainId: token.chainId as Hex,
+          address: token.address as Hex,
+          standard: TokenStandard.ERC20,
+        };
+
+        const amount = new BigNumber(token.amountHuman).negated();
+        const amountFiatFormatted = fiatFormatter(
+          new BigNumber(token.amountUsd).toNumber(),
+        );
+
+        return (
+          <ConfirmInfoRow
+            key={`${token.chainId}-${token.address}`}
+            data-testid="required-tokens-row"
+            label={t('requiredToken')}
+            rowVariant={variant}
+          >
+            <Box
+              display={Display.Flex}
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={1}
+            >
+              <AmountPill asset={asset} amount={amount} />
+              <AssetPill asset={asset} />
+              {isDefaultVariant && (
+                <Text color={TextColor.textAlternative}>
+                  {amountFiatFormatted}
+                </Text>
+              )}
+            </Box>
+          </ConfirmInfoRow>
+        );
+      })}
+    </>
+  );
+};

--- a/ui/pages/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/total-row/total-row.test.tsx
@@ -8,16 +8,20 @@ import {
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { TotalRow } from './total-row';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import { TotalRow, TotalRowProps } from './total-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../../../hooks/useI18nContext');
 
 const mockStore = configureMockStore([]);
 
-function render() {
+function render(props: TotalRowProps = {}) {
   const state = getMockPersonalSignConfirmState();
-  return renderWithConfirmContextProvider(<TotalRow />, mockStore(state));
+  return renderWithConfirmContextProvider(
+    <TotalRow {...props} />,
+    mockStore(state),
+  );
 }
 
 describe('TotalRow', () => {
@@ -44,16 +48,41 @@ describe('TotalRow', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(false);
   });
 
-  it('renders the total amount', () => {
-    const { getByText } = render();
-    expect(getByText('$123.46')).toBeInTheDocument();
-  });
-
-  it('renders skeleton when quotes are loading', () => {
+  it('renders skeleton with label when loading (Default variant)', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
 
-    const { getByTestId } = render();
+    const { getByTestId, getByText } = render();
 
     expect(getByTestId('total-row-skeleton')).toBeInTheDocument();
+    expect(getByText('Total')).toBeInTheDocument();
+  });
+
+  it('renders full skeleton without label when loading (Small variant)', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId, queryByText } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    expect(getByTestId('total-row-skeleton')).toBeInTheDocument();
+    expect(queryByText('Total')).not.toBeInTheDocument();
+  });
+
+  it('renders total value with ConfirmInfoRowText for Default variant', () => {
+    const { getByTestId } = render();
+
+    const totalValue = getByTestId('total-value');
+    expect(totalValue).toBeInTheDocument();
+    expect(totalValue).toHaveTextContent('$123.46');
+  });
+
+  it('renders total value with Text component for Small variant', () => {
+    const { getByTestId } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    const totalValue = getByTestId('total-value');
+    expect(totalValue).toBeInTheDocument();
+    expect(totalValue).toHaveTextContent('$123.46');
   });
 });

--- a/ui/pages/confirmations/components/rows/total-row/total-row.tsx
+++ b/ui/pages/confirmations/components/rows/total-row/total-row.tsx
@@ -10,6 +10,7 @@ import {
   ConfirmInfoRowSize,
   ConfirmInfoRowSkeleton,
 } from '../../../../../components/app/confirm/info/row/row';
+import { ConfirmInfoRowText } from '../../../../../components/app/confirm/info/row/text';
 import {
   useIsTransactionPayLoading,
   useTransactionPayTotals,
@@ -17,8 +18,14 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 
+export type TotalRowProps = {
+  variant?: ConfirmInfoRowSize;
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function TotalRow() {
+export function TotalRow({
+  variant = ConfirmInfoRowSize.Default,
+}: TotalRowProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
   const isLoading = useIsTransactionPayLoading();
@@ -32,20 +39,31 @@ export function TotalRow() {
     return formatFiat(new BigNumber(totals.total.usd).toNumber());
   }, [totals, formatFiat]);
 
+  const isSmall = variant === ConfirmInfoRowSize.Small;
+  const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;
+
   if (isLoading) {
-    return <ConfirmInfoRowSkeleton data-testid="total-row-skeleton" />;
+    return (
+      <Box data-testid="total-row-skeleton">
+        <ConfirmInfoRowSkeleton label={t('total')} rowVariant={variant} />
+      </Box>
+    );
   }
 
   return (
     <Box data-testid="total-row">
-      <ConfirmInfoRow label={t('total')} rowVariant={ConfirmInfoRowSize.Small}>
-        <Text
-          variant={TextVariant.bodyMd}
-          color={TextColor.textAlternative}
-          data-testid="total-value"
-        >
-          {totalUsd}
-        </Text>
+      <ConfirmInfoRow label={t('total')} rowVariant={variant}>
+        {isSmall ? (
+          <Text
+            variant={textVariant}
+            color={TextColor.textAlternative}
+            data-testid="total-value"
+          >
+            {totalUsd}
+          </Text>
+        ) : (
+          <ConfirmInfoRowText text={totalUsd} data-testid="total-value" />
+        )}
       </ConfirmInfoRow>
     </Box>
   );

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/index.ts
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/index.ts
@@ -1,0 +1,1 @@
+export { TransactionPaySection } from './transaction-pay-section';

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { getMockPersonalSignConfirmState } from '../../../../../../test/data/confirmations/helper';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { TransactionPaySection } from './transaction-pay-section';
+
+jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/pay/useTransactionPayToken');
+
+jest.mock('../pay-with-row/pay-with-row', () => ({
+  PayWithRow: () => <div data-testid="pay-with-row">PayWithRow</div>,
+}));
+
+jest.mock('../bridge-fee-row/bridge-fee-row', () => ({
+  BridgeFeeRow: () => <div data-testid="bridge-fee-row">BridgeFeeRow</div>,
+}));
+
+jest.mock('../total-row/total-row', () => ({
+  TotalRow: () => <div data-testid="total-row">TotalRow</div>,
+}));
+
+jest.mock('../required-tokens-row', () => ({
+  RequiredTokensRow: () => (
+    <div data-testid="required-tokens-row">RequiredTokensRow</div>
+  ),
+}));
+
+const mockStore = configureMockStore([]);
+
+function render() {
+  const state = getMockPersonalSignConfirmState();
+  return renderWithConfirmContextProvider(
+    <TransactionPaySection />,
+    mockStore(state),
+  );
+}
+
+describe('TransactionPaySection', () => {
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...originalEnv, MM_PAY_DAPPS_ENABLED: 'true' };
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+      isNative: false,
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when MM_PAY_DAPPS_ENABLED is not set', () => {
+    process.env = { ...originalEnv };
+    delete process.env.MM_PAY_DAPPS_ENABLED;
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when MM_PAY_DAPPS_ENABLED is false', () => {
+    process.env = { ...originalEnv, MM_PAY_DAPPS_ENABLED: 'false' };
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when no required tokens and not loading', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+
+    const { container } = render();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders section when loading', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('transaction-pay-section')).toBeInTheDocument();
+    expect(getByTestId('required-tokens-row')).toBeInTheDocument();
+    expect(getByTestId('pay-with-row')).toBeInTheDocument();
+  });
+
+  it('renders section when has required tokens', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { chainId: '0x1', address: '0x123' },
+    ] as never);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('transaction-pay-section')).toBeInTheDocument();
+    expect(getByTestId('required-tokens-row')).toBeInTheDocument();
+    expect(getByTestId('pay-with-row')).toBeInTheDocument();
+  });
+
+  it('does not render BridgeFeeRow and TotalRow when no payToken', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { chainId: '0x1', address: '0x123' },
+    ] as never);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+      isNative: false,
+    });
+
+    const { getByTestId, queryByTestId } = render();
+
+    expect(getByTestId('transaction-pay-section')).toBeInTheDocument();
+    expect(queryByTestId('bridge-fee-row')).not.toBeInTheDocument();
+    expect(queryByTestId('total-row')).not.toBeInTheDocument();
+  });
+
+  it('renders BridgeFeeRow and TotalRow when payToken exists', () => {
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { chainId: '0x1', address: '0x123' },
+    ] as never);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        chainId: '0x1',
+        address: '0x456',
+        symbol: 'ETH',
+        balanceUsd: '100',
+      },
+      setPayToken: jest.fn(),
+      isNative: true,
+    } as never);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('transaction-pay-section')).toBeInTheDocument();
+    expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
+    expect(getByTestId('total-row')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ConfirmInfoSection } from '../../../../../components/app/confirm/info/row/section';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { PayWithRow } from '../pay-with-row/pay-with-row';
+import { BridgeFeeRow } from '../bridge-fee-row/bridge-fee-row';
+import { TotalRow } from '../total-row/total-row';
+import { RequiredTokensRow } from '../required-tokens-row';
+
+export const TransactionPaySection = () => {
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const isLoading = useIsTransactionPayLoading();
+  const { payToken } = useTransactionPayToken();
+
+  if (!process.env.MM_PAY_DAPPS_ENABLED) {
+    return null;
+  }
+
+  const hasRequiredTokens = Boolean(requiredTokens?.length);
+  const hasPaymentToken = Boolean(payToken);
+  const showPayWithRow = isLoading || hasRequiredTokens;
+
+  if (!showPayWithRow) {
+    return null;
+  }
+
+  return (
+    <ConfirmInfoSection data-testid="transaction-pay-section">
+      <RequiredTokensRow />
+      <PayWithRow />
+      {hasPaymentToken && (
+        <>
+          <BridgeFeeRow />
+          <TotalRow />
+        </>
+      )}
+    </ConfirmInfoSection>
+  );
+};

--- a/ui/pages/confirmations/components/token-icon/token-icon.tsx
+++ b/ui/pages/confirmations/components/token-icon/token-icon.tsx
@@ -12,7 +12,7 @@ import {
 import { selectNetworkConfigurationByChainId } from '../../../../selectors';
 import { useSendTokens } from '../../hooks/send/useSendTokens';
 
-export type TokenIconSize = 'sm' | 'md';
+export type TokenIconSize = 'xs' | 'sm' | 'md';
 
 export type TokenIconProps = {
   chainId: Hex;
@@ -21,13 +21,21 @@ export type TokenIconProps = {
 };
 
 const TOKEN_ICON_SIZE_MAP: Record<TokenIconSize, AvatarTokenSize> = {
+  xs: AvatarTokenSize.Xs,
   sm: AvatarTokenSize.Sm,
   md: AvatarTokenSize.Md,
 };
 
 const NETWORK_BADGE_SIZE_MAP: Record<TokenIconSize, AvatarNetworkSize> = {
+  xs: AvatarNetworkSize.Xs,
   sm: AvatarNetworkSize.Xs,
   md: AvatarNetworkSize.Xs,
+};
+
+const NETWORK_BADGE_STYLE_MAP: Record<TokenIconSize, React.CSSProperties> = {
+  xs: { width: '10px', height: '10px', minWidth: '10px' },
+  sm: {},
+  md: {},
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -57,6 +65,7 @@ export function TokenIcon({
           size={NETWORK_BADGE_SIZE_MAP[size]}
           name={networkConfiguration?.name ?? ''}
           src={CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId]}
+          style={NETWORK_BADGE_STYLE_MAP[size]}
         />
       }
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -5640,10 +5640,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdn/browser-compat-data@npm:7.2.4":
-  version: 7.2.4
-  resolution: "@mdn/browser-compat-data@npm:7.2.4"
-  checksum: 10/20ff6fbda1d423215ec0e2f2ef96a6a34b0677d6f5ff8b08b6bf87494085993bf23766a9ab67221f80633280fd3795924b1a9a935bcd32477dfc40964640d8d3
+"@mdn/browser-compat-data@npm:7.3.0":
+  version: 7.3.0
+  resolution: "@mdn/browser-compat-data@npm:7.3.0"
+  checksum: 10/800b1d8cbbc3631f7b02ec5f86623bc8ce41538fc2603aa0f2127ecf2f8d461e7dce8568b06e51f74831fb0237893fe5205dd5557ddf60dc76a45bc4f0674682
   languageName: node
   linkType: hard
 
@@ -5755,6 +5755,36 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/f63101ea9804dde3a9d3810ecc3a1c7184aa1a9c479d05eeb6c1246e8103618aa435bbcaa414c573acbe01ecfe9684c891cdd572d7f196309af9fd0537d2496d
+  languageName: node
+  linkType: hard
+
+"@metamask/accounts-controller@npm:^36.0.0":
+  version: 36.0.0
+  resolution: "@metamask/accounts-controller@npm:36.0.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/eth-snap-keyring": "npm:^19.0.0"
+    "@metamask/keyring-api": "npm:^21.5.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-sdk": "npm:^10.3.0"
+    "@metamask/snaps-utils": "npm:^11.7.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    deepmerge: "npm:^4.2.2"
+    ethereum-cryptography: "npm:^2.1.2"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/fe8199bda61fda63ce9d787115a536645a485bb797f154566396144c4da00fe01b782c75aa063b7e5089a75cc3d0570c6e9fdea4212bc1604d9474c255604a46
   languageName: node
   linkType: hard
 
@@ -5888,114 +5918,6 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/9511e927310959e84a6a046ffde6a7f553c9c64e122d7951010ed0cb7da4066d6f27b4ef874706ebce3c664de0662ccd792339bb66ac9359b5686ec53858e9ae
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^95.1.0":
-  version: 95.3.0
-  resolution: "@metamask/assets-controllers@npm:95.3.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.2"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^5.0.0"
-    "@metamask/network-controller": "npm:^29.0.0"
-    "@metamask/permission-controller": "npm:^12.2.0"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.2"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/snaps-sdk": "npm:^10.3.0"
-    "@metamask/snaps-utils": "npm:^11.7.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
-    "@metamask/utils": "npm:^11.9.0"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/c44d5ede2f9bb9b54005ac3f0141788cf267edb489dc5feda53848caf9f106fa1f13f669bc4a7cda1e9d2123f925a8ac6594796d0a32a1741a7c8654526abba4
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controllers@npm:^96.0.0":
-  version: 96.0.0
-  resolution: "@metamask/assets-controllers@npm:96.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.0.0"
-    "@metamask/accounts-controller": "npm:^35.0.2"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/contract-metadata": "npm:^2.4.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/core-backend": "npm:^5.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-controller": "npm:^25.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^5.1.0"
-    "@metamask/network-controller": "npm:^29.0.0"
-    "@metamask/permission-controller": "npm:^12.2.0"
-    "@metamask/phishing-controller": "npm:^16.1.0"
-    "@metamask/polling-controller": "npm:^16.0.2"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/snaps-sdk": "npm:^10.3.0"
-    "@metamask/snaps-utils": "npm:^11.7.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
-    "@metamask/utils": "npm:^11.9.0"
-    "@types/bn.js": "npm:^5.1.5"
-    "@types/uuid": "npm:^8.3.0"
-    async-mutex: "npm:^0.5.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-    bn.js: "npm:^5.2.1"
-    immer: "npm:^9.0.6"
-    lodash: "npm:^4.17.21"
-    multiformats: "npm:^9.9.0"
-    reselect: "npm:^5.1.1"
-    single-call-balance-checker-abi: "npm:^1.0.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/c5cf7363972b2f267ba96a925fd74eaee3eebde8bf470af7d4c49589b33b34fc9b8574289e4592cbce13e941201893d2ad20018da0dada8025317db0ce33df0f
   languageName: node
   linkType: hard
 
@@ -6163,37 +6085,6 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/d9a73530421d74606ebcabccd6348a38a21ef786eb42d529bd73b05aee567e44e952482b26c2a7d5f93863afc955ced8dbd4979f76b3f0c7a0d9805e2abcceab
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-controller@npm:^64.4.1":
-  version: 64.8.1
-  resolution: "@metamask/bridge-controller@npm:64.8.1"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^35.0.2"
-    "@metamask/assets-controllers": "npm:^96.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.2"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.0.2"
-    "@metamask/network-controller": "npm:^29.0.0"
-    "@metamask/polling-controller": "npm:^16.0.2"
-    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/c1e73b783666eeb1480ca78ace999e80cb06270666e05965059416d156b60dafbe631ca7a6519538cd7f7e4999371f5e992a5e8440035472b1f80e88ba58423c
   languageName: node
   linkType: hard
 
@@ -6381,18 +6272,18 @@ __metadata:
   linkType: hard
 
 "@metamask/core-backend@npm:^5.0.0, @metamask/core-backend@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@metamask/core-backend@npm:5.1.0"
+  version: 5.1.1
+  resolution: "@metamask/core-backend@npm:5.1.1"
   dependencies:
-    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/accounts-controller": "npm:^36.0.0"
     "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/keyring-controller": "npm:^25.1.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
     "@metamask/utils": "npm:^11.9.0"
     "@tanstack/query-core": "npm:^5.62.16"
     uuid: "npm:^8.3.2"
-  checksum: 10/8d966656b33a5582772ab6c29d04d7d7f9d47ffb52ad18a2d06f9e134a9bc6939b835452224230fc269631ee394b6642473dec8b309fead1e1f324b6e26f286e
+  checksum: 10/ee6c956511cf530342cac9dc27f21705109bea9c57b3babe51390ca0601a913507cf40db9fbf27459cff8d1de551dd291afeb0d5ea8119fd5d00130df222aafe
   languageName: node
   linkType: hard
 
@@ -6892,6 +6783,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-snap-keyring@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "@metamask/eth-snap-keyring@npm:19.0.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-api": "npm:^21.4.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-internal-snap-client": "npm:^9.0.0"
+    "@metamask/keyring-snap-sdk": "npm:^7.2.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.1.0"
+    "@types/uuid": "npm:^9.0.8"
+    async-mutex: "npm:^0.5.0"
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@metamask/keyring-api": ^21.4.0
+  checksum: 10/6e307295cb15ab44aba4ff89fb1886ad8c0ea6636748e5d84c87250fbaff9d5a3c316e63b614d7b472e4027aad0a7912109b36981e978e978bf31deea7980726
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-token-tracker@npm:^10.0.2":
   version: 10.0.2
   resolution: "@metamask/eth-token-tracker@npm:10.0.2"
@@ -7064,7 +6978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^26.0.0, @metamask/gas-fee-controller@npm:^26.0.1, @metamask/gas-fee-controller@npm:^26.0.2":
+"@metamask/gas-fee-controller@npm:^26.0.0, @metamask/gas-fee-controller@npm:^26.0.2":
   version: 26.0.2
   resolution: "@metamask/gas-fee-controller@npm:26.0.2"
   dependencies:
@@ -7335,9 +7249,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^21.0.0, @metamask/keyring-api@npm:^21.2.0, @metamask/keyring-api@npm:^21.4.0":
-  version: 21.4.0
-  resolution: "@metamask/keyring-api@npm:21.4.0"
+"@metamask/keyring-api@npm:^21.0.0, @metamask/keyring-api@npm:^21.2.0, @metamask/keyring-api@npm:^21.4.0, @metamask/keyring-api@npm:^21.5.0":
+  version: 21.5.0
+  resolution: "@metamask/keyring-api@npm:21.5.0"
   dependencies:
     "@ethereumjs/tx": "npm:^5.4.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
@@ -7348,7 +7262,7 @@ __metadata:
     async-mutex: "npm:^0.5.0"
     bitcoin-address-validation: "npm:^2.2.3"
     uuid: "npm:^9.0.1"
-  checksum: 10/f780ccdda9f072effa0472bddefeb210618ba597e1c3c9d333056c8a7770d0fb6f18e6647d77069c63b0297184f676cc682d6347cf30e164567655f0fa82b567
+  checksum: 10/a7f2a8c66bc76edabde15b66b80904208b71fd62406ebb91579db4c65d74a8f66db6c610afe265823313df7423b6727a4de03cb1f43e41d840d51a5039f9ef4d
   languageName: node
   linkType: hard
 
@@ -7391,6 +7305,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-internal-api@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@metamask/keyring-internal-api@npm:10.0.0"
+  dependencies:
+    "@metamask/keyring-api": "npm:^21.4.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+  checksum: 10/f49499572418128b03ed0d1e5d028082530b0b84f5d4554d24216b1caf0a196fe23b6038f719fc32af6c262e33de4dbd346b593b98236ad40b3ca67026f1a998
+  languageName: node
+  linkType: hard
+
 "@metamask/keyring-internal-api@npm:^9.0.0, @metamask/keyring-internal-api@npm:^9.1.0, @metamask/keyring-internal-api@npm:^9.1.1":
   version: 9.1.1
   resolution: "@metamask/keyring-internal-api@npm:9.1.1"
@@ -7415,6 +7340,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-internal-snap-client@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/keyring-internal-snap-client@npm:9.0.0"
+  dependencies:
+    "@metamask/keyring-api": "npm:^21.4.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-snap-client": "npm:^8.2.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/messenger": "npm:^0.3.0"
+  checksum: 10/d3a63d0a1aff343af013c5bc872f782eec80d048a76b169a17034fd004c61a42fe07d703c8227a1341569b62fb1fe091f66494c4658419a3e2827d864487e608
+  languageName: node
+  linkType: hard
+
 "@metamask/keyring-snap-client@npm:^1.1.0":
   version: 1.1.0
   resolution: "@metamask/keyring-snap-client@npm:1.1.0"
@@ -7431,35 +7369,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-snap-client@npm:^8.0.0, @metamask/keyring-snap-client@npm:^8.1.0, @metamask/keyring-snap-client@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "@metamask/keyring-snap-client@npm:8.1.1"
+"@metamask/keyring-snap-client@npm:^8.0.0, @metamask/keyring-snap-client@npm:^8.1.0, @metamask/keyring-snap-client@npm:^8.1.1, @metamask/keyring-snap-client@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "@metamask/keyring-snap-client@npm:8.2.0"
   dependencies:
-    "@metamask/keyring-api": "npm:^21.2.0"
-    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/keyring-api": "npm:^21.4.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@types/uuid": "npm:^9.0.8"
     uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^19.0.0
-  checksum: 10/dcdc9a286137a4ae884b709e565b988fb2e555a8a80db5d2ed3e93ee5262c81567a4efac6ff663b6751caf5b1173f92bc8437a395696058018a3b6e93fc30b35
+  checksum: 10/a64dafdc718061c55da3522d1598def5d7934b60d6141af64eccc9f8a0fecf72154d6ffc202913c2dd48fff8aa3266557bb914cd09901e00dccc3849dc932868
   languageName: node
   linkType: hard
 
-"@metamask/keyring-snap-sdk@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@metamask/keyring-snap-sdk@npm:7.1.1"
+"@metamask/keyring-snap-sdk@npm:^7.1.1, @metamask/keyring-snap-sdk@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@metamask/keyring-snap-sdk@npm:7.2.0"
   dependencies:
-    "@metamask/keyring-utils": "npm:^3.1.0"
-    "@metamask/snaps-sdk": "npm:^9.0.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/snaps-sdk": "npm:^10.4.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-api": ^21.2.0
+    "@metamask/keyring-api": ^21.4.0
     "@metamask/providers": ^19.0.0
-  checksum: 10/ac4ce050f4647096ef66ebd04d99d1423c002ca0fb05bd83e11caec59754b56d73bb8a95ac3a76f64472713256205e889d6785003dfe2c35f5f1d67c2f2efd12
+  checksum: 10/e805566d60bef72efb7298e9ee05d23acbd6e77e2cc17d47b6e9d09854f1a029b5873754d3ab0a5631a468267c0f21607de1c2cb37f57522a62cabca34b99b4d
   languageName: node
   linkType: hard
 
@@ -7586,7 +7524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^5.0.0, @metamask/multichain-account-service@npm:^5.1.0":
+"@metamask/multichain-account-service@npm:^5.1.0":
   version: 5.1.0
   resolution: "@metamask/multichain-account-service@npm:5.1.0"
   dependencies:
@@ -7771,33 +7709,6 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
-  languageName: node
-  linkType: hard
-
-"@metamask/network-controller@npm:^28.0.0":
-  version: 28.0.0
-  resolution: "@metamask/network-controller@npm:28.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/eth-block-tracker": "npm:^15.0.0"
-    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    immer: "npm:^9.0.6"
-    loglevel: "npm:^1.8.1"
-    reselect: "npm:^5.1.1"
-    uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/893142b6c27bc787c7ed647de112655851df4b51f3cf4e61773a2c9abdfcfb90a7907ad1a574b82ba6664cbf0d0fe0d31456ac513859ad66072053bf9336ec1c
   languageName: node
   linkType: hard
 
@@ -8928,7 +8839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.15.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.9.1, @metamask/transaction-controller@npm:^62.9.2":
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.15.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.9.2":
   version: 62.16.0
   resolution: "@metamask/transaction-controller@npm:62.16.0"
   dependencies:
@@ -8967,29 +8878,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^11.0.1":
-  version: 11.0.1
-  resolution: "@metamask/transaction-pay-controller@npm:11.0.1"
+"@metamask/transaction-pay-controller@npm:^12.2.0":
+  version: 12.2.0
+  resolution: "@metamask/transaction-pay-controller@npm:12.2.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
-    "@metamask/assets-controllers": "npm:^95.1.0"
+    "@metamask/assets-controllers": "npm:^99.2.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^64.4.1"
-    "@metamask/bridge-status-controller": "npm:^64.4.2"
+    "@metamask/bridge-controller": "npm:^65.3.0"
+    "@metamask/bridge-status-controller": "npm:^66.0.0"
     "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.1"
+    "@metamask/gas-fee-controller": "npm:^26.0.2"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^28.0.0"
+    "@metamask/network-controller": "npm:^29.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "npm:^62.9.1"
+    "@metamask/transaction-controller": "npm:^62.14.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/e88485020ef2f08d6ec1aee2f43d6a160433324d600c6ddb35bcf2372bbd5af99ae155131df232990fb0129eb21a5e39dcd50d18d5059d279dbf673023627a04
+  checksum: 10/f654439303d7a6dd28d56f15d11b9b2b7902e288a7cc0f00b29e6bbc602c9f11462aed0e2e951e18b9f3b8662fe90a3bfd393bd83817c25c30fa7fa4a82d5461
   languageName: node
   linkType: hard
 
@@ -18585,17 +18496,17 @@ __metadata:
   linkType: hard
 
 "addons-linter@npm:^9.5.0":
-  version: 9.5.0
-  resolution: "addons-linter@npm:9.5.0"
+  version: 9.6.0
+  resolution: "addons-linter@npm:9.6.0"
   dependencies:
     "@fluent/syntax": "npm:0.19.0"
     "@fregante/relaxed-json": "npm:2.0.0"
-    "@mdn/browser-compat-data": "npm:7.2.4"
+    "@mdn/browser-compat-data": "npm:7.3.0"
     addons-moz-compare: "npm:1.3.0"
     addons-scanner-utils: "npm:10.2.0"
     ajv: "npm:8.17.1"
     chalk: "npm:4.1.2"
-    cheerio: "npm:1.1.2"
+    cheerio: "npm:1.2.0"
     columnify: "npm:1.6.0"
     common-tags: "npm:1.8.2"
     deepmerge: "npm:4.3.1"
@@ -18607,7 +18518,7 @@ __metadata:
     fast-json-patch: "npm:3.1.1"
     image-size: "npm:2.0.2"
     json-merge-patch: "npm:1.0.2"
-    pino: "npm:10.2.1"
+    pino: "npm:10.3.0"
     semver: "npm:7.7.3"
     source-map-support: "npm:0.5.21"
     upath: "npm:2.0.1"
@@ -18615,7 +18526,7 @@ __metadata:
     yauzl: "npm:2.10.0"
   bin:
     addons-linter: bin/addons-linter
-  checksum: 10/aa573e98e5cd0ab810d65803bc868b9c73ea9809a426d83bafc2c74e233761b6daf37f0fdecf4b45820dace9ba1288eb72f4eef60c79f040d50871da5764ce8c
+  checksum: 10/bdc667bdc6b00eaf9c2938231ff70c3e3cab3cb42804d155aa5ec46c65055014a1c1008bc2ffa676f805ba1e51c495e0868d914b6b9e5eeddf68e66533baccfe
   languageName: node
   linkType: hard
 
@@ -21410,22 +21321,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:1.1.2":
-  version: 1.1.2
-  resolution: "cheerio@npm:1.1.2"
+"cheerio@npm:1.2.0":
+  version: 1.2.0
+  resolution: "cheerio@npm:1.2.0"
   dependencies:
     cheerio-select: "npm:^2.1.0"
     dom-serializer: "npm:^2.0.0"
     domhandler: "npm:^5.0.3"
     domutils: "npm:^3.2.2"
     encoding-sniffer: "npm:^0.2.1"
-    htmlparser2: "npm:^10.0.0"
+    htmlparser2: "npm:^10.1.0"
     parse5: "npm:^7.3.0"
     parse5-htmlparser2-tree-adapter: "npm:^7.1.0"
     parse5-parser-stream: "npm:^7.1.2"
-    undici: "npm:^7.12.0"
+    undici: "npm:^7.19.0"
     whatwg-mimetype: "npm:^4.0.0"
-  checksum: 10/6b654bf5a358d3406eed5a3ae84530bab0d6d2d581d0a92d3c0666c310648d4300a00b11335e15007a35922ad3743931385ef17bec8d67b4fa077f10d1aaf2b5
+  checksum: 10/eda2ad43e1d649c99c1338789bb58a4add3b7995d881db889be94e70b3c95a83074c366486e46379eb145d22ddf6d2f207da945d70c5dff5fae1afb54b8a39e0
   languageName: node
   linkType: hard
 
@@ -29013,7 +28924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^10.0.0":
+"htmlparser2@npm:^10.1.0":
   version: 10.1.0
   resolution: "htmlparser2@npm:10.1.0"
   dependencies:
@@ -33914,7 +33825,7 @@ __metadata:
     "@metamask/test-dapp-tron": "npm:^0.3.1"
     "@metamask/test-snaps": "npm:^3.4.0"
     "@metamask/transaction-controller": "npm:^62.16.0"
-    "@metamask/transaction-pay-controller": "npm:^11.0.1"
+    "@metamask/transaction-pay-controller": "npm:^12.2.0"
     "@metamask/tron-wallet-snap": "npm:^1.21.1"
     "@metamask/user-operation-controller": "npm:^40.0.0"
     "@metamask/utils": "npm:^11.4.2"
@@ -36880,9 +36791,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino@npm:10.2.1":
-  version: 10.2.1
-  resolution: "pino@npm:10.2.1"
+"pino@npm:10.3.0":
+  version: 10.3.0
+  resolution: "pino@npm:10.3.0"
   dependencies:
     "@pinojs/redact": "npm:^0.4.0"
     atomic-sleep: "npm:^1.0.0"
@@ -36897,7 +36808,7 @@ __metadata:
     thread-stream: "npm:^4.0.0"
   bin:
     pino: bin.js
-  checksum: 10/6f674ee35017edf17105677b539914be01c83b938ab89c7701c50f8cb1197cf3f4426437ff37b59a2d0ff8b58926801b96cd883c40c740989380168bda95c510
+  checksum: 10/c96eb30c95e5e9ad1d6ee229a63251ee1e7a73cabd62036ab75b621fbfe0c62c9001369af2a4f01268e1fef228c2b804e110db8213f7f766399b162061d54828
   languageName: node
   linkType: hard
 
@@ -43958,10 +43869,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.12.0":
-  version: 7.19.2
-  resolution: "undici@npm:7.19.2"
-  checksum: 10/26a01804402e5f09d02a5d09607e42096828698dddbcf32132dd313af4fda99f3c04ed84d884e28528f945a5b77d87df5c01ec6c1bdc918fd28878cb35f1cb4a
+"undici@npm:^7.19.0":
+  version: 7.20.0
+  resolution: "undici@npm:7.20.0"
+  checksum: 10/09ca3e1255cf05f3c76e6dff2ae760131ea5bba57290b9b184bd94f5167939548e7ea73292c524c25eb91f5a2152623394d4c6124e222d34fcd53ef733c6b156
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Initial support for MetaMask Pay in dApp transaction confirmations.

Currently disabled unless `MM_PAY_DAPPS_ENABLED` set.

### New Components
- `TransactionPaySection` - Container component that orchestrates the pay flow UI, gated by `MM_PAY_DAPPS_ENABLED`
- `RequiredTokensRow` - Displays required tokens with amount/asset pills and fiat values

### Modified Components
- `PayWithRow` - Added `variant` prop for Default (pill styling) vs Small (inline) display
- `BridgeFeeRow` - Added `variant` prop; Default hides MetaMask fee, Small shows it
- `TotalRow` - Added `variant` prop for consistent styling across contexts
- `BridgeTimeRow` - Added `rowVariant` prop for size control
- `GasFeeSection` - Hide when `sourceAmounts` exist (Pay flow handles fees)
- `TokenIcon` - Added `xs` size (16px) for compact displays

### Integration
- Integrated `TransactionPaySection` into `BaseTransactionInfo`, `NativeTransferInfo`, `TokenTransferInfo`
- Added `ConfirmInfoRowSize` enum export from row component

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="379" height="625" alt="Confirmation" src="https://github.com/user-attachments/assets/e1dfe968-040e-4920-af14-38b14c01972d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirmation UI/logic and upgrades `@metamask/transaction-pay-controller`, which can affect fee/payment presentation and transaction flows, though the new Pay section is gated by `MM_PAY_DAPPS_ENABLED`.
> 
> **Overview**
> Adds initial *MetaMask Pay* support to dapp transaction confirmations behind `MM_PAY_DAPPS_ENABLED`, inserting a new `TransactionPaySection` (with `RequiredTokensRow`, `PayWithRow`, and optional fee/total rows) into the main confirmation info flows.
> 
> Updates confirmation rows to support size variants and improved loading states (new labeled skeleton behavior, compact `PayWithRow` pill UI, and variant-driven `BridgeFeeRow`/`BridgeTimeRow`/`TotalRow` rendering), and hides `GasFeesSection` when pay `sourceAmounts` are present.
> 
> Wires additional permitted-account lookups into `wallet_getCapabilities`/`wallet_sendCalls`, adds the `requiredToken` i18n string, introduces `TokenIcon` `xs` size, and bumps `@metamask/transaction-pay-controller` (plus related LavaMoat policy and lockfile dependency updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92216ea43729260f5836ea9fe214c25ca15163af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->