### PR TITLE
fix: After deserializing gator permissions map, ensure all keys exist cp-13.17.0 cp-13.16.2

### DIFF
--- a/ui/selectors/gator-permissions/gator-permissions.test.ts
+++ b/ui/selectors/gator-permissions/gator-permissions.test.ts
@@ -272,9 +272,7 @@ describe('Gator Permissions Selectors', () => {
       };
       const result = getGatorPermissionsMap(stateWithPartial);
       expect(result['native-token-stream']).toBeDefined();
-      expect(result['native-token-stream'][MOCK_CHAIN_ID_MAINNET]).toEqual(
-        [],
-      );
+      expect(result['native-token-stream'][MOCK_CHAIN_ID_MAINNET]).toEqual([]);
       expect(result['erc20-token-stream']).toEqual({});
       expect(result['native-token-periodic']).toEqual({});
       expect(result['erc20-token-periodic']).toEqual({});

--- a/ui/selectors/gator-permissions/gator-permissions.test.ts
+++ b/ui/selectors/gator-permissions/gator-permissions.test.ts
@@ -258,6 +258,29 @@ describe('Gator Permissions Selectors', () => {
         mockGatorPermissionsMap,
       );
     });
+
+    it('should fill in missing keys when serialized map omits permission types', () => {
+      const partialSerialized = JSON.stringify({
+        'native-token-stream': { [MOCK_CHAIN_ID_MAINNET]: [] },
+        // other keys intentionally omitted
+      });
+      const stateWithPartial: AppState = {
+        metamask: {
+          ...mockState.metamask,
+          gatorPermissionsMapSerialized: partialSerialized,
+        },
+      };
+      const result = getGatorPermissionsMap(stateWithPartial);
+      expect(result['native-token-stream']).toBeDefined();
+      expect(result['native-token-stream'][MOCK_CHAIN_ID_MAINNET]).toEqual(
+        [],
+      );
+      expect(result['erc20-token-stream']).toEqual({});
+      expect(result['native-token-periodic']).toEqual({});
+      expect(result['erc20-token-periodic']).toEqual({});
+      expect(result['erc20-token-revocation']).toEqual({});
+      expect(result.other).toEqual({});
+    });
   });
 
   describe('getAggregatedGatorPermissionsCountAcrossAllChains', () => {

--- a/ui/selectors/gator-permissions/gator-permissions.ts
+++ b/ui/selectors/gator-permissions/gator-permissions.ts
@@ -140,22 +140,20 @@ function sortGatorPermissionsByStartTime<
  */
 export const getGatorPermissionsMap = createSelector(
   [getMetamask],
-  (metamask) =>
-    {
-      const rawDeserialized = deserializeGatorPermissionsMap(metamask.gatorPermissionsMapSerialized);
+  (metamask) => {
+    const rawDeserialized = deserializeGatorPermissionsMap(
+      metamask.gatorPermissionsMapSerialized,
+    );
 
-      rawDeserialized['erc20-token-revocation'] = undefined;
+    // Ensure all permission-type keys are present in the deserialized map
+    GATOR_PERMISSIONS_MAP_KEYS.forEach((permissionType) => {
+      if (rawDeserialized[permissionType] === undefined) {
+        rawDeserialized[permissionType] = {};
+      }
+    });
 
-      // Ensure all permission-type keys are present in the deserialized map
-      GATOR_PERMISSIONS_MAP_KEYS.forEach(permissionType => {
-        if (rawDeserialized[permissionType] === undefined) {
-          rawDeserialized[permissionType] = {};
-        }
-      });
-
-
-      return rawDeserialized;
-    }
+    return rawDeserialized;
+  },
 );
 
 /**

--- a/ui/selectors/gator-permissions/gator-permissions.ts
+++ b/ui/selectors/gator-permissions/gator-permissions.ts
@@ -65,6 +65,12 @@ const TOKEN_TRANSFER_PERMISSION_TYPES: SupportedGatorPermissionType[] = [
   'erc20-token-revocation',
 ];
 
+/** All keys required by GatorPermissionsMap; used to normalize deserialized state with missing keys. */
+const GATOR_PERMISSIONS_MAP_KEYS: SupportedGatorPermissionType[] = [
+  ...TOKEN_TRANSFER_PERMISSION_TYPES,
+  'other',
+];
+
 const getMetamask = (state: AppState) => state.metamask;
 
 /**
@@ -135,7 +141,21 @@ function sortGatorPermissionsByStartTime<
 export const getGatorPermissionsMap = createSelector(
   [getMetamask],
   (metamask) =>
-    deserializeGatorPermissionsMap(metamask.gatorPermissionsMapSerialized),
+    {
+      const rawDeserialized = deserializeGatorPermissionsMap(metamask.gatorPermissionsMapSerialized);
+
+      rawDeserialized['erc20-token-revocation'] = undefined;
+
+      // Ensure all permission-type keys are present in the deserialized map
+      GATOR_PERMISSIONS_MAP_KEYS.forEach(permissionType => {
+        if (rawDeserialized[permissionType] === undefined) {
+          rawDeserialized[permissionType] = {};
+        }
+      });
+
+
+      return rawDeserialized;
+    }
 );
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is a mitigation of #39756 where new permission types do not exist on the controller state. We are working on a more thorough refactor of the controller state that will be more resilient to this type of issue, and remove the need for state migration.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39766?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Resolves issue where All Permissions page won't load with unmigrated gator permissions controller state

## **Related issues**

Fixes: #39756

## **Manual testing steps**

- Create a new wallet with extension 13.13.0
- Upgrade to 13.16.0
- Open "All Permissions" page

Error is shown as per #39756

- Create a new wallet with extension 13.13.0
- Upgrade to this version
- Open "All Permissions" page

Permissions page is shown

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change in UI selectors: it only adds default empty objects for missing permission-type keys after deserialization, with a focused unit test covering the partial-state scenario.
> 
> **Overview**
> Prevents the All Permissions/Gator permissions selectors from breaking when `gatorPermissionsMapSerialized` was saved without newer permission-type keys.
> 
> `getGatorPermissionsMap` now normalizes the deserialized map by ensuring all expected permission-type keys (including `other`) exist, defaulting missing ones to `{}`; tests were added to verify behavior with a partially-serialized map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0151c11c49e093bc6504380e123fa0201e160fae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->