### PR TITLE
fix: flaky test `Request Queuing Send Tx -> SwitchChain -> SendTx switching network should reject pending confirmations`

### DIFF
--- a/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-switchChain-sendTx.spec.ts
@@ -45,6 +45,9 @@ describe('Request Queuing Send Tx -> SwitchChain -> SendTx', function (this: Sui
 
         // Dapp Send Button
         await testDapp.clickSimpleSendButton();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        const transactionConfirmation = new TransactionConfirmation(driver);
+        await transactionConfirmation.checkPageIsLoaded();
 
         // Navigate back to test dapp
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
@@ -67,7 +70,6 @@ describe('Request Queuing Send Tx -> SwitchChain -> SendTx', function (this: Sui
         await testDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        const transactionConfirmation = new TransactionConfirmation(driver);
         await transactionConfirmation.clickNextPage();
 
         // Confirm Switch Chain


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There's a disoreder in how the dialog transaction and permission screens are shown, because after clicking Send, we don't wait for the dialog to appear and the tx to be present, so it can be the case that the next action (switch networks) happens very fast right after, and the 2 screens appear in the reverse order.

To fix this, we wait until the confirmation appears, before proceeding with the next action

<img width="400" height="619" alt="image" src="https://github.com/user-attachments/assets/05f34393-02a1-475c-b39e-e6d5e697d254" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39781?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to an e2e test and only add an explicit wait/window switch to reduce timing-related flakiness.
> 
> **Overview**
> Fixes flakiness in `sendTx-switchChain-sendTx.spec.ts` by switching to the confirmation dialog immediately after the first `Send` and waiting for `TransactionConfirmation` to load before continuing.
> 
> This prevents the network-switch permission screen and transaction confirmation from appearing out of order during fast executions, making the queued-confirmation assertions deterministic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad7685a28116db70507a395bbbb45b4ef3e7d99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->