### PR TITLE
fix: handle evm unsupported chains gracefully in send flow for custom network cp-13.17.0

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -70,12 +70,12 @@ describe('asset-utils', () => {
       ]);
     });
 
-    it('should return undefined if getNativeAssetForChainId throws an error', () => {
+    it('should return undefined if getNativeAssetForChainId returns undefined for unsupported chain', () => {
       const nativeAddress = '0x0000000000000000000000000000000000000000';
       const chainId = 'eip155:1231' as CaipChainId;
 
-      // toAssetId now catches errors from getNativeAssetForChainId and returns undefined
-      // This allows the send flow to work for custom networks even if they're not in the swaps map
+      // getNativeAssetForChainId returns undefined (not throws) for chains not in the swaps map
+      // Format normalization in isEvmChainId should prevent conversion errors
       const result = toAssetId(nativeAddress, chainId);
       expect(result).toBeUndefined();
     });
@@ -471,6 +471,31 @@ describe('asset-utils', () => {
 
     it('should return false for non-EVM chain ids', () => {
       expect(isEvmChainId('solana:1')).toBe(false);
+    });
+
+    it('should return true for EVM chain ids passed as decimal strings', () => {
+      // Test Injective testnet (1439) - the original bug case
+      expect(isEvmChainId('1439' as Hex)).toBe(true);
+      // Test other EVM chains as decimal strings
+      expect(isEvmChainId('1' as Hex)).toBe(true); // Ethereum mainnet
+      expect(isEvmChainId('137' as Hex)).toBe(true); // Polygon
+      expect(isEvmChainId('1776' as Hex)).toBe(true); // Injective mainnet
+    });
+
+    it('should return false for non-EVM chain ids passed as decimal strings', () => {
+      // Test Solana (1151111081099710)
+      expect(isEvmChainId('1151111081099710' as Hex)).toBe(false);
+      // Test Bitcoin (20000000000001)
+      expect(isEvmChainId('20000000000001' as Hex)).toBe(false);
+      // Test Tron (728126428)
+      expect(isEvmChainId('728126428' as Hex)).toBe(false);
+    });
+
+    it('should handle Injective testnet chainId in different formats', () => {
+      // All these should return true for Injective testnet (1439)
+      expect(isEvmChainId('1439' as Hex)).toBe(true); // Decimal string
+      expect(isEvmChainId('0x59f' as Hex)).toBe(true); // Hex format
+      expect(isEvmChainId('eip155:1439' as CaipChainId)).toBe(true); // CAIP format
     });
   });
 });

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -74,9 +74,10 @@ describe('asset-utils', () => {
       const nativeAddress = '0x0000000000000000000000000000000000000000';
       const chainId = 'eip155:1231' as CaipChainId;
 
-      expect(() => toAssetId(nativeAddress, chainId)).toThrow(
-        'No XChain Swaps native asset found for chainId: eip155:1231',
-      );
+      // toAssetId now catches errors from getNativeAssetForChainId and returns undefined
+      // This allows the send flow to work for custom networks even if they're not in the swaps map
+      const result = toAssetId(nativeAddress, chainId);
+      expect(result).toBeUndefined();
     });
 
     it('should create Solana token asset ID correctly', () => {

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -51,7 +51,13 @@ export const toAssetId = (
   }
 
   if (isNativeAddress(addressToUse)) {
-    return getNativeAssetForChainId(chainIdToUse)?.assetId;
+    try {
+      return getNativeAssetForChainId(chainIdToUse)?.assetId;
+    } catch {
+      // Return undefined for unsupported chains (e.g., custom networks)
+      // This allows the send flow to work for custom networks even if they're not in the swaps map
+      return undefined;
+    }
   }
   if (chainIdToUse === MultichainNetworks.SOLANA) {
     return CaipAssetTypeStruct.create(`${chainIdToUse}/token:${addressToUse}`);

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -9,6 +9,7 @@ import {
   isStrictHexString,
   parseCaipAssetType,
   KnownCaipNamespace,
+  numberToHex,
 } from '@metamask/utils';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -56,6 +57,7 @@ export const toAssetId = (
     } catch {
       // Return undefined for unsupported chains (e.g., custom networks)
       // This allows the send flow to work for custom networks even if they're not in the swaps map
+      // Format normalization in isEvmChainId should prevent most errors, but this is a defensive fallback
       return undefined;
     }
   }
@@ -227,9 +229,23 @@ export const fetchAssetMetadataForAssetIds = async (
  * @returns `true` if the chain ID is an EVM chain ID, `false` otherwise.
  */
 export const isEvmChainId = (chainId: CaipChainId | Hex) => {
-  const chainIdInCaip = isCaipChainId(chainId)
-    ? chainId
-    : toEvmCaipChainId(chainId);
+  let chainIdInCaip: CaipChainId;
+
+  if (isCaipChainId(chainId)) {
+    chainIdInCaip = chainId;
+  } else if (isStrictHexString(chainId)) {
+    chainIdInCaip = toEvmCaipChainId(chainId);
+  } else {
+    // Before converting decimal strings to hex, check if it's a non-EVM chainId
+    // This prevents misidentifying non-EVM chains (e.g., Solana, Bitcoin, Tron) as EVM
+    if (isNonEvmChainId(chainId)) {
+      return false;
+    }
+    // Handle decimal strings by converting to hex first
+    // This fixes issues where chainIds are passed as decimal strings (e.g., '1439' for Injective testnet)
+    // instead of hex format (e.g., '0x59f')
+    chainIdInCaip = toEvmCaipChainId(numberToHex(Number(chainId)));
+  }
 
   // TODO Replace with isEvmCaipChainId from @metamask/multichain-network-controller when it is exported
   const { namespace } = parseCaipChainId(chainIdInCaip);

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -60,6 +60,25 @@ export const getMaybeHexChainId = (chainId?: string) => {
 };
 
 /**
+ * Safely gets the native asset for a given chainId.
+ * Returns undefined if the chainId is not supported by the bridge controller.
+ * This wrapper prevents errors for custom networks that aren't in the swaps map.
+ *
+ * @param chainId - The chain ID to get the native asset for
+ * @returns The native asset, or undefined if not supported
+ */
+export const getNativeAssetForChainIdSafe = (
+  chainId: string | number | Hex | CaipChainId,
+) => {
+  try {
+    return getNativeAssetForChainId(chainId);
+  } catch {
+    // Return undefined for unsupported chains (e.g., custom networks, test chains)
+    return undefined;
+  }
+};
+
+/**
  * Safely gets the native token name for a given chainId.
  * Returns undefined if the chainId is not supported by the bridge controller.
  *

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -1,6 +1,4 @@
-import {
-  AssetType,
-} from '@metamask/bridge-controller';
+import { AssetType } from '@metamask/bridge-controller';
 import { CaipAssetType } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -1,6 +1,5 @@
 import {
   AssetType,
-  getNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import { CaipAssetType } from '@metamask/utils';
 import { useSelector } from 'react-redux';
@@ -9,6 +8,7 @@ import { getCurrencyRates, getMarketData } from '../../../selectors';
 import { getAssetsRates } from '../../../selectors/assets';
 import { Asset } from '../types/asset';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+import { getNativeAssetForChainIdSafe } from '../../../ducks/bridge/utils';
 
 /**
  * Get the current price of an asset.
@@ -46,7 +46,13 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
   const assetId =
     type === AssetType.token
       ? asset.address
-      : getNativeAssetForChainId(chainId).assetId;
+      : getNativeAssetForChainIdSafe(chainId)?.assetId;
+
+  // If we can't get the assetId for a native token (unsupported chain), return undefined price
+  if (!assetId && type === AssetType.native) {
+    return { currentPrice: undefined };
+  }
+
   const currentPriceAsString =
     nonEvmConversionRates?.[assetId as CaipAssetType]?.rate;
 

--- a/ui/pages/asset/hooks/useCurrentPrice.ts
+++ b/ui/pages/asset/hooks/useCurrentPrice.ts
@@ -43,6 +43,7 @@ export const useCurrentPrice = (asset: Asset): { currentPrice?: number } => {
     return { currentPrice };
   }
 
+  // Format normalization in isEvmChainId should prevent most errors, but using safe wrapper as defensive fallback
   const assetId =
     type === AssetType.token
       ? asset.address


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes error when sending native tokens on EVM networks with decimal string chainIds (e.g., Injective testnet). The fix normalizes decimal string chainIds to hex format in `isEvmChainId` before conversion, preventing conversion errors. Defensive error handling is also added as a fallback for unsupported chains.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39806?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed error when sending native tokens on EVM networks when chainId is provided as decimal string.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/33102161-974b-4b4f-9f85-0e5100014cb3



### **After**

https://github.com/user-attachments/assets/afc9c80a-bfd7-4e5a-b671-47a33ef18ede


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chain-id normalization and native asset lookups that can affect pricing/send flows across many networks; changes are small but impact broad utility functions and error handling paths.
> 
> **Overview**
> Fixes failures when EVM `chainId`s are provided as **decimal strings** (e.g. Injective testnet) by updating `isEvmChainId` to normalize non-CAIP/non-hex inputs (after guarding with `isNonEvmChainId`) before converting to CAIP.
> 
> Makes native-asset resolution more defensive on unsupported/custom networks: `toAssetId` now catches `getNativeAssetForChainId` errors and returns `undefined`, the UI adds `getNativeAssetForChainIdSafe`, and `useCurrentPrice` uses it to avoid throwing and to return no price when a native `assetId` can’t be derived. Tests were updated/added to cover decimal-string chain IDs and unsupported-chain native asset handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fbca988e86549a09983a85e2038c3259783c5d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>3fbca98</u></sup><!-- /BUGBOT_STATUS -->