### PR TITLE
chore: upgrade @metamask/design-system-react to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@metamask/delegation-controller": "^1.0.0",
     "@metamask/delegation-core": "^0.2.0-rc.1",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react": "^0.5.0",
+    "@metamask/design-system-react": "^0.6.1",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.1.1",
     "@metamask/eip-5792-middleware": "^2.1.0",

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -479,10 +479,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -526,10 +526,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -573,10 +573,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -620,10 +620,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -667,10 +667,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -714,10 +714,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -761,10 +761,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -808,10 +808,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -855,10 +855,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1716,10 +1716,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1763,10 +1763,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1810,10 +1810,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1857,10 +1857,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1904,10 +1904,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1951,10 +1951,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1998,10 +1998,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -2045,10 +2045,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"
@@ -2092,10 +2092,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     >
                       <button
                         aria-label="Add"
-                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
                       >
                         <svg
-                          class="inline-block w-5 h-5 text-inherit"
+                          class="inline-block w-6 h-6 text-inherit"
                           fill="currentColor"
                           viewBox="0 0 24 24"
                           xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
@@ -169,11 +169,11 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -364,11 +364,11 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -539,11 +539,11 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -729,11 +729,11 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -919,11 +919,11 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
@@ -1109,11 +1109,11 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
           </p>
           <button
             aria-label="expand"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
             color="text-icon-muted"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/multichain/pages/gator-permissions/review-permissions/__snapshots__/review-gator-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/review-permissions/__snapshots__/review-gator-permissions-page.test.tsx.snap
@@ -19,11 +19,11 @@ exports[`Review Gator Permissions Page render renders correctly 1`] = `
         >
           <button
             aria-label="Back"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default connections-header__start-accessory"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default connections-header__start-accessory"
             color="text-icon-default"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"

--- a/ui/components/multichain/pages/gator-permissions/token-transfer/__snapshots__/token-transfer-page.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/token-transfer/__snapshots__/token-transfer-page.test.tsx.snap
@@ -19,11 +19,11 @@ exports[`Token Transfer Page render renders correctly 1`] = `
         >
           <button
             aria-label="Back"
-            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded bg-transparent hover:bg-hover active:bg-pressed text-icon-default connections-header__start-accessory"
+            class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default connections-header__start-accessory"
             color="text-icon-default"
           >
             <svg
-              class="inline-block w-4 h-4 text-inherit"
+              class="inline-block w-5 h-5 text-inherit"
               fill="currentColor"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,11 +6371,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/design-system-react@npm:0.5.0"
+"@metamask/design-system-react@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@metamask/design-system-react@npm:0.6.1"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.1.1"
+    "@metamask/design-system-shared": "npm:^0.1.2"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@radix-ui/react-slot": "npm:^1.1.0"
     blo: "npm:^2.0.0"
@@ -6383,19 +6383,19 @@ __metadata:
   peerDependencies:
     "@metamask/design-system-tailwind-preset": ^0.6.0
     "@metamask/design-tokens": ^8.1.0
-    "@metamask/utils": ^11.8.0
+    "@metamask/utils": ^11.9.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/111b2bf69bfb59487471923bcd9d7dc47631ad00d94cd38eb5204db18f2d78a12d6a903d5e264572937a1cf81ad28595772b9d5eec1a091d20ec39e6e9ad916c
+  checksum: 10/ce95f6374915fa8cea645c7692afac1cbb2ca9562e87d31d24acc93c57a1ea082b2bccfd568a345a804370af887ffd95f554ba848efe934a783737ee7e4bd590
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@metamask/design-system-shared@npm:0.1.1"
+"@metamask/design-system-shared@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@metamask/design-system-shared@npm:0.1.2"
   dependencies:
-    "@metamask/utils": "npm:^11.8.0"
-  checksum: 10/8e8dab9ca59f83da76078a9f644d73d90cdb309ce5549acb915fbe2fdfb03803b3d73533e3d64a1bdca4ac2a19514d6885fe5c727832353a5691d310f06735d9
+    "@metamask/utils": "npm:^11.9.0"
+  checksum: 10/91f35b7e3db217aa7b83507bec3f59b4bacda6c86e97d0431ab49e610d8e4b118279bd3482975c3f2777f2876ba43c9f35566d513304cb481b53983b83e87e17
   languageName: node
   linkType: hard
 
@@ -8968,7 +8968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.9.0
   resolution: "@metamask/utils@npm:11.9.0"
   dependencies:
@@ -33631,7 +33631,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^1.0.0"
     "@metamask/delegation-core": "npm:^0.2.0-rc.1"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react": "npm:^0.5.0"
+    "@metamask/design-system-react": "npm:^0.6.1"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.1.1"
     "@metamask/eip-5792-middleware": "npm:^2.1.0"


### PR DESCRIPTION
## **Description**

This PR upgrades `@metamask/design-system-react` from version 0.5.0 to 0.6.1 to incorporate the latest design system improvements and new components.

The upgrade includes:
- New `ButtonHero` component for prominent call-to-action buttons
- Updated `ButtonIcon` icon sizes to align with Figma specifications:
  - Small variant: 20px icons (previously 16px)
  - Medium variant: 24px icons (previously 20px)
  - Large variant: 32px icons (previously 24px)
- Standardized `ButtonIcon` border radius to 8px for non-floating variants

Snapshot tests have been updated to reflect the visual changes to `ButtonIcon` components.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39770?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - Routine dependency upgrade

## **Manual testing steps**

1. Build the extension and load it
2. Navigate to pages that use ButtonIcon components (e.g., network list, gator permissions)
3. Verify that button icons display correctly with updated sizes
4. Test ButtonIcon interactions in small, medium, and large variants
5. Verify no visual regressions in existing UI

## **Screenshots/Recordings**

### **Before**

ButtonIcon components used smaller icon sizes (small: 16px, medium: 20px, large: 24px)

<img width="295" height="198" alt="Screenshot 2026-02-04 at 5 12 33 PM" src="https://github.com/user-attachments/assets/2e38e23e-3ed7-4072-92ff-7d45bb4e8c2a" />

https://github.com/user-attachments/assets/72b0fe36-ec5e-443a-9a65-5264e4dcab2e

### **After**

ButtonIcon components now use updated icon sizes matching Figma specs (small: 20px, medium: 24px, large: 32px) and standardized 8px border radius

<img width="254" height="187" alt="Screenshot 2026-02-04 at 5 11 47 PM" src="https://github.com/user-attachments/assets/21fc3dc5-1f9f-4821-b4c5-12510b67c0bd" />

https://github.com/user-attachments/assets/71603977-5205-46b1-8a98-9cb559aca9dd

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump primarily affecting UI styling and snapshot expectations; main risk is minor visual regressions where `ButtonIcon` sizing/radius changes propagate.
> 
> **Overview**
> Upgrades `@metamask/design-system-react` from `0.5.0` to `0.6.1` (with related lockfile updates to `@metamask/design-system-shared` and peer `@metamask/utils` ranges).
> 
> Updates Jest snapshots for multichain UI to match design-system changes, notably `ButtonIcon` styling (rounded corners to `rounded-lg`) and larger SVG icon sizes in places like the network list and gator permissions pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aac22844ef7dde5ba0a095ce8341f4caf25cf6bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->