### PR TITLE
bump(ci): update to the newest versions of all actions packages

### DIFF
--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -12,7 +12,7 @@ jobs:
       semver: ${{ steps.out.outputs.semver }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: out
         shell: bash

--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # We don't want to use action-checkout-and-setup here because it forces `yarn --immutable`
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up Node.js
         if: ${{ steps.prevent-loops.outputs.stop_loop != 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: yarn

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -63,7 +63,7 @@ jobs:
       previous_ref: ${{ steps.out.outputs.previous_ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: out
         shell: bash

--- a/.github/workflows/crowdin-action.yml
+++ b/.github/workflows/crowdin-action.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -146,7 +146,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: .
           pattern: test-e2e-chrome*
@@ -156,7 +156,7 @@ jobs:
         run: yarn tsx .github/scripts/create-e2e-test-report.ts
 
       - name: Upload test runs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-e2e-chrome-report
           path: ${{ env.TEST_RUNS_PATH }}

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -103,7 +103,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: .
           pattern: test-e2e-firefox*
@@ -113,7 +113,7 @@ jobs:
         run: yarn tsx .github/scripts/create-e2e-test-report.ts
 
       - name: Upload test runs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-e2e-firefox-report
           path: ${{ env.TEST_RUNS_PATH }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -329,7 +329,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-dist-browserify
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
@@ -437,7 +437,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-dist-browserify
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
@@ -487,7 +487,7 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         id: download-changed-files
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: changed-files
           path: ./changed-files/
@@ -515,7 +515,7 @@ jobs:
 
       - name: Download artifact 'build-dist-browserify'
         if: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-dist-browserify
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.

--- a/.github/workflows/page-load-benchmark.yml
+++ b/.github/workflows/page-load-benchmark.yml
@@ -42,7 +42,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download artifact 'build-test-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-test-browserify
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
@@ -55,7 +55,7 @@ jobs:
         run: yarn test:e2e:benchmark --preset=pageLoadBenchmark
 
       - name: Upload benchmark results (github artifacts)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: page-load-benchmark-results
           path: test-artifacts/benchmarks/page-load-benchmark-results.json

--- a/.github/workflows/prep-e2e.yml
+++ b/.github/workflows/prep-e2e.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn tsx .github/scripts/git-diff-default-branch.ts
 
       - name: Upload changed files artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: changed-files
           path: ./changed-files/
@@ -44,7 +44,7 @@ jobs:
 
       - name: Download test-e2e-chrome-report
         if: ${{ steps.get-last-completed-main-workflow.outputs.LAST_COMPLETED_MAIN_WORKFLOW != 'null'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-e2e-chrome-report
           path: test/test-results/
@@ -53,7 +53,7 @@ jobs:
 
       - name: Download test-e2e-firefox-report
         if: ${{ steps.get-last-completed-main-workflow.outputs.LAST_COMPLETED_MAIN_WORKFLOW != 'null'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-e2e-firefox-report
           path: test/test-results/
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload test-runs-for-splitting
         if: ${{ steps.get-last-completed-main-workflow.outputs.LAST_COMPLETED_MAIN_WORKFLOW != 'null'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-runs-for-splitting
           path: test/test-results/test-runs-*.json

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Find the associated PR
         if: ${{ startsWith(env.BRANCH, 'release/') && (!env.PR_NUMBER || !env.BASE_COMMIT_HASH || !env.HEAD_COMMIT_HASH) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prs = await github.rest.pulls.list({
@@ -75,7 +75,7 @@ jobs:
 
       - name: Download page load benchmark results
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: page-load-benchmark-results
           path: test-artifacts/benchmarks

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,7 +72,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: build-dist-browserify
           name: build-dist-browserify
@@ -81,7 +81,7 @@ jobs:
         run: yarn sentry:publish --dist-directory build-dist-browserify/dist
 
       - name: Download artifact 'build-dist-mv2-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: build-dist-mv2-browserify
           name: build-dist-mv2-browserify
@@ -90,7 +90,7 @@ jobs:
         run: yarn sentry:publish --dist mv2 --dist-directory build-dist-mv2-browserify/dist
 
       - name: Download artifact 'build-flask-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: build-flask-browserify
           name: build-flask-browserify
@@ -99,7 +99,7 @@ jobs:
         run: yarn sentry:publish --build-type flask --dist-directory build-flask-browserify/dist
 
       - name: Download artifact 'build-flask-mv2-browserify'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: build-flask-mv2-browserify
           name: build-flask-mv2-browserify

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('yarn.lock') }}
@@ -88,7 +88,7 @@ jobs:
         run: yarn mm-foundryup
 
       - name: Download artifact '${{ env.ARTIFACT_NAME }}'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -110,7 +110,7 @@ jobs:
         run: yarn mozilla-lint
 
       - name: Upload artifact '${{ inputs.build-name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.build-name }}
           path: |

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('yarn.lock') }}
@@ -100,7 +100,7 @@ jobs:
         if: ${{ inputs.build-artifact != '' }}
         id: download-build-artifact
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
@@ -117,7 +117,7 @@ jobs:
         if: ${{ env.BRANCH != 'main' }}
         id: download-changed-files
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: changed-files
           path: ./changed-files/
@@ -127,7 +127,7 @@ jobs:
         if: ${{ steps.download-changed-files.outcome == 'failure' }}
 
       - name: Download test-runs-for-splitting
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: test-runs-for-splitting
@@ -138,7 +138,7 @@ jobs:
         if: ${{ github.run_attempt > 1 }}
         id: download-previous-results
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.JOB_NAME }}
           path: ./previous-test-results/
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.JOB_NAME }}
           path: ${{ inputs.test-artifacts-path }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Rename coverage
         run: mv coverage/unit/coverage-final.json coverage/unit/coverage-unit-${{matrix.shard}}.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage-unit-${{matrix.shard}}
           path: coverage/unit/coverage-unit-${{matrix.shard}}.json
@@ -55,7 +55,7 @@ jobs:
       - name: Rename coverage
         run: mv coverage/webpack/coverage-final.json coverage/webpack/coverage-webpack.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage-webpack
           path: coverage/webpack/coverage-webpack.json
@@ -78,7 +78,7 @@ jobs:
       - name: Rename coverage
         run: mv coverage/integration/coverage-final.json coverage/integration/coverage-integration.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage-integration
           path: coverage/integration/coverage-integration.json
@@ -104,7 +104,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: coverage
           pattern: coverage-*
@@ -113,7 +113,7 @@ jobs:
       - name: Merge coverage reports
         run: yarn nyc merge coverage .nyc_output/coverage-final.json && yarn nyc report --reporter lcov
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: lcov.info
           path: coverage/lcov.info

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,14 +28,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }} # Use the repository that triggered the workflow
           ref: ${{ github.event.workflow_run.head_branch }} # Use the branch that triggered the workflow
           fetch-depth: 0 # Shallow clones should be disabled for better relevancy of analysis
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: lcov.info
           path: coverage

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -17,7 +17,7 @@ jobs:
       next-version: ${{ env.NEXT_SEMVER_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag-release-branch.yml
+++ b/.github/workflows/tag-release-branch.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Using version: ${VERSION}"
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -30,7 +30,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: React to the comment
         run: |
           gh api \
@@ -55,7 +55,7 @@ jobs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -82,7 +82,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -97,7 +97,7 @@ jobs:
       - name: Generate Attributions
         run: yarn attributions:generate
       - name: Cache attributions file
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -113,7 +113,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Restore attributions file
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -185,7 +185,7 @@ jobs:
       - is-fork-pull-request
       - check-status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post comment if the update failed

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -23,7 +23,7 @@ jobs:
       STORED_COVERAGE: ${{ needs.run-tests.outputs.stored-coverage }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
 

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
@@ -81,7 +81,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -97,7 +97,7 @@ jobs:
         run: yarn lavamoat:build:auto
 
       - name: Cache build policy
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -115,7 +115,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -128,7 +128,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Restore build policy
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -138,7 +138,7 @@ jobs:
         run: yarn lavamoat:webapp:auto
 
       - name: Cache webapp application policy
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: lavamoat/browserify
           key: cache-webapp-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -155,7 +155,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -171,7 +171,7 @@ jobs:
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:build
 
       - name: Cache webpack build policy
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: lavamoat/webpack/build
           key: cache-webpack-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -189,7 +189,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -202,7 +202,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Restore webpack build policy
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/webpack/build
           key: cache-webpack-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -212,7 +212,7 @@ jobs:
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:mv2
 
       - name: Cache webpack MV2 policy
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: lavamoat/webpack/mv2
           key: cache-webpack-mv2-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -230,7 +230,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -243,7 +243,7 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Restore webpack build policy
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/webpack/build
           key: cache-webpack-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -253,7 +253,7 @@ jobs:
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:mv3
 
       - name: Cache webpack MV3 policy
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: lavamoat/webpack/mv3
           key: cache-webpack-mv3-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -279,7 +279,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
@@ -290,7 +290,7 @@ jobs:
 
       - name: Restore browserify build policy
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/build-system
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -298,7 +298,7 @@ jobs:
 
       - name: Restore browserify webapp policy
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/browserify
           key: cache-webapp-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -306,7 +306,7 @@ jobs:
 
       - name: Restore webpack build policy
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/webpack/build
           key: cache-webpack-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -314,7 +314,7 @@ jobs:
 
       - name: Restore webpack MV2 policy
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/webpack/mv2
           key: cache-webpack-mv2-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -322,7 +322,7 @@ jobs:
 
       - name: Restore webpack MV3 policy
         if: ${{ env.UPSTREAM_SUCCESS == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: lavamoat/webpack/mv3
           key: cache-webpack-mv3-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-onboarding-fixture.yml
+++ b/.github/workflows/update-onboarding-fixture.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine whether this PR is from a fork
         id: is-fork
@@ -32,7 +32,7 @@ jobs:
     environment: default-branch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: React to the comment
         run: |
@@ -59,7 +59,7 @@ jobs:
       BRANCH: ${{ steps.branch.outputs.BRANCH }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -113,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
 
       - name: Cache dist artifact
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: build-dist-browserify
           key: dist-${{ steps.commit-sha.outputs.COMMIT_SHA }}
@@ -131,7 +131,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.BRANCH }}
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('yarn.lock') }}
@@ -155,7 +155,7 @@ jobs:
         run: yarn mm-foundryup
 
       - name: Restore dist artifact
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: build-dist-browserify
           key: dist-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-artifacts-fixture-update
           path: |
@@ -183,7 +183,7 @@ jobs:
             ./test/test-results/e2e
 
       - name: Cache updated fixture
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: test/e2e/fixtures/onboarding-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -200,7 +200,7 @@ jobs:
     environment: default-branch
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
 
@@ -211,7 +211,7 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
 
       - name: Restore updated fixture
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: test/e2e/fixtures/onboarding-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -278,7 +278,7 @@ jobs:
       - check-status
     environment: default-branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
 


### PR DESCRIPTION
## **Description**

All GitHub Actions packages are now the newest versions:
- actions/checkout@v6
- actions/setup-node@v6
- actions/download-artifact@v7
- actions/upload-artifact@v6 <-- this mismatch is interesting 🙁 
- actions/github-script@v8
- actions/cache/restore@v5
- actions/cache/save@v5

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadly touches many CI workflows; while changes are mostly version bumps, new major versions can subtly change artifact/caching behavior and impact pipeline reliability.
> 
> **Overview**
> Updates GitHub Actions used throughout `.github/workflows` to their latest major versions (e.g., `actions/checkout@v6`, `actions/setup-node@v6`, `actions/download-artifact@v7`, `actions/upload-artifact@v6`, `actions/cache/*@v5`, `actions/github-script@v8`).
> 
> This is a repo-wide CI/automation maintenance change affecting build/test, artifact upload/download, caching, release PR creation/publishing, and bot-driven policy/fixture/attribution update workflows, without modifying application code or workflow logic beyond action version bumps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1719d8a98df575f49530265726273a1ff33b928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->