### PR TITLE
feat: remove the petnames modal from the activity list recipient address

### DIFF
--- a/ui/components/app/name/name-details/name-display.tsx
+++ b/ui/components/app/name/name-details/name-display.tsx
@@ -22,6 +22,10 @@ export type NameDisplayProps = {
    * The fallback value to display if the name is not found or cannot be resolved.
    */
   fallbackName?: string;
+  /**
+   * Whether to disable the onClick handler.
+   */
+  disableNameClick?: boolean;
 };
 
 const NameDisplay = memo(
@@ -33,6 +37,7 @@ const NameDisplay = memo(
     handleClick,
     showFullName = false,
     fallbackName,
+    disableNameClick,
     ...props
   }: NameDisplayProps) => {
     const { name, image, icon, displayState, isAccount } = useDisplayName({
@@ -91,7 +96,7 @@ const NameDisplay = memo(
           name: true,
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          name__clickable: Boolean(handleClick) && !isAccount,
+          name__clickable: Boolean(handleClick) && !isAccount && !disableNameClick,
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           name__saved: displayState === TrustSignalDisplayState.Petname,

--- a/ui/components/app/name/name-details/name-display.tsx
+++ b/ui/components/app/name/name-details/name-display.tsx
@@ -96,7 +96,8 @@ const NameDisplay = memo(
           name: true,
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          name__clickable: Boolean(handleClick) && !isAccount && !disableNameClick,
+          name__clickable:
+            Boolean(handleClick) && !isAccount && !disableNameClick,
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           name__saved: displayState === TrustSignalDisplayState.Petname,

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -55,6 +55,11 @@ export type NameProps = {
    * The class name to apply to the box.
    */
   className?: string;
+
+  /**
+   * Whether to disable the onClick handler.
+   */
+  disableNameClick?: boolean;
 };
 
 const Name = memo(
@@ -64,6 +69,7 @@ const Name = memo(
     preferContractSymbol = false,
     variation,
     className,
+    disableNameClick = false,
     ...props
   }: NameProps) => {
     const [modalOpen, setModalOpen] = useState(false);
@@ -93,7 +99,7 @@ const Name = memo(
     }, []);
 
     const handleClick = useCallback(() => {
-      if (isAccount) {
+      if (isAccount || disableNameClick) {
         return;
       }
       setModalOpen(true);
@@ -123,6 +129,7 @@ const Name = memo(
           preferContractSymbol={preferContractSymbol}
           variation={variation}
           handleClick={handleClick}
+          disableNameClick={disableNameClick}
           {...props}
         />
         {subtitle && (

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -103,7 +103,7 @@ const Name = memo(
         return;
       }
       setModalOpen(true);
-    }, [isAccount, setModalOpen]);
+    }, [disableNameClick, isAccount, setModalOpen]);
 
     const handleModalClose = useCallback(() => {
       setModalOpen(false);

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -77,7 +77,7 @@ export function RecipientWithAddress({
         type={NameType.ETHEREUM_ADDRESS}
         variation={chainId}
         variant={TextVariant.BodyXs}
-        disableNameClick={true}
+        disableNameClick
       />
     </div>
   );

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -34,6 +34,7 @@ function SenderAddress({
       <PreferredAvatar
         address={toChecksumHexAddress(senderAddress)}
         size={AvatarAccountSize.Xs}
+        className="rounded-md"
       />
       <div className="sender-to-recipient__name text-s-body-xs">
         {addressOnly ? (

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -65,21 +65,20 @@ export function RecipientWithAddress({
   className = '',
 }) {
   return (
-    <>
-      <div
-        className={classnames(
-          'sender-to-recipient__party sender-to-recipient__party--recipient sender-to-recipient__party--recipient-with-address',
-          className,
-        )}
-      >
-        <Name
-          value={checksummedRecipientAddress}
-          type={NameType.ETHEREUM_ADDRESS}
-          variation={chainId}
-          variant={TextVariant.BodyXs}
-        />
-      </div>
-    </>
+    <div
+      className={classnames(
+        'sender-to-recipient__party sender-to-recipient__party--recipient sender-to-recipient__party--recipient-with-address',
+        className,
+      )}
+    >
+      <Name
+        value={checksummedRecipientAddress}
+        type={NameType.ETHEREUM_ADDRESS}
+        variation={chainId}
+        variant={TextVariant.BodyXs}
+        disableNameClick={true}
+      />
+    </div>
   );
 }
 

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -33,7 +33,7 @@ function SenderAddress({
     <div className="sender-to-recipient__party sender-to-recipient__party--sender gap-1">
       <PreferredAvatar
         address={toChecksumHexAddress(senderAddress)}
-        size={AvatarAccountSize.Sm}
+        size={AvatarAccountSize.Xs}
       />
       <div className="sender-to-recipient__name text-s-body-xs">
         {addressOnly ? (


### PR DESCRIPTION
## **Description**

Removes the petname modal interaction from the transaction activity list. Previously, clicking on recipient addresses in the activity list would open the petname modal for non-owned accounts.

**Changes:**
- Added `disableNameClick` prop to `Name` and `NameDisplay` components to conditionally disable the modal trigger and associated "clickable" styling
- Applied `disableNameClick={true}` to the recipient `Name` component in `SenderToRecipient`
- Updated sender avatar size from `Sm` to `Xs` and increased border radius to match the Name component's avatar size for visual consistency

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39816?quickstart=1)

## **Changelog**

CHANGELOG entry: Removed petname modal from appearing when clicking recipient addresses in activity list

## **Related issues**

Fixes: [CEUX-894](https://consensyssoftware.atlassian.net/browse/CEUX-894)

## **Manual testing steps**

1. Go to the Activity tab on the home page
2. Click on any transaction to expand it
3. Click on the recipient address in the "From → To" display
4. Verify the petname modal does NOT open
5. Verify the sender and recipient avatars are the same size

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/92641028-6d81-4f95-b1ec-0d5c4b53fe99




### **After**

https://github.com/user-attachments/assets/d87ed78c-15de-415e-9adb-ce774fd2f760

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CEUX-894]: https://consensyssoftware.atlassian.net/browse/CEUX-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change gated by a new prop; main risk is unintended loss of click-to-open behavior in places that opt into `disableNameClick`.
> 
> **Overview**
> Prevents the petname modal from opening when clicking recipient addresses in the activity list.
> 
> Adds a `disableNameClick` prop to `Name`/`NameDisplay` to suppress the modal trigger and remove the `name__clickable` styling when set, and applies it in `RecipientWithAddress` (while also tweaking the sender avatar to `Xs` with rounded corners for visual consistency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 744b13e656b2790027d6be9cd0c7e1adc0d8bf3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->