### PR TITLE
feat: handle in app shield notification nav

### DIFF
--- a/shared/modules/shield/constants.ts
+++ b/shared/modules/shield/constants.ts
@@ -23,5 +23,5 @@ export function isNonUISubscriptionError(error: Error | undefined): boolean {
 
 export const SHIELD_CAROUSEL_ID = 'contentful-1MftLVfZkCqPH1EA8jtSOm';
 
-export const SHIELD_ANNOUNCEMENT_NOFICATION_ID =
+export const SHIELD_ANNOUNCEMENT_NOTIFICATION_ID =
   'get-transaction-shield-and-earn-metamask-rewards-extension';

--- a/shared/modules/shield/constants.ts
+++ b/shared/modules/shield/constants.ts
@@ -22,3 +22,6 @@ export function isNonUISubscriptionError(error: Error | undefined): boolean {
 }
 
 export const SHIELD_CAROUSEL_ID = 'contentful-1MftLVfZkCqPH1EA8jtSOm';
+
+export const SHIELD_ANNOUNCEMENT_NOFICATION_ID =
+  'get-transaction-shield-and-earn-metamask-rewards-extension';

--- a/shared/modules/shield/shield.ts
+++ b/shared/modules/shield/shield.ts
@@ -10,6 +10,8 @@ import { DefaultSubscriptionPaymentOptions } from '../../types/metametrics';
 import { PreferencesController } from '../../../app/scripts/controllers/preferences-controller';
 // eslint-disable-next-line import/no-restricted-paths
 import MetaMetricsController from '../../../app/scripts/controllers/metametrics-controller';
+import { SETTINGS_ROUTE } from '../../lib/deep-links/routes/route';
+import { SHIELD_QUERY_PARAMS } from '../../lib/deep-links/routes/shield';
 import { loadShieldConfig } from './config';
 
 export async function getShieldGatewayConfig(
@@ -150,4 +152,20 @@ export function updatePreferencesAndMetricsForShieldSubscription(
   preferencesController.setUsePhishDetect(true);
   // shield subscribers have to turn on transaction simulations
   preferencesController.setUseTransactionSimulations(true);
+}
+
+/**
+ * Get the shield in app navigation from an external link.
+ * This function is used to navigate to the shield page from an external link instead of opening a new tab
+ * TODO: clean this once we have better control of how deeplink are opened
+ *
+ * @param externalLink - The external link.
+ * @returns The shield in app navigation.
+ */
+export function getShieldInAppNavigationFromExternalLink(
+  externalLink: string,
+): string {
+  const url = new URL(externalLink);
+  const params = url.searchParams.toString();
+  return `${SETTINGS_ROUTE}?${SHIELD_QUERY_PARAMS.showShieldEntryModal}=true${params ? `&${params}` : ''}`;
 }

--- a/ui/components/multichain/carousel/stack-card/stack-card.tsx
+++ b/ui/components/multichain/carousel/stack-card/stack-card.tsx
@@ -13,8 +13,7 @@ import {
   TextColor,
 } from '../../../../helpers/constants/design-system';
 import { SHIELD_CAROUSEL_ID } from '../../../../../shared/modules/shield/constants';
-import { SETTINGS_ROUTE } from '../../../../helpers/constants/routes';
-import { SHIELD_QUERY_PARAMS } from '../../../../../shared/lib/deep-links/routes/shield';
+import { getShieldInAppNavigationFromExternalLink } from '../../../../../shared/modules/shield';
 import type { StackCardProps } from './stack-card.types';
 
 export const StackCard: React.FC<StackCardProps> = ({
@@ -55,11 +54,8 @@ export const StackCard: React.FC<StackCardProps> = ({
         // in app navigation for shield carousel
         // TODO: clean this once we have better control of how deeplink are opened
         try {
-          const url = new URL(slide.href);
-          const params = url.searchParams.toString();
-          navigate(
-            `${SETTINGS_ROUTE}?${SHIELD_QUERY_PARAMS.showShieldEntryModal}=true${params ? `&${params}` : ''}`,
-          );
+          const path = getShieldInAppNavigationFromExternalLink(slide.href);
+          navigate(path);
         } catch (error) {
           console.error('[StackCard] error parsing slide.href', error);
         }

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -9,7 +9,7 @@ import { NotificationDetailButton } from '../../../../components/multichain';
 import { ButtonVariant } from '../../../../components/component-library';
 import {
   getShieldInAppNavigationFromExternalLink,
-  SHIELD_ANNOUNCEMENT_NOFICATION_ID,
+  SHIELD_ANNOUNCEMENT_NOTIFICATION_ID,
 } from '../../../../../shared/modules/shield';
 import { FeatureAnnouncementNotification } from './types';
 
@@ -85,7 +85,7 @@ export const ExternalLinkButton = (props: {
 
   let href: string | undefined = notification.data.externalLink.externalLinkUrl;
   const isShieldAnnouncementNotification =
-    notification.id === SHIELD_ANNOUNCEMENT_NOFICATION_ID;
+    notification.id === SHIELD_ANNOUNCEMENT_NOTIFICATION_ID;
   // use native navigation for shield announcement instead of opening new tab
   // TODO: clean this when we have better control of how deeplink are opened
   if (isShieldAnnouncementNotification) {

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -6,6 +7,10 @@ import {
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { NotificationDetailButton } from '../../../../components/multichain';
 import { ButtonVariant } from '../../../../components/component-library';
+import {
+  getShieldInAppNavigationFromExternalLink,
+  SHIELD_ANNOUNCEMENT_NOFICATION_ID,
+} from '../../../../../shared/modules/shield';
 import { FeatureAnnouncementNotification } from './types';
 
 const useAnalyticEventCallback = (props: {
@@ -66,8 +71,9 @@ export const ExtensionLinkButton = (props: {
 export const ExternalLinkButton = (props: {
   notification: FeatureAnnouncementNotification;
 }) => {
+  const navigate = useNavigate();
   const { notification } = props;
-  const onClick = useAnalyticEventCallback({
+  const analyticCallback = useAnalyticEventCallback({
     id: notification.id,
     type: notification.type,
     clickType: 'external_link',
@@ -77,11 +83,29 @@ export const ExternalLinkButton = (props: {
     return null;
   }
 
+  let href: string | undefined = notification.data.externalLink.externalLinkUrl;
+  const isShieldAnnouncementNotification =
+    notification.id === SHIELD_ANNOUNCEMENT_NOFICATION_ID;
+  // use native navigation for shield announcement instead of opening new tab
+  // TODO: clean this when we have better control of how deeplink are opened
+  if (isShieldAnnouncementNotification) {
+    href = undefined;
+  }
+  const onClick = () => {
+    analyticCallback();
+    if (isShieldAnnouncementNotification && notification.data.externalLink) {
+      const path = getShieldInAppNavigationFromExternalLink(
+        notification.data.externalLink.externalLinkUrl,
+      );
+      navigate(path);
+    }
+  };
+
   return (
     <NotificationDetailButton
       variant={ButtonVariant.Secondary}
       text={notification.data.externalLink.externalLinkText}
-      href={`${notification.data.externalLink.externalLinkUrl}`}
+      href={href}
       isExternal={true}
       onClick={onClick}
     />

--- a/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/annonucement-footer-buttons.tsx
@@ -84,20 +84,31 @@ export const ExternalLinkButton = (props: {
   }
 
   let href: string | undefined = notification.data.externalLink.externalLinkUrl;
+  let isExternal = true;
   const isShieldAnnouncementNotification =
     notification.id === SHIELD_ANNOUNCEMENT_NOTIFICATION_ID;
   // use native navigation for shield announcement instead of opening new tab
   // TODO: clean this when we have better control of how deeplink are opened
   if (isShieldAnnouncementNotification) {
+    // don't open new tab with href
     href = undefined;
+    // don't show external arrow icon
+    isExternal = false;
   }
   const onClick = () => {
     analyticCallback();
     if (isShieldAnnouncementNotification && notification.data.externalLink) {
-      const path = getShieldInAppNavigationFromExternalLink(
-        notification.data.externalLink.externalLinkUrl,
-      );
-      navigate(path);
+      try {
+        const path = getShieldInAppNavigationFromExternalLink(
+          notification.data.externalLink.externalLinkUrl,
+        );
+        navigate(path);
+      } catch (error) {
+        console.error(
+          '[ExternalLinkButton] error parsing external link',
+          error,
+        );
+      }
     }
   };
 
@@ -106,7 +117,7 @@ export const ExternalLinkButton = (props: {
       variant={ButtonVariant.Secondary}
       text={notification.data.externalLink.externalLinkText}
       href={href}
-      isExternal={true}
+      isExternal={isExternal}
       onClick={onClick}
     />
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Handle in app navigation for shield feature announcement notification

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39788?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Shield notification in app navigation

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to notfications page
2. Select shield announcement notification
3. Click on CTA button
4. Should navigate to shield page in app instead of opening new tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/3dacae0d-a8cd-43b5-9c2d-3e8c65de983c


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI routing change limited to Shield-specific carousel/notification IDs, with URL parsing guarded by try/catch. Main risk is a mis-match on IDs or query-param handling causing the CTA to do nothing or navigate incorrectly.
> 
> **Overview**
> Routes Shield marketing entry points *in-app* instead of opening a new tab. Adds `SHIELD_ANNOUNCEMENT_NOTIFICATION_ID` plus a shared helper (`getShieldInAppNavigationFromExternalLink`) that converts an external Shield URL into an internal `SETTINGS_ROUTE` navigation with `showShieldEntryModal` and preserved query params.
> 
> Updates the Shield carousel card click handler to use the shared helper, and changes the feature-announcement external CTA so the Shield announcement notification uses `react-router` navigation (no `href`/external icon) while still emitting the same analytics event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77ce10fec7746cc2261cd34bc6932871446d30b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->