### PR TITLE
fix: Update activity log header to use arrow disclosure variant

### DIFF
--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -7,6 +7,7 @@ import { Button, ButtonSize } from '@metamask/design-system-react';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { DEFAULT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants';
 import Disclosure from '../../ui/disclosure';
+import { DisclosureVariant } from '../../ui/disclosure/disclosure.constants';
 import TransactionActivityLog from '../transaction-activity-log';
 import TransactionBreakdown from '../transaction-breakdown';
 import Tooltip from '../../ui/tooltip';
@@ -276,7 +277,7 @@ export default class TransactionListItemDetails extends PureComponent {
                   <Disclosure
                     title={t('activityLog')}
                     size="small"
-                    variant="arrow"
+                    variant={DisclosureVariant.Arrow}
                     isScrollToBottomOnOpen
                   >
                     <TransactionActivityLog

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -276,6 +276,7 @@ export default class TransactionListItemDetails extends PureComponent {
                   <Disclosure
                     title={t('activityLog')}
                     size="small"
+                    variant="arrow"
                     isScrollToBottomOnOpen
                   >
                     <TransactionActivityLog


### PR DESCRIPTION
## **Description**

This PR addresses [MDP-464](https://consensyssoftware.atlassian.net/browse/MDP-464) by updating the Activity Log header in the transaction details modal to use a more intuitive accordion-style interface.

**What is the reason for the change?**
The Activity Log header was using a "+" icon which didn't follow standard accordion UI patterns and the interaction was inconsistent with typical disclosure components.

**What is the improvement/solution?**
- Removed the "+" icon
- Changed to "Activity Log" with proper capitalization
- Added a down caret icon (↓) with 8px left margin that rotates when opened/closed
- Uses the existing arrow variant of the Disclosure component

## **Changelog**

CHANGELOG entry: Updated Activity Log header to use arrow disclosure variant for better UX consistency

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-464

## **Manual testing steps**

1. Open MetaMask extension
2. Navigate to Activity tab
3. Click on any transaction to open the transaction details modal
4. Scroll down to the Activity Log section
5. Verify that the header shows "Activity Log" with a down caret icon (↓)
6. Click to expand/collapse and verify the caret rotates properly

## **Screenshots/Recordings**

### **Before**
- Header displayed "Activity log" with "+" icon
- Non-standard accordion interaction

<img width="300" height="871" alt="Screenshot 2026-02-03 at 4 04 43 PM" src="https://github.com/user-attachments/assets/6bb86c79-4278-428d-8d29-24edd2aba360" />


### **After**
- Header displays "Activity Log" with down caret (↓) icon
- Standard accordion behavior with rotating caret
- 8px margin between text and icon

<img width="469" height="751" alt="Screenshot 2026-02-04 at 7 07 46 PM" src="https://github.com/user-attachments/assets/93165831-2edc-4a33-bb54-ed5a687cea04" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MDP-464]: https://consensyssoftware.atlassian.net/browse/MDP-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that alters the `Disclosure` variant used for the transaction details Activity Log; minimal functional risk beyond potential styling/regression in that section.
> 
> **Overview**
> Updates the transaction details modal’s Activity Log section to use the `DisclosureVariant.Arrow` accordion styling instead of the default disclosure presentation.
> 
> This adds an import for `DisclosureVariant` and passes `variant={DisclosureVariant.Arrow}` to the Activity Log `Disclosure`, aligning the header behavior/iconography with standard accordion patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61ed57bc3962d5063b8f6630aa5d032fbf7c64a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->