### PR TITLE
fix: render "Dapp Connections" pages with constrained max width

### DIFF
--- a/ui/components/multichain/pages/gator-permissions/__snapshots__/gator-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/__snapshots__/gator-permissions-page.test.tsx.snap
@@ -47,9 +47,6 @@ exports[`Gator Permissions Page render renders correctly 1`] = `
         style="overflow: auto;"
       >
         <div
-          class="mm-box"
-        />
-        <div
           class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--align-items-baseline mm-box--width-full mm-box--background-color-background-default"
           data-testid="permission-list"
         >

--- a/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
+++ b/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { Content, Header, Page } from '../page';
@@ -44,7 +44,6 @@ export const GatorPermissionsPage = () => {
   const t = useI18nContext();
   const theme = useTheme();
   const navigate = useNavigate();
-  const headerRef = useRef<HTMLSpanElement>(null);
   const totalGatorPermissions = useSelector((state: AppState) =>
     getAggregatedGatorPermissionsCountAcrossAllChains(state, 'token-transfer'),
   );
@@ -213,10 +212,7 @@ export const GatorPermissionsPage = () => {
           {t('dappConnections')}
         </Text>
       </Header>
-      <Content padding={0}>
-        <Box ref={headerRef}></Box>
-        {renderPageContent()}
-      </Content>
+      <Content padding={0}>{renderPageContent()}</Content>
     </Page>
   );
 };

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -279,14 +279,14 @@ const GatorPermissionsPage = mmLazy(
       '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
     )) as unknown as DynamicImportType,
 );
-const TokenTransferPage = mmLazy(
+const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
   // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
   (() =>
     import(
       '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
     )) as unknown as DynamicImportType,
 );
-const ReviewGatorPermissionsPage = mmLazy(
+const GatorPermissionsReviewPermissionsPage = mmLazy(
   // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
   (() =>
     import(
@@ -695,31 +695,31 @@ export default function Routes() {
       createRouteWithLayout({
         path: GATOR_PERMISSIONS,
         component: GatorPermissionsPage,
-        layout: LegacyLayout,
+        layout: RootLayout,
         authenticated: true,
       }),
       createRouteWithLayout({
         path: `${TOKEN_TRANSFER_ROUTE}/:origin`,
-        component: TokenTransferPage,
-        layout: LegacyLayout,
+        component: GatorPermissionsTokenTransferPermissionsPage,
+        layout: RootLayout,
         authenticated: true,
       }),
       createRouteWithLayout({
         path: TOKEN_TRANSFER_ROUTE,
-        component: TokenTransferPage,
-        layout: LegacyLayout,
+        component: GatorPermissionsTokenTransferPermissionsPage,
+        layout: RootLayout,
         authenticated: true,
       }),
       createRouteWithLayout({
         path: `${REVIEW_GATOR_PERMISSIONS_ROUTE}/:chainId/:permissionGroupName/:origin`,
-        component: ReviewGatorPermissionsPage,
-        layout: LegacyLayout,
+        component: GatorPermissionsReviewPermissionsPage,
+        layout: RootLayout,
         authenticated: true,
       }),
       createRouteWithLayout({
         path: `${REVIEW_GATOR_PERMISSIONS_ROUTE}/:chainId/:permissionGroupName`,
-        component: ReviewGatorPermissionsPage,
-        layout: LegacyLayout,
+        component: GatorPermissionsReviewPermissionsPage,
+        layout: RootLayout,
         authenticated: true,
       }),
       createRouteWithLayout({


### PR DESCRIPTION
## **Description**

When reviewing Dapp Connections, the user must navigate the page hierarchy to refine the permissions list. Some of these interim pages were rendered fullscreen instead of with an appropriate max width constraint.

This PR fixes that by updating the "layout" to "DefaultLayout" (previously "LegacyLayout").

Also:
- remove unused ref from first permissions page
- rename page variables in routes component for clarity (GatorPermissions prefix)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39801?quickstart=1)

## **Changelog**

CHANGELOG entry: fixes fullscreen rendering of Dapp Connections pages by updating layout from "LegacyLayout" to "DefaultLayout"

## **Related issues**

Fixes:

## **Manual testing steps**

The following should be tested in Popup, Fullscreen, and side panel modes. 

Via "Sites"
1. Navigate to "Dapp Connections" page (previously "All Permissions")
2. Click "Sites"
3. Click any connected site
4. Click any listed network

Via "Token transfer" permissions
1. Navigate to "Dapp Connections" page (previously "All Permissions")
2. Click "Token transfer"
3. Click any listed network

Note that all pages are rendered with the appropriate max width constraint consistent with the rest of the wallet interface.

## **Screenshots/Recordings**

### **Before**

Note this page is rendered in full width

<img width="1562" height="768" alt="image" src="https://github.com/user-attachments/assets/d1192dcf-6551-451b-8e70-77a771e63acc" />

### **After**

Note that all pages are now constrained to an appropriate max width

https://github.com/user-attachments/assets/f939054d-4dd2-4fb6-bb19-3fa34a192623


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI routing/layout change; main risk is unintended styling/navigation regressions on the `GATOR_PERMISSIONS`/token-transfer/review routes due to layout swap and route component renames.
> 
> **Overview**
> Ensures the **Dapp Connections (Gator Permissions)** route set renders with the standard max-width constraints by switching these routes from `LegacyLayout` to `RootLayout` (including token transfer and review subpages).
> 
> Cleans up related plumbing by removing an unused `useRef`/placeholder `Box` in `GatorPermissionsPage` and renaming the lazy-loaded route variables with a `GatorPermissions` prefix; updates the Jest snapshot accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e794234094f934dc94b69c09fbd54d906c3e15ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->