### PR TITLE
fix: reducing circular dependencies

### DIFF
--- a/development/circular-deps.jsonc
+++ b/development/circular-deps.jsonc
@@ -22,7 +22,6 @@
     "ui/components/app/metamask-translation/metamask-translation.js"
   ],
   [
-    "ui/ducks/alerts/unconnected-account.js",
     "ui/ducks/metamask/metamask.js",
     "ui/selectors/confirm-transaction.js",
     "ui/selectors/custom-gas.js",
@@ -31,7 +30,6 @@
     "ui/store/actions.ts"
   ],
   [
-    "ui/ducks/alerts/unconnected-account.js",
     "ui/ducks/metamask/metamask.js",
     "ui/selectors/confirm-transaction.js",
     "ui/selectors/custom-gas.js",
@@ -39,7 +37,6 @@
     "ui/store/actions.ts"
   ],
   [
-    "ui/ducks/alerts/unconnected-account.js",
     "ui/ducks/metamask/metamask.js",
     "ui/selectors/confirm-transaction.js",
     "ui/selectors/index.js",
@@ -47,20 +44,17 @@
     "ui/store/actions.ts"
   ],
   [
-    "ui/ducks/alerts/unconnected-account.js",
     "ui/ducks/metamask/metamask.js",
     "ui/selectors/confirm-transaction.js",
     "ui/selectors/index.js",
     "ui/store/actions.ts"
   ],
   [
-    "ui/ducks/alerts/unconnected-account.js",
     "ui/ducks/metamask/metamask.js",
     "ui/selectors/index.js",
     "ui/selectors/selectors.js",
     "ui/store/actions.ts"
   ],
-  ["ui/ducks/alerts/unconnected-account.js", "ui/store/actions.ts"],
   ["ui/ducks/metamask/metamask.js", "ui/selectors/selectors.js"],
   ["ui/ducks/metamask/metamask.js", "ui/store/actions.ts"],
   ["ui/selectors/multichain.ts", "ui/selectors/selectors.js"]

--- a/ui/ducks/alerts/index.js
+++ b/ui/ducks/alerts/index.js
@@ -1,4 +1,4 @@
-export { default as unconnectedAccount } from './unconnected-account';
+export { default as unconnectedAccount } from './unconnected-account-slice';
 export { default as invalidCustomNetwork } from './invalid-custom-network';
 
 export { ALERT_STATE } from './enums';

