### PR TITLE
chore: Ignore glob deprecation cp-13.16.1

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -63,6 +63,9 @@ npmAuditIgnoreAdvisories:
   # update.
   - '@metamask/error-reporting-service (deprecation)'
 
+  # A deprecated v10.x version is used in a few different places, most notably Storybook.
+  - 'glob (deprecation)'
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'


### PR DESCRIPTION
## **Description**

The package `glob` has been deprecated, which in turn is causing the audit status check to fail. This deprecation has been temporarily ignored because there is no path to updating from the deprecated version yet (Storybook hasn't updated past this version yet).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39755?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects Yarn audit/deprecation filtering, with no runtime code or dependency updates.
> 
> **Overview**
> Updates `.yarnrc.yml` to **ignore the `glob` package deprecation** by adding it to `npmAuditIgnoreAdvisories` (noting its usage in v10.x, e.g. Storybook), unblocking audit status checks without changing application code or dependency versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a45a5f8dbc5df35aaf8bfa099154b9e3a8c423f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->