### PR TITLE
feat: reset user's preferences when resetting wallet

### DIFF
--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -1489,7 +1489,7 @@ describe('preferences controller', () => {
         false,
       );
       expect(controller.state.preferences.showNativeTokenAsMainBalance).toBe(
-        false,
+        true,
       );
       expect(controller.state.preferences.autoLockTimeLimit).toBe(
         DEFAULT_AUTO_LOCK_TIME_LIMIT,

--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -1419,4 +1419,74 @@ describe('preferences controller', () => {
       });
     });
   });
+
+  describe('resetState', () => {
+    it('resets the preferences state to the default values', () => {
+      const { controller } = setupController({
+        state: {
+          currentLocale: 'ja',
+          useBlockie: true,
+          theme: ThemeType.dark,
+          knownMethodData: { '0x12345678': 'transfer' },
+          advancedGasFee: { '0x1': { maxBaseFee: '100', priorityFee: '10' } },
+          preferences: {
+            autoLockTimeLimit: undefined,
+            avatarType: 'jazzicon',
+            showExtensionInFullSizeView: true,
+            privacyMode: true,
+            showFiatInTestnets: true,
+            showTestNetworks: true,
+            smartTransactionsMigrationApplied: false,
+            smartTransactionsOptInStatus: true,
+            useNativeCurrencyAsPrimaryCurrency: true,
+            useSidePanelAsDefault: false,
+            hideZeroBalanceTokens: true,
+            petnamesEnabled: false,
+            skipDeepLinkInterstitial: false,
+            dismissSmartAccountSuggestionEnabled: false,
+            featureNotificationsEnabled: true,
+            showConfirmationAdvancedDetails: true,
+            showMultiRpcModal: false,
+            showNativeTokenAsMainBalance: true,
+            smartAccountOptIn: true,
+            tokenSortConfig: {
+              key: 'tokenFiatAmount',
+              order: 'dsc',
+              sortCallback: 'stringNumeric',
+            },
+            tokenNetworkFilter: {},
+          },
+        },
+      });
+
+      // Verify state was customized
+      expect(controller.state.currentLocale).toBe('ja');
+      expect(controller.state.useBlockie).toBe(true);
+      expect(controller.state.theme).toBe(ThemeType.dark);
+
+      controller.resetState();
+
+      // Verify state was reset to defaults
+      expect(controller.state.currentLocale).toBe('');
+      expect(controller.state.useBlockie).toBe(false);
+      expect(controller.state.theme).toBe(ThemeType.os);
+      expect(controller.state.knownMethodData).toStrictEqual({});
+      expect(controller.state.advancedGasFee).toStrictEqual({});
+      expect(controller.state.preferences.avatarType).toBe('maskicon');
+      expect(controller.state.preferences.privacyMode).toBe(false);
+      expect(controller.state.preferences.showFiatInTestnets).toBe(false);
+      expect(controller.state.preferences.showTestNetworks).toBe(false);
+      expect(controller.state.preferences.hideZeroBalanceTokens).toBe(false);
+      expect(controller.state.preferences.petnamesEnabled).toBe(true);
+      expect(controller.state.preferences.featureNotificationsEnabled).toBe(
+        false,
+      );
+      expect(controller.state.preferences.showConfirmationAdvancedDetails).toBe(
+        false,
+      );
+      expect(controller.state.preferences.showNativeTokenAsMainBalance).toBe(
+        false,
+      );
+    });
+  });
 });