--- a/ui/ducks/alerts/unconnected-account-slice.ts
+++ b/ui/ducks/alerts/unconnected-account-slice.ts
@@ -1,0 +1,73 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { AlertTypes } from '../../../shared/constants/alerts';
+import * as actionConstants from '../../store/actionConstants';
+import { ALERT_STATE } from './enums';
+
+const initialState = {
+  state: ALERT_STATE.CLOSED,
+};
+
+export const unconnectedAccountSlice = createSlice({
+  name: AlertTypes.unconnectedAccount,
+  initialState,
+  reducers: {
+    connectAccountFailed: (state) => {
+      state.state = ALERT_STATE.ERROR;
+    },
+    connectAccountRequested: (state) => {
+      state.state = ALERT_STATE.LOADING;
+    },
+    connectAccountSucceeded: (state) => {
+      state.state = ALERT_STATE.CLOSED;
+    },
+    disableAlertFailed: (state) => {
+      state.state = ALERT_STATE.ERROR;
+    },
+    disableAlertRequested: (state) => {
+      state.state = ALERT_STATE.LOADING;
+    },
+    disableAlertSucceeded: (state) => {
+      state.state = ALERT_STATE.CLOSED;
+    },
+    dismissAlert: (state) => {
+      state.state = ALERT_STATE.CLOSED;
+    },
+    switchAccountFailed: (state) => {
+      state.state = ALERT_STATE.ERROR;
+    },
+    switchAccountRequested: (state) => {
+      state.state = ALERT_STATE.LOADING;
+    },
+    switchAccountSucceeded: (state) => {
+      state.state = ALERT_STATE.CLOSED;
+    },
+    switchedToUnconnectedAccount: (state) => {
+      state.state = ALERT_STATE.OPEN;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(actionConstants.SELECTED_ADDRESS_CHANGED, (state) => {
+      // close the alert if the account is switched while it's open
+      if (state.state === ALERT_STATE.OPEN) {
+        state.state = ALERT_STATE.CLOSED;
+      }
+    });
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const {
+  connectAccountFailed,
+  connectAccountRequested,
+  connectAccountSucceeded,
+  disableAlertFailed,
+  disableAlertRequested,
+  disableAlertSucceeded,
+  dismissAlert,
+  switchAccountFailed,
+  switchAccountRequested,
+  switchAccountSucceeded,
+  switchedToUnconnectedAccount,
+} = unconnectedAccountSlice.actions;
+
+export default unconnectedAccountSlice.reducer;

--- a/ui/ducks/alerts/unconnected-account.js
+++ b/ui/ducks/alerts/unconnected-account.js
@@ -1,8 +1,5 @@
-import { createSlice } from '@reduxjs/toolkit';
-
 import { captureException } from '../../../shared/lib/sentry';
 import { AlertTypes } from '../../../shared/constants/alerts';
-import * as actionConstants from '../../store/actionConstants';
 import {
   addPermittedAccount,
   setAlertEnabledness,
@@ -14,79 +11,7 @@ import {
   getOriginOfCurrentTab,
   getSelectedInternalAccount,
 } from '../../selectors';
-import { ALERT_STATE } from './enums';
-
-// Constants
-
-const name = AlertTypes.unconnectedAccount;
-
-const initialState = {
-  state: ALERT_STATE.CLOSED,
-};
-
-// Slice (reducer plus auto-generated actions and action creators)
-
-const slice = createSlice({
-  name,
-  initialState,
-  reducers: {
-    connectAccountFailed: (state) => {
-      state.state = ALERT_STATE.ERROR;
-    },
-    connectAccountRequested: (state) => {
-      state.state = ALERT_STATE.LOADING;
-    },
-    connectAccountSucceeded: (state) => {
-      state.state = ALERT_STATE.CLOSED;
-    },
-    disableAlertFailed: (state) => {
-      state.state = ALERT_STATE.ERROR;
-    },
-    disableAlertRequested: (state) => {
-      state.state = ALERT_STATE.LOADING;
-    },
-    disableAlertSucceeded: (state) => {
-      state.state = ALERT_STATE.CLOSED;
-    },
-    dismissAlert: (state) => {
-      state.state = ALERT_STATE.CLOSED;
-    },
-    switchAccountFailed: (state) => {
-      state.state = ALERT_STATE.ERROR;
-    },
-    switchAccountRequested: (state) => {
-      state.state = ALERT_STATE.LOADING;
-    },
-    switchAccountSucceeded: (state) => {
-      state.state = ALERT_STATE.CLOSED;
-    },
-    switchedToUnconnectedAccount: (state) => {
-      state.state = ALERT_STATE.OPEN;
-    },
-  },
-  extraReducers: (builder) => {
-    builder.addCase(actionConstants.SELECTED_ADDRESS_CHANGED, (state) => {
-      // close the alert if the account is switched while it's open
-      if (state.state === ALERT_STATE.OPEN) {
-        state.state = ALERT_STATE.CLOSED;
-      }
-    });
-  },
-});
-
-const { actions, reducer } = slice;
-
-export default reducer;
-
-// Selectors
-
-export const getAlertState = (state) => state[name].state;
-
-export const alertIsOpen = (state) => state[name].state !== ALERT_STATE.CLOSED;
-
-// Actions / action-creators
-
-const {
+import {
   connectAccountFailed,
   connectAccountRequested,
   connectAccountSucceeded,
@@ -98,9 +23,17 @@ const {
   switchAccountRequested,
   switchAccountSucceeded,
   switchedToUnconnectedAccount,
-} = actions;
+} from './unconnected-account-slice';
 
 export { dismissAlert, switchedToUnconnectedAccount };
+
+const name = AlertTypes.unconnectedAccount;
+
+// Selectors
+
+export const getAlertState = (state) => state[name].state;
+
+// Thunk actions
 
 export const dismissAndDisableAlert = () => {
   return async (dispatch) => {

--- a/ui/pages/confirmations/selectors/preferences.ts
+++ b/ui/pages/confirmations/selectors/preferences.ts
@@ -1,8 +1,11 @@
-import { getPreferences } from '../../../selectors';
-
 export type RootState = {
   metamask: {
     useTransactionSimulations?: boolean;
+    preferences?: {
+      showConfirmationAdvancedDetails?: boolean;
+      dismissSmartAccountSuggestionEnabled?: boolean;
+      smartAccountOptIn?: boolean;
+    };
   };
 };
 
@@ -10,13 +13,16 @@ export const selectUseTransactionSimulations = (state: RootState) =>
   state.metamask.useTransactionSimulations;
 
 export function selectConfirmationAdvancedDetailsOpen(state: RootState) {
-  return Boolean(getPreferences(state).showConfirmationAdvancedDetails);
+  const { metamask } = state;
+  return Boolean(metamask.preferences?.showConfirmationAdvancedDetails);
 }
 
 export function getDismissSmartAccountSuggestionEnabled(state: RootState) {
-  return Boolean(getPreferences(state).dismissSmartAccountSuggestionEnabled);
+  const { metamask } = state;
+  return Boolean(metamask.preferences?.dismissSmartAccountSuggestionEnabled);
 }
 
 export function getUseSmartAccount(state: RootState) {
-  return Boolean(getPreferences(state).smartAccountOptIn);
+  const { metamask } = state;
+  return Boolean(metamask.preferences?.smartAccountOptIn);
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -117,7 +117,7 @@ import {
   getSelectedNetworkClientId,
   getProviderConfig,
 } from '../../shared/modules/selectors/networks';
-import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account';
+import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account-slice';
 import {
   getUnconnectedAccountAlertEnabledness,
   getCompletedOnboarding,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reducing circular dependencies

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39799?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors Redux alert wiring and changes preference selectors to read state directly, which could cause regressions if reducer keys or preference defaults differ from the previous selector.
> 
> **Overview**
> Reduces circular dependencies by extracting the `unconnectedAccount` Redux slice into a new `unconnected-account-slice.ts` and updating exports/imports (including `ui/store/actions.ts`) to reference the slice directly.
> 
> Updates `ui/ducks/alerts/unconnected-account.js` to focus on thunks/selectors while consuming actions from the new slice, and adjusts confirmation preference selectors to access `state.metamask.preferences` directly (removing the `getPreferences` dependency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4931570b4693f51f50404b6c772ae0ad5d31ed4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->