### PR TITLE
release: make update-changelog command match github-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "storybook": "storybook dev -p 6006 -c .storybook",
     "storybook:build": "storybook build -c .storybook -o storybook-build",
     "storybook:deploy": "storybook-to-ghpages --existing-output-dir storybook-build --remote storybook --branch stable",
-    "update-changelog": "auto-changelog update --autoCategorize --useChangelogEntry --useShortPrLink",
+    "update-changelog": "auto-changelog update --rc --autoCategorize --useChangelogEntry --useShortPrLink --requirePrNumbers",
     "generate:migration": "./development/generate-migration.sh",
     "lavamoat:build": "lavamoat development/build/index.js --policy lavamoat/build-system/policy.json --policyOverride lavamoat/build-system/policy-override.json",
     "lavamoat:build:auto": "yarn lavamoat:build --writeAutoPolicy",


### PR DESCRIPTION
## **Description**

Make the local `update-changelog` command match what is found here in github-tools update-release-changelog.sh:

https://github.com/MetaMask/github-tools/blob/main/.github/scripts/update-release-changelog.sh#L148

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/release scripting-only change; main risk is CI/release automation failing if PR numbers are missing or flags differ across environments.
> 
> **Overview**
> Updates the `update-changelog` npm script to run `auto-changelog update` in *release-candidate* mode and enforce inclusion of PR numbers (via `--requirePrNumbers`), aligning local changelog generation with the shared `github-tools` release workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc724594993361b23edd7d702d1707a07ac0e3a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->