### PR TITLE
ci: Use default-branch for build-storybook

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -6,17 +6,16 @@ on:
       STORYBOOK_TOKEN:
         required: true
 
-env:
-  # For a `pull_request` event, the branch is `github.head_ref``.
-  # For a `push` event, the branch is `github.ref_name`.
-  BRANCH: ${{ github.head_ref || github.ref_name }}
-
 jobs:
   build-storybook:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ env.BRANCH == 'main' && 'default-branch' }}
+    environment: ${{ github.ref_name == 'main' && 'default_branch' }}
+    env:
+      # For a `pull_request` event, the branch is `github.head_ref``.
+      # For a `push` event, the branch is `github.ref_name`.
+      BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ github.ref_name == 'main' && 'default_branch' }}
+    environment: ${{ github.ref_name == 'main' && 'default_branch' || null }}
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -6,16 +6,17 @@ on:
       STORYBOOK_TOKEN:
         required: true
 
+env:
+  # For a `pull_request` event, the branch is `github.head_ref``.
+  # For a `push` event, the branch is `github.ref_name`.
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+
 jobs:
   build-storybook:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: default-branch
-    env:
-      # For a `pull_request` event, the branch is `github.head_ref``.
-      # For a `push` event, the branch is `github.ref_name`.
-      BRANCH: ${{ github.head_ref || github.ref_name }}
+    environment: ${{ env.BRANCH == 'main' && 'default-branch' }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -11,6 +11,7 @@ jobs:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: default-branch
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The GitHub token used to deploy the Storybook site expired, and in recreating this token we've decided to place it under a `default-branch` environment.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39857?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

No manual testing steps, but the job to deploy Storybook should now succeed.

## **Screenshots/Recordings**

N/A

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single GitHub Actions config change to job environment selection; main risk is misconfigured environment permissions or missing secrets causing the Storybook deploy step to fail.
> 
> **Overview**
> The `Build storybook` GitHub Actions workflow now runs its `build-storybook` job in the `default-branch` GitHub Environment, allowing deployment to use environment-scoped secrets/variables (e.g., the refreshed `STORYBOOK_TOKEN`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adb53b61fca1faf11b67eaf145ba3d42ac9e8e4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->