### PR TITLE
test(e2e): fix upcoming problem in E2E test when recipientPlaceholderText is now defined in Deutsch

### DIFF
--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -3,7 +3,7 @@ import { Driver } from '../../../webdriver/driver';
 class SendPage {
   private readonly driver: Driver;
 
-  private readonly amountInput = '[data-testid="send-amount-input"]';
+  private readonly amountInput = { testId: 'send-amount-input' };
 
   private readonly continueButton = {
     text: 'Continue',
@@ -17,8 +17,9 @@ class SendPage {
 
   private readonly hexDataInput = '[placeholder="Enter hex data (optional)"]';
 
-  private readonly inputRecipient =
-    'input[placeholder="Enter or paste an address or name"]';
+  private readonly inputRecipient = {
+    testId: 'recipient-address-input',
+  };
 
   private readonly insufficientFundsError = {
     text: 'Insufficient funds',
@@ -41,15 +42,19 @@ class SendPage {
     testId: 'send-network-filter-toggle',
   };
 
-  private readonly recipientModalButton =
-    '[data-testid="open-recipient-modal-btn"]';
+  private readonly recipientModalButton = {
+    testId: 'open-recipient-modal-btn',
+  };
 
   private readonly solanaNetwork = {
     text: 'Solana',
   };
 
-  private readonly tokenAsset = (chainId: string, symbol: string) =>
-    `[data-testid="token-asset-${chainId}-${symbol}"]`;
+  private readonly tokenAsset = (chainId: string, symbol: string) => {
+    return {
+      testId: `token-asset-${chainId}-${symbol}`,
+    };
+  };
 
   constructor(driver: Driver) {
     this.driver = driver;

--- a/test/e2e/tests/settings/change-language.spec.ts
+++ b/test/e2e/tests/settings/change-language.spec.ts
@@ -29,7 +29,7 @@ const selectors = {
   waterTextDansk: `[placeholder="${da.search.message}"]`,
   headerTextDansk: { text: da.settings.message, tag: 'h3' },
   buttonTextDansk: {
-    css: '[data-testid="auto-lockout-button"]',
+    testId: 'auto-lockout-button',
     text: da.save.message,
   },
   dialogTextDeutsch: { text: de.invalidAddress.message, tag: 'p' },

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1072,7 +1072,7 @@ class Driver {
   /**
    * Paste a string into a field.
    *
-   * @param {string} rawLocator  - Element locator
+   * @param {string | object} rawLocator  - Element locator
    * @param {string} contentToPaste - content to paste
    * @returns {Promise<WebElement>}  promise that resolves to the WebElement
    */

--- a/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
+++ b/ui/pages/confirmations/components/send/recipient-input/recipient-input.tsx
@@ -163,6 +163,7 @@ export const RecipientInput = ({
           }
           onChange={onToChange}
           placeholder={t('recipientPlaceholderText')}
+          testId="recipient-address-input"
           ref={recipientInputRef}
           value={to}
           width={BlockSize.Full}


### PR DESCRIPTION
## **Description**

The current Crowdin PR #38977 is failing on 
`test/e2e/tests/settings/change-language.spec.ts`
`Settings - general tab validate "Deutsch" language on error messages`

It's failing because `recipientPlaceholderText` is now defined in Deutsch, and when
`test/e2e/page-objects/pages/send/send-page.ts`
looks for `'input[placeholder="Enter or paste an address or name"]'`
that's not the placeholder text anymore 🤭 

So I gave it a `testId`, and also updated all of the related files to use the simpler `testId` syntax I defined in #28065.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E selectors and a UI `testId` prop, with no impact to runtime business logic. Main risk is only potential selector mismatch if `data-testid` values diverge.
> 
> **Overview**
> Fixes a flaky/failing E2E language test by **stop relying on localized placeholder text** for the send recipient field and switching to a stable `data-testid` selector.
> 
> Adds `testId="recipient-address-input"` to the send `RecipientInput` `TextField`, and updates E2E page objects/tests (e.g., `SendPage`, Dansk settings selector) to use the object-based `{ testId: ... }` locator style (including token asset and recipient modal button locators).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa59d384732947b4ac741537a10ff671c06489b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->