### PR TITLE
feat: move quote card to align with mobile UI

### DIFF
--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Bridge renders the component with initial props 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default"
             style="position: relative;"
           >
             <div
@@ -257,21 +257,21 @@ exports[`Bridge renders the component with initial props 1`] = `
                 </a>
               </div>
             </div>
+          </div>
+          <div
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+          >
             <div
-              class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+              style="display: contents;"
             >
               <div
-                style="display: contents;"
+                class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
               >
-                <div
-                  class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
                 >
-                  <p
-                    class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
-                  >
-                    Select amount
-                  </p>
-                </div>
+                  Select amount
+                </p>
               </div>
             </div>
           </div>

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
       </div>
     </div>
     <div
-      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
+      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default"
       style="position: relative;"
     >
       <div
@@ -204,21 +204,21 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
           </a>
         </div>
       </div>
+    </div>
+    <div
+      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+    >
       <div
-        class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+        style="display: contents;"
       >
         <div
-          style="display: contents;"
+          class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
         >
-          <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
+          <p
+            class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
           >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
-            >
-              Select amount
-            </p>
-          </div>
+            Select amount
+          </p>
         </div>
       </div>
     </div>
@@ -320,7 +320,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
       </div>
     </div>
     <div
-      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--height-full mm-box--background-color-background-default"
+      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default"
       style="position: relative;"
     >
       <div
@@ -435,21 +435,21 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
           </a>
         </div>
       </div>
+    </div>
+    <div
+      class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+    >
       <div
-        class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--justify-content-flex-end mm-box--width-full mm-box--height-full"
+        style="display: contents;"
       >
         <div
-          style="display: contents;"
+          class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
         >
-          <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-center mm-box--align-items-center"
+          <p
+            class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
           >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--text-align-center mm-box--color-text-alternative"
-            >
-              Select amount
-            </p>
-          </div>
+            Select amount
+          </p>
         </div>
       </div>
     </div>

--- a/ui/pages/bridge/prepare/index.scss
+++ b/ui/pages/bridge/prepare/index.scss
@@ -61,8 +61,37 @@
   }
 
   .mascot-background-animation__animation {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
     margin-top: 24px;
     margin-bottom: 16px;
+  }
+
+  .mascot-background-animation__background-1,
+  .mascot-background-animation__background-2 {
+    width: 120px;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    -webkit-animation: bridge-loader-spin 38s linear infinite;
+    -moz-animation: bridge-loader-spin 38s linear infinite;
+    animation: bridge-loader-spin 38s linear infinite;
+  }
+
+  .mascot-background-animation__background-2 {
+    width: 120px;
+    height: 128px;
+    -webkit-animation: bridge-loader-spin 42s linear infinite;
+    -moz-animation: bridge-loader-spin 42s linear infinite;
+    animation: bridge-loader-spin 42s linear infinite;
+  }
+
+  .mascot-background-animation__mascot-container {
+    position: relative;
   }
 
   .highlight {
@@ -91,6 +120,13 @@
       box-shadow: 0 0 2px 0 #18191b, 0 0 16px 0 #18191b;
     }
     /* stylelint-enable color-no-hex */
+  }
+}
+
+@keyframes bridge-loader-spin {
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 

--- a/ui/pages/bridge/prepare/prepare-bridge-page-footer.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page-footer.tsx
@@ -12,8 +12,8 @@ export const PrepareBridgePageFooter = (
         display: 'contents',
       }}
     >
-      <BridgeCTAInfoText />
       <BridgeCTAButton {...props} />
+      <BridgeCTAInfoText />
       <BridgeNoFeeMessage />
     </div>
   );

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -429,7 +429,6 @@ const PrepareBridgePage = ({
         />
 
         <Column
-          height={BlockSize.Full}
           padding={4}
           gap={4}
           backgroundColor={BackgroundColor.backgroundDefault}
@@ -602,80 +601,89 @@ const PrepareBridgePage = ({
             }}
             isDestination={true}
           />
+        </Column>
 
-          <Column
-            justifyContent={
-              isLoading && !unvalidatedQuote
-                ? JustifyContent.center
-                : JustifyContent.flexEnd
-            }
-            width={BlockSize.Full}
-            height={BlockSize.Full}
-            gap={3}
-          >
-            {!wasTxDeclined && unvalidatedQuote && (
-              <MultichainBridgeQuoteCard
-                onOpenRecipientModal={() =>
-                  setIsDestinationAccountPickerOpen(true)
-                }
-                onOpenSlippageModal={onOpenSettings}
-                selectedDestinationAccount={selectedDestinationAccount}
-              />
-            )}
-            {isNoQuotesAvailable &&
-              !isQuoteExpired &&
-              quoteParams &&
-              // Only show banner if quoteParams (inputs) are valid
-              isValidQuoteRequest(quoteParams, true) && (
-                <BannerAlert
-                  severity={BannerAlertSeverity.Danger}
-                  description={t('noOptionsAvailableMessage')}
-                  textAlign={TextAlign.Left}
-                />
-              )}
-            {isLoading && !unvalidatedQuote ? (
-              <>
-                <Text
-                  textAlign={TextAlign.Center}
-                  color={TextColor.textAlternative}
-                >
-                  {t('swapFetchingQuotes')}
-                </Text>
-                <MascotBackgroundAnimation height="64" width="64" />
-              </>
-            ) : (
-              <PrepareBridgePageFooter
-                onFetchNewQuotes={() => {
-                  if (!quoteParams) {
-                    return;
-                  }
-                  debouncedUpdateQuoteRequestInController.current(quoteParams, {
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    stx_enabled: smartTransactionsEnabled,
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    token_symbol_source: fromToken?.symbol ?? '',
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    token_symbol_destination: toToken?.symbol ?? '',
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    security_warnings: securityWarnings,
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    usd_amount_source: fromAmountInCurrency.usd.toNumber(),
-                  });
-                }}
-                needsDestinationAddress={
-                  isToOrFromNonEvm && !selectedDestinationAccount
-                }
-                onOpenRecipientModal={() =>
-                  setIsDestinationAccountPickerOpen(true)
-                }
-              />
-            )}
+        {/* Quote details - displayed below the swap form */}
+        {!wasTxDeclined && unvalidatedQuote && (
+          <Column paddingInline={4} gap={2}>
+            <MultichainBridgeQuoteCard
+              onOpenRecipientModal={() =>
+                setIsDestinationAccountPickerOpen(true)
+              }
+              onOpenSlippageModal={onOpenSettings}
+              selectedDestinationAccount={selectedDestinationAccount}
+            />
           </Column>
+        )}
+
+        {isNoQuotesAvailable &&
+          !isQuoteExpired &&
+          quoteParams &&
+          // Only show banner if quoteParams (inputs) are valid
+          isValidQuoteRequest(quoteParams, true) && (
+            <Column paddingInline={4}>
+              <BannerAlert
+                severity={BannerAlertSeverity.Danger}
+                description={t('noOptionsAvailableMessage')}
+                textAlign={TextAlign.Left}
+              />
+            </Column>
+          )}
+
+        <Column
+          justifyContent={
+            isLoading && !unvalidatedQuote
+              ? JustifyContent.center
+              : JustifyContent.flexEnd
+          }
+          width={BlockSize.Full}
+          height={BlockSize.Full}
+          gap={3}
+          paddingInline={4}
+          paddingBottom={4}
+        >
+          {isLoading && !unvalidatedQuote ? (
+            <>
+              <Text
+                textAlign={TextAlign.Center}
+                color={TextColor.textAlternative}
+              >
+                {t('swapFetchingQuotes')}
+              </Text>
+              <MascotBackgroundAnimation height="64" width="64" />
+            </>
+          ) : (
+            <PrepareBridgePageFooter
+              onFetchNewQuotes={() => {
+                if (!quoteParams) {
+                  return;
+                }
+                debouncedUpdateQuoteRequestInController.current(quoteParams, {
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  stx_enabled: smartTransactionsEnabled,
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  token_symbol_source: fromToken?.symbol ?? '',
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  token_symbol_destination: toToken?.symbol ?? '',
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  security_warnings: securityWarnings,
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  usd_amount_source: fromAmountInCurrency.usd.toNumber(),
+                });
+              }}
+              needsDestinationAddress={
+                isToOrFromNonEvm && !selectedDestinationAccount
+              }
+              onOpenRecipientModal={() =>
+                setIsDestinationAccountPickerOpen(true)
+              }
+            />
+          )}
         </Column>
       </Column>
 

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -55,6 +55,7 @@ import {
   Text,
 } from '../../../components/component-library';
 import {
+  AlignItems,
   BackgroundColor,
   BlockSize,
   Display,
@@ -363,6 +364,7 @@ const PrepareBridgePage = ({
   const [blockExplorerToken, setBlockExplorerToken] =
     useState<BridgeToken | null>(null);
   const [toastTriggerCounter, setToastTriggerCounter] = useState(0);
+  const isInitialQuoteLoading = isLoading && !unvalidatedQuote;
 
   const getFromInputHeader = () => {
     return t('swapSelectToken');
@@ -632,7 +634,7 @@ const PrepareBridgePage = ({
 
         <Column
           justifyContent={
-            isLoading && !unvalidatedQuote
+            isInitialQuoteLoading
               ? JustifyContent.center
               : JustifyContent.flexEnd
           }
@@ -642,8 +644,8 @@ const PrepareBridgePage = ({
           paddingInline={4}
           paddingBottom={4}
         >
-          {isLoading && !unvalidatedQuote ? (
-            <>
+          {isInitialQuoteLoading ? (
+            <Column alignItems={AlignItems.center}>
               <Text
                 textAlign={TextAlign.Center}
                 color={TextColor.textAlternative}
@@ -651,7 +653,7 @@ const PrepareBridgePage = ({
                 {t('swapFetchingQuotes')}
               </Text>
               <MascotBackgroundAnimation height="64" width="64" />
-            </>
+            </Column>
           ) : (
             <PrepareBridgePageFooter
               onFetchNewQuotes={() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Moves the quote card from being above the swap button to below the form. This aligns the extension UI with the mobile UI, increasing consistency. It also moves the % fee disclaimer to under the swap button, this also aligns with the mobile UI.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39928?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Aligns extension swaps UI with metamask mobile UI for consistency

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3971

## **Manual testing steps**

1. Go to the swaps screen and get a quote
2. The UI of the quote card and fee disclaimer should match mobile

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="394" height="597" alt="Screenshot 2026-02-09 at 4 42 14 PM" src="https://github.com/user-attachments/assets/77367e57-8db1-4a74-932f-c65aa024ad12" />


<!-- [screenshots/recordings] -->

### **After**

<img width="397" height="596" alt="Screenshot 2026-02-09 at 4 41 09 PM" src="https://github.com/user-attachments/assets/4625f2b8-69d6-444d-ab1f-1b4504402085" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI layout/styling reflow with snapshot updates; logic changes are limited to presentation/placement of existing quote/loading components.
> 
> **Overview**
> Reworks the `PrepareBridgePage` layout to render `MultichainBridgeQuoteCard` *below* the token input form (and wraps the “no quotes available” banner in its own padded section), aligning the extension’s bridge/swap screen with mobile.
> 
> Updates the footer to place `BridgeCTAInfoText` under the primary CTA, tweaks the initial-quote loading state container/centering, and enhances the loading mascot animation styling (new background layers + `bridge-loader-spin` keyframes). Snapshots were updated to reflect the new DOM structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c91c79ee19b2a58608f821d893df39cc0677635a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->