### PR TITLE
feat: implement disconnect all button to dapp connections main screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2242,6 +2242,18 @@
   "disconnectAllSnapsText": {
     "message": "Snaps"
   },
+  "disconnectAllSites": {
+    "message": "Disconnect All"
+  },
+  "disconnectAllSitesDescriptionText": {
+    "message": "If you disconnect from all sites, you'll need to reconnect your accounts and networks to use them again."
+  },
+  "disconnectAllSitesSuccess": {
+    "message": "All dapps successfully disconnected."
+  },
+  "disconnectAllSitesError": {
+    "message": "Some dapps couldn't be disconnected. Please try again."
+  },
   "disconnectMessage": {
     "message": "This will disconnect you from this site"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2239,20 +2239,20 @@
   "disconnectAllDescriptionText": {
     "message": "If you disconnect from this site, you’ll need to reconnect your accounts and networks to use this site again."
   },
-  "disconnectAllSnapsText": {
-    "message": "Snaps"
-  },
   "disconnectAllSites": {
     "message": "Disconnect All"
   },
   "disconnectAllSitesDescriptionText": {
     "message": "If you disconnect from all sites, you'll need to reconnect your accounts and networks to use them again."
   },
+  "disconnectAllSitesError": {
+    "message": "Some dapps couldn't be disconnected. Please try again."
+  },
   "disconnectAllSitesSuccess": {
     "message": "All dapps successfully disconnected."
   },
-  "disconnectAllSitesError": {
-    "message": "Some dapps couldn't be disconnected. Please try again."
+  "disconnectAllSnapsText": {
+    "message": "Snaps"
   },
   "disconnectMessage": {
     "message": "This will disconnect you from this site"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2242,6 +2242,18 @@
   "disconnectAllSnapsText": {
     "message": "Snaps"
   },
+  "disconnectAllSites": {
+    "message": "Disconnect All"
+  },
+  "disconnectAllSitesDescriptionText": {
+    "message": "If you disconnect from all sites, you'll need to reconnect your accounts and networks to use them again."
+  },
+  "disconnectAllSitesSuccess": {
+    "message": "All dapps successfully disconnected."
+  },
+  "disconnectAllSitesError": {
+    "message": "Some dapps couldn't be disconnected. Please try again."
+  },
   "disconnectMessage": {
     "message": "This will disconnect you from this site"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2239,20 +2239,20 @@
   "disconnectAllDescriptionText": {
     "message": "If you disconnect from this site, you’ll need to reconnect your accounts and networks to use this site again."
   },
-  "disconnectAllSnapsText": {
-    "message": "Snaps"
-  },
   "disconnectAllSites": {
     "message": "Disconnect All"
   },
   "disconnectAllSitesDescriptionText": {
     "message": "If you disconnect from all sites, you'll need to reconnect your accounts and networks to use them again."
   },
+  "disconnectAllSitesError": {
+    "message": "Some dapps couldn't be disconnected. Please try again."
+  },
   "disconnectAllSitesSuccess": {
     "message": "All dapps successfully disconnected."
   },
-  "disconnectAllSitesError": {
-    "message": "Some dapps couldn't be disconnected. Please try again."
+  "disconnectAllSnapsText": {
+    "message": "Snaps"
   },
   "disconnectMessage": {
     "message": "This will disconnect you from this site"

--- a/ui/components/multichain/disconnect-all-modal/__snapshots__/disconnect-all-sites-modal.test.tsx.snap
+++ b/ui/components/multichain/disconnect-all-modal/__snapshots__/disconnect-all-sites-modal.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisconnectAllSitesModal renders correctly when open 1`] = `<div />`;

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-sites-modal.test.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-sites-modal.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { fireEvent } from '../../../../test/jest';
+import { DisconnectAllSitesModal } from './disconnect-all-sites-modal';
+
+const mockOnClick = jest.fn();
+const mockOnClose = jest.fn();
+
+describe('DisconnectAllSitesModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly when open', () => {
+    const { container } = render(
+      <DisconnectAllSitesModal
+        isOpen
+        onClick={mockOnClick}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('does not render when closed', () => {
+    const { queryByTestId } = render(
+      <DisconnectAllSitesModal
+        isOpen={false}
+        onClick={mockOnClick}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(queryByTestId('disconnect-all-sites-modal')).not.toBeInTheDocument();
+  });
+
+  it('calls onClick when confirm button is clicked', () => {
+    const { getByTestId } = render(
+      <DisconnectAllSitesModal
+        isOpen
+        onClick={mockOnClick}
+        onClose={mockOnClose}
+      />,
+    );
+
+    fireEvent.click(getByTestId('disconnect-all-sites-confirm'));
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const { getByRole } = render(
+      <DisconnectAllSitesModal
+        isOpen
+        onClick={mockOnClick}
+        onClose={mockOnClose}
+      />,
+    );
+
+    // Click the close button in the header
+    const closeButton = getByRole('button', { name: /close/iu });
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-sites-modal.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-sites-modal.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  IconName,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '../../component-library';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export type DisconnectAllSitesModalProps = {
+  isOpen: boolean;
+  onClick: () => void;
+  onClose: () => void;
+};
+
+export const DisconnectAllSitesModal: React.FC<
+  DisconnectAllSitesModalProps
+> = ({ isOpen, onClick, onClose }) => {
+  const t = useI18nContext();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="disconnect-all-sites-modal"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={onClose}>{t('disconnectAllSites')}</ModalHeader>
+        <ModalBody>
+          <Text>{t('disconnectAllSitesDescriptionText')}</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            onClick={onClick}
+            startIconName={IconName.Logout}
+            block
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            danger
+            data-testid="disconnect-all-sites-confirm"
+          >
+            {t('disconnectAllSites')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/components/multichain/disconnect-all-modal/index.ts
+++ b/ui/components/multichain/disconnect-all-modal/index.ts
@@ -1,1 +1,3 @@
 export { DisconnectAllModal } from './disconnect-all-modal';
+export { DisconnectAllSitesModal } from './disconnect-all-sites-modal';
+export type { DisconnectAllSitesModalProps } from './disconnect-all-sites-modal';

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -105,6 +105,24 @@ exports[`All Connections render renders correctly 1`] = `
           </div>
         </button>
       </div>
+      <div
+        class="mm-box multichain-page-footer mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--width-full"
+      >
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-button-secondary--type-danger mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-background-muted mm-box--rounded-xl"
+            data-testid="disconnect-all-button"
+          >
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-1 mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/logout.svg');"
+            />
+            Disconnect All
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -204,7 +204,7 @@ const PermissionsPage = () => {
                   onClose={() => setShowSuccessToast(false)}
                   autoHideTime={5000}
                   onAutoHideToast={() => setShowSuccessToast(false)}
-                  data-testid="disconnect-all-success-toast"
+                  dataTestId="disconnect-all-success-toast"
                 />
               </ToastContainer>
             )}
@@ -215,7 +215,7 @@ const PermissionsPage = () => {
                   onClose={() => setShowErrorToast(false)}
                   autoHideTime={5000}
                   onAutoHideToast={() => setShowErrorToast(false)}
-                  data-testid="disconnect-all-error-toast"
+                  dataTestId="disconnect-all-error-toast"
                 />
               </ToastContainer>
             )}

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -1,12 +1,15 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { isSnapId } from '@metamask/snaps-utils';
-import { Content, Header, Page } from '../page';
+import { Content, Footer, Header, Page } from '../page';
 import {
   Box,
+  Button,
   ButtonIcon,
   ButtonIconSize,
+  ButtonSize,
+  ButtonVariant,
   IconName,
   Text,
 } from '../../../component-library';
@@ -15,6 +18,7 @@ import { useTheme } from '../../../../hooks/useTheme';
 import { TabEmptyState } from '../../../ui/tab-empty-state';
 import { ThemeType } from '../../../../../shared/constants/preferences';
 import {
+  AlignItems,
   BackgroundColor,
   BlockSize,
   Color,
@@ -29,17 +33,27 @@ import {
   REVIEW_PERMISSIONS,
   GATOR_PERMISSIONS,
 } from '../../../../helpers/constants/routes';
-import { getConnectedSitesListWithNetworkInfo } from '../../../../selectors';
+import {
+  getConnectedSitesListWithNetworkInfo,
+  getPermissionSubjects,
+} from '../../../../selectors';
 import { getMergedConnectionsListWithGatorPermissions } from '../../../../selectors/gator-permissions/gator-permissions';
 import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../../shared/modules/environment';
+import { removePermissionsFor } from '../../../../store/actions';
+import { DisconnectAllSitesModal } from '../../disconnect-all-modal';
+import { Toast, ToastContainer } from '../../toast';
 import { ConnectionListItem } from './connection-list-item';
 
 const PermissionsPage = () => {
   const t = useI18nContext();
   const theme = useTheme();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const headerRef = useRef();
   const [totalConnections, setTotalConnections] = useState(0);
+  const [showDisconnectAllModal, setShowDisconnectAllModal] = useState(false);
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [showErrorToast, setShowErrorToast] = useState(false);
 
   const mergedConnectionsList = useSelector((state) => {
     if (!isGatorPermissionsRevocationFeatureEnabled()) {
@@ -48,9 +62,46 @@ const PermissionsPage = () => {
     return getMergedConnectionsListWithGatorPermissions(state);
   });
 
+  const subjects = useSelector(getPermissionSubjects);
+
   useEffect(() => {
     setTotalConnections(Object.keys(mergedConnectionsList).length);
   }, [mergedConnectionsList]);
+
+  const handleDisconnectAll = useCallback(() => {
+    const errors = [];
+    // Get all non-snap origins from the merged connections list
+    const origins = Object.keys(mergedConnectionsList).filter(
+      (origin) => !isSnapId(origin),
+    );
+
+    origins.forEach((origin) => {
+      try {
+        const subject = subjects[origin];
+        if (subject) {
+          const permissionMethodNames = Object.values(subject.permissions).map(
+            ({ parentCapability }) => parentCapability,
+          );
+          if (permissionMethodNames.length > 0) {
+            const permissionsRecord = {
+              [origin]: permissionMethodNames,
+            };
+            dispatch(removePermissionsFor(permissionsRecord));
+          }
+        }
+      } catch (error) {
+        errors.push({ origin, error });
+      }
+    });
+
+    setShowDisconnectAllModal(false);
+
+    if (errors.length > 0) {
+      setShowErrorToast(true);
+    } else {
+      setShowSuccessToast(true);
+    }
+  }, [dispatch, mergedConnectionsList, subjects]);
 
   const handleConnectionClick = (connection) => {
     const hostName = connection.origin;
@@ -137,6 +188,56 @@ const PermissionsPage = () => {
           </Box>
         )}
       </Content>
+      {totalConnections > 0 && (
+        <Footer>
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
+            width={BlockSize.Full}
+            gap={2}
+            alignItems={AlignItems.center}
+          >
+            {showSuccessToast && (
+              <ToastContainer>
+                <Toast
+                  text={t('disconnectAllSitesSuccess')}
+                  onClose={() => setShowSuccessToast(false)}
+                  autoHideTime={5000}
+                  onAutoHideToast={() => setShowSuccessToast(false)}
+                  data-testid="disconnect-all-success-toast"
+                />
+              </ToastContainer>
+            )}
+            {showErrorToast && (
+              <ToastContainer>
+                <Toast
+                  text={t('disconnectAllSitesError')}
+                  onClose={() => setShowErrorToast(false)}
+                  autoHideTime={5000}
+                  onAutoHideToast={() => setShowErrorToast(false)}
+                  data-testid="disconnect-all-error-toast"
+                />
+              </ToastContainer>
+            )}
+            <Button
+              size={ButtonSize.Lg}
+              block
+              variant={ButtonVariant.Secondary}
+              startIconName={IconName.Logout}
+              danger
+              onClick={() => setShowDisconnectAllModal(true)}
+              data-testid="disconnect-all-button"
+            >
+              {t('disconnectAllSites')}
+            </Button>
+          </Box>
+        </Footer>
+      )}
+      <DisconnectAllSitesModal
+        isOpen={showDisconnectAllModal}
+        onClose={() => setShowDisconnectAllModal(false)}
+        onClick={handleDisconnectAll}
+      />
     </Page>
   );
 };

--- a/ui/components/multichain/pages/permissions-page/permissions-page.test.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../../shared/modules/environment';
+import * as actions from '../../../../store/actions';
 import PermissionsPage from './permissions-page';
 
 mockState.metamask.subjectMetadata = {
@@ -150,6 +152,138 @@ describe('All Connections', () => {
         .mockReturnValue(true);
       const { getByTestId } = renderWithProvider(<PermissionsPage />, store);
       expect(getByTestId('permissions-page-title')).toHaveTextContent('Sites');
+    });
+  });
+
+  describe('Disconnect All functionality', () => {
+    let storeWithConnections;
+
+    beforeEach(() => {
+      const stateWithConnections = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET, id: 'mainnet' }),
+          subjectMetadata: {
+            'https://metamask.github.io': {
+              iconUrl: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
+              name: 'E2E Test Dapp',
+              subjectType: 'website',
+              origin: 'https://metamask.github.io',
+              extensionId: null,
+            },
+          },
+          subjects: {
+            'https://metamask.github.io': {
+              origin: 'https://metamask.github.io',
+              permissions: {
+                'endowment:caip25': {
+                  caveats: [
+                    {
+                      type: 'authorizedScopes',
+                      value: {
+                        requiredScopes: {},
+                        optionalScopes: {
+                          'eip155:1': {
+                            accounts: [
+                              'eip155:1:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+                            ],
+                          },
+                        },
+                        isMultichainOrigin: false,
+                      },
+                    },
+                  ],
+                  date: 1698071087770,
+                  id: 'BIko27gpEajmo_CcNYPxD',
+                  invoker: 'https://metamask.github.io',
+                  parentCapability: 'endowment:caip25',
+                },
+              },
+            },
+          },
+        },
+      };
+      storeWithConnections = configureStore(stateWithConnections);
+    });
+
+    it('renders Disconnect All button when there are connections', () => {
+      const { getByTestId } = renderWithProvider(
+        <PermissionsPage />,
+        storeWithConnections,
+      );
+      expect(getByTestId('disconnect-all-button')).toBeInTheDocument();
+    });
+
+    it('does not render Disconnect All button when there are no connections', () => {
+      const stateWithNoConnections = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET, id: 'mainnet' }),
+          subjectMetadata: {},
+          subjects: {},
+          snaps: {},
+        },
+      };
+      const emptyStore = configureStore(stateWithNoConnections);
+      const { queryByTestId } = renderWithProvider(
+        <PermissionsPage />,
+        emptyStore,
+      );
+      expect(queryByTestId('disconnect-all-button')).not.toBeInTheDocument();
+    });
+
+    it('opens Disconnect All Sites modal when button is clicked', () => {
+      const { getByTestId } = renderWithProvider(
+        <PermissionsPage />,
+        storeWithConnections,
+      );
+
+      fireEvent.click(getByTestId('disconnect-all-button'));
+
+      expect(getByTestId('disconnect-all-sites-modal')).toBeInTheDocument();
+    });
+
+    it('closes modal when close button is clicked', async () => {
+      const { getByTestId, queryByTestId, getByRole } = renderWithProvider(
+        <PermissionsPage />,
+        storeWithConnections,
+      );
+
+      fireEvent.click(getByTestId('disconnect-all-button'));
+      expect(getByTestId('disconnect-all-sites-modal')).toBeInTheDocument();
+
+      // Click the close button in the modal header
+      const closeButton = getByRole('button', { name: /close/iu });
+      fireEvent.click(closeButton);
+
+      await waitFor(() => {
+        expect(
+          queryByTestId('disconnect-all-sites-modal'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('calls removePermissionsFor when confirm is clicked', () => {
+      const removePermissionsForSpy = jest.spyOn(
+        actions,
+        'removePermissionsFor',
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <PermissionsPage />,
+        storeWithConnections,
+      );
+
+      fireEvent.click(getByTestId('disconnect-all-button'));
+      fireEvent.click(getByTestId('disconnect-all-sites-confirm'));
+
+      expect(removePermissionsForSpy).toHaveBeenCalledWith({
+        'https://metamask.github.io': ['endowment:caip25'],
+      });
+
+      removePermissionsForSpy.mockRestore();
     });
   });
 });

--- a/ui/components/multichain/pages/permissions-page/permissions-page.test.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.test.js
@@ -266,10 +266,11 @@ describe('All Connections', () => {
     });
 
     it('calls removePermissionsFor when confirm is clicked', () => {
-      const removePermissionsForSpy = jest.spyOn(
-        actions,
-        'removePermissionsFor',
-      );
+      // Mock removePermissionsFor to return a no-op thunk to avoid
+      // calling the background method (which isn't initialized in tests)
+      const removePermissionsForMock = jest
+        .spyOn(actions, 'removePermissionsFor')
+        .mockImplementation(() => () => undefined);
 
       const { getByTestId } = renderWithProvider(
         <PermissionsPage />,
@@ -279,11 +280,11 @@ describe('All Connections', () => {
       fireEvent.click(getByTestId('disconnect-all-button'));
       fireEvent.click(getByTestId('disconnect-all-sites-confirm'));
 
-      expect(removePermissionsForSpy).toHaveBeenCalledWith({
+      expect(removePermissionsForMock).toHaveBeenCalledWith({
         'https://metamask.github.io': ['endowment:caip25'],
       });
 
-      removePermissionsForSpy.mockRestore();
+      removePermissionsForMock.mockRestore();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a “Disconnect All” button to the Dapp Connections screen. This will allow users to quickly revoke access for all connected dapps from one place, without needing to open each one individually.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39791?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add disconnect all button to dapp connections main screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-898

## **Manual testing steps**

1. Make sure to have permissions to multiple dapps
2. Navigate to Dapp Connections screens (Extension View -> Hamburger Icon -> Dapp Connections -> Sites)
3. There should be a button labeled "Disconnect All"
4. Pressing this button should open a confirmation modal, to which proceeding should revoke permissions from all connected dapps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/f837945a-9bbc-46da-947a-4ef0ff24763d

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds bulk permission revocation from the connections screen by dispatching `removePermissionsFor` across all connected origins, which can impact user connectivity if the selection/mapping is wrong. Error handling is mostly synchronous and may not reflect async revocation failures accurately.
> 
> **Overview**
> Adds a **“Disconnect All”** button to the Dapp Connections/Sites (`PermissionsPage`) screen (only when connections exist), backed by a new confirmation modal (`DisconnectAllSitesModal`).
> 
> On confirm, the page iterates all non-snap connected origins and dispatches `removePermissionsFor` with each origin’s permission `parentCapability` list, then shows a success/error toast. Includes new i18n strings and Jest tests/snapshots for the modal and the new page behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b726e16f362e2816c3e280f52b985cf6e09a7bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->