### PR TITLE
fix: shield-cohort-post-tx-modal-not-show

### DIFF
--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -970,6 +970,7 @@ describe('AppStateController', () => {
               "nftsDetectionNoticeDismissed": false,
               "onboardingDate": null,
               "outdatedBrowserWarningLastShown": null,
+              "pendingShieldCohort": null,
               "pendingShieldCohortTxType": null,
               "pna25Acknowledged": false,
               "productTour": "accountIcon",

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -688,7 +688,7 @@ const controllerMetadata: StateMetadata<AppStateControllerState> = {
   },
   pendingShieldCohort: {
     includeInStateLogs: true,
-    persist: false,
+    persist: true,
     includeInDebugSnapshot: true,
     usedInUi: true,
   },

--- a/app/scripts/services/subscription/subscription-service.ts
+++ b/app/scripts/services/subscription/subscription-service.ts
@@ -733,7 +733,9 @@ export class SubscriptionService {
 
       const { pendingShieldCohort, shieldSubscriptionMetricsProps } =
         this.#messenger.call('AppStateController:getState');
-      if (isPostTxTransaction && !pendingShieldCohort) {
+      const hasSetPostTxPendingCohort =
+        pendingShieldCohort === COHORT_NAMES.POST_TX;
+      if (isPostTxTransaction && !hasSetPostTxPendingCohort) {
         this.#messenger.call(
           'AppStateController:setPendingShieldCohort',
           COHORT_NAMES.POST_TX,

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -66,6 +66,7 @@
       "nftsDetectionNoticeDismissed": false,
       "onboardingDate": 1764061390455,
       "outdatedBrowserWarningLastShown": null,
+      "pendingShieldCohort": null,
       "pendingShieldCohortTxType": null,
       "pna25Acknowledged": false,
       "productTour": "accountIcon",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -58,7 +58,7 @@
     "notificationGasPollTokens": "object",
     "onboardingDate": null,
     "outdatedBrowserWarningLastShown": "object",
-    "pendingShieldCohort": null,
+    "pendingShieldCohort": "string",
     "pendingShieldCohortTxType": null,
     "pna25Acknowledged": "boolean",
     "popupGasPollTokens": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -269,7 +269,7 @@
     "pendingApprovalCount": "number",
     "pendingApprovals": "object",
     "pendingRevocations": "object",
-    "pendingShieldCohort": null,
+    "pendingShieldCohort": "string",
     "pendingShieldCohortTxType": null,
     "permissionActivityLog": "object",
     "permissionHistory": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -45,6 +45,7 @@
       "nftsDetectionNoticeDismissed": false,
       "onboardingDate": null,
       "outdatedBrowserWarningLastShown": "object",
+      "pendingShieldCohort": null,
       "pendingShieldCohortTxType": null,
       "pna25Acknowledged": "boolean",
       "productTour": "accountIcon",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -827,7 +827,7 @@
     "pendingApprovalCount": "number",
     "pendingApprovals": {},
     "pendingRevocations": [],
-    "pendingShieldCohort": "null",
+    "pendingShieldCohort": "string",
     "pendingShieldCohortTxType": "null",
     "pna25Acknowledged": "boolean",
     "permissionActivityLog": [

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -155,6 +155,12 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
           return;
         }
 
+        // Clear the pending cohort before any async work to prevent a race
+        // condition: if #assignPostTxCohort sets POST_TX while the eligibility
+        // check is in-flight, a late clear would clobber the new value.
+        // The entrypointCohort argument already captures the value we need.
+        await dispatch(setPendingShieldCohort(null));
+
         const shieldEligibility = await getShieldSubscriptionEligibility();
 
         if (
@@ -215,7 +221,6 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
               shouldUpdateBackgroundState: false,
             }),
           );
-          await dispatch(setPendingShieldCohort(null));
           return;
         }
 
@@ -243,8 +248,14 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
             );
           }
         }
-        await dispatch(setPendingShieldCohort(null));
       } catch (error) {
+        // Restore the pending cohort so it can be retried on the next
+        // componentDidUpdate cycle instead of being silently lost.
+        try {
+          await dispatch(setPendingShieldCohort(entrypointCohort));
+        } catch {
+          // if this also fails - the next transaction will re-set the cohort.
+        }
         captureException(
           createSentryError(
             'Failed to evaluate cohort eligibility',

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -241,9 +241,9 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
                 shouldUpdateBackgroundState: false,
               }),
             );
