### PR TITLE
fix: additional network icon style

### DIFF
--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -428,10 +428,10 @@ exports[`NetworkListMenu renders properly 1`] = `
                         Additional networks
                       </p>
                       <div
-                        class="mm-box mm-box--margin-top-1"
+                        class="mm-box mm-box--display-flex mm-box--align-items-center"
                       >
                         <div
-                          class="mm-box mm-box--margin-left-2"
+                          class="mm-box mm-box--margin-left-2 mm-box--display-flex"
                         >
                           <svg
                             class="inline-block w-4 h-4 text-icon-muted add-network__warning-icon"
@@ -1665,10 +1665,10 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                         Additional networks
                       </p>
                       <div
-                        class="mm-box mm-box--margin-top-1"
+                        class="mm-box mm-box--display-flex mm-box--align-items-center"
                       >
                         <div
-                          class="mm-box mm-box--margin-left-2"
+                          class="mm-box mm-box--margin-left-2 mm-box--display-flex"
                         >
                           <svg
                             class="inline-block w-4 h-4 text-icon-muted add-network__warning-icon"

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -85,8 +85,12 @@ const PopularNetworkList = ({
             {t('additionalNetworks')}
           </Text>
 
-          <Box onMouseEnter={handleMouseEnter}>
-            <Box marginLeft={2}>
+          <Box
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            onMouseEnter={handleMouseEnter}
+          >
+            <Box marginLeft={2} display={Display.Flex}>
               <Icon
                 className="add-network__warning-icon"
                 name={IconName.Info}

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -85,7 +85,7 @@ const PopularNetworkList = ({
             {t('additionalNetworks')}
           </Text>
 
-          <Box onMouseEnter={handleMouseEnter} marginTop={1}>
+          <Box onMouseEnter={handleMouseEnter}>
             <Box marginLeft={2}>
               <Icon
                 className="add-network__warning-icon"


### PR DESCRIPTION
## **Description**

Fixed tiny style issue on the Additional networks icon positioning.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Test on Menu -> Networks

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="539" height="826" alt="image" src="https://github.com/user-attachments/assets/62c50881-00e9-4af9-b0ea-318d851583ee" />

### **After**

<img width="496" height="758" alt="image" src="https://github.com/user-attachments/assets/cca7d044-1fa3-40a2-a609-a4fe6f696f6c" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational UI layout change with snapshot updates; no business logic or data flow changes.
> 
> **Overview**
> Adjusts the layout for the "Additional networks" label/info icon in `popular-network-list.tsx` by replacing margin-based positioning with `flex` + `alignItems: center` wrappers, fixing the icon’s vertical alignment.
> 
> Updates the `NetworkListMenu` Jest snapshots to reflect the new DOM/class structure for this header area.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce824a96f2a549c6280790991df98405c298724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->