### PR TITLE
fix: in Sign Permission confirmation, ensure requested permission is enabled 

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1844,7 +1844,7 @@
       "React: Act warnings (component updates not wrapped)": 40,
       "Reselect: Identity function warnings": 7,
       "Reselect: Input stability warnings": 4,
-      "Test errors: Uncaught Errors": 1,
+      "Test errors: Uncaught Errors": 2,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.test.tsx": {

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -133,7 +133,7 @@ describe('Info', () => {
     const state = getMockTypedSignPermissionConfirmState();
     const mockStore = configureMockStore([])(state);
     expect(() => renderWithConfirmContextProvider(<Info />, mockStore)).toThrow(
-      "Permission type 'native-token-stream' is not enabled",
+      'Invalid eth_signTypedData_v4 request - Advanced Permission type: native-token-stream not enabled',
     );
   });
 
@@ -146,7 +146,7 @@ describe('Info', () => {
     const state = getMockTypedSignPermissionConfirmState();
     const mockStore = configureMockStore([])(state);
     expect(() => renderWithConfirmContextProvider(<Info />, mockStore)).toThrow(
-      "Permission type 'native-token-stream' is not enabled",
+      'Invalid eth_signTypedData_v4 request - Advanced Permission type: native-token-stream not enabled',
     );
   });
 

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -127,12 +127,26 @@ describe('Info', () => {
   });
 
   it('throws an error if gator permissions feature is not enabled', () => {
+    // the requested permission type is `native-token-stream`
     jest.mocked(getEnabledAdvancedPermissions).mockReturnValue([]);
 
     const state = getMockTypedSignPermissionConfirmState();
     const mockStore = configureMockStore([])(state);
     expect(() => renderWithConfirmContextProvider(<Info />, mockStore)).toThrow(
-      'Gator permissions feature is not enabled',
+      "Permission type 'native-token-stream' is not enabled",
+    );
+  });
+
+  it('throws an error if the specific permission type is not enabled', () => {
+    // the requested permission type is `native-token-stream`
+    jest
+      .mocked(getEnabledAdvancedPermissions)
+      .mockReturnValue(['erc20-token-stream']);
+
+    const state = getMockTypedSignPermissionConfirmState();
+    const mockStore = configureMockStore([])(state);
+    expect(() => renderWithConfirmContextProvider(<Info />, mockStore)).toThrow(
+      "Permission type 'native-token-stream' is not enabled",
     );
   });
 

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -74,9 +74,9 @@ const Info = () => {
             // This should never happen, as `wallet_requestExecutionPermissions`
             // only accepts permissions of enabled types. This is here as a
             // security precaution, to ensure that permission types that are not
-            // yet complete are never available to sign.
+            // yet enabled are never available to sign.
             throw new Error(
-              `Permission type '${requestedPermissionType ?? 'unknown'}' is not enabled`,
+              `Invalid eth_signTypedData_v4 request - Advanced Permission type: ${requestedPermissionType} not enabled`,
             );
           }
 

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -65,8 +65,19 @@ const Info = () => {
           return TypedSignV1Info;
         }
         if (signatureRequest?.decodedPermission) {
-          if (getEnabledAdvancedPermissions().length === 0) {
-            throw new Error('Gator permissions feature is not enabled');
+          const requestedPermissionType =
+            signatureRequest.decodedPermission.permission.type;
+
+          const enabledPermissions = getEnabledAdvancedPermissions();
+
+          if (!enabledPermissions.includes(requestedPermissionType)) {
+            // This should never happen, as `wallet_requestExecutionPermissions`
+            // only accepts permissions of enabled types. This is here as a
+            // security precaution, to ensure that permission types that are not
+            // yet complete are never available to sign.
+            throw new Error(
+              `Permission type '${requestedPermissionType ?? 'unknown'}' is not enabled`,
+            );
           }
 
           return TypedSignPermissionInfo;


### PR DESCRIPTION
## **Description**

When rendering Sign Permission confirmation, previously we checked to ensure that _some_ permissions are enabled. This is because originally we checked whether the _feature_ is enabled, and when we swapped out the _feature_ flag for specifically enabled permission types, we did a simple replace.

This change updates the check so that when rendering the Sign Permission confirmation we check the requested permission type against the list of enabled permissions. As before, if the check fails an error is thrown.

Note: This is a case that should never happen.

- When  `metamask-controller.js` processes a `wallet_requestExecutionPermissions` RPC, it will reject if the requested permission is not enabled
- When `@metamask/gator-permissions-controller` decodes a permission signature (via `eth_signTypedData_v4` RPC), it will reject if the origin is not `@metamask/gator-permissions-snap`

This means that only `eth_signTypedData_v4` requests from `@metamask/gator-permissions-snap` will ever appear in the sign permission confirmation, and `@metamask/gator-permissions-snap` will only ever receive `wallet_requestExecutionPermissions` requests where _all_ requested permissions are enabled.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39776?quickstart=1)

## **Changelog** 

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Load gator permissions snap testing page
2. Request a permission of a supported type: `erc20-token-revocation`
3. Click approve on the permission picker
4. Optionally click cancel or approve if the smart contract account upgrade confirmation is shown

Expect the sign permission confirmation to be shown

note: there is no way to test the validation directly, as this is an unreachable security mitigation.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, defensive validation change in confirmation rendering with corresponding test updates; behavior only changes for invalid/unsupported permission types.
> 
> **Overview**
> **Sign Permission confirmations now validate the exact requested permission type.** When rendering `eth_signTypedData_v4` confirmations with a decoded permission, the UI checks that `signatureRequest.decodedPermission.permission.type` is included in `getEnabledAdvancedPermissions()` and throws a more specific error if not.
> 
> **Tests/baselines updated** to assert the new error message and cover the case where other permission types are enabled but the requested one is not, which increases the expected uncaught error count for `info.test.tsx` in the Jest console baseline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35dee51d51224933fc09d6c9184db961d870d76c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->