### PR TITLE
feat: init edit margin ui

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5202,6 +5202,9 @@
   "perpsAddFundsDescription": {
     "message": "Add funds to start trading perpetual contracts with leverage"
   },
+  "perpsAddMargin": {
+    "message": "Add Margin"
+  },
   "perpsAddToFavorites": {
     "message": "Add to favorites"
   },
@@ -5211,6 +5214,9 @@
   "perpsAvailable": {
     "message": "available",
     "description": "is the available balance amount"
+  },
+  "perpsAvailableBalance": {
+    "message": "Available balance"
   },
   "perpsBuy": {
     "message": "buy"
@@ -5299,9 +5305,6 @@
   "perpsFilterStocks": {
     "message": "Stocks"
   },
-  "perpsGiveFeedback": {
-    "message": "Give us feedback"
-  },
   "perpsFunding": {
     "message": "Funding"
   },
@@ -5310,6 +5313,9 @@
   },
   "perpsFundingRate": {
     "message": "Funding Rate"
+  },
+  "perpsGiveFeedback": {
+    "message": "Give us feedback"
   },
   "perpsIncreasedPosition": {
     "message": "Increased position"
@@ -5326,6 +5332,9 @@
   "perpsLimit": {
     "message": "Limit"
   },
+  "perpsLiquidationDistance": {
+    "message": "Liq. distance"
+  },
   "perpsLiquidationPrice": {
     "message": "Liquidation price"
   },
@@ -5338,26 +5347,8 @@
   "perpsMargin": {
     "message": "Margin"
   },
-  "perpsAddMargin": {
-    "message": "Add Margin"
-  },
-  "perpsRemoveMargin": {
-    "message": "Remove Margin"
-  },
-  "perpsAvailableBalance": {
-    "message": "Available balance"
-  },
-  "perpsMaxRemovable": {
-    "message": "Max removable"
-  },
-  "perpsLiquidationDistance": {
-    "message": "Liq. distance"
-  },
   "perpsMarginRiskWarning": {
     "message": "Removing margin moves your liquidation price closer. Ensure you have sufficient buffer."
-  },
-  "perpsMax": {
-    "message": "Max"
   },
   "perpsMarket": {
     "message": "Market"
@@ -5371,6 +5362,12 @@
   },
   "perpsMarkets": {
     "message": "Markets"
+  },
+  "perpsMax": {
+    "message": "Max"
+  },
+  "perpsMaxRemovable": {
+    "message": "Max removable"
   },
   "perpsModify": {
     "message": "Modify"
@@ -5425,8 +5422,15 @@
   "perpsRecentActivity": {
     "message": "Recent Activity"
   },
+  "perpsRemoveMargin": {
+    "message": "Remove Margin"
+  },
   "perpsReturn": {
     "message": "Return"
+  },
+  "perpsSaveChanges": {
+    "message": "Save Changes",
+    "description": "Button text for saving TP/SL changes"
   },
   "perpsSearchMarkets": {
     "message": "Search markets"
@@ -5509,6 +5513,10 @@
   "perpsStatusTriggered": {
     "message": "Triggered"
   },
+  "perpsStopLoss": {
+    "message": "Stop Loss",
+    "description": "Label for stop loss price input"
+  },
   "perpsSubmitting": {
     "message": "Submitting...",
     "description": "Loading text shown while an order is being submitted"
@@ -5516,14 +5524,6 @@
   "perpsTakeProfit": {
     "message": "Take Profit",
     "description": "Label for take profit price input"
-  },
-  "perpsStopLoss": {
-    "message": "Stop Loss",
-    "description": "Label for stop loss price input"
-  },
-  "perpsSaveChanges": {
-    "message": "Save Changes",
-    "description": "Button text for saving TP/SL changes"
   },
   "perpsTotalBalance": {
     "message": "Total Balance"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5338,6 +5338,27 @@
   "perpsMargin": {
     "message": "Margin"
   },
+  "perpsAddMargin": {
+    "message": "Add Margin"
+  },
+  "perpsRemoveMargin": {
+    "message": "Remove Margin"
+  },
+  "perpsAvailableBalance": {
+    "message": "Available balance"
+  },
+  "perpsMaxRemovable": {
+    "message": "Max removable"
+  },
+  "perpsLiquidationDistance": {
+    "message": "Liq. distance"
+  },
+  "perpsMarginRiskWarning": {
+    "message": "Removing margin moves your liquidation price closer. Ensure you have sufficient buffer."
+  },
+  "perpsMax": {
+    "message": "Max"
+  },
   "perpsMarket": {
     "message": "Market"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5202,6 +5202,9 @@
   "perpsAddFundsDescription": {
     "message": "Add funds to start trading perpetual contracts with leverage"
   },
+  "perpsAddMargin": {
+    "message": "Add Margin"
+  },
   "perpsAddToFavorites": {
     "message": "Add to favorites"
   },
@@ -5211,6 +5214,9 @@
   "perpsAvailable": {
     "message": "available",
     "description": "is the available balance amount"
+  },
+  "perpsAvailableBalance": {
+    "message": "Available balance"
   },
   "perpsBuy": {
     "message": "buy"
@@ -5299,9 +5305,6 @@
   "perpsFilterStocks": {
     "message": "Stocks"
   },
-  "perpsGiveFeedback": {
-    "message": "Give us feedback"
-  },
   "perpsFunding": {
     "message": "Funding"
   },
@@ -5310,6 +5313,9 @@
   },
   "perpsFundingRate": {
     "message": "Funding Rate"
+  },
+  "perpsGiveFeedback": {
+    "message": "Give us feedback"
   },
   "perpsIncreasedPosition": {
     "message": "Increased position"
@@ -5326,6 +5332,9 @@
   "perpsLimit": {
     "message": "Limit"
   },
+  "perpsLiquidationDistance": {
+    "message": "Liq. distance"
+  },
   "perpsLiquidationPrice": {
     "message": "Liquidation price"
   },
@@ -5337,6 +5346,9 @@
   },
   "perpsMargin": {
     "message": "Margin"
+  },
+  "perpsMarginRiskWarning": {
+    "message": "Removing margin moves your liquidation price closer. Ensure you have sufficient buffer."
   },
   "perpsMarket": {
     "message": "Market"
@@ -5350,6 +5362,12 @@
   },
   "perpsMarkets": {
     "message": "Markets"
+  },
+  "perpsMax": {
+    "message": "Max"
+  },
+  "perpsMaxRemovable": {
+    "message": "Max removable"
   },
   "perpsModify": {
     "message": "Modify"
@@ -5404,8 +5422,15 @@
   "perpsRecentActivity": {
     "message": "Recent Activity"
   },
+  "perpsRemoveMargin": {
+    "message": "Remove Margin"
+  },
   "perpsReturn": {
     "message": "Return"
+  },
+  "perpsSaveChanges": {
+    "message": "Save Changes",
+    "description": "Button text for saving TP/SL changes"
   },
   "perpsSearchMarkets": {
     "message": "Search markets"
@@ -5487,6 +5512,18 @@
   },
   "perpsStatusTriggered": {
     "message": "Triggered"
+  },
+  "perpsStopLoss": {
+    "message": "Stop Loss",
+    "description": "Label for stop loss price input"
+  },
+  "perpsSubmitting": {
+    "message": "Submitting...",
+    "description": "Loading text shown while an order is being submitted"
+  },
+  "perpsTakeProfit": {
+    "message": "Take Profit",
+    "description": "Label for take profit price input"
   },
   "perpsTotalBalance": {
     "message": "Total Balance"

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -438,6 +438,9 @@
     "ui/components/app/permission-connect-header/permission-connect-header.test.js": {
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/components/app/perps/order-card/order-card.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },
@@ -449,7 +452,6 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx": {
-      "Material-UI: JSS warnings": 15,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.test.tsx": {

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import { EditMarginExpandable } from './edit-margin-expandable';
+import { mockPositions, mockAccountState } from '../mocks';
+
+const mockGetPerpsController = jest.fn();
+const mockGetPerpsStreamManager = jest.fn();
+
+jest.mock('../../../../providers/perps', () => ({
+  getPerpsController: (...args: unknown[]) => mockGetPerpsController(...args),
+}));
+
+jest.mock('../../../../providers/perps/PerpsStreamManager', () => ({
+  getPerpsStreamManager: () => mockGetPerpsStreamManager(),
+}));
+
+const mockStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+  },
+});
+
+const defaultProps = {
+  position: mockPositions[0],
+  account: mockAccountState,
+  currentPrice: 2900,
+  selectedAddress: '0x123',
+  isExpanded: true,
+  onToggle: jest.fn(),
+};
+
+describe('EditMarginExpandable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPerpsController.mockResolvedValue({
+      updateMargin: jest.fn().mockResolvedValue({ success: true }),
+      getPositions: jest.fn().mockResolvedValue(mockPositions),
+    });
+    mockGetPerpsStreamManager.mockReturnValue({
+      pushPositionsWithOverrides: jest.fn(),
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders Add Margin and Remove Margin mode options when expanded', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+      expect(screen.getByText('Remove Margin')).toBeInTheDocument();
+    });
+
+    it('renders amount input and preset buttons when expanded', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument();
+      expect(screen.getByText('25%')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+      expect(screen.getByText('Max')).toBeInTheDocument();
+    });
+
+    it('renders confirm button with Add Margin when in add mode', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      const buttons = screen.getAllByRole('button', { name: /Add Margin/i });
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows Available balance in add mode', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      expect(screen.getByText('Available balance')).toBeInTheDocument();
+    });
+
+    it('shows Max removable when Remove is selected', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByText('Remove Margin'));
+
+      expect(screen.getByText('Max removable')).toBeInTheDocument();
+    });
+  });
+
+  describe('mode toggle', () => {
+    it('switches to Remove mode when Remove Margin is clicked', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByText('Remove Margin'));
+
+      expect(screen.getByText('Max removable')).toBeInTheDocument();
+    });
+
+    it('switches back to Add mode when Add Margin is clicked', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByText('Remove Margin'));
+      fireEvent.click(screen.getByText('Add Margin'));
+
+      expect(screen.getByText('Available balance')).toBeInTheDocument();
+    });
+  });
+
+  describe('preset buttons', () => {
+    it('sets amount when a preset is clicked', () => {
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByText('25%'));
+
+      const input = screen.getByPlaceholderText('0.00');
+      expect(input).toHaveValue();
+      expect(parseFloat((input as HTMLInputElement).value)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('submit', () => {
+    it('calls controller updateMargin and onToggle on successful submit', async () => {
+      const onToggle = jest.fn();
+      const updateMargin = jest.fn().mockResolvedValue({ success: true });
+      const getPositions = jest.fn().mockResolvedValue(mockPositions);
+
+      mockGetPerpsController.mockResolvedValue({
+        updateMargin,
+        getPositions,
+      });
+
+      renderWithProvider(
+        <EditMarginExpandable
+          {...defaultProps}
+          onToggle={onToggle}
+          isExpanded
+        />,
+        mockStore,
+      );
+
+      const input = screen.getByPlaceholderText('0.00');
+      fireEvent.change(input, { target: { value: '100' } });
+
+      const confirmButton = screen.getByRole('button', {
+        name: /Add Margin/i,
+      });
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(mockGetPerpsController).toHaveBeenCalledWith('0x123');
+        expect(updateMargin).toHaveBeenCalledWith({
+          symbol: mockPositions[0].symbol,
+          amount: '100',
+        });
+      });
+      await waitFor(() => {
+        expect(onToggle).toHaveBeenCalled();
+      });
+    });
+
+    it('does not call updateMargin when amount is empty', () => {
+      const updateMargin = jest.fn().mockResolvedValue({ success: true });
+
+      mockGetPerpsController.mockResolvedValue({
+        updateMargin,
+        getPositions: jest.fn().mockResolvedValue(mockPositions),
+      });
+
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      const confirmButton = screen.getByRole('button', {
+        name: /Add Margin/i,
+      });
+      expect(confirmButton).toBeDisabled();
+      fireEvent.click(confirmButton);
+
+      expect(updateMargin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error display', () => {
+    it('shows error message when updateMargin fails', async () => {
+      mockGetPerpsController.mockResolvedValue({
+        updateMargin: jest
+          .fn()
+          .mockResolvedValue({ success: false, error: 'Insufficient balance' }),
+        getPositions: jest.fn().mockResolvedValue(mockPositions),
+      });
+
+      renderWithProvider(
+        <EditMarginExpandable {...defaultProps} isExpanded />,
+        mockStore,
+      );
+
+      const input = screen.getByPlaceholderText('0.00');
+      fireEvent.change(input, { target: { value: '100' } });
+
+      const confirmButton = screen.getByRole('button', {
+        name: /Add Margin/i,
+      });
+      fireEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Insufficient balance')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -51,7 +51,9 @@ describe('EditMarginExpandable', () => {
         mockStore,
       );
 
-      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+      const addMarginElements = screen.getAllByText('Add Margin');
+      // Mode toggle tab + confirm button both show 'Add Margin'
+      expect(addMarginElements.length).toBeGreaterThanOrEqual(2);
       expect(screen.getByText('Remove Margin')).toBeInTheDocument();
     });
 

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -3,8 +3,8 @@ import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
-import { EditMarginExpandable } from './edit-margin-expandable';
 import { mockPositions, mockAccountState } from '../mocks';
+import { EditMarginExpandable } from './edit-margin-expandable';
 
 const mockGetPerpsController = jest.fn();
 const mockGetPerpsStreamManager = jest.fn();
@@ -75,7 +75,7 @@ describe('EditMarginExpandable', () => {
         mockStore,
       );
 
-      const buttons = screen.getAllByRole('button', { name: /Add Margin/i });
+      const buttons = screen.getAllByRole('button', { name: /Add Margin/iu });
       expect(buttons.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -164,7 +164,7 @@ describe('EditMarginExpandable', () => {
       fireEvent.change(input, { target: { value: '100' } });
 
       const confirmButton = screen.getByRole('button', {
-        name: /Add Margin/i,
+        name: /Add Margin/iu,
       });
       fireEvent.click(confirmButton);
 
@@ -194,7 +194,7 @@ describe('EditMarginExpandable', () => {
       );
 
       const confirmButton = screen.getByRole('button', {
-        name: /Add Margin/i,
+        name: /Add Margin/iu,
       });
       expect(confirmButton).toBeDisabled();
       fireEvent.click(confirmButton);
@@ -221,7 +221,7 @@ describe('EditMarginExpandable', () => {
       fireEvent.change(input, { target: { value: '100' } });
 
       const confirmButton = screen.getByRole('button', {
-        name: /Add Margin/i,
+        name: /Add Margin/iu,
       });
       fireEvent.click(confirmButton);
 

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
@@ -1,0 +1,443 @@
+import React, { useState, useCallback } from 'react';
+import {
+  twMerge,
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { TextField, TextFieldSize } from '../../../../components/component-library';
+import {
+  BorderRadius,
+  BackgroundColor,
+} from '../../../../helpers/constants/design-system';
+import { getPerpsController } from '../../../../providers/perps';
+import { getPerpsStreamManager } from '../../../../providers/perps/PerpsStreamManager';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { usePerpsMarginCalculations } from '../../../../hooks/perps/usePerpsMarginCalculations';
+import type { Position, AccountState } from '../types';
+
+const MARGIN_PRESETS = [25, 50, 100] as const; // 25%, 50%, Max (100%)
+
+export type EditMarginExpandableProps = {
+  position: Position;
+  account: AccountState | null;
+  currentPrice: number;
+  selectedAddress: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+};
+
+/**
+ * Expandable section for adding or removing margin from an isolated position.
+ * Renders the expandable content only; the margin card header lives in the parent.
+ */
+export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
+  position,
+  account,
+  currentPrice,
+  selectedAddress,
+  isExpanded,
+  onToggle,
+}) => {
+  const t = useI18nContext();
+  const { formatNumber } = useFormatters();
+
+  const [marginMode, setMarginMode] = useState<'add' | 'remove'>('add');
+  const [marginAmount, setMarginAmount] = useState<string>('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [marginError, setMarginError] = useState<string | null>(null);
+
+  const calculations = usePerpsMarginCalculations({
+    position,
+    currentPrice,
+    account,
+    mode: marginMode,
+    amount: marginAmount,
+  });
+
+  const {
+    maxAmount,
+    newLiquidationPrice,
+    currentLiquidationDistance,
+    newLiquidationDistance,
+    riskAssessment,
+    isValid,
+  } = calculations;
+
+  const handleAmountChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+      if (value === '' || /^[\d,]*\.?\d{0,2}$/u.test(value)) {
+        let cleaned = value.replace(/,/gu, '');
+        if (marginMode === 'remove' && maxAmount > 0) {
+          const num = parseFloat(cleaned) || 0;
+          if (num > maxAmount) {
+            cleaned = maxAmount.toFixed(2);
+          }
+        }
+        setMarginAmount(cleaned);
+      }
+    },
+    [marginMode, maxAmount],
+  );
+
+  const handlePresetClick = useCallback(
+    (percent: number) => {
+      if (maxAmount <= 0) {
+        return;
+      }
+      const value = (maxAmount * percent) / 100;
+      setMarginAmount(value.toFixed(2));
+    },
+    [maxAmount],
+  );
+
+  const handleSaveMargin = useCallback(async () => {
+    if (!selectedAddress || !isValid) {
+      return;
+    }
+
+    const amountNum = parseFloat(marginAmount) || 0;
+    if (amountNum <= 0) {
+      return;
+    }
+
+    setIsSaving(true);
+    setMarginError(null);
+
+    try {
+      const controller = await getPerpsController(selectedAddress);
+      const signedAmount =
+        marginMode === 'add' ? marginAmount : `-${marginAmount}`;
+
+      const result = await controller.updateMargin({
+        symbol: position.symbol,
+        amount: signedAmount,
+      });
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to update margin');
+      }
+
+      const streamManager = getPerpsStreamManager();
+      const freshPositions = await controller.getPositions({
+        skipCache: true,
+      });
+      streamManager.pushPositionsWithOverrides(freshPositions);
+
+      setMarginAmount('');
+      onToggle();
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'An unknown error occurred';
+      setMarginError(errorMessage);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    selectedAddress,
+    marginMode,
+    marginAmount,
+    isValid,
+    position.symbol,
+    onToggle,
+  ]);
+
+  const currentLiqPrice = position.liquidationPrice
+    ? parseFloat(position.liquidationPrice)
+    : null;
+
+  const showRiskWarning =
+    marginMode === 'remove' &&
+    riskAssessment &&
+    (riskAssessment.riskLevel === 'warning' || riskAssessment.riskLevel === 'danger');
+
+  const confirmDisabled =
+    !isValid || isSaving || parseFloat(marginAmount) <= 0;
+
+  return (
+    <Box
+      className="rounded-xl bg-muted overflow-hidden"
+      flexDirection={BoxFlexDirection.Column}
+    >
+      <Box
+        className={twMerge(
+          'grid transition-all duration-300 ease-in-out',
+          isExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
+        )}
+      >
+        <Box
+          className="overflow-hidden border-t border-muted"
+          flexDirection={BoxFlexDirection.Column}
+        >
+          <Box
+            className="px-4 py-3"
+            flexDirection={BoxFlexDirection.Column}
+            gap={4}
+          >
+            {/* Mode toggle: Add / Remove */}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              className="w-full bg-background-default rounded-xl p-1 gap-1"
+            >
+              <Box
+                onClick={
+                  isSaving
+                    ? undefined
+                    : () => {
+                        setMarginMode('add');
+                        setMarginError(null);
+                      }
+                }
+                className={twMerge(
+                  'flex-1 py-2 rounded-lg text-center cursor-pointer transition-colors',
+                  marginMode === 'add'
+                    ? 'bg-primary-default'
+                    : 'hover:bg-muted-hover active:bg-muted-pressed',
+                  isSaving && 'opacity-50 cursor-not-allowed pointer-events-none',
+                )}
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={marginMode === 'add' ? TextColor.primaryInverse : TextColor.TextDefault}
+                >
+                  {t('perpsAddMargin')}
+                </Text>
+              </Box>
+              <Box
+                onClick={
+                  isSaving
+                    ? undefined
+                    : () => {
+                        setMarginMode('remove');
+                        setMarginError(null);
+                      }
+                }
+                className={twMerge(
+                  'flex-1 py-2 rounded-lg text-center cursor-pointer transition-colors',
+                  marginMode === 'remove'
+                    ? 'bg-primary-default'
+                    : 'hover:bg-muted-hover active:bg-muted-pressed',
+                  isSaving && 'opacity-50 cursor-not-allowed pointer-events-none',
+                )}
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={marginMode === 'remove' ? TextColor.primaryInverse : TextColor.TextDefault}
+                >
+                  {t('perpsRemoveMargin')}
+                </Text>
+              </Box>
+            </Box>
+
+            {/* Amount input */}
+            <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                fontWeight={FontWeight.Medium}
+              >
+                {t('perpsOrderAmount')}
+              </Text>
+              <TextField
+                size={TextFieldSize.Md}
+                value={marginAmount}
+                onChange={handleAmountChange}
+                placeholder="0.00"
+                borderRadius={BorderRadius.MD}
+                borderWidth={0}
+                backgroundColor={BackgroundColor.backgroundMuted}
+                className="w-full"
+                disabled={isSaving}
+                startAccessory={
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
+                  >
+                    $
+                  </Text>
+                }
+              />
+            </Box>
+
+            {/* Preset buttons: 25%, 50%, Max */}
+            <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+              {MARGIN_PRESETS.map((preset) => (
+                <Box
+                  key={`margin-preset-${preset}`}
+                  onClick={
+                    isSaving ? undefined : () => handlePresetClick(preset)
+                  }
+                  className={twMerge(
+                    'flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center',
+                    'hover:bg-muted-hover active:bg-muted-pressed',
+                    'border border-muted transition-colors duration-150',
+                    isSaving &&
+                      'opacity-50 cursor-not-allowed pointer-events-none',
+                  )}
+                >
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                  >
+                    {preset === 100 ? t('perpsMax') : `${preset}%`}
+                  </Text>
+                </Box>
+              ))}
+            </Box>
+
+            {/* Info rows */}
+            <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                justifyContent={BoxJustifyContent.Between}
+                alignItems={BoxAlignItems.Center}
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {marginMode === 'add'
+                    ? t('perpsAvailableBalance')
+                    : t('perpsMaxRemovable')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                >
+                  ${formatNumber(maxAmount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </Text>
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                justifyContent={BoxJustifyContent.Between}
+                alignItems={BoxAlignItems.Center}
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {t('perpsLiquidationPrice')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {currentLiqPrice !== null ? `$${formatNumber(currentLiqPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '-'}
+                  {newLiquidationPrice !== null &&
+                    ` → $${formatNumber(newLiquidationPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+                </Text>
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                justifyContent={BoxJustifyContent.Between}
+                alignItems={BoxAlignItems.Center}
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {t('perpsLiquidationDistance')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {formatNumber(currentLiquidationDistance, {
+                    minimumFractionDigits: 1,
+                    maximumFractionDigits: 1,
+                  })}
+                  %
+                  {newLiquidationDistance !== null &&
+                    ` → ${formatNumber(newLiquidationDistance, {
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    })}%`}
+                </Text>
+              </Box>
+            </Box>
+
+            {/* Risk warning (remove mode) */}
+            {showRiskWarning && (
+              <Box
+                className="bg-warning-muted rounded-lg px-3 py-2"
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={2}
+              >
+                <Icon
+                  name={IconName.Warning}
+                  size={IconSize.Sm}
+                  color={IconColor.WarningDefault}
+                />
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.WarningDefault}
+                >
+                  {t('perpsMarginRiskWarning')}
+                </Text>
+              </Box>
+            )}
+
+            {/* Error message */}
+            {marginError && (
+              <Box
+                className="bg-error-muted rounded-lg px-3 py-2"
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={2}
+              >
+                <Icon
+                  name={IconName.Warning}
+                  size={IconSize.Sm}
+                  color={IconColor.ErrorDefault}
+                />
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
+                  {marginError}
+                </Text>
+              </Box>
+            )}
+
+            {/* Confirm button */}
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Md}
+              onClick={handleSaveMargin}
+              disabled={confirmDisabled}
+              className={twMerge(
+                'w-full',
+                confirmDisabled && 'opacity-70 cursor-not-allowed',
+              )}
+            >
+              {isSaving
+                ? t('perpsSubmitting')
+                : marginMode === 'add'
+                  ? t('perpsAddMargin')
+                  : t('perpsRemoveMargin')}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
@@ -180,7 +180,7 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
         )}
       >
         <Box
-          className="overflow-hidden border-t border-muted"
+          className="overflow-hidden"
           flexDirection={BoxFlexDirection.Column}
         >
           <Box

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
@@ -233,7 +233,7 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   fontWeight={FontWeight.Medium}
                   color={
                     marginMode === 'add'
-                      ? TextColor.primaryInverse
+                      ? TextColor.PrimaryInverse
                       : TextColor.TextDefault
                   }
                 >
@@ -263,7 +263,7 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   fontWeight={FontWeight.Medium}
                   color={
                     marginMode === 'remove'
-                      ? TextColor.primaryInverse
+                      ? TextColor.PrimaryInverse
                       : TextColor.TextDefault
                   }
                 >

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.tsx
@@ -18,7 +18,7 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { TextField, TextFieldSize } from '../../../../components/component-library';
+import { TextField, TextFieldSize } from '../../../component-library';
 import {
   BorderRadius,
   BackgroundColor,
@@ -43,6 +43,14 @@ export type EditMarginExpandableProps = {
 /**
  * Expandable section for adding or removing margin from an isolated position.
  * Renders the expandable content only; the margin card header lives in the parent.
+ *
+ * @param options0 - Component props
+ * @param options0.position - The position to adjust margin for
+ * @param options0.account - The user's account state
+ * @param options0.currentPrice - The current market price
+ * @param options0.selectedAddress - The selected wallet address
+ * @param options0.isExpanded - Whether the expandable section is open
+ * @param options0.onToggle - Callback when the section is toggled
  */
 export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
   position,
@@ -163,10 +171,17 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
   const showRiskWarning =
     marginMode === 'remove' &&
     riskAssessment &&
-    (riskAssessment.riskLevel === 'warning' || riskAssessment.riskLevel === 'danger');
+    (riskAssessment.riskLevel === 'warning' ||
+      riskAssessment.riskLevel === 'danger');
 
-  const confirmDisabled =
-    !isValid || isSaving || parseFloat(marginAmount) <= 0;
+  const confirmDisabled = !isValid || isSaving || parseFloat(marginAmount) <= 0;
+
+  const getConfirmButtonLabel = () => {
+    if (isSaving) {
+      return t('perpsSubmitting');
+    }
+    return marginMode === 'add' ? t('perpsAddMargin') : t('perpsRemoveMargin');
+  };
 
   return (
     <Box
@@ -176,7 +191,9 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
       <Box
         className={twMerge(
           'grid transition-all duration-300 ease-in-out',
-          isExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
+          isExpanded
+            ? 'grid-rows-[1fr] opacity-100'
+            : 'grid-rows-[0fr] opacity-0',
         )}
       >
         <Box
@@ -207,13 +224,18 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   marginMode === 'add'
                     ? 'bg-primary-default'
                     : 'hover:bg-muted-hover active:bg-muted-pressed',
-                  isSaving && 'opacity-50 cursor-not-allowed pointer-events-none',
+                  isSaving &&
+                    'opacity-50 cursor-not-allowed pointer-events-none',
                 )}
               >
                 <Text
                   variant={TextVariant.BodyMd}
                   fontWeight={FontWeight.Medium}
-                  color={marginMode === 'add' ? TextColor.primaryInverse : TextColor.TextDefault}
+                  color={
+                    marginMode === 'add'
+                      ? TextColor.primaryInverse
+                      : TextColor.TextDefault
+                  }
                 >
                   {t('perpsAddMargin')}
                 </Text>
@@ -232,13 +254,18 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   marginMode === 'remove'
                     ? 'bg-primary-default'
                     : 'hover:bg-muted-hover active:bg-muted-pressed',
-                  isSaving && 'opacity-50 cursor-not-allowed pointer-events-none',
+                  isSaving &&
+                    'opacity-50 cursor-not-allowed pointer-events-none',
                 )}
               >
                 <Text
                   variant={TextVariant.BodyMd}
                   fontWeight={FontWeight.Medium}
-                  color={marginMode === 'remove' ? TextColor.primaryInverse : TextColor.TextDefault}
+                  color={
+                    marginMode === 'remove'
+                      ? TextColor.primaryInverse
+                      : TextColor.TextDefault
+                  }
                 >
                   {t('perpsRemoveMargin')}
                 </Text>
@@ -320,7 +347,11 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
                 >
-                  ${formatNumber(maxAmount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                  $
+                  {formatNumber(maxAmount, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
                 </Text>
               </Box>
 
@@ -339,7 +370,9 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
                 >
-                  {currentLiqPrice !== null ? `$${formatNumber(currentLiqPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '-'}
+                  {currentLiqPrice === null
+                    ? '-'
+                    : `$${formatNumber(currentLiqPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
                   {newLiquidationPrice !== null &&
                     ` → $${formatNumber(newLiquidationPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
                 </Text>
@@ -429,11 +462,7 @@ export const EditMarginExpandable: React.FC<EditMarginExpandableProps> = ({
                 confirmDisabled && 'opacity-70 cursor-not-allowed',
               )}
             >
-              {isSaving
-                ? t('perpsSubmitting')
-                : marginMode === 'add'
-                  ? t('perpsAddMargin')
-                  : t('perpsRemoveMargin')}
+              {getConfirmButtonLabel()}
             </Button>
           </Box>
         </Box>

--- a/ui/components/app/perps/edit-margin/index.ts
+++ b/ui/components/app/perps/edit-margin/index.ts
@@ -1,0 +1,2 @@
+export { EditMarginExpandable } from './edit-margin-expandable';
+export type { EditMarginExpandableProps } from './edit-margin-expandable';

--- a/ui/components/app/perps/index.ts
+++ b/ui/components/app/perps/index.ts
@@ -57,6 +57,10 @@ export type {
   AccountState,
 } from './types';
 
+// Edit Margin expandable
+export { EditMarginExpandable } from './edit-margin';
+export type { EditMarginExpandableProps } from './edit-margin';
+
 // Order Entry components
 export { OrderEntry } from './order-entry';
 export type {

--- a/ui/components/app/perps/order-card/order-card.test.tsx
+++ b/ui/components/app/perps/order-card/order-card.test.tsx
@@ -97,34 +97,6 @@ describe('OrderCard', () => {
     expect(screen.getByText('Market')).toBeInTheDocument();
   });
 
-  it('displays open status correctly', () => {
-    const order = createMockOrder({ status: 'open' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
-
-    expect(screen.getByText('Open')).toBeInTheDocument();
-  });
-
-  it('displays filled status correctly', () => {
-    const order = createMockOrder({ status: 'filled' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
-
-    expect(screen.getByText('Filled')).toBeInTheDocument();
-  });
-
-  it('displays canceled status correctly', () => {
-    const order = createMockOrder({ status: 'canceled' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
-
-    expect(screen.getByText('Canceled')).toBeInTheDocument();
-  });
-
-  it('displays queued status correctly', () => {
-    const order = createMockOrder({ status: 'queued' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
-
-    expect(screen.getByText('Queued')).toBeInTheDocument();
-  });
-
   it('renders the token logo', () => {
     const order = createMockOrder({ symbol: 'SOL' });
     renderWithProvider(<OrderCard order={order} />, mockStore);

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -148,6 +148,11 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             leverage={formState.leverage}
             onLeverageChange={handleLeverageChange}
             maxLeverage={maxLeverage}
+            minLeverage={
+              mode === 'modify' && existingPosition
+                ? existingPosition.leverage
+                : undefined
+            }
           />
         )}
 

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -27,6 +27,8 @@ export type OrderMode = 'new' | 'modify' | 'close';
  * Used in 'modify' and 'close' modes
  */
 export type ExistingPositionData = {
+  /** Asset symbol (e.g., 'ETH', 'BTC') - used for tracking position identity */
+  symbol?: string;
   /** Position size (signed: positive = long, negative = short) */
   size: string;
   /** Current leverage multiplier */

--- a/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
@@ -82,7 +82,7 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
       {/* Period Selector Skeleton */}
       <Box
         flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.SpaceEvenly}
+        justifyContent={BoxJustifyContent.Evenly}
         paddingTop={3}
         paddingBottom={3}
         paddingLeft={4}

--- a/ui/components/app/perps/perps-tab-view.test.tsx
+++ b/ui/components/app/perps/perps-tab-view.test.tsx
@@ -6,10 +6,15 @@ import mockState from '../../../../test/data/mock-state.json';
 import * as mocks from './mocks';
 import { PerpsTabView } from './perps-tab-view';
 
-// Mock the PerpsControllerProvider to render children directly
+// Mock the PerpsControllerProvider and getPerpsStreamManager
 jest.mock('../../../providers/perps', () => ({
   PerpsControllerProvider: ({ children }: { children: React.ReactNode }) =>
     children,
+  getPerpsStreamManager: () => ({
+    init: jest.fn().mockResolvedValue(undefined),
+    prewarm: jest.fn(),
+    cleanupPrewarm: jest.fn(),
+  }),
 }));
 
 // Mock the perps stream hooks
@@ -24,6 +29,12 @@ jest.mock('../../../hooks/perps/stream', () => ({
   }),
   usePerpsLiveAccount: () => ({
     account: mocks.mockAccountState,
+    isInitialLoading: false,
+  }),
+  usePerpsLiveMarketData: () => ({
+    markets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
+    cryptoMarkets: mocks.mockCryptoMarkets,
+    hip3Markets: mocks.mockHip3Markets,
     isInitialLoading: false,
   }),
 }));

--- a/ui/components/app/perps/types.ts
+++ b/ui/components/app/perps/types.ts
@@ -25,6 +25,10 @@ export type {
   CancelOrderParams,
   CancelOrderResult,
 
+  // Margin adjustment types
+  UpdateMarginParams,
+  MarginResult,
+
   // Price and market data
   PriceUpdate,
 

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -369,7 +369,9 @@ export const isHip3Market = (
   market: PerpsMarketData,
   allowedSources: Set<string>,
 ): boolean => {
-  return Boolean(market.marketSource && allowedSources.has(market.marketSource));
+  return Boolean(
+    market.marketSource && allowedSources.has(market.marketSource),
+  );
 };
 
 /**

--- a/ui/hooks/perps/index.ts
+++ b/ui/hooks/perps/index.ts
@@ -15,3 +15,10 @@ export type {
   UsePerpsTransactionHistoryParams,
   UsePerpsTransactionHistoryResult,
 } from './usePerpsTransactionHistory';
+
+export { usePerpsMarginCalculations } from './usePerpsMarginCalculations';
+export type {
+  UsePerpsMarginCalculationsParams,
+  UsePerpsMarginCalculationsReturn,
+  MarginRiskAssessment,
+} from './usePerpsMarginCalculations';

--- a/ui/hooks/perps/marginUtils.ts
+++ b/ui/hooks/perps/marginUtils.ts
@@ -41,6 +41,9 @@ export type CalculateNewLiquidationPriceParams = {
 
 /**
  * Assess liquidation risk after margin removal.
+ *
+ * @param params - The parameters for assessing margin removal risk
+ * @returns The risk assessment containing risk level, price diff, and risk ratio
  */
 export function assessMarginRemovalRisk(
   params: AssessMarginRemovalRiskParams,
@@ -77,6 +80,9 @@ export function assessMarginRemovalRisk(
 
 /**
  * Calculate maximum margin that can be safely removed from a position.
+ *
+ * @param params - The parameters for calculating max removable margin
+ * @returns The maximum amount of margin that can be safely removed
  */
 export function calculateMaxRemovableMargin(
   params: CalculateMaxRemovableMarginParams,
@@ -128,6 +134,9 @@ export function calculateMaxRemovableMargin(
 
 /**
  * Calculate new liquidation price after margin adjustment.
+ *
+ * @param params - The parameters for calculating new liquidation price
+ * @returns The new liquidation price after the margin adjustment
  */
 export function calculateNewLiquidationPrice(
   params: CalculateNewLiquidationPriceParams,

--- a/ui/hooks/perps/marginUtils.ts
+++ b/ui/hooks/perps/marginUtils.ts
@@ -1,0 +1,159 @@
+/**
+ * Margin adjustment calculation utilities for the edit-margin UI.
+ * Mirrors the logic from @metamask/perps-controller (not exported from package).
+ *
+ * HyperLiquid: transfer_margin_required = max(initial_margin_required, 0.1 × total_position_value)
+ * See: https://hyperliquid.gitbook.io/hyperliquid-docs/trading/margin-and-pnl
+ */
+
+import { MARGIN_ADJUSTMENT_CONFIG } from '@metamask/perps-controller';
+
+export type RiskLevel = 'safe' | 'warning' | 'danger';
+
+export type MarginRiskAssessment = {
+  riskLevel: RiskLevel;
+  priceDiff: number;
+  riskRatio: number;
+};
+
+export type AssessMarginRemovalRiskParams = {
+  newLiquidationPrice: number;
+  currentPrice: number;
+  isLong: boolean;
+};
+
+export type CalculateMaxRemovableMarginParams = {
+  currentMargin: number;
+  positionSize: number;
+  entryPrice: number;
+  currentPrice: number;
+  positionLeverage: number;
+  notionalValue?: number;
+};
+
+export type CalculateNewLiquidationPriceParams = {
+  newMargin: number;
+  positionSize: number;
+  entryPrice: number;
+  isLong: boolean;
+  currentLiquidationPrice: number;
+};
+
+/**
+ * Assess liquidation risk after margin removal.
+ */
+export function assessMarginRemovalRisk(
+  params: AssessMarginRemovalRiskParams,
+): MarginRiskAssessment {
+  const { newLiquidationPrice, currentPrice, isLong } = params;
+  if (
+    !newLiquidationPrice ||
+    !currentPrice ||
+    Number.isNaN(newLiquidationPrice) ||
+    Number.isNaN(currentPrice)
+  ) {
+    return { riskLevel: 'safe', priceDiff: 0, riskRatio: 0 };
+  }
+  const priceDiff = isLong
+    ? currentPrice - newLiquidationPrice
+    : newLiquidationPrice - currentPrice;
+  const riskRatio = priceDiff / newLiquidationPrice;
+  let riskLevel: RiskLevel;
+  if (
+    riskRatio <
+    (MARGIN_ADJUSTMENT_CONFIG.LiquidationRiskThreshold as number) - 1
+  ) {
+    riskLevel = 'danger';
+  } else if (
+    riskRatio <
+    (MARGIN_ADJUSTMENT_CONFIG.LiquidationWarningThreshold as number) - 1
+  ) {
+    riskLevel = 'warning';
+  } else {
+    riskLevel = 'safe';
+  }
+  return { riskLevel, priceDiff, riskRatio };
+}
+
+/**
+ * Calculate maximum margin that can be safely removed from a position.
+ */
+export function calculateMaxRemovableMargin(
+  params: CalculateMaxRemovableMarginParams,
+): number {
+  const {
+    currentMargin,
+    positionSize,
+    currentPrice,
+    positionLeverage,
+    notionalValue: providedNotionalValue,
+  } = params;
+
+  if (
+    Number.isNaN(currentMargin) ||
+    Number.isNaN(positionLeverage) ||
+    currentMargin <= 0 ||
+    positionLeverage <= 0
+  ) {
+    return 0;
+  }
+
+  let notionalValue = providedNotionalValue;
+  if (
+    notionalValue === undefined ||
+    Number.isNaN(notionalValue) ||
+    notionalValue <= 0
+  ) {
+    if (
+      Number.isNaN(positionSize) ||
+      Number.isNaN(currentPrice) ||
+      positionSize <= 0 ||
+      currentPrice <= 0
+    ) {
+      return 0;
+    }
+    notionalValue = positionSize * currentPrice;
+  }
+
+  const initialMarginRequired = notionalValue / positionLeverage;
+  const tenPercentMargin =
+    notionalValue *
+    (MARGIN_ADJUSTMENT_CONFIG.MarginRemovalSafetyBuffer as number);
+  const transferMarginRequired = Math.max(
+    initialMarginRequired,
+    tenPercentMargin,
+  );
+  return Math.max(0, currentMargin - transferMarginRequired);
+}
+
+/**
+ * Calculate new liquidation price after margin adjustment.
+ */
+export function calculateNewLiquidationPrice(
+  params: CalculateNewLiquidationPriceParams,
+): number {
+  const {
+    newMargin,
+    positionSize,
+    entryPrice,
+    isLong,
+    currentLiquidationPrice,
+  } = params;
+
+  if (
+    Number.isNaN(newMargin) ||
+    Number.isNaN(positionSize) ||
+    Number.isNaN(entryPrice) ||
+    newMargin <= 0 ||
+    positionSize <= 0 ||
+    entryPrice <= 0
+  ) {
+    return currentLiquidationPrice;
+  }
+
+  const marginPerUnit = newMargin / positionSize;
+  if (isLong) {
+    return Math.max(0, entryPrice - marginPerUnit);
+  }
+  return entryPrice + marginPerUnit;
+}

--- a/ui/hooks/perps/usePerpsMarginCalculations.test.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { usePerpsMarginCalculations } from './usePerpsMarginCalculations';
 import { mockPositions, mockAccountState } from '../../components/app/perps/mocks';
 

--- a/ui/hooks/perps/usePerpsMarginCalculations.test.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.test.ts
@@ -1,0 +1,188 @@
+import { renderHook } from '@testing-library/react';
+import { usePerpsMarginCalculations } from './usePerpsMarginCalculations';
+import { mockPositions, mockAccountState } from '../../components/app/perps/mocks';
+
+describe('usePerpsMarginCalculations', () => {
+  const position = mockPositions[0]; // ETH long, marginUsed 2375, leverage 3
+  const currentPrice = 2900;
+  const account = mockAccountState;
+
+  describe('add mode', () => {
+    it('returns available balance as maxAmount', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '0',
+        }),
+      );
+
+      expect(result.current.maxAmount).toBe(
+        parseFloat(mockAccountState.availableBalance),
+      );
+    });
+
+    it('returns null riskAssessment in add mode', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '100',
+        }),
+      );
+
+      expect(result.current.riskAssessment).toBeNull();
+    });
+
+    it('isValid is true when amount is between min and max', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '500',
+        }),
+      );
+
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('isValid is false when amount is zero', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '0',
+        }),
+      );
+
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it('computes currentLiquidationDistance from position', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '100',
+        }),
+      );
+
+      const liqPrice = parseFloat(position.liquidationPrice ?? '0');
+      const expected =
+        (Math.abs(currentPrice - liqPrice) / currentPrice) * 100;
+      expect(result.current.currentLiquidationDistance).toBeCloseTo(expected);
+    });
+  });
+
+  describe('remove mode', () => {
+    it('returns maxRemovable as maxAmount', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'remove',
+          amount: '0',
+        }),
+      );
+
+      expect(result.current.maxAmount).toBeGreaterThanOrEqual(0);
+      expect(typeof result.current.maxAmount).toBe('number');
+    });
+
+    it('returns riskAssessment when amount is set in remove mode', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'remove',
+          amount: '500',
+        }),
+      );
+
+      expect(result.current.riskAssessment).toEqual(
+        expect.objectContaining({
+          riskLevel: expect.stringMatching(/^(safe|warning|danger)$/),
+          priceDiff: expect.any(Number),
+          riskRatio: expect.any(Number),
+        }),
+      );
+    });
+
+    it('isValid is false when remove amount exceeds maxAmount', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account,
+          mode: 'remove',
+          amount: '999999',
+        }),
+      );
+
+      expect(result.current.isValid).toBe(false);
+    });
+  });
+
+  describe('with null account', () => {
+    it('returns maxAmount 0 in add mode', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account: null,
+          mode: 'add',
+          amount: '100',
+        }),
+      );
+
+      expect(result.current.maxAmount).toBe(0);
+    });
+  });
+
+  describe('with position that has no liquidation price', () => {
+    const positionNoLiq = {
+      ...mockPositions[0],
+      liquidationPrice: null as string | null,
+    };
+
+    it('returns currentLiquidationDistance 0', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position: positionNoLiq,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '0',
+        }),
+      );
+
+      expect(result.current.currentLiquidationDistance).toBe(0);
+    });
+
+    it('returns newLiquidationPrice null when current liq is null', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position: positionNoLiq,
+          currentPrice,
+          account,
+          mode: 'add',
+          amount: '100',
+        }),
+      );
+
+      expect(result.current.newLiquidationPrice).toBeNull();
+    });
+  });
+});

--- a/ui/hooks/perps/usePerpsMarginCalculations.test.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
+import {
+  mockPositions,
+  mockAccountState,
+} from '../../components/app/perps/mocks';
 import { usePerpsMarginCalculations } from './usePerpsMarginCalculations';
-import { mockPositions, mockAccountState } from '../../components/app/perps/mocks';
 
 describe('usePerpsMarginCalculations', () => {
   const position = mockPositions[0]; // ETH long, marginUsed 2375, leverage 3
@@ -78,8 +81,7 @@ describe('usePerpsMarginCalculations', () => {
       );
 
       const liqPrice = parseFloat(position.liquidationPrice ?? '0');
-      const expected =
-        (Math.abs(currentPrice - liqPrice) / currentPrice) * 100;
+      const expected = (Math.abs(currentPrice - liqPrice) / currentPrice) * 100;
       expect(result.current.currentLiquidationDistance).toBeCloseTo(expected);
     });
   });
@@ -113,7 +115,7 @@ describe('usePerpsMarginCalculations', () => {
 
       expect(result.current.riskAssessment).toEqual(
         expect.objectContaining({
-          riskLevel: expect.stringMatching(/^(safe|warning|danger)$/),
+          riskLevel: expect.stringMatching(/^(safe|warning|danger)$/u),
           priceDiff: expect.any(Number),
           riskRatio: expect.any(Number),
         }),

--- a/ui/hooks/perps/usePerpsMarginCalculations.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.ts
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import { MARGIN_ADJUSTMENT_CONFIG } from '@metamask/perps-controller';
+import type { Position, AccountState } from '../../components/app/perps/types';
+
+import {
+  calculateMaxRemovableMargin,
+  calculateNewLiquidationPrice,
+  assessMarginRemovalRisk,
+} from './marginUtils';
+import type { MarginRiskAssessment } from './marginUtils';
+
+export type { MarginRiskAssessment } from './marginUtils';
+
+export type UsePerpsMarginCalculationsParams = {
+  position: Position;
+  currentPrice: number;
+  account: AccountState | null;
+  mode: 'add' | 'remove';
+  amount: string;
+};
+
+export type UsePerpsMarginCalculationsReturn = {
+  maxAmount: number;
+  newLiquidationPrice: number | null;
+  currentLiquidationDistance: number;
+  newLiquidationDistance: number | null;
+  riskAssessment: MarginRiskAssessment | null;
+  isValid: boolean;
+};
+
+/**
+ * Compute max addable/removable margin, new liquidation price, distances, and risk.
+ * Used by the edit margin expandable to drive the info panel and validation.
+ */
+export function usePerpsMarginCalculations({
+  position,
+  currentPrice,
+  account,
+  mode,
+  amount,
+}: UsePerpsMarginCalculationsParams): UsePerpsMarginCalculationsReturn {
+  return useMemo(() => {
+    const currentMargin = parseFloat(position.marginUsed) || 0;
+    const positionSize = Math.abs(parseFloat(position.size)) || 0;
+    const entryPrice = parseFloat(position.entryPrice) || 0;
+    const positionLeverage =
+      position.leverage?.value ?? MARGIN_ADJUSTMENT_CONFIG.FallbackMaxLeverage;
+    const currentLiqPrice = position.liquidationPrice
+      ? parseFloat(position.liquidationPrice)
+      : null;
+    const isLong = parseFloat(position.size) >= 0;
+    const availableBalance = account
+      ? parseFloat(account.availableBalance) || 0
+      : 0;
+    const notionalValue = parseFloat(position.positionValue) || 0;
+
+    const maxAmount =
+      mode === 'add'
+        ? availableBalance
+        : Math.max(
+            0,
+            calculateMaxRemovableMargin({
+              currentMargin,
+              positionSize,
+              entryPrice,
+              currentPrice,
+              positionLeverage,
+              notionalValue: notionalValue || undefined,
+            }),
+          );
+
+    const amountNum = parseFloat(amount) || 0;
+    const newMargin =
+      mode === 'add' ? currentMargin + amountNum : currentMargin - amountNum;
+
+    let newLiquidationPrice: number | null = null;
+    if (currentLiqPrice !== null && newMargin > 0 && positionSize > 0) {
+      newLiquidationPrice = calculateNewLiquidationPrice({
+        newMargin,
+        positionSize,
+        entryPrice,
+        isLong,
+        currentLiquidationPrice: currentLiqPrice,
+      });
+    }
+
+    const currentLiquidationDistance =
+      currentPrice > 0 && currentLiqPrice !== null
+        ? (Math.abs(currentPrice - currentLiqPrice) / currentPrice) * 100
+        : 0;
+
+    let newLiquidationDistance: number | null = null;
+    if (
+      currentPrice > 0 &&
+      newLiquidationPrice !== null &&
+      Number.isFinite(newLiquidationPrice)
+    ) {
+      newLiquidationDistance =
+        (Math.abs(currentPrice - newLiquidationPrice) / currentPrice) * 100;
+    }
+
+    let riskAssessment: MarginRiskAssessment | null = null;
+    if (
+      mode === 'remove' &&
+      newLiquidationPrice !== null &&
+      Number.isFinite(newLiquidationPrice)
+    ) {
+      riskAssessment = assessMarginRemovalRisk({
+        newLiquidationPrice,
+        currentPrice,
+        isLong,
+      });
+    }
+
+    const minAdjustment = MARGIN_ADJUSTMENT_CONFIG.MinAdjustmentAmount;
+    const isValid =
+      amountNum >= minAdjustment &&
+      amountNum <= maxAmount &&
+      (mode === 'add' || amountNum <= currentMargin);
+
+    return {
+      maxAmount,
+      newLiquidationPrice,
+      currentLiquidationDistance,
+      newLiquidationDistance,
+      riskAssessment,
+      isValid,
+    };
+  }, [
+    position.marginUsed,
+    position.size,
+    position.entryPrice,
+    position.positionValue,
+    position.leverage?.value,
+    position.liquidationPrice,
+    currentPrice,
+    account,
+    mode,
+    amount,
+  ]);
+}

--- a/ui/hooks/perps/usePerpsMarginCalculations.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.ts
@@ -31,6 +31,14 @@ export type UsePerpsMarginCalculationsReturn = {
 /**
  * Compute max addable/removable margin, new liquidation price, distances, and risk.
  * Used by the edit margin expandable to drive the info panel and validation.
+ *
+ * @param options0 - The hook parameters
+ * @param options0.position - The current position to adjust margin for
+ * @param options0.currentPrice - The current market price
+ * @param options0.account - The user's account state (null if not loaded)
+ * @param options0.mode - Whether adding or removing margin
+ * @param options0.amount - The margin adjustment amount as a string
+ * @returns Computed margin calculations including max amount, liquidation data, and validation
  */
 export function usePerpsMarginCalculations({
   position,

--- a/ui/pages/perps/perps-home-page.tsx
+++ b/ui/pages/perps/perps-home-page.tsx
@@ -267,6 +267,7 @@ const PerpsHomePage: React.FC = () => {
               const isLong = parseFloat(position.size) >= 0;
               const pnlValue = parseFloat(position.unrealizedPnl);
               const isProfit = pnlValue >= 0;
+              const leverage = position.leverage?.value ?? 1;
 
               return (
                 <Box
@@ -290,7 +291,7 @@ const PerpsHomePage: React.FC = () => {
                       variant={TextVariant.BodySm}
                       fontWeight={FontWeight.Medium}
                     >
-                      {displaySymbol} |{' '}
+                      {displaySymbol} {leverage}x{' '}
                       {isLong ? t('perpsLong') : t('perpsShort')}
                     </Text>
                     <Text

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import mockState from '../../../test/data/mock-state.json';
 import {
@@ -292,6 +293,32 @@ describe('PerpsMarketDetailPage', () => {
       );
 
       expect(getByText('Learn the basics of perps')).toBeInTheDocument();
+    });
+
+    it('expands edit margin section when margin card is clicked', () => {
+      const store = mockStore(createMockState(true));
+
+      renderWithProvider(<PerpsMarketDetailPage />, store);
+
+      expect(screen.queryByText('Add Margin')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Margin'));
+
+      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+      expect(screen.getByText('Remove Margin')).toBeInTheDocument();
+    });
+
+    it('collapses margin section when auto close is opened (mutual exclusion)', () => {
+      const store = mockStore(createMockState(true));
+
+      renderWithProvider(<PerpsMarketDetailPage />, store);
+
+      fireEvent.click(screen.getByText('Margin'));
+      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Auto close'));
+      expect(screen.getByText('Take Profit')).toBeInTheDocument();
+      expect(screen.getByText('Stop Loss')).toBeInTheDocument();
     });
   });
 

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -260,7 +260,9 @@ describe('PerpsMarketDetailPage', () => {
       expect(getByText('Entry price')).toBeInTheDocument();
       // 'Liquidation price' appears in both the Details section and the
       // Edit Margin expandable, so use getAllByText
-      expect(getAllByText('Liquidation price').length).toBeGreaterThanOrEqual(1);
+      expect(getAllByText('Liquidation price').length).toBeGreaterThanOrEqual(
+        1,
+      );
     });
 
     it('displays stats section', () => {

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -250,7 +250,7 @@ describe('PerpsMarketDetailPage', () => {
     it('displays position details section', () => {
       const store = mockStore(createMockState(true));
 
-      const { getByText } = renderWithProvider(
+      const { getByText, getAllByText } = renderWithProvider(
         <PerpsMarketDetailPage />,
         store,
       );
@@ -258,7 +258,9 @@ describe('PerpsMarketDetailPage', () => {
       expect(getByText('Details')).toBeInTheDocument();
       expect(getByText('Direction')).toBeInTheDocument();
       expect(getByText('Entry price')).toBeInTheDocument();
-      expect(getByText('Liquidation price')).toBeInTheDocument();
+      // 'Liquidation price' appears in both the Details section and the
+      // Edit Margin expandable, so use getAllByText
+      expect(getAllByText('Liquidation price').length).toBeGreaterThanOrEqual(1);
     });
 
     it('displays stats section', () => {
@@ -300,11 +302,13 @@ describe('PerpsMarketDetailPage', () => {
 
       renderWithProvider(<PerpsMarketDetailPage />, store);
 
-      expect(screen.queryByText('Add Margin')).not.toBeInTheDocument();
-
+      // The Edit Margin expandable is rendered but collapsed (hidden via CSS grid)
+      // Before expanding, the 'Add Margin' text exists in the DOM but is not visible
       fireEvent.click(screen.getByText('Margin'));
 
-      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+      // After expanding, both the mode toggle and confirm button show 'Add Margin'
+      const addMarginElements = screen.getAllByText('Add Margin');
+      expect(addMarginElements.length).toBeGreaterThanOrEqual(2);
       expect(screen.getByText('Remove Margin')).toBeInTheDocument();
     });
 
@@ -314,7 +318,8 @@ describe('PerpsMarketDetailPage', () => {
       renderWithProvider(<PerpsMarketDetailPage />, store);
 
       fireEvent.click(screen.getByText('Margin'));
-      expect(screen.getByText('Add Margin')).toBeInTheDocument();
+      const addMarginElements = screen.getAllByText('Add Margin');
+      expect(addMarginElements.length).toBeGreaterThanOrEqual(1);
 
       fireEvent.click(screen.getByText('Auto close'));
       expect(screen.getByText('Take Profit')).toBeInTheDocument();

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -544,7 +544,6 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Handle form state changes from OrderEntry
   const handleFormStateChange = useCallback((formState: OrderFormState) => {
-    console.log('[Perps] handleFormStateChange:', formState.amount, formState);
     setOrderFormState(formState);
   }, []);
 
@@ -566,14 +565,7 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Handle order submission
   const handleOrderSubmit = useCallback(async () => {
-    console.log('[Perps] handleOrderSubmit called');
-    console.log('[Perps] orderFormState:', orderFormState);
-    console.log('[Perps] orderMode:', orderMode);
-
     if (!orderFormState || !selectedAddress) {
-      console.log(
-        '[Perps] Early return - missing orderFormState or selectedAddress',
-      );
       return;
     }
 
@@ -626,18 +618,12 @@ const PerpsMarketDetailPage: React.FC = () => {
           orderMode,
           position?.size,
         );
-        console.log('[Perps] Placing order with params:', orderParams);
         const result = await controller.placeOrder(orderParams);
-        console.log('[Perps] Order result:', result);
         if (!result.success) {
           throw new Error(result.error || 'Failed to place order');
         }
 
         // Set pending state - wait for position to appear in stream before navigating
-        console.log(
-          '[Perps] Setting pending order symbol:',
-          orderFormState.asset,
-        );
         setPendingOrderSymbol(orderFormState.asset);
         return; // Don't navigate yet, wait for stream confirmation
       }
@@ -649,7 +635,6 @@ const PerpsMarketDetailPage: React.FC = () => {
       const errorMessage =
         error instanceof Error ? error.message : 'An unknown error occurred';
       setSubmitError(errorMessage);
-      console.error('Order submission failed:', error);
     } finally {
       setIsSubmitting(false);
     }
@@ -661,13 +646,6 @@ const PerpsMarketDetailPage: React.FC = () => {
   const hasInitializedTpsl = useRef(false);
 
   useEffect(() => {
-    console.log(
-      '[Perps] Init effect - isAutoCloseExpanded:',
-      isAutoCloseExpanded,
-      'hasInitialized:',
-      hasInitializedTpsl.current,
-    );
-
     // Reset the initialization flag when card is collapsed
     if (!isAutoCloseExpanded) {
       hasInitializedTpsl.current = false;
@@ -676,10 +654,6 @@ const PerpsMarketDetailPage: React.FC = () => {
 
     // Only initialize once when the card is first expanded
     if (isAutoCloseExpanded && position && !hasInitializedTpsl.current) {
-      console.log('[Perps] Initializing TP/SL from position:', {
-        tp: position.takeProfitPrice,
-        sl: position.stopLossPrice,
-      });
       setEditingTpPrice(position.takeProfitPrice ?? '');
       setEditingSlPrice(position.stopLossPrice ?? '');
       setTpslError(null);
@@ -696,7 +670,6 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Handle margin card toggle (expand/collapse edit margin section)
   const handleMarginToggle = useCallback(() => {
-    console.log('[Perps] handleMarginToggle called');
     setIsMarginExpanded((prev) => !prev);
     setIsAutoCloseExpanded(false);
   }, []);
@@ -727,9 +700,7 @@ const PerpsMarketDetailPage: React.FC = () => {
         stopLossPrice: cleanSlPrice || undefined,
       };
 
-      console.log('[Perps] Updating TP/SL with params:', tpslParams);
       const result = await controller.updatePositionTPSL(tpslParams);
-      console.log('[Perps] TP/SL update result:', result);
       if (!result.success) {
         throw new Error(result.error || 'Failed to update TP/SL');
       }
@@ -807,22 +778,12 @@ const PerpsMarketDetailPage: React.FC = () => {
       return;
     }
 
-    console.log(
-      '[Perps] Watching for position, pendingOrderSymbol:',
-      pendingOrderSymbol,
-    );
-    console.log(
-      '[Perps] Current allPositions symbols:',
-      allPositions.map((p) => p.symbol),
-    );
-
     // Check if position for this symbol now exists
     const hasPosition = allPositions.some(
       (p) => p.symbol === pendingOrderSymbol,
     );
 
     if (hasPosition) {
-      console.log('[Perps] Position found! Navigating to detail view');
       // Position confirmed - clear pending and navigate to detail view
       setPendingOrderSymbol(null);
       setIsSubmitting(false);
@@ -838,9 +799,6 @@ const PerpsMarketDetailPage: React.FC = () => {
     }
 
     const timeout = setTimeout(() => {
-      console.warn(
-        '[Perps] Position stream confirmation timed out, navigating anyway',
-      );
       setPendingOrderSymbol(null);
       setIsSubmitting(false);
       setCurrentView('detail');

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -62,6 +62,7 @@ import {
   type OrderFormState,
   type OrderMode,
 } from '../../components/app/perps/order-entry';
+import { EditMarginExpandable } from '../../components/app/perps/edit-margin';
 import type { OrderType, OrderParams } from '../../components/app/perps/types';
 import { TextField, TextFieldSize } from '../../components/component-library';
 import {
@@ -254,6 +255,7 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Auto close card expansion state
   const [isAutoCloseExpanded, setIsAutoCloseExpanded] = useState(false);
+  const [isMarginExpanded, setIsMarginExpanded] = useState(false);
   const [editingTpPrice, setEditingTpPrice] = useState<string>('');
   const [editingSlPrice, setEditingSlPrice] = useState<string>('');
   const [isSavingTPSL, setIsSavingTPSL] = useState(false);
@@ -688,7 +690,15 @@ const PerpsMarketDetailPage: React.FC = () => {
   // Handle auto close card toggle
   const handleAutoCloseToggle = useCallback(() => {
     setIsAutoCloseExpanded((prev) => !prev);
+    setIsMarginExpanded(false);
     setTpslError(null);
+  }, []);
+
+  // Handle margin card toggle (expand/collapse edit margin section)
+  const handleMarginToggle = useCallback(() => {
+    console.log('[Perps] handleMarginToggle called');
+    setIsMarginExpanded((prev) => !prev);
+    setIsAutoCloseExpanded(false);
   }, []);
 
   // Handle saving TP/SL changes
@@ -1289,9 +1299,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Box
                     className="flex-1 cursor-pointer rounded-xl bg-muted px-4 py-3 hover:bg-muted-hover active:bg-muted-pressed"
                     flexDirection={BoxFlexDirection.Column}
-                    onClick={() => {
-                      // TODO: Handle margin card press
-                    }}
+                    onClick={handleMarginToggle}
                   >
                     <Box paddingBottom={1}>
                       <Text
@@ -1309,6 +1317,18 @@ const PerpsMarketDetailPage: React.FC = () => {
                     </Text>
                   </Box>
                 </Box>
+
+                {/* Edit Margin - Expandable (full width) */}
+                {position && selectedAddress && (
+                  <EditMarginExpandable
+                    position={position}
+                    account={account}
+                    currentPrice={currentPrice}
+                    selectedAddress={selectedAddress}
+                    isExpanded={isMarginExpanded}
+                    onToggle={handleMarginToggle}
+                  />
+                )}
 
                 {/* Third Row: Auto Close (Full Width) - Expandable */}
                 <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39951?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new margin-adjustment UI that calls `perps-controller` to update position margin and pushes fresh positions into the stream; incorrect calculation/validation could lead to confusing or risky UX (though core trading logic remains in the controller).
> 
> **Overview**
> Adds a new **Perps “Edit Margin” expandable** on the market detail page, letting users switch between *Add*/*Remove* margin, enter an amount (with presets), see updated liquidation price/distance, and submit changes via `controller.updateMargin` (refreshing positions in the stream and showing errors/risk warnings).
> 
> Introduces `usePerpsMarginCalculations` + `marginUtils` to compute max addable/removable amounts, projected liquidation metrics, and removal risk levels (mirroring controller config thresholds), and wires new i18n strings for the margin UI.
> 
> Also tightens related perps UI behavior/tests: margin vs auto-close expanders are mutually exclusive, modify-mode leverage slider now enforces a minimum leverage equal to the existing position, home positions list shows leverage, and several tests/baselines/mocks are updated (including removing noisy console logs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54b61b2f9d670eb87f6a2b2948ba3b8dab591d9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->