--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -16,8 +16,12 @@ import {
 import type { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
-import { ThemeType } from '../../../shared/constants/preferences';
+import {
+  DEFAULT_AUTO_LOCK_TIME_LIMIT,
+  ThemeType,
+} from '../../../shared/constants/preferences';
 import { DefiReferralPartner } from '../../../shared/constants/defi-referrals';
+import { FALLBACK_LOCALE } from '../../../shared/modules/i18n';
 import type {
   PreferencesControllerMessenger,
   PreferencesControllerState,
@@ -1467,7 +1471,7 @@ describe('preferences controller', () => {
       controller.resetState();
 
       // Verify state was reset to defaults
-      expect(controller.state.currentLocale).toBe('');
+      expect(controller.state.currentLocale).toBe(FALLBACK_LOCALE);
       expect(controller.state.useBlockie).toBe(false);
       expect(controller.state.theme).toBe(ThemeType.os);
       expect(controller.state.knownMethodData).toStrictEqual({});
@@ -1486,6 +1490,9 @@ describe('preferences controller', () => {
       );
       expect(controller.state.preferences.showNativeTokenAsMainBalance).toBe(
         false,
+      );
+      expect(controller.state.preferences.autoLockTimeLimit).toBe(
+        DEFAULT_AUTO_LOCK_TIME_LIMIT,
       );
     });
   });

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -1031,6 +1031,14 @@ export class PreferencesController extends BaseController<
   }
   ///: END:ONLY_INCLUDE_IF
 
+  /**
+   * Resets the preferences state to the default values.
+   * This is used when the wallet is reset during the "Forgot Password" flow.
+   */
+  resetState(): void {
+    this.update(() => getDefaultPreferencesControllerState());
+  }
+
   #handleAccountsControllerSync(
     newAccountsControllerState: AccountsControllerState,
   ): void {

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -18,8 +18,12 @@ import { NetworkControllerGetStateAction } from '@metamask/network-controller';
 import { type PreferencesState } from '@metamask/preferences-controller';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../../../shared/constants/network';
 import { LedgerTransportTypes } from '../../../shared/constants/hardware-wallets';
-import { ThemeType } from '../../../shared/constants/preferences';
+import {
+  DEFAULT_AUTO_LOCK_TIME_LIMIT,
+  ThemeType,
+} from '../../../shared/constants/preferences';
 import { DefiReferralPartner } from '../../../shared/constants/defi-referrals';
+import { FALLBACK_LOCALE } from '../../../shared/modules/i18n';
 
 /**
  * Referral status for an account
@@ -1036,7 +1040,15 @@ export class PreferencesController extends BaseController<
    * This is used when the wallet is reset during the "Forgot Password" flow.
    */
   resetState(): void {
-    this.update(() => getDefaultPreferencesControllerState());
+    const defaultStateWithLocale = {
+      ...getDefaultPreferencesControllerState(),
+      currentLocale: FALLBACK_LOCALE,
+      preferences: {
+        ...getDefaultPreferencesControllerState().preferences,
+        autoLockTimeLimit: DEFAULT_AUTO_LOCK_TIME_LIMIT,
+      },
+    };
+    this.update(() => defaultStateWithLocale);
   }
 
   #handleAccountsControllerSync(

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -1040,15 +1040,17 @@ export class PreferencesController extends BaseController<
    * This is used when the wallet is reset during the "Forgot Password" flow.
    */
   resetState(): void {
-    const defaultStateWithLocale = {
-      ...getDefaultPreferencesControllerState(),
+    const defaultState = getDefaultPreferencesControllerState();
+    const resetState = {
+      ...defaultState,
       currentLocale: FALLBACK_LOCALE,
       preferences: {
-        ...getDefaultPreferencesControllerState().preferences,
+        ...defaultState.preferences,
         autoLockTimeLimit: DEFAULT_AUTO_LOCK_TIME_LIMIT,
+        showNativeTokenAsMainBalance: true,
       },
     };
-    this.update(() => defaultStateWithLocale);
+    this.update(() => resetState);
   }
 
   #handleAccountsControllerSync(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3745,6 +3745,12 @@ export default class MetamaskController extends EventEmitter {
     this.shieldController.clearState();
     this.claimsController.clearState();
 
+    // clear contacts (address book)
+    this.addressBookController.clear();
+
+    // reset preferences to defaults
+    this.preferencesController.resetState();
+
     if (!restoreOnly) {
       // reset onboarding state
       this.onboardingController.resetOnboarding();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user resets their wallet via the "Forgot Password" flow, certain state was not being fully cleared. Specifically, the **PreferencesController** state (locale, theme, blockies, advanced gas fees, known method data, etc.) and the **AddressBookController** state (saved contacts) were persisted across wallet resets, leaking previous wallet configuration into the freshly restored wallet.

This PR:
1. Adds a `resetState()` method to `PreferencesController` that resets all preferences back to their default values.
2. Calls `addressBookController.clear()` during wallet reset to remove saved contacts.
3. Calls `preferencesController.resetState()` during wallet reset to restore default preferences.
4. Adds unit tests for the new `resetState()` method.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39973?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug where user preferences and saved contacts were not cleared when resetting the wallet

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39863

## **Manual testing steps**

1. Install the extension and complete onboarding with a seed phrase.
2. Customize some preferences: change locale, switch to dark theme, enable blockies, add a contact in the address book.
3. Navigate to **Settings → Advanced → Reset Wallet** (or use the "Forgot Password" flow from the lock screen).
4. Complete the wallet restore using the same or different seed phrase.
5. Verify that all preferences are reset to defaults (OS theme, jazzicon avatar, default locale, etc.).
6. Verify that the address book / contacts list is empty.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the wallet reset flow and preference defaults; mistakes could cause incorrect post-reset configuration or unintended data persistence/clearing.
> 
> **Overview**
> Ensures the "Forgot Password" wallet reset flow fully clears user-specific configuration by **resetting `PreferencesController` state back to defaults** and **clearing the address book**.
> 
> Adds `PreferencesController.resetState()` (overriding a couple of defaults like `currentLocale` to `FALLBACK_LOCALE` and `autoLockTimeLimit` to `DEFAULT_AUTO_LOCK_TIME_LIMIT`) and wires it into `metamask-controller.resetWallet`, with a new unit test verifying key preference fields are reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71fcf8010093547a6c6920f497ec6392c0935dd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->