### PR TITLE
ci: Fix `get-requirements.yml` checks for `pull_request` events

### DIFF
--- a/.github/scripts/identify-builds-from-run.sh
+++ b/.github/scripts/identify-builds-from-run.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+COMMIT_HASH=$1
+
+if [[ -z "$COMMIT_HASH" ]]
+then
+  echo "Missing commit hash argument"
+  exit 1
+fi
+
 # If the string `[builds-from-run: <run-id>]` is contained in the last commit message
-if [[ "$(git log -1 --pretty=%B)" =~ \[builds-from-run:[[:space:]]*([0-9]+)\] ]]; then
+if [[ "$(git log -1 --pretty=%B "$COMMIT_HASH")" =~ \[builds-from-run:[[:space:]]*([0-9]+)\] ]]; then
   # Extract the <run-id> value from the commit message
   builds_from_run="${BASH_REMATCH[1]}"
   echo "Found builds-from-run directive in commit message: $builds_from_run"

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -63,6 +63,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Fetch HEAD commit for message checks
+        if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
+        run: git fetch --depth=1 origin "${HEAD_COMMIT_HASH}"
+
       # Do this before we use dorny/paths-filter, which might checkout other commits
       - name: Check skip-e2e tag
         id: skip-e2e-tag

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -61,8 +61,6 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
         with:
-          # Specifying `ref` ensures that the head commit is checked out directly.
-          ref: ${{ env.HEAD_COMMIT_HASH }}
           fetch-depth: 1
 
       # Do this before we use dorny/paths-filter, which might checkout other commits

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -82,7 +82,7 @@ jobs:
       - name: 'Look for `[builds-from-run: <run>]` in the last commit message'
         id: identify-builds
         if: ${{ env.IS_RUN_EVERYTHING_BRANCH != 'true' && steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
-        run: .github/scripts/identify-builds-from-run.sh
+        run: .github/scripts/identify-builds-from-run.sh "${HEAD_COMMIT_HASH}"
 
       - id: filter
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}


### PR DESCRIPTION
## **Description**

When triggered by a `pull_request` event, the `get-requirements` workflow was checking out the wrong commit. It was using the tip of the `head` branch rather than `github.ref` (the tip of the pull request merge branch), which is what all of our other CI steps use.

As a consequence of this, files that are expected by `get-requirements` to exist may not exist (as we saw already with the `filter` step breaking on outdated PRs). But even more concerningly, the filter step will be using the _wrong diff_ to compute which checks are needed.

This has been fixed by removing the `ref` from the checkout step. The default ref (`github.ref`) is correct in this case. The filter step didn't need any adjustment either; `dorny/paths-filter` is already using the merge-base of the default branch (or PR base branch) and `github.ref` as the point of comparison by default.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39949?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes bug raised on Slack, which can be seen in this failed workflow run: https://github.com/MetaMask/metamask-extension/actions/runs/21868499967/job/63116352430?pr=39903

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- [skip-e2e] -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change that adjusts which commit is checked out; risk is limited to potentially altering which checks run for PRs.
> 
> **Overview**
> Fixes `get-requirements.yml` using the wrong commit on `pull_request` runs by removing the explicit `ref: ${{ env.HEAD_COMMIT_HASH }}` from `actions/checkout`, letting GitHub’s default `github.ref` (merge ref) be checked out.
> 
> This ensures downstream steps like `dorny/paths-filter` compute required jobs (and avoid missing files) from the correct PR merge diff, aligning behavior with the rest of CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e058c39d47bef2ca14dcffbcc83e42d74e820dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->