### PR TITLE
perf(sentry): fix trace context propagation for cross-boundary spans

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -78,8 +78,17 @@ function getClientOptions() {
       Sentry.extraErrorDataIntegration(),
       Sentry.browserTracingIntegration({
         shouldCreateSpanForRequest: (url) => {
-          // Do not create spans for outgoing requests to a 'sentry.io' domain.
-          return !url.match(/^https?:\/\/([\w\d.@-]+\.)?sentry\.io(\/|$)/u);
+          if (url.match(/^https?:\/\/([\w\d.@-]+\.)?sentry\.io(\/|$)/u)) {
+            return false;
+          }
+          // Skip auto-spans for extension internal URLs (manually instrumented)
+          if (
+            url.startsWith('chrome-extension://') ||
+            url.startsWith('moz-extension://')
+          ) {
+            return false;
+          }
+          return true;
         },
       }),
       filterEvents({ getMetaMetricsEnabled, log }),

--- a/shared/lib/trace.test.ts
+++ b/shared/lib/trace.test.ts
@@ -1,15 +1,29 @@
 import type * as Sentry from '@sentry/browser';
-import { endTrace, trace, TraceName } from './trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  getSerializedTraceContext,
+  serializeTraceContext,
+} from './trace';
 
 jest.replaceProperty(global, 'sentry', {
   withIsolationScope: jest.fn(),
   startSpan: jest.fn(),
   startSpanManual: jest.fn(),
   setMeasurement: jest.fn(),
+  getActiveSpan: jest.fn(),
+  continueTrace: jest.fn(),
 });
 
-const { setMeasurement, startSpan, startSpanManual, withIsolationScope } =
-  global.sentry as typeof Sentry;
+const {
+  setMeasurement,
+  startSpan,
+  startSpanManual,
+  withIsolationScope,
+  getActiveSpan,
+  continueTrace,
+} = global.sentry as typeof Sentry;
 
 const NAME_MOCK = TraceName.Transaction;
 const ID_MOCK = 'testId';
