### PR TITLE
fix: hide legacy network manager modal in sidepanel confirmation

### DIFF
--- a/ui/hooks/useModalState.ts
+++ b/ui/hooks/useModalState.ts
@@ -1,21 +1,14 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { closeNetworkMenu, hideModal } from '../store/actions';
-import { useAppSelector } from '../store/store';
 
 export function useModalState() {
   const dispatch = useDispatch();
-  const legacyModalName = useAppSelector(
-    ({ appState }) => appState.modal.modalState?.name,
-  );
 
   const closeModals = useCallback(() => {
     dispatch(closeNetworkMenu());
-    // Close legacy modal if NETWORK_MANAGER is open
-    if (legacyModalName === 'NETWORK_MANAGER') {
-      dispatch(hideModal());
-    }
-  }, [dispatch, legacyModalName]);
+    dispatch(hideModal()); // Close any open legacy modals
+  }, [dispatch]);
 
   return {
     closeModals,

--- a/ui/hooks/useModalState.ts
+++ b/ui/hooks/useModalState.ts
@@ -1,14 +1,21 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { closeNetworkMenu } from '../store/actions';
+import { closeNetworkMenu, hideModal } from '../store/actions';
+import { useAppSelector } from '../store/store';
 
 export function useModalState() {
   const dispatch = useDispatch();
-
-  const closeModals = useCallback(
-    () => dispatch(closeNetworkMenu()),
-    [dispatch],
+  const legacyModalName = useAppSelector(
+    ({ appState }) => appState.modal.modalState?.name,
   );
+
+  const closeModals = useCallback(() => {
+    dispatch(closeNetworkMenu());
+    // Close legacy modal if NETWORK_MANAGER is open
+    if (legacyModalName === 'NETWORK_MANAGER') {
+      dispatch(hideModal());
+    }
+  }, [dispatch, legacyModalName]);
 
   return {
     closeModals,


### PR DESCRIPTION
## **Description**

When the Network Manager modal is open in the side panel view and a dapp request comes in, the confirmation screen navigates but the Network Manager modal remains visible and broken.

The `useModalState.closeModals()` hook only closed the `NetworkListMenu` but not legacy modals like `NETWORK_MANAGER`. This fix extends `closeModals()` to also close any open legacy modals, as modals should not persist on top of confirmation screens.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39908?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed Network Manager modal not closing when navigating to dapp confirmation screens in side panel view

## **Related issues**

Fixes: #39880

## **Manual testing steps**

1. Open MetaMask in side panel view
2. Open the Network Manager modal (via token list control bar)
3. Trigger a dapp request (e.g. connect or sign request from a dapp)
4. Verify the Network Manager modal closes and the confirmation screen displays correctly

## **Screenshots/Recordings**

### **Before**

<!-- Network Manager modal overlays confirmation screen -->

### **After**

<!-- Network Manager modal closes, confirmation screen displays cleanly -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-state change that dispatches an additional `MODAL_CLOSE` action; low risk aside from potentially closing other legacy modals more broadly than intended.
> 
> **Overview**
> Fixes a sidepanel navigation issue where the legacy Network Manager modal could remain visible over dapp confirmation screens.
> 
> `useModalState.closeModals()` now dispatches `hideModal()` in addition to `closeNetworkMenu()`, ensuring any open legacy modal is closed when the app attempts to close modal UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d66e86b0138dd5b8b63c1687cdf9d88e4daf1dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->