### PR TITLE
fix: rename network banner analytics event for mobile alignment

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -797,7 +797,7 @@ export enum MetaMetricsEventName {
   NavPermissionsOpened = 'Permissions Opened',
   NetworkConnectionBannerShown = 'Network Connection Banner Shown',
   NetworkConnectionBannerUpdateRpcClicked = 'Network Connection Banner Update RPC Clicked',
-  NetworkConnectionBannerSwitchToInfuraClicked = 'Network Connection Banner Switch To Infura Clicked',
+  NetworkConnectionBannerSwitchToMetaMaskDefaultRpcClicked = 'Network Connection Banner Switch To MetaMask Default RPC Clicked',
   NetworkConnectionBannerRpcUpdated = 'Network Connection Banner RPC Updated',
   UpdatePermissionedNetworks = 'Update Permissioned Networks',
   UpdatePermissionedAccounts = 'Update Permissioned Accounts',

--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -365,7 +365,7 @@ describe('NetworkConnectionBanner', () => {
       expect(trackNetworkBannerEventMock).toHaveBeenCalledWith({
         bannerType: 'degraded',
         eventName:
-          MetaMetricsEventName.NetworkConnectionBannerSwitchToInfuraClicked,
+          MetaMetricsEventName.NetworkConnectionBannerSwitchToMetaMaskDefaultRpcClicked,
         networkClientId: 'custom-arbitrum',
       });
     });
@@ -397,7 +397,7 @@ describe('NetworkConnectionBanner', () => {
       expect(trackNetworkBannerEventMock).toHaveBeenCalledWith({
         bannerType: 'unavailable',
         eventName:
-          MetaMetricsEventName.NetworkConnectionBannerSwitchToInfuraClicked,
+          MetaMetricsEventName.NetworkConnectionBannerSwitchToMetaMaskDefaultRpcClicked,
         networkClientId: 'custom-arbitrum',
       });
     });

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -266,7 +266,7 @@ export const NetworkConnectionBanner = () => {
       networkConnectionBanner.trackNetworkBannerEvent({
         bannerType: networkConnectionBanner.status,
         eventName:
-          MetaMetricsEventName.NetworkConnectionBannerSwitchToInfuraClicked,
+          MetaMetricsEventName.NetworkConnectionBannerSwitchToMetaMaskDefaultRpcClicked,
         networkClientId: networkConnectionBanner.networkClientId,
       });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason for the change:** Extension analytics used a different event name than mobile for the "Switch to MetaMask default RPC" action, making cross-platform analytics inconsistent.

Rename the event from `Network Connection Banner Switch To Infura Clicked` to `Network Connection Banner Switch To MetaMask Default RPC Clicked` so extension and mobile use the same event name.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39939?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only rename with corresponding test updates; no changes to network switching logic or user-facing behavior.
> 
> **Overview**
> Renames the MetaMetrics event for the network connection banner’s "Switch to MetaMask default RPC" action from the Infura-specific name to `NetworkConnectionBannerSwitchToMetaMaskDefaultRpcClicked` for cross-platform analytics alignment.
> 
> Updates `NetworkConnectionBanner` tracking and its unit tests to assert the new event name while leaving the underlying switch behavior (`switchToInfura`) unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8fbe34907a671980dae9758dddabb71328d31af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->