### PR TITLE
ci: Fix build-storybook workflow again

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -17,17 +17,6 @@ jobs:
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
-      - name: Check for STORYBOOK_TOKEN
-        id: check-for-storybook-token
-        env:
-          STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
-        run: |
-          if [[ -n $STORYBOOK_TOKEN ]]; then
-            echo "HAS_STORYBOOK_TOKEN=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "HAS_STORYBOOK_TOKEN=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1
         with:
@@ -48,7 +37,7 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.BRANCH == 'main' && steps.check-for-storybook-token.outputs.HAS_STORYBOOK_TOKEN == 'true' }}
+        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
         env:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     secrets:
       STORYBOOK_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build-storybook:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ github.ref_name == 'main' && 'default_branch' || null }}
+    environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
@@ -37,7 +37,7 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
+        if: ${{ env.BRANCH == 'main' && secrets.STORYBOOK_TOKEN }}
         env:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -23,9 +23,9 @@ jobs:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |
           if [[ -n $STORYBOOK_TOKEN ]]; then
-            echo "HAS_STORYBOOK_TOKEN=true" >> $GITHUB_OUTPUT
+            echo "HAS_STORYBOOK_TOKEN=true" >> "$GITHUB_OUTPUT"
           else
-            echo "HAS_STORYBOOK_TOKEN=false" >> $GITHUB_OUTPUT
+            echo "HAS_STORYBOOK_TOKEN=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout and setup high risk environment

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -16,8 +16,18 @@ jobs:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
-      STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
     steps:
+      - name: Check for STORYBOOK_TOKEN
+        id: check-for-storybook-token
+        env:
+          STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
+        run: |
+          if [[ -n $STORYBOOK_TOKEN ]]; then
+            echo "HAS_STORYBOOK_TOKEN=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_STORYBOOK_TOKEN=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1
         with:
@@ -38,7 +48,9 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
+        if: ${{ env.BRANCH == 'main' && steps.check-for-storybook-token.outputs.HAS_STORYBOOK_TOKEN == 'true' }}
+        env:
+          STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |
           git remote add storybook "https://${STORYBOOK_TOKEN}@github.com/MetaMask/metamask-storybook.git"
           yarn storybook:deploy

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -16,6 +16,7 @@ jobs:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
+      STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
     steps:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -37,9 +38,7 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.BRANCH == 'main' && secrets.STORYBOOK_TOKEN }}
-        env:
-          STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
+        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
         run: |
           git remote add storybook "https://${STORYBOOK_TOKEN}@github.com/MetaMask/metamask-storybook.git"
           yarn storybook:deploy


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Although the `build-storybook` workflow successfully runs now, there are a couple of issues that prevent it from working the way we want it to:

1. The environment is incorrectly named (should be `default-branch`). This prevents the `deploy-storybook` job from running. I've fixed this.
2. Even if the environment name is corrected, the `deploy-storybook` job isn't running on pushes to `main`, anyway. It seems that we are checking for the existence of a `STORYBOOK_TOKEN` environment variable when we should be checking for the secret, so I've fixed this. (You can see a faulty run here: https://github.com/MetaMask/metamask-extension/actions/runs/21755772831/job/62765506522) Although in practice, the secret has been required this whole time so the conditional seems redundant. I've corrected this by making the secret optional.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39883?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

(N/A)

## **Manual testing steps**

(N/A)

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change limited to workflow configuration; main risk is misconfiguration causing Storybook deploys to not run or to run in the wrong environment.
> 
> **Overview**
> Fixes the `build-storybook` reusable workflow so runs on `main` use the correct GitHub `environment` name (`default-branch` instead of `default_branch`), unblocking downstream jobs that depend on environment-scoped variables/secrets.
> 
> Makes the `workflow_call` `STORYBOOK_TOKEN` secret optional (was required), preventing the workflow from failing/being incorrectly gated when the token isn’t available and allowing non-deploy builds to run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b81138605ccd86447da2dc763ca0909cccfe4fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->