### PR TITLE
feat: update network list item active state to mobile style

### DIFF
--- a/test/e2e/page-objects/pages/network-manager.ts
+++ b/test/e2e/page-objects/pages/network-manager.ts
@@ -161,10 +161,6 @@ class NetworkManager {
     const selector = `[data-testid="network-list-item-${caipChainId}"].multichain-network-list-item--selected`;
     await this.driver.waitForSelector(selector);
 
-    // Additional verification: ensure the selected indicator is present
-    const indicatorSelector = `[data-testid="network-list-item-${caipChainId}"] .multichain-network-list-item__selected-indicator`;
-    await this.driver.waitForSelector(indicatorSelector);
-
     console.log(
       `Custom network ${caipChainId} is properly selected with background indication`,
     );

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -49,12 +49,6 @@ describe('MultichainAccountCell', () => {
     expect(screen.getByText('Test Account')).toBeInTheDocument();
     expect(screen.getByText('$2,400.00')).toBeInTheDocument();
     expect(screen.getByTestId('end-accessory')).toBeInTheDocument();
-
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${defaultProps.accountId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
   });
 
   it('shows selection state correctly and applies proper styling', () => {
@@ -63,11 +57,10 @@ describe('MultichainAccountCell', () => {
       store,
     );
 
-    expect(
-      screen.getByTestId(
-        `multichain-account-cell-${defaultProps.accountId}-selected-indicator`,
-      ),
-    ).toBeInTheDocument();
+    const cellElement = screen.getByTestId(
+      `multichain-account-cell-${defaultProps.accountId}`,
+    );
+    expect(cellElement).toHaveClass('is-selected');
   });
 
   it('handles click events and applies pointer cursor when onClick is provided', () => {
@@ -129,15 +122,11 @@ describe('MultichainAccountCell', () => {
     expect(screen.getByText('Complete Account')).toBeInTheDocument();
     expect(screen.getByText('$1,234.56')).toBeInTheDocument();
     expect(screen.getByTestId('end-accessory')).toBeInTheDocument();
-    expect(
-      screen.getByTestId(
-        `multichain-account-cell-${defaultProps.accountId}-selected-indicator`,
-      ),
-    ).toBeInTheDocument();
 
     const cellElement = screen.getByTestId(
       `multichain-account-cell-${defaultProps.accountId}`,
     );
+    expect(cellElement).toHaveClass('is-selected');
     expect(cellElement.style.cursor).toBe('pointer');
 
     fireEvent.click(cellElement);
@@ -177,11 +166,6 @@ describe('MultichainAccountCell', () => {
     );
 
     expect(screen.getByTestId('start-accessory')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${defaultProps.accountId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
   });
 
   it('hides balance value when privacy mode is enabled', () => {

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.test.tsx
@@ -150,7 +150,7 @@ describe('MultichainAccountCell', () => {
     expect(screen.getByText('Start')).toBeInTheDocument();
   });
 
-  it('hides selected bar when startAccessory is present', () => {
+  it('renders with startAccessory when provided', () => {
     // Arrange
     const startAccessoryElement = (
       <span data-testid="start-accessory">Start</span>

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -76,24 +76,9 @@ export const MultichainAccountCell = ({
       data-testid={`multichain-account-cell-${accountId}`}
       key={`multichain-account-cell-${accountId}`}
       backgroundColor={
-        selected ? BackgroundColor.infoMuted : BackgroundColor.transparent
+        selected ? BackgroundColor.backgroundMuted : BackgroundColor.transparent
       }
     >
-      {selected && !startAccessory && (
-        <Box
-          className="multichain-account-cell__selected-indicator"
-          style={{
-            width: '4px',
-            position: 'absolute',
-            left: '4px',
-            top: '4px',
-            bottom: '4px',
-          }}
-          borderRadius={BorderRadius.pill}
-          backgroundColor={BackgroundColor.primaryDefault}
-          data-testid={`multichain-account-cell-${accountId}-selected-indicator`}
-        />
-      )}
       {startAccessory}
       <Box
         display={Display.Flex}

--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -72,11 +72,13 @@ export const MultichainAccountCell = ({
       padding={4}
       gap={4}
       onClick={handleClick}
-      className={`multichain-account-cell${disableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected ? ' is-selected' : ''}`}
+      className={`multichain-account-cell${disableHoverEffect ? ' multichain-account-cell--no-hover' : ''}${selected && !startAccessory ? ' is-selected' : ''}`}
       data-testid={`multichain-account-cell-${accountId}`}
       key={`multichain-account-cell-${accountId}`}
       backgroundColor={
-        selected ? BackgroundColor.backgroundMuted : BackgroundColor.transparent
+        selected && !startAccessory
+          ? BackgroundColor.backgroundMuted
+          : BackgroundColor.transparent
       }
     >
       {startAccessory}

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -240,11 +240,6 @@ describe('MultichainAccountList', () => {
     );
     expect(selectedCell).toHaveClass('is-selected');
 
-    const unselectedCell = screen.getByTestId(
-      `multichain-account-cell-${walletTwoGroupId}`,
-    );
-    expect(unselectedCell).not.toHaveClass('is-selected');
-
     // Find and click the second account cell (wallet two)
     const accountCell = screen.getByTestId(
       `multichain-account-cell-${walletTwoGroupId}`,
@@ -271,11 +266,6 @@ describe('MultichainAccountList', () => {
     );
     expect(selectedCell).toHaveClass('is-selected');
 
-    let unselectedCell = screen.getByTestId(
-      `multichain-account-cell-${walletTwoGroupId}`,
-    );
-    expect(unselectedCell).not.toHaveClass('is-selected');
-
     // Change the selected account to wallet two
     rerender(
       <MultichainAccountList
@@ -293,29 +283,13 @@ describe('MultichainAccountList', () => {
       `multichain-account-cell-${walletTwoGroupId}`,
     );
     expect(selectedCell).toHaveClass('is-selected');
-
-    unselectedCell = screen.getByTestId(
-      `multichain-account-cell-${walletOneGroupId}`,
-    );
-    expect(unselectedCell).not.toHaveClass('is-selected');
   });
 
-  it('shows no checkboxes and no selected icons when selectedAccountGroups is empty', () => {
+  it('shows no checkboxes when selectedAccountGroups is empty', () => {
     renderComponent({ selectedAccountGroups: [] });
 
     // No checkboxes should be present
     expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
-
-    // No accounts should have is-selected class since no accounts are marked as selected
-    const walletOneCell = screen.getByTestId(
-      `multichain-account-cell-${walletOneGroupId}`,
-    );
-    expect(walletOneCell).not.toHaveClass('is-selected');
-
-    const walletTwoCell = screen.getByTestId(
-      `multichain-account-cell-${walletTwoGroupId}`,
-    );
-    expect(walletTwoCell).not.toHaveClass('is-selected');
   });
 
   it('handles multiple account groups within a single wallet', () => {
@@ -752,12 +726,8 @@ describe('MultichainAccountList', () => {
         />,
       );
 
-      // Now checkboxes should be visible and is-selected class should be removed
+      // Now checkboxes should be visible
       expect(screen.getAllByRole('checkbox')).toHaveLength(2);
-      selectedCell = screen.getByTestId(
-        `multichain-account-cell-${walletOneGroupId}`,
-      );
-      expect(selectedCell).not.toHaveClass('is-selected');
     });
 
     it('hides account menu (3 dots) when showAccountCheckbox is true', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -234,17 +234,16 @@ describe('MultichainAccountList', () => {
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
 
-    // Selected icon should be present for the selected account
-    expect(
-      screen.getByTestId(
-        `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${walletTwoGroupId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
+    // Selected account should have is-selected class
+    const selectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletOneGroupId}`,
+    );
+    expect(selectedCell).toHaveClass('is-selected');
+
+    const unselectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    expect(unselectedCell).not.toHaveClass('is-selected');
 
     // Find and click the second account cell (wallet two)
     const accountCell = screen.getByTestId(
@@ -266,17 +265,16 @@ describe('MultichainAccountList', () => {
     let checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
 
-    // Selected icon should be present for the selected account
-    expect(
-      screen.getByTestId(
-        `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${walletTwoGroupId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
+    // Selected account should have is-selected class
+    let selectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletOneGroupId}`,
+    );
+    expect(selectedCell).toHaveClass('is-selected');
+
+    let unselectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    expect(unselectedCell).not.toHaveClass('is-selected');
 
     // Change the selected account to wallet two
     rerender(
@@ -290,17 +288,16 @@ describe('MultichainAccountList', () => {
     checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
 
-    // Now wallet two should have the selected icon
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId(
-        `multichain-account-cell-${walletTwoGroupId}-selected-indicator`,
-      ),
-    ).toBeInTheDocument();
+    // Now wallet two should have the is-selected class
+    selectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    expect(selectedCell).toHaveClass('is-selected');
+
+    unselectedCell = screen.getByTestId(
+      `multichain-account-cell-${walletOneGroupId}`,
+    );
+    expect(unselectedCell).not.toHaveClass('is-selected');
   });
 
   it('shows no checkboxes and no selected icons when selectedAccountGroups is empty', () => {
@@ -309,17 +306,16 @@ describe('MultichainAccountList', () => {
     // No checkboxes should be present
     expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
 
-    // No selected icons should be present since no accounts are marked as selected
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(
-        `multichain-account-cell-${walletTwoGroupId}-selected-indicator`,
-      ),
-    ).not.toBeInTheDocument();
+    // No accounts should have is-selected class since no accounts are marked as selected
+    const walletOneCell = screen.getByTestId(
+      `multichain-account-cell-${walletOneGroupId}`,
+    );
+    expect(walletOneCell).not.toHaveClass('is-selected');
+
+    const walletTwoCell = screen.getByTestId(
+      `multichain-account-cell-${walletTwoGroupId}`,
+    );
+    expect(walletTwoCell).not.toHaveClass('is-selected');
   });
 
   it('handles multiple account groups within a single wallet', () => {
@@ -740,13 +736,12 @@ describe('MultichainAccountList', () => {
         showAccountCheckbox: false,
       });
 
-      // With checkboxes disabled, selected icon should be visible
+      // With checkboxes disabled, is-selected class should be present
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
-      expect(
-        screen.getByTestId(
-          `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-        ),
-      ).toBeInTheDocument();
+      let selectedCell = screen.getByTestId(
+        `multichain-account-cell-${walletOneGroupId}`,
+      );
+      expect(selectedCell).toHaveClass('is-selected');
 
       // Enable checkboxes
       rerender(
@@ -757,13 +752,12 @@ describe('MultichainAccountList', () => {
         />,
       );
 
-      // Now checkboxes should be visible and selected icon should be hidden
+      // Now checkboxes should be visible and is-selected class should be removed
       expect(screen.getAllByRole('checkbox')).toHaveLength(2);
-      expect(
-        screen.queryByTestId(
-          `multichain-account-cell-${walletOneGroupId}-selected-indicator`,
-        ),
-      ).not.toBeInTheDocument();
+      selectedCell = screen.getByTestId(
+        `multichain-account-cell-${walletOneGroupId}`,
+      );
+      expect(selectedCell).not.toHaveClass('is-selected');
     });
 
     it('hides account menu (3 dots) when showAccountCheckbox is true', () => {

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -712,7 +712,7 @@ describe('MultichainAccountList', () => {
 
       // With checkboxes disabled, is-selected class should be present
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
-      let selectedCell = screen.getByTestId(
+      const selectedCell = screen.getByTestId(
         `multichain-account-cell-${walletOneGroupId}`,
       );
       expect(selectedCell).toHaveClass('is-selected');

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -704,7 +704,7 @@ describe('MultichainAccountList', () => {
       expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
     });
 
-    it('checkboxes and selected icons are mutually exclusive', () => {
+    it('shows is-selected class or checkboxes based on showAccountCheckbox prop', () => {
       const { rerender } = renderComponent({
         selectedAccountGroups: [walletOneGroupId],
         showAccountCheckbox: false,

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -19,7 +19,6 @@ import {
   AlignItems,
   BackgroundColor,
   BlockSize,
-  BorderRadius,
   Color,
   Display,
   FlexDirection,
@@ -88,7 +87,6 @@ const AccountListItem = ({
   showConnectedStatus = true,
   privacyMode = false,
   showAccountLabels = true,
-  showSelectionIndicator = true,
 }) => {
   const t = useI18nContext();
 
@@ -223,14 +221,6 @@ const AccountListItem = ({
           {startAccessory}
         </Box>
       ) : null}
-      {selected && showSelectionIndicator && (
-        <Box
-          className="multichain-account-list-item__selected-indicator"
-          borderRadius={BorderRadius.pill}
-          backgroundColor={Color.primaryDefault}
-          data-testid="account-list-item-selected-indicator"
-        />
-      )}
 
       <Box className="flex w-full gap-2 items-center">
         <Box
@@ -496,10 +486,6 @@ AccountListItem.propTypes = {
    * Determines if account labels should be shown
    */
   showAccountLabels: PropTypes.bool,
-  /**
-   * Determines if left dark blue selection indicator is displayed or not
-   */
-  showSelectionIndicator: PropTypes.bool,
 };
 
 AccountListItem.displayName = 'AccountListItem';

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -200,7 +200,9 @@ const AccountListItem = ({
     <Box
       display={Display.Flex}
       padding={4}
-      backgroundColor={selected ? Color.primaryMuted : Color.transparent}
+      backgroundColor={
+        selected ? BackgroundColor.backgroundMuted : BackgroundColor.transparent
+      }
       className={classnames('multichain-account-list-item items-center', {
         'multichain-account-list-item--selected': selected,
         'multichain-account-list-item--connected': Boolean(connectedAvatar),

--- a/ui/components/multichain/account-list-item/account-list-item.test.js
+++ b/ui/components/multichain/account-list-item/account-list-item.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { merge } from 'lodash';
 import { BtcScope } from '@metamask/keyring-api';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -166,21 +166,6 @@ describe('AccountListItem', () => {
     expect(
       document.querySelector('.multichain-account-list-item--selected'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('account-list-item-selected-indicator'),
-    ).toBeInTheDocument();
-  });
-
-  it('does not render selection indicator if showSelectionIndicator is false', async () => {
-    render({ selected: true, showSelectionIndicator: false });
-    expect(
-      document.querySelector('.multichain-account-list-item--selected'),
-    ).toBeInTheDocument();
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId('account-list-item-selected-indicator'),
-      ).not.toBeInTheDocument();
-    });
   });
 
   it('renders the account name tooltip for long names', () => {

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                 data-testid="network-list-item-0x1"
               >
                 <div
-                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
                   <img
                     alt="Ethereum logo"

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -310,14 +310,11 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
               class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
               <div
-                class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-primary-muted"
+                class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
                 data-testid="network-list-item-0x1"
               >
                 <div
-                  class="mm-box multichain-network-list-item__selected-indicator mm-box--background-color-primary-default mm-box--rounded-pill"
-                />
-                <div
-                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
                   <img
                     alt="Ethereum logo"

--- a/ui/components/multichain/network-list-item/network-list-item.test.js
+++ b/ui/components/multichain/network-list-item/network-list-item.test.js
@@ -42,9 +42,7 @@ describe('NetworkListItem', () => {
       <NetworkListItem {...DEFAULT_PROPS} selected />,
     );
     expect(
-      container.querySelector(
-        '.multichain-network-list-item__selected-indicator',
-      ),
+      container.querySelector('.multichain-network-list-item--selected'),
     ).toBeInTheDocument();
   });
 

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -243,11 +243,7 @@ export const NetworkListItem = ({
       ) : (
         <AvatarNetwork
           borderColor={BorderColor.backgroundDefault}
-          backgroundColor={
-            selected
-              ? BackgroundColor.primaryDefault
-              : getAvatarNetworkColor(name)
-          }
+          backgroundColor={getAvatarNetworkColor(name)}
           name={name}
           src={iconSrc}
           size={iconSize as AvatarNetworkSize}

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -13,7 +13,6 @@ import {
   AlignItems,
   BackgroundColor,
   BlockSize,
-  BorderRadius,
   Display,
   JustifyContent,
   TextColor,
@@ -224,7 +223,7 @@ export const NetworkListItem = ({
       paddingBottom={rpcEndpoint ? 2 : 4}
       gap={4}
       backgroundColor={
-        selected ? BackgroundColor.primaryMuted : BackgroundColor.transparent
+        selected ? BackgroundColor.backgroundMuted : BackgroundColor.transparent
       }
       className={classnames('multichain-network-list-item', {
         'multichain-network-list-item--selected': selected,
@@ -239,19 +238,16 @@ export const NetworkListItem = ({
       onClick={disabled ? undefined : onClick}
     >
       {startAccessory ? <Box marginTop={1}>{startAccessory}</Box> : null}
-      {selected && (
-        <Box
-          className="multichain-network-list-item__selected-indicator"
-          borderRadius={BorderRadius.pill}
-          backgroundColor={BackgroundColor.primaryDefault}
-        />
-      )}
       {isIconSrc(iconSrc) ? (
         <Icon name={iconSrc} size={iconSize as IconSize} />
       ) : (
         <AvatarNetwork
           borderColor={BorderColor.backgroundDefault}
-          backgroundColor={getAvatarNetworkColor(name)}
+          backgroundColor={
+            selected
+              ? BackgroundColor.primaryDefault
+              : getAvatarNetworkColor(name)
+          }
           name={name}
           src={iconSrc}
           size={iconSize as AvatarNetworkSize}

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
   style="position: absolute; left: 0px; top: 0px; width: calc(100% - 24px); padding: 0px; height: 90%; max-height: 90%; display: flex; flex-direction: column; overflow: scroll; bottom: 0px; transform: translate(0px, -12px);"
 >
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-primary-muted"
+    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
     data-testid="network-list-item-undefined"
   >
     <div
@@ -34,10 +34,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       </div>
     </div>
     <div
-      class="mm-box multichain-network-list-item__selected-indicator mm-box--background-color-primary-default mm-box--rounded-pill"
-    />
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
       A
     </div>
@@ -419,7 +416,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
   style="position: absolute; left: 0px; top: 0px; width: calc(100% - 24px); padding: 0px; height: 90%; max-height: 90%; display: flex; flex-direction: column; overflow: scroll; bottom: 0px; transform: translate(0px, -12px);"
 >
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-primary-muted"
+    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
     data-testid="network-list-item-undefined"
   >
     <div
@@ -442,10 +439,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       </div>
     </div>
     <div
-      class="mm-box multichain-network-list-item__selected-indicator mm-box--background-color-primary-default mm-box--rounded-pill"
-    />
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
       A
     </div>

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       </div>
     </div>
     <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
       A
     </div>
@@ -439,7 +439,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       </div>
     </div>
     <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-primary-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
       A
     </div>


### PR DESCRIPTION
## **Description**

Update network and account list item active/selected state styling to match the mobile implementation as specified in MDP-669. This brings consistency between the extension and mobile app.

**Components Updated:**
1. **NetworkListItem** - Removed blue pill indicator, updated background when selected to backgroundMuted
2. **MultichainAccountCell** - Removed blue pill indicator, changed background from infoMuted to backgroundMuted
3. **AccountListItem** - Removed blue pill indicator and showSelectionIndicator prop

**What is the reason for the change?**
The network menu and account list active states in the extension did not match the mobile style, causing an inconsistent user experience across platforms.

<img width="300" height="889" alt="Screenshot 2026-02-03 at 2 40 52 PM" src="https://github.com/user-attachments/assets/d6390110-dd5c-4dcd-8b20-8dc7aa9a2fd0" /><img width="300" height="878" alt="Screenshot 2026-02-03 at 2 55 50 PM" src="https://github.com/user-attachments/assets/80cb9049-b538-464a-813e-ab29ffb1a6e7" />

**What is the improvement/solution?**
Align the extension's list item styling with the mobile implementation for a consistent, unified design system across both network and account selection.

## **Changelog**

CHANGELOG entry: Updated network and account list item active state styling to match mobile design

## **Related issues**

Fixes: [MDP-669](https://consensyssoftware.atlassian.net/browse/MDP-669)

## **Manual testing steps**

### Network List Item:
1. Open MetaMask extension
2. Click on the network selector/menu
3. Observe the currently selected network item:
   - Should have background-muted background color
   - Should NOT have a blue pill indicator on the left
4. Select a different network
5. Verify the new selected network displays with the same styling

### Account List Item:
1. Open MetaMask extension
2. Click on the account selector to open the accounts modal
3. Observe the currently selected account item:
   - Should have primaryMuted background color
   - Should NOT have a blue pill indicator on the left
4. Select a different account
5. Verify the new selected account displays with the same styling

### Storybook Testing:
- Run `yarn storybook`
- Navigate to `Components/Multichain/NetworkListItem` → View `SelectedStory`
- Navigate to `Components/MultichainAccounts/MultichainAccountCell` → View `Selected`

## **Screenshots/Recordings**

### **Before**

- Selected network/account had a blue pill indicator (left border)

https://github.com/user-attachments/assets/26671600-b395-4b60-a9a1-2e1a229e49ba

old account list item still used

<img width="383" height="311" alt="Screenshot 2026-02-03 at 4 35 19 PM" src="https://github.com/user-attachments/assets/961f1c62-5a12-4d54-894b-6706019fa457" />

### **After**

- Selected network/account has no blue pill indicator
- Network icon/avatar uses primary color when selected
- Background uses background-muted/primaryMuted (consistent)

https://github.com/user-attachments/assets/ca8f2908-7faa-4138-a81a-36c6e7c693b3

old account list item 

<img width="388" height="243" alt="Screenshot 2026-02-03 at 4 35 09 PM" src="https://github.com/user-attachments/assets/79fc8300-0631-416b-85e1-424c1eefb526" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MDP-669]: https://consensyssoftware.atlassian.net/browse/MDP-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily visual/styling changes plus test updates; main risk is minor UI regression in selected-state presentation/conditional styling.
> 
> **Overview**
> Aligns multichain network/account selection UI with mobile by **removing the left “pill” selection indicator** and switching selected-state styling to use `BackgroundColor.backgroundMuted`.
> 
> This updates `NetworkListItem`, `MultichainAccountCell` (selection now suppressed when `startAccessory` is present), and `AccountListItem` (drops the `showSelectionIndicator` prop entirely), with unit tests, snapshots, and an E2E selector check updated to assert selection via CSS class/background rather than indicator elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca99aaaf70df2c0e6434afc9b012e1deacaa5ece. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->