### PR TITLE
fix: flaky test `Profile Metrics when MetaMetrics is enabled, the feature flag is on, and the user acknowledged the privacy change sends new accounts to the API when they are created after wallet unlock`

### DIFF
--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -107,7 +107,7 @@ describe('Profile Metrics', function () {
           const [authCall] = mockedEndpoint;
           // There are 2 PUT requests:
           // 1. One for default EVM Account 1 alone
-          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added -- due to old fixtures)
+          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added)
           await waitForEndpointToBeCalled(driver, authCall, 2);
 
           const requests = await authCall.getSeenRequests();
@@ -157,7 +157,7 @@ describe('Profile Metrics', function () {
 
           // There are 3 PUT requests:
           // 1. One for default EVM Account 1 alone
-          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added -- due to old fixtures)
+          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added)
           // 3. One for Account 2 (Solana + EVM Accounts in one request)
           await waitForEndpointToBeCalled(driver, authCall, 3);
 

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -77,7 +77,7 @@ async function waitForEndpointToBeCalled(
 
 describe('Profile Metrics', function () {
   describe('when MetaMetrics is enabled, the feature flag is on, and the user acknowledged the privacy change', function () {
-    it('sends exising accounts to the API on wallet unlock after activating MetaMetrics and an initial delay', async function () {
+    it('sends existing accounts to the API on wallet unlock after activating MetaMetrics and an initial delay', async function () {
       await withFixtures(
         {
           fixtures: new FixtureBuilder()
@@ -108,6 +108,7 @@ describe('Profile Metrics', function () {
           await waitForEndpointToBeCalled(driver, authCall);
 
           const requests = await authCall.getSeenRequests();
+          console.log(requests);
           assert.equal(
             requests.length,
             2,

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -152,8 +152,8 @@ describe('Profile Metrics', function () {
           const [authCall] = mockedEndpoint;
           await waitForEndpointToBeCalled(driver, authCall, 2);
 
-          console.log(requests);
           const requests = await authCall.getSeenRequests();
+          console.log(requests);
           assert.equal(
             requests.length,
             2,

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -105,10 +105,12 @@ describe('Profile Metrics', function () {
           await driver.delay(1000);
 
           const [authCall] = mockedEndpoint;
-          await waitForEndpointToBeCalled(driver, authCall);
+          // There are 2 PUT requests:
+          // 1. One for default EVM Account 1 alone
+          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added -- due to old fixtures)
+          await waitForEndpointToBeCalled(driver, authCall, 2);
 
           const requests = await authCall.getSeenRequests();
-          console.log(requests);
           assert.equal(
             requests.length,
             2,
@@ -149,14 +151,20 @@ describe('Profile Metrics', function () {
           const accountListPage = new AccountListPage(driver);
           await accountListPage.checkPageIsLoaded();
           await accountListPage.addMultichainAccount();
+          await accountListPage.checkAccountDisplayedInAccountList('Account 2');
+          await accountListPage.closeMultichainAccountsPage();
           const [authCall] = mockedEndpoint;
-          await waitForEndpointToBeCalled(driver, authCall, 2);
+
+          // There are 3 PUT requests:
+          // 1. One for default EVM Account 1 alone
+          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added -- due to old fixtures)
+          // 3. One for Account 2 (Solana + EVM Accounts in one request)
+          await waitForEndpointToBeCalled(driver, authCall, 3);
 
           const requests = await authCall.getSeenRequests();
-          console.log(requests);
           assert.equal(
             requests.length,
-            2,
+            3,
             'Expected two requests to the auth API.',
           );
         },

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -152,6 +152,7 @@ describe('Profile Metrics', function () {
           const [authCall] = mockedEndpoint;
           await waitForEndpointToBeCalled(driver, authCall, 2);
 
+          console.log(requests);
           const requests = await authCall.getSeenRequests();
           assert.equal(
             requests.length,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The number of PUT requests that we were asserting was incorrect, causing the test to be flaky.

- EVM account is always created first --> this triggers the first PUT request with the EVM account
- Other provider accounts (Solana) is created afterwards --> this triggers the second PUT request with the Solana account
- The ProfileMetricsController fires a PUT request each time an account is added. In the spec, we add a second Account --> this triggers the third PUT request with the EVM and Solana Accounts in 1 single request.

(see video below)

https://github.com/user-attachments/assets/e1d026d6-2b9c-423c-ab47-069f2ce4921b



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39902?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust timing and request-count assertions; no production logic is modified.
> 
> **Overview**
> Updates the `Profile Metrics` E2E spec to expect multiple profile-account `PUT` calls: **2 requests** on initial unlock (EVM then Solana) and **3 requests** after adding a new multichain account.
> 
> Adds explicit UI waits (verify `Account 2` appears and close the accounts page) and corrects a test typo to reduce timing-related flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1911c25408acab4a6a5b35010c24609d1cc41e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->