### PR TITLE
fix: cp-13.17.0 Re-enable Chromium bug workaround for all versions

### DIFF
--- a/app/scripts/on-update.ts
+++ b/app/scripts/on-update.ts
@@ -1,7 +1,5 @@
 import log from 'loglevel';
-import Bowser from 'bowser';
 import { PLATFORM_FIREFOX } from '../../shared/constants/app';
-import { getIsChromiumBrowserMV3StableUpdatesSupported } from '../../shared/modules/browser-runtime.utils';
 import { getPlatform } from './lib/util';
 import type MetaMaskController from './metamask-controller';
 import type ExtensionPlatform from './platforms/extension';
@@ -52,17 +50,14 @@ export function onUpdate(
   appStateController.setLastUpdatedAt(lastUpdatedAt);
   appStateController.setLastUpdatedFromVersion(previousVersion);
 
-  if (
-    !isFirefox &&
-    !getIsChromiumBrowserMV3StableUpdatesSupported(
-      Bowser.getParser(globalThis.navigator.userAgent),
-    )
-  ) {
+  if (!isFirefox) {
     // Work around Chromium bug https://issues.chromium.org/issues/40805401
-    // by doing a safe reload after an update. We have gated this workaround behind
-    // a Chromium version check for `<143`, to prevent it from running on
-    // newer versions that are no longer affected by the bug. Once the affected
-    // Chromium versions are no longer supported, we should remove this.
+    // by doing a safe reload after an update.
+    //
+    // This was initially only used for Chromium versions `<143`, because it
+    // was supposed to be fixed in v143. But we continued to see reports of
+    // this crash in later versions.
+    //
     // We only want to do the safe reload when the version actually changed,
     // just as a safe guard, as Chrome fires this event each time we call
     // `runtime.reload` -- as we really don't want to send Chrome into a restart

--- a/shared/modules/browser-runtime.utils.js
+++ b/shared/modules/browser-runtime.utils.js
@@ -7,7 +7,6 @@ import browser from 'webextension-polyfill';
 import log from 'loglevel';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
-  FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
   // TODO: Remove restricted import
   // eslint-disable-next-line import/no-restricted-paths
@@ -76,22 +75,6 @@ export function getIsBrowserPrerenderBroken(
   return (
     (bowser.satisfies(BROKEN_PRERENDER_BROWSER_VERSIONS) &&
       !bowser.satisfies(FIXED_PRERENDER_BROWSER_VERSIONS)) ??
-    false
-  );
-}
-
-/**
- * Returns true if the Chromium-based browser is no longer affected by a bug
- * that causes MV3 updates to break service workers, and Extension updates are stable.
- *
- * @param {import('bowser').Parser} bowser - optional Bowser Parser instance to check against
- * @returns {boolean} Whether the browser is no longer affected by the MV3 update bug.
- */
-export function getIsChromiumBrowserMV3StableUpdatesSupported(
-  bowser = Bowser.getParser(window.navigator.userAgent),
-) {
-  return (
-    bowser.satisfies(FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS) ??
     false
   );
 }

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -70,16 +70,3 @@ export const FIXED_PRERENDER_BROWSER_VERSIONS = {
   chrome: '>=121',
   edge: '>=121',
 };
-
-/**
- * Specifies the Chromium-based browser and their versions where
- * MV3 updates are stable and don't break service workers.
- *
- * @see {@link https://chromium.googlesource.com/chromium/src/+/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5}
- * @see {@link https://chromium.googlesource.com/chromium/src/+/a5d13d7b91139dfac4721708937f75094d3c24e3}
- */
-export const FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS = {
-  // https://chromiumdash.appspot.com/commit/4ff63e1f75af997e93f53b57aca21fc9cfd1cdb5
-  chrome: '>=143.0.7465.0',
-  edge: '>=143',
-};


### PR DESCRIPTION
## **Description**

We had a mitigation for the bug https://issues.chromium.org/issues/40805401 that was applied to versions below v143, because it was supposed to be fixed in v143. We are continuing to see reports in later versions though, so the workaround has now been enabled for all Chromium versions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39790?quickstart=1)

## **Changelog**

CHANGELOG entry: Enable workaround for "crash after update" Chromium bug on Chromium versions >=143

## **Related issues**

https://github.com/MetaMask/metamask-extension/issues/37503
https://issues.chromium.org/issues/40805401

## **Manual testing steps**

The issue occurs sometimes when updating from the Chrome Web Store. It has never been reproducible for any other types of test update flows, not even using the Chrome update testing tool.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes update/reload behavior for all non-Firefox installs, which can impact extension startup/restart loops if the safeguard is insufficient. Scope is small and targeted, but it affects a critical lifecycle path (post-update background reload).
> 
> **Overview**
> Re-enables the Chromium post-update mitigation for https://issues.chromium.org/issues/40805401 by **always requesting a "safe reload" on update for all non-Firefox browsers**, removing the previous Chromium-version gating.
> 
> Cleans up the now-unused MV3 stable-update version detection by deleting `getIsChromiumBrowserMV3StableUpdatesSupported` and removing the associated `FIXED_MV3_STABLE_UPDATES_CHROMIUM_BROWSER_VERSIONS` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e9bd14a15f9bee840c30721a400f36926d5900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->