@@ -34,6 +48,8 @@ describe('Trace', () => {
   const startSpanManualMock = jest.mocked(startSpanManual);
   const withIsolationScopeMock = jest.mocked(withIsolationScope);
   const setMeasurementMock = jest.mocked(setMeasurement);
+  const getActiveSpanMock = jest.mocked(getActiveSpan);
+  const continueTraceMock = jest.mocked(continueTrace);
   const setTagMock = jest.fn();
 
   beforeEach(() => {
@@ -44,6 +60,8 @@ describe('Trace', () => {
       startSpanManual: startSpanManualMock,
       withIsolationScope: withIsolationScopeMock,
       setMeasurement: setMeasurementMock,
+      getActiveSpan: getActiveSpanMock,
+      continueTrace: continueTraceMock,
     };
 
     startSpanMock.mockImplementation((_, fn) => fn({} as Sentry.Span));
@@ -369,6 +387,210 @@ describe('Trace', () => {
 
         endTrace({ name: NAME_MOCK, id: ID_MOCK });
       }).not.toThrow();
+    });
+  });
+
+  describe('getActiveSpan fallback', () => {
+    it('inherits from active span when no parentContext provided', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn().mockReturnValue({
+          traceId: 'abc123',
+          spanId: 'def456',
+        }),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      trace({ name: NAME_MOCK }, () => true);
+
+      expect(getActiveSpanMock).toHaveBeenCalledTimes(1);
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: activeSpanMock,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('does not call getActiveSpan when parentContext is provided', () => {
+      trace(
+        { name: NAME_MOCK, parentContext: PARENT_CONTEXT_MOCK },
+        () => true,
+      );
+
+      expect(getActiveSpanMock).not.toHaveBeenCalled();
+    });
+
+    it('uses null parentSpan when no active span and no parentContext', () => {
+      getActiveSpanMock.mockReturnValue(undefined);
+
+      trace({ name: NAME_MOCK }, () => true);
+
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: null,
+        }),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('cross-process trace context (continueTrace)', () => {
+    it('uses continueTrace when parentContext has _traceId and _spanId', () => {
+      continueTraceMock.mockImplementation((_opts, fn) => fn());
+
+      trace(
+        {
+          name: NAME_MOCK,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          parentContext: { _traceId: 'trace123', _spanId: 'span456' },
+        },
+        () => true,
+      );
+
+      expect(continueTraceMock).toHaveBeenCalledTimes(1);
+      expect(continueTraceMock).toHaveBeenCalledWith(
+        { sentryTrace: 'trace123-span456-1', baggage: undefined },
+        expect.any(Function),
+      );
+    });
+
+    it('passes parentSpan as undefined inside continueTrace callback', () => {
+      continueTraceMock.mockImplementation((_opts, fn) => fn());
+
+      trace(
+        {
+          name: NAME_MOCK,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          parentContext: { _traceId: 'trace123', _spanId: 'span456' },
+        },
+        () => true,
+      );
+
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: undefined,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('falls back to map lookup when _name is also present', () => {
+      const spanEndMock = jest.fn();
+      const parentSpanMock = {
+        end: spanEndMock,
+        spanContext: jest.fn(),
+      } as unknown as Sentry.Span;
+
+      startSpanManualMock.mockImplementationOnce((_, fn) =>
+        fn(parentSpanMock, () => {
+          // Intentionally empty
+        }),
+      );
+
+      // Create a pending trace
+      trace({ name: TraceName.Transaction, id: 'parent-id' });
+
+      // Use serialized context with _name (for map lookup) and _traceId/_spanId
+      trace(
+        {
+          name: TraceName.Middleware,
+          parentContext: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _name: TraceName.Transaction,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _id: 'parent-id',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _traceId: 'trace123',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            _spanId: 'span456',
+          },
+        },
+        () => true,
+      );
+
+      // Should use map lookup result, not continueTrace
+      expect(continueTraceMock).not.toHaveBeenCalled();
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSpan: parentSpanMock,
+        }),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('getSerializedTraceContext', () => {
+    it('returns undefined when no active span', () => {
+      getActiveSpanMock.mockReturnValue(undefined);
+      expect(getSerializedTraceContext()).toBeUndefined();
+    });
+
+    it('returns traceId and spanId from active span', () => {
+      const activeSpanMock = {
+        spanContext: jest.fn().mockReturnValue({
+          traceId: 'abc123',
+          spanId: 'def456',
+        }),
+      } as unknown as Sentry.Span;
+
+      getActiveSpanMock.mockReturnValue(activeSpanMock);
+
+      /* eslint-disable @typescript-eslint/naming-convention */
+      expect(getSerializedTraceContext()).toStrictEqual({
+        _traceId: 'abc123',
+        _spanId: 'def456',
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    it('returns undefined when sentry is not initialized', () => {
+      globalThis.sentry = undefined;
+      expect(getSerializedTraceContext()).toBeUndefined();
+    });
+  });
+
+  describe('serializeTraceContext', () => {
+    it('includes name and id from request', () => {
+      const result = serializeTraceContext(null, {
+        name: 'Test',
+        id: 'test-id',
+      });
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      expect(result).toStrictEqual({ _name: 'Test', _id: 'test-id' });
+    });
+
+    it('includes traceId and spanId from span', () => {
+      const spanMock = {
+        spanContext: jest.fn().mockReturnValue({
+          traceId: 'trace789',
+          spanId: 'span012',
+        }),
+      } as unknown as Sentry.Span;
+
+      const result = serializeTraceContext(spanMock, { name: 'Test' });
+      expect(result).toStrictEqual({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        _name: 'Test',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        _id: undefined,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        _traceId: 'trace789',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        _spanId: 'span012',
+      });
+    });
+
+    it('handles span that throws on spanContext', () => {
+      const spanMock = {
+        spanContext: jest.fn().mockImplementation(() => {
+          throw new Error('span ended');
+        }),
+      } as unknown as Sentry.Span;
+
+      const result = serializeTraceContext(spanMock, { name: 'Test' });
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      expect(result).toStrictEqual({ _name: 'Test', _id: undefined });
     });
   });
 });

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -84,6 +84,8 @@ export enum TraceName {
   CreateMultichainAccount = 'Create Multichain Account',
   DiscoverAccounts = 'Discover Accounts',
   EvmDiscoverAccounts = 'EVM Discover Accounts',
+  BackgroundRpc = 'Background RPC',
+  MessengerCall = 'Messenger Call',
 }
 
 /**
@@ -123,6 +125,18 @@ type PendingTrace = {
  * A context object to associate traces with each other and generate nested traces.
  */
 export type TraceContext = unknown;
+
+/**
+ * Serialized trace context for cross-boundary propagation.
+ * Contains trace/span IDs for distributed tracing and optional name/id for
+ * same-process parent lookup via the tracesByKey map.
+ */
+export type SerializedTraceContext = {
+  _name?: string;
+  _id?: string;
+  _traceId?: string;
+  _spanId?: string;
+};
 
 /**
  * A callback function that can be traced.
@@ -267,6 +281,57 @@ export function endTrace(request: EndTraceRequest): void {
   logTrace(pendingRequest, startTime, endTime);
 }
 
+/**
+ * Get the serialized trace context from the currently active Sentry span.
+ * Used by cross-boundary wrappers to propagate trace context over RPC.
+ *
+ * @returns Serialized context with traceId/spanId, or undefined if no active span.
+ */
+export function getSerializedTraceContext():
+  | SerializedTraceContext
+  | undefined {
+  const activeSpan = sentryGetActiveSpan();
+  if (!activeSpan) {
+    return undefined;
+  }
+  try {
+    const ctx = activeSpan.spanContext();
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    return { _traceId: ctx.traceId, _spanId: ctx.spanId };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Serialize a trace context from a specific span and request metadata.
+ * Includes both name/id (for same-process map lookup) and traceId/spanId
+ * (for cross-process distributed tracing).
+ *
+ * @param span - The Sentry span to extract IDs from.
+ * @param request - Request metadata for same-process lookup fallback.
+ * @param request.name - The trace name for same-process map lookup.
+ * @param request.id - Optional trace ID for same-process map lookup.
+ * @returns Serialized trace context.
+ */
+export function serializeTraceContext(
+  span: Sentry.Span | null | undefined,
+  request: { name: string; id?: string },
+): SerializedTraceContext {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const ctx: SerializedTraceContext = { _name: request.name, _id: request.id };
+  if (span) {
+    try {
+      const spanCtx = span.spanContext();
+      ctx._traceId = spanCtx.traceId;
+      ctx._spanId = spanCtx.spanId;
+    } catch {
+      // Span may have ended or be invalid
+    }
+  }
+  return ctx;
+}
+
 function traceCallback<ResultType>(
   request: TraceRequest,
   fn: TraceCallback<ResultType>,
@@ -377,6 +442,17 @@ function resolveParentSpan(parentContext: unknown): Sentry.Span | null {
   return null;
 }
 
+function hasDistributedTraceIds(
+  value: unknown,
+): value is { _traceId: string; _spanId: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>)._traceId === 'string' &&
+    typeof (value as Record<string, unknown>)._spanId === 'string'
+  );
+}
+
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function startSpan<T>(
@@ -384,7 +460,21 @@ function startSpan<T>(
   callback: (spanOptions: StartSpanOptions) => T,
 ) {
   const { data: attributes, name, parentContext, startTime, op } = request;
-  const parentSpan = resolveParentSpan(parentContext);
+  let parentSpan = resolveParentSpan(parentContext);
+
+  // Inherit from active span (e.g. browserTracingIntegration's pageload/navigation)
+  // when no explicit parent is provided. Must capture before withIsolationScope
+  // severs the active span context chain.
+  // forceTransaction preserves transaction-level visibility for monitoring while
+  // linking to the auto-instrumentation hierarchy.
+  let forceTransaction: boolean | undefined;
+  if (!parentSpan && !parentContext) {
+    const activeSpan = sentryGetActiveSpan();
+    if (activeSpan) {
+      parentSpan = activeSpan;
+      forceTransaction = true;
+    }
+  }
 
   const spanOptions: StartSpanOptions = {
     attributes,
@@ -392,7 +482,20 @@ function startSpan<T>(
     op: op ?? OP_DEFAULT,
     parentSpan,
     startTime,
+    forceTransaction,
   };
+
+  // Cross-process propagation via continueTrace when we have serialized
+  // trace/span IDs but couldn't resolve a local parent span from the map.
+  if (!parentSpan && hasDistributedTraceIds(parentContext)) {
+    const sentryTrace = `${parentContext._traceId}-${parentContext._spanId}-1`;
+    return sentryContinueTrace(sentryTrace, () =>
+      sentryWithIsolationScope((scope: Sentry.Scope) => {
+        initScope(scope, request);
+        return callback({ ...spanOptions, parentSpan: undefined });
+      }),
+    );
+  }
 
   return sentryWithIsolationScope((scope: Sentry.Scope) => {
     initScope(scope, request);
@@ -555,4 +658,26 @@ function sentrySetMeasurement(
   }
 
   actual(key, value, unit);
+}
+
+function sentryGetActiveSpan(): Sentry.Span | null {
+  const actual = globalThis.sentry?.getActiveSpan;
+
+  if (!actual) {
+    return null;
+  }
+
+  return actual() ?? null;
+}
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function sentryContinueTrace<T>(sentryTrace: string, callback: () => T): T {
+  const actual = globalThis.sentry?.continueTrace;
+
+  if (!actual) {
+    return callback();
+  }
+
+  return actual({ sentryTrace, baggage: undefined }, callback);
 }


### PR DESCRIPTION
## Description

Fixes parent-child linking between `browserTracingIntegration` auto-spans and manual `trace()` spans in `shared/lib/trace.ts`. Currently, custom spans created via `trace()` become root-level siblings of `pageload` spans instead of nesting under them, producing a flat, disconnected trace hierarchy.

### Root Causes

1. **No `getActiveSpan()` fallback**: `startSpan` in `trace.ts` never inherits from Sentry's active span when no explicit `parentContext` is provided
2. **`withIsolationScope` severs context**: The isolation scope in `trace()` breaks the active-span chain from `browserTracingIntegration`
3. **Fragile serialization**: Current `parentContext` uses `{_name, _id}` map lookup that fails if the parent span ends before the child resolves it

### Changes Planned

- [ ] **Part 1**: Inherit from `Sentry.getActiveSpan()` when no explicit `parentContext` — connects manual traces to auto-instrumentation hierarchy
- [ ] **Part 2**: Enhanced serialization with `_traceId`/`_spanId` for robust cross-process context propagation (replaces fragile map lookup)
- [ ] **Part 3** (optional): `shouldCreateSpanForRequest` filter in `browserTracingIntegration` to skip internal extension URLs

### Files

- `shared/lib/trace.ts` — core fix
- `app/scripts/lib/setupSentry.js` — optional auto-instrumentation scoping

## Changelog

CHANGELOG entry: Fix Sentry custom spans becoming root-level siblings of `pageload` spans instead of being nested under the correct `parentContext`.

## Related Issues

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6838
Parent Epic: https://github.com/MetaMask/MetaMask-planning/issues/6759

## Screenshots/Recordings

### Before

`http.client` spans erroneously nested under `pageLoad`.

<img width="1336" height="627" alt="Screenshot 2026-03-17 at 4 08 49 PM" src="https://github.com/user-attachments/assets/b67c0ce0-4a73-4830-9fa5-b29e38300ff2" />

> [sentry link](https://metamask.sentry.io/explore/traces/trace/913c31ad06e64f528220649b00c632da/?aggregateField=%7B%22groupBy%22%3A%22trace%22%7D&aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=trace&mode=aggregate&project=4510302346608640&query=span.op%3A%EF%80%8DContains%EF%80%8Dhttp.client%20transaction%3A%EF%80%8DContains%EF%80%8D%2Fbackground.html&statsPeriod=90d)

### After

`http.client` spans attached to correct trace context.

<img width="1336" height="627" alt="Screenshot 2026-03-17 at 4 09 28 PM" src="https://github.com/user-attachments/assets/20f3c279-0067-46a5-b607-48a8a904d10e" />

> [sentry link](https://metamask.sentry.io/explore/traces/trace/52305204cada4751944fd7c8ad735625/?aggregateField=%7B%22groupBy%22%3A%22trace%22%7D&aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=trace&mode=aggregate&node=span-bf43826becdeaece&project=4510302346608640&query=span.op%3A%EF%80%8DContains%EF%80%8Dhttp.client&statsPeriod=24h)

## Pre-merge author checklist

- [ ] Tests included
- [ ] [PR template](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md) completed
- [ ] Follows [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md)

## Pre-merge reviewer checklist

- [ ] Manual testing against Sentry trace waterfall confirms parent-child nesting
- [ ] Existing `trace()` call sites unaffected (no behavioral regression)
- [ ] No performance overhead from `getActiveSpan()` fallback path


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches performance/telemetry instrumentation and span-parenting logic, which could change trace structure or sampling/overhead if mis-linked, but does not impact user funds or auth flows.
> 
> **Overview**
> Fixes Sentry trace parenting so manual `trace()` spans reliably nest under existing auto-instrumented spans and can propagate across RPC/process boundaries.
> 
> In `shared/lib/trace.ts`, `startSpan` now falls back to `sentry.getActiveSpan()` (with `forceTransaction`) when no explicit parent is provided, and supports distributed parent context via `_traceId`/`_spanId` using `sentry.continueTrace`; new helpers `getSerializedTraceContext`/`serializeTraceContext` are added and tests are expanded to cover these behaviors. Separately, Sentry browser tracing is updated to skip creating auto-spans for internal extension URLs (`chrome-extension://`/`moz-extension://`) to avoid duplicate/manual instrumentation overlap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0807995a51239861f9ea5640e77df0b81354c0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->