### PR TITLE
chore: Prevent OOM error during bundle script

### DIFF
--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -63,5 +63,5 @@ corepack enable
 # 5. Install dependencies
 yarn
 
-# 6. Run the production build command
-yarn build prod
+# 6. Run the production build command with 4GB of heap space
+NODE_OPTIONS='--max-old-space-size=4096' yarn build prod


### PR DESCRIPTION
## **Description**

The bundle script used by Firefox reviewers to validate our build was throwing an OOM error when run on devices where the default heap size of Node.js was set to ~2GB. There was an unwritten assumption that over 2GB was available.

The script has been updated to set a max heap size of 4GB, which should prevent this problem from happening again.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39754?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `bundle.sh` to set `NODE_OPTIONS` for the build step; main potential impact is higher memory usage on constrained machines.
> 
> **Overview**
> Prevents Node.js out-of-memory failures during the Firefox reviewer bundle build by running `yarn build prod` with `NODE_OPTIONS='--max-old-space-size=4096'` in `.github/scripts/bundle.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed2f837323401fd54ee13f30e1e392ea4bd53ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->