### PR TITLE
fix: increase clickable outside area from asset list control buttons

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -3,7 +3,6 @@ import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import type { NetworkConfiguration } from '@metamask/network-controller';
-import { act } from '@testing-library/react';
 import { fireEvent } from '../../../../../../test/jest';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../../test/data/mock-state.json';
@@ -96,9 +95,7 @@ describe('NFTs options', () => {
     let tooltipWrapper = sortButton.closest('[data-testid="tooltip"]');
     expect(tooltipWrapper).toHaveAttribute('data-disabled', 'false');
 
-    await act(async () => {
-      fireEvent.click(sortButton);
-    });
+    fireEvent.click(sortButton);
 
     tooltipWrapper = sortButton.closest('[data-testid="tooltip"]');
     expect(tooltipWrapper).toHaveAttribute('data-disabled', 'true');
@@ -106,7 +103,7 @@ describe('NFTs options', () => {
     const actionButton = await findByTestId(
       'asset-list-control-bar-action-button',
     );
-    actionButton.click();
+    fireEvent.click(actionButton);
 
     const refreshButton = await findByTestId('refresh-list-button__button');
 
@@ -146,7 +143,7 @@ describe('NFTs options', () => {
     const actionButton = await findByTestId(
       'asset-list-control-bar-action-button',
     );
-    actionButton.click();
+    fireEvent.click(actionButton);
 
     const refreshButton = await findByTestId('refresh-list-button__button');
 
@@ -188,7 +185,7 @@ describe('NFTs options', () => {
     const actionButton = await findByTestId(
       'asset-list-control-bar-action-button',
     );
-    actionButton.click();
+    fireEvent.click(actionButton);
 
     const autodetectButton = await findByTestId(
       'enable-autodetect-button__button',

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -73,7 +73,6 @@ import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
 } from '../../../../../../shared/constants/app';
-import NetworkFilter from '../network-filter';
 import {
   checkAndUpdateAllNftsOwnershipStatus,
   detectNfts,
@@ -95,14 +94,12 @@ import { SECURITY_ROUTE } from '../../../../../helpers/constants/routes';
 
 type AssetListControlBarProps = {
   showTokensLinks?: boolean;
-  showTokenFiatBalance?: boolean;
   showImportTokenButton?: boolean;
   showSortControl?: boolean;
 };
 
 const AssetListControlBar = ({
   showTokensLinks,
-  showTokenFiatBalance,
   showImportTokenButton = true,
   showSortControl = true,
 }: AssetListControlBarProps) => {
@@ -110,7 +107,8 @@ const AssetListControlBar = ({
   const dispatch = useDispatch();
   const { trackEvent } = useContext(MetaMetricsContext);
   const navigate = useNavigate();
-  const popoverRef = useRef<HTMLDivElement>(null);
+  const sortButtonRef = useRef<HTMLButtonElement>(null);
+  const importButtonRef = useRef<HTMLButtonElement>(null);
   const useNftDetection = useSelector(getUseNftDetection);
   const currentMultichainNetwork = useSelector(getMultichainNetwork);
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
@@ -136,8 +134,6 @@ const AssetListControlBar = ({
   const tokenNetworkFilter = useSelector(getTokenNetworkFilter);
   const [isTokenSortPopoverOpen, setIsTokenSortPopoverOpen] = useState(false);
   const [isImportTokensPopoverOpen, setIsImportTokensPopoverOpen] =
-    useState(false);
-  const [isNetworkFilterPopoverOpen, setIsNetworkFilterPopoverOpen] =
     useState(false);
   const [isImportNftPopoverOpen, setIsImportNftPopoverOpen] = useState(false);
 
@@ -229,7 +225,6 @@ const AssetListControlBar = ({
     windowType !== ENVIRONMENT_TYPE_POPUP;
 
   const toggleTokenSortPopover = () => {
-    setIsNetworkFilterPopoverOpen(false);
     setIsImportTokensPopoverOpen(false);
     setIsImportNftPopoverOpen(false);
     setIsTokenSortPopoverOpen(!isTokenSortPopoverOpen);
@@ -237,21 +232,18 @@ const AssetListControlBar = ({
 
   const toggleImportTokensPopover = () => {
     setIsTokenSortPopoverOpen(false);
-    setIsNetworkFilterPopoverOpen(false);
     setIsImportNftPopoverOpen(false);
     setIsImportTokensPopoverOpen(!isImportTokensPopoverOpen);
   };
 
   const toggleImportNftPopover = () => {
     setIsTokenSortPopoverOpen(false);
-    setIsNetworkFilterPopoverOpen(false);
     setIsImportTokensPopoverOpen(false);
     setIsImportNftPopoverOpen(!isImportNftPopoverOpen);
   };
 
   const closePopover = () => {
     setIsTokenSortPopoverOpen(false);
-    setIsNetworkFilterPopoverOpen(false);
     setIsImportTokensPopoverOpen(false);
     setIsImportNftPopoverOpen(false);
   };
@@ -370,12 +362,7 @@ const AssetListControlBar = ({
   }, [allEnabledNetworksForAllNamespaces, totalEnabledNetworkCount]);
 
   return (
-    <Box
-      className="asset-list-control-bar"
-      marginLeft={4}
-      marginRight={4}
-      ref={popoverRef}
-    >
+    <Box className="asset-list-control-bar" marginLeft={4} marginRight={4}>
       <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
         <ButtonBase
           data-testid="sort-by-networks"
@@ -384,11 +371,7 @@ const AssetListControlBar = ({
           onClick={handleNetworkManager}
           size={ButtonBaseSize.Sm}
           endIconName={IconName.ArrowDown}
-          backgroundColor={
-            isNetworkFilterPopoverOpen
-              ? BackgroundColor.backgroundPressed
-              : BackgroundColor.backgroundDefault
-          }
+          backgroundColor={BackgroundColor.backgroundDefault}
           color={TextColor.textDefault}
           marginRight={isFullScreen ? 2 : null}
           borderColor={BorderColor.borderMuted}
@@ -424,6 +407,7 @@ const AssetListControlBar = ({
               disabled={isTokenSortPopoverOpen}
             >
               <ButtonBase
+                ref={sortButtonRef}
                 data-testid="sort-by-popover-toggle"
                 className="asset-list-control-bar__button"
                 onClick={toggleTokenSortPopover}
@@ -444,6 +428,7 @@ const AssetListControlBar = ({
           {showImportTokenButton &&
             (isEvm ? (
               <ImportControl
+                ref={importButtonRef}
                 showTokensLinks={showTokensLinks}
                 onClick={
                   showTokensLinks
@@ -458,6 +443,7 @@ const AssetListControlBar = ({
                 distance={20}
               >
                 <ButtonBase
+                  ref={importButtonRef}
                   data-testid="importTokens-button"
                   className="asset-list-control-bar__button"
                   onClick={handleTokenImportModal}
@@ -477,31 +463,11 @@ const AssetListControlBar = ({
         </Box>
       </Box>
 
-      {/* Network Filter Popover */}
-      <Popover
-        onClickOutside={closePopover}
-        isOpen={isNetworkFilterPopoverOpen}
-        position={PopoverPosition.BottomStart}
-        referenceElement={popoverRef.current}
-        matchWidth={false}
-        style={{
-          zIndex: 10,
-          display: 'flex',
-          flexDirection: 'column',
-          padding: 0,
-          minWidth: isFullScreen ? '250px' : '',
-        }}
-      >
-        <NetworkFilter
-          handleClose={closePopover}
-          showTokenFiatBalance={showTokenFiatBalance}
-        />
-      </Popover>
       <Popover
         onClickOutside={closePopover}
         isOpen={isTokenSortPopoverOpen}
         position={PopoverPosition.BottomEnd}
-        referenceElement={popoverRef.current}
+        referenceElement={sortButtonRef.current}
         matchWidth={false}
         style={{
           zIndex: 10,
@@ -519,7 +485,7 @@ const AssetListControlBar = ({
         onClickOutside={closePopover}
         isOpen={isImportTokensPopoverOpen}
         position={PopoverPosition.BottomEnd}
-        referenceElement={popoverRef.current}
+        referenceElement={importButtonRef.current}
         matchWidth={false}
         style={{
           zIndex: 10,
@@ -551,7 +517,7 @@ const AssetListControlBar = ({
         onClickOutside={closePopover}
         isOpen={isImportNftPopoverOpen}
         position={PopoverPosition.BottomEnd}
-        referenceElement={popoverRef.current}
+        referenceElement={importButtonRef.current}
         matchWidth={false}
         style={{
           zIndex: 10,

--- a/ui/components/app/assets/asset-list/import-control/import-control.tsx
+++ b/ui/components/app/assets/asset-list/import-control/import-control.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
   ButtonBase,
@@ -12,33 +12,35 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { getMultichainIsEvm } from '../../../../../selectors/multichain';
 
-type AssetListControlBarProps = {
+type ImportControlProps = {
   showTokensLinks?: boolean;
   onClick?: () => void;
 };
 
-const AssetListControlBar = ({
-  showTokensLinks,
-  onClick,
-}: AssetListControlBarProps) => {
-  const isEvm = useSelector(getMultichainIsEvm);
-  // NOTE: Since we can parametrize it now, we keep the original behavior
-  // for EVM assets
-  const shouldShowTokensLinks = showTokensLinks ?? isEvm;
+const ImportControl = forwardRef<HTMLButtonElement, ImportControlProps>(
+  ({ showTokensLinks, onClick }, ref) => {
+    const isEvm = useSelector(getMultichainIsEvm);
+    // NOTE: Since we can parametrize it now, we keep the original behavior
+    // for EVM assets
+    const shouldShowTokensLinks = showTokensLinks ?? isEvm;
 
-  return (
-    <ButtonBase
-      className="asset-list-control-bar__button"
-      data-testid="asset-list-control-bar-action-button"
-      disabled={!shouldShowTokensLinks}
-      size={ButtonBaseSize.Sm}
-      startIconName={IconName.MoreVertical}
-      startIconProps={{ marginInlineEnd: 0, size: IconSize.Md }}
-      backgroundColor={BackgroundColor.backgroundDefault}
-      color={TextColor.textDefault}
-      onClick={onClick}
-    />
-  );
-};
+    return (
+      <ButtonBase
+        ref={ref}
+        className="asset-list-control-bar__button"
+        data-testid="asset-list-control-bar-action-button"
+        disabled={!shouldShowTokensLinks}
+        size={ButtonBaseSize.Sm}
+        startIconName={IconName.MoreVertical}
+        startIconProps={{ marginInlineEnd: 0, size: IconSize.Md }}
+        backgroundColor={BackgroundColor.backgroundDefault}
+        color={TextColor.textDefault}
+        onClick={onClick}
+      />
+    );
+  },
+);
 
-export default AssetListControlBar;
+ImportControl.displayName = 'ImportControl';
+
+export default ImportControl;


### PR DESCRIPTION
## **Description**

Fixes an issue where clicking outside the sort/import popovers did not close them.

**Root cause:** All popovers used the entire `asset-list-control-bar` Box as their `referenceElement`. The Popover's `onClickOutside` excludes clicks inside the reference element, making the exclusion zone too large.

**Solution:** Use specific refs for each popover trigger button instead of the entire control bar:
- Created `sortButtonRef` for the sort button
- Created `importButtonRef` for the import control button
- Updated `ImportControl` to use `forwardRef` to receive the ref
- Removed unused Network Filter Popover and related dead code

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39823?quickstart=1)

## **Changelog**

CHANGELOG entry: Increased clickable area to close buttons in asset list control bar

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37628

## **Manual testing steps**

1. Open the extension and go to the Portfolio view (Tokens tab)
2. Click the sort/filter button (funnel icon) to open the sort popover
3. Click on the "NFTs" or "Activity" tab
4. Verify the popover closes
5. Repeat with the vertical "..." menu popover

## **Screenshots/Recordings**

### **Before**

See issue description

### **After**

https://github.com/user-attachments/assets/e330245f-f5ca-46b4-b97d-ff84503e0639




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactoring of popover anchoring and minor test updates; low risk aside from potential popover positioning/regression in click-outside behavior.
> 
> **Overview**
> Fixes a UX bug where clicking “outside” the asset list sort/import popovers wouldn’t close them by changing each `Popover`’s `referenceElement` from the whole control bar to a dedicated ref on the corresponding trigger button.
> 
> `ImportControl` is updated to `forwardRef` so the import popovers can anchor to the actual button, and dead network-filter popover state/code is removed. Tests are adjusted to use consistent `fireEvent.click` interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de4bcae7a2179415011cc85dffa8ad20f769755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->