-            await dispatch(setPendingShieldCohort(null));
           }
         }
+        await dispatch(setPendingShieldCohort(null));
       } catch (error) {
         captureException(
           createSentryError(

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -185,7 +185,7 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
             return;
           }
 
-          // could continue if entrypointCohort is wallet_home and assignedCohort has not expired
+          // could continue if entrypointCohort is post_tx and assignedCohort has not expired
           // so we need to check hasExpired here before recording the event
           if (hasExpired) {
             // User has an assigned cohort but it has expired

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -25,6 +25,8 @@ import { MetaMaskReduxDispatch } from '../../store/store';
 import { getIsUnlocked } from '../../ducks/metamask/metamask';
 import { useSubscriptionMetrics } from '../../hooks/shield/metrics/useSubscriptionMetrics';
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { captureException } from '../../../shared/lib/sentry';
+import { createSentryError } from '../../../shared/modules/error';
 
 export const ShieldSubscriptionContext = React.createContext<{
   evaluateCohortEligibility: (entrypointCohort: string) => Promise<void>;
@@ -201,7 +203,7 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
             return;
           }
 
-          dispatch(
+          await dispatch(
             setShowShieldEntryModalOnce({
               show: true,
               shouldSubmitEvents: true, // submits `shield_entry_modal_viewed` event
@@ -226,7 +228,7 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
             modalType,
           );
           if (selectedCohort?.cohort === COHORT_NAMES.WALLET_HOME) {
-            dispatch(
+            await dispatch(
               setShowShieldEntryModalOnce({
                 show: true,
                 shouldSubmitEvents: true, // submits `shield_entry_modal_viewed` event to subscription backend
@@ -240,6 +242,12 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
           }
         }
       } catch (error) {
+        captureException(
+          createSentryError(
+            'Failed to evaluate cohort eligibility',
+            error as Error,
+          ),
+        );
         log.warn('[evaluateCohortEligibility] error', error);
       }
     },

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -176,20 +176,28 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
             return;
           }
 
-          // User has an assigned cohort but it has expired
-          // track `shield_eligibility_cohort_timeout` event
-          await captureShieldEligibilityCohortEvent(
-            {
-              cohort: assignedCohortName as CohortName,
-              numberOfEligibleCohorts: eligibleCohorts.length,
-            },
-            MetaMetricsEventName.ShieldEligibilityCohortTimeout,
-          );
+          // could continue if entrypointCohort is wallet_home and assignedCohort has not expired
+          // so we need to check hasExpired here before recording the event
+          if (hasExpired) {
+            // User has an assigned cohort but it has expired
+            // track `shield_eligibility_cohort_timeout` event
+            await captureShieldEligibilityCohortEvent(
+              {
+                cohort: assignedCohortName as CohortName,
+                numberOfEligibleCohorts: eligibleCohorts.length,
+              },
+              MetaMetricsEventName.ShieldEligibilityCohortTimeout,
+            );
+          }
 
           const cohort = eligibleCohorts.find(
             (c) => c.cohort === entrypointCohort,
           );
           if (!cohort) {
+            log.warn(
+              '[evaluateCohortEligibility] error',
+              'user pending no cohort found',
+            );
             return;
           }
 

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -11,6 +11,7 @@ import log from 'loglevel';
 import { useSubscriptionEligibility } from '../../hooks/subscription/useSubscription';
 import {
   assignUserToCohort,
+  setPendingShieldCohort,
   setShowShieldEntryModalOnce,
   subscriptionsStartPolling,
 } from '../../store/actions';
@@ -214,6 +215,7 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
               shouldUpdateBackgroundState: false,
             }),
           );
+          await dispatch(setPendingShieldCohort(null));
           return;
         }
 
@@ -239,6 +241,7 @@ export const ShieldSubscriptionProvider: React.FC = ({ children }) => {
                 shouldUpdateBackgroundState: false,
               }),
             );
+            await dispatch(setPendingShieldCohort(null));
           }
         }
       } catch (error) {

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -226,7 +226,6 @@ export default class Home extends PureComponent {
       clearNewNetworkAdded,
       pendingShieldCohort,
       evaluateCohortEligibility,
-      setPendingShieldCohort,
       isSignedIn,
     } = this.props;
 
@@ -256,10 +255,7 @@ export default class Home extends PureComponent {
       evaluateCohortEligibility &&
       isSignedIn
     ) {
-      evaluateCohortEligibility(pendingShieldCohort).then(() => {
-        // reset pending shield cohort only if evaluation succeeded
-        setPendingShieldCohort(null);
-      });
+      evaluateCohortEligibility(pendingShieldCohort);
       this.setState({ shouldEvaluateCohortEligibility: false });
     }
 

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -256,8 +256,10 @@ export default class Home extends PureComponent {
       evaluateCohortEligibility &&
       isSignedIn
     ) {
-      setPendingShieldCohort(null);
-      evaluateCohortEligibility(pendingShieldCohort);
+      evaluateCohortEligibility(pendingShieldCohort).then(() => {
+        // reset pending shield cohort only if evaluation succeeded
+        setPendingShieldCohort(null);
+      });
       this.setState({ shouldEvaluateCohortEligibility: false });
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Shield announcement modal uses a cohort strategy (wallet_home / post_tx) to determine when to show users the entry modal. Users assigned to the `post_tx` cohort were never seeing the modal due to multiple issues in the evaluation flow:

1. **`pendingShieldCohort` was not persisted** - With `persist: false`, the `POST_TX` cohort value set by `#assignPostTxCohort` after a swap/transfer was lost whenever the MV3 service worker restarted. On the next Home page visit, `componentDidMount` would overwrite it with `WALLET_HOME`, causing the evaluation to return early for pending-but-not-expired users. Changed to `persist: true` so the value survives service worker restarts.

2. **Pending cohort cleared before evaluation completed** - `setPendingShieldCohort(null)` was called synchronously before `evaluateCohortEligibility` had a chance to finish. If the evaluation failed, the pending cohort was permanently lost with no retry. Now the pending cohort is only cleared after the evaluation promise resolves successfully.

3. **Timeout event fired incorrectly for non-expired cohorts** - When `entrypointCohort === POST_TX`, the guard `entrypointCohort !== POST_TX && !hasExpired` was always `false`, causing the `ShieldEligibilityCohortTimeout` event to fire even when the assigned cohort had not actually expired. Added a `hasExpired` guard so the timeout event only fires when the cohort has genuinely expired.

4. **Missing error observability** - Failures in `evaluateCohortEligibility` were only logged with `log.warn`. Added Sentry error capture so cohort evaluation failures surface in monitoring.

5. **`post_tx` could not overwrite an existing `wallet_home` pending cohort** - `#assignPostTxCohort` only set `POST_TX` when `pendingShieldCohort` was falsy (`!pendingShieldCohort`). If the user had already visited Home (setting it to `WALLET_HOME`), a subsequent swap would not overwrite it. Now the guard checks specifically for `pendingShieldCohort === POST_TX` instead, allowing `POST_TX` to take priority over `WALLET_HOME`.

Ref: [cohort technical details](https://docs.google.com/document/d/1oZWmOHt-nZyX57DAVXx-pz6GGE3j7Ss_QrQ2EndoQxg/edit?tab=t.0#heading=h.tkr15yfg1gk4)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39898?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where users assigned to the post-transaction Shield cohort would never see the Shield announcement modal

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and load the extension with Shield feature enabled
2. For `post_tx` cohort, sign in and navigate to the Home pageverify no modal appears (initial cohort assignment happens silently for post_tx users)
3. Perform a swap or token transfer transaction
4. Navigate back to the Home page
7. Verify the Shield entry modal appears for users assigned to the `post_tx` cohort
8. Close the extension completely, reopen it, and repeat steps 3-5, verify the `pendingShieldCohort` value persists across restarts and the modal still appears
9. For `wallet_home` cohort users: verify the modal still appears immediately on first Home page visit (no regression)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted app state and Shield cohort/metrics flow, which could affect when modals appear and what telemetry is emitted, but changes are localized and largely additive/guarded.
> 
> **Overview**
> Fixes Shield cohort handling so users assigned to the `post_tx` cohort reliably see the Shield entry modal.
> 
> `pendingShieldCohort` is now persisted in `AppStateController`, `SubscriptionService` now allows `POST_TX` to override an existing pending cohort, and the UI evaluation flow was hardened by clearing/restoring the pending cohort around async eligibility checks (with added Sentry capture), awaiting modal state updates, and only emitting the `ShieldEligibilityCohortTimeout` metric when the assigned cohort has actually expired. Test fixtures/state snapshots were updated to reflect the new persisted `pendingShieldCohort` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08c36592adec1bbff46e4992ae0fe18689f4c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->