### PR TITLE
feat: SUBS-932 - add notification on payment success

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5651,6 +5651,9 @@
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
     "message": "Your plan has been paused due to payment failure."
   },
+  "pushNotificationShieldSubscriptionPaymentSucceededDescriptionShort": {
+    "message": "Your payment was successful. Your plan is active."
+  },
   "pushNotificationShieldSubscriptionTitle": {
     "message": "MetaMask Transaction Shield"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5651,6 +5651,9 @@
   "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
     "message": "Your plan has been paused due to payment failure."
   },
+  "pushNotificationShieldSubscriptionPaymentSucceededDescriptionShort": {
+    "message": "Your payment was successful. Your plan is active."
+  },
   "pushNotificationShieldSubscriptionTitle": {
     "message": "MetaMask Transaction Shield"
   },

--- a/app/scripts/controllers/push-notifications/get-notification-message.ts
+++ b/app/scripts/controllers/push-notifications/get-notification-message.ts
@@ -90,6 +90,8 @@ const shieldTranslations = {
     t('pushNotificationShieldSubscriptionCreatedDescriptionShort'),
   ShieldSubscriptionPaymentFailedDescriptionShort: () =>
     t('pushNotificationShieldSubscriptionPaymentFailedDescriptionShort'),
+  ShieldSubscriptionPaymentSucceededDescriptionShort: () =>
+    t('pushNotificationShieldSubscriptionPaymentSucceededDescriptionShort'),
   ShieldSubscriptionUpdatePaymentCta: () =>
     t('pushNotificationShieldUpdatePaymentCta'),
   ShieldSubscriptionLearnMoreCta: () => t('pushNotificationShieldLearnMoreCta'),


### PR DESCRIPTION
## **Description**

Add client-side support for Shield subscription payment success push notification. This adds the locale string and translation key so the extension can display push notifications when a recurring Shield subscription payment succeeds.

**Changes:**
- Added `pushNotificationShieldSubscriptionPaymentSucceededDescriptionShort` locale string in `messages.json`
- Added `ShieldSubscriptionPaymentSucceededDescriptionShort` to `shieldTranslations` in `get-notification-message.ts`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39974?quickstart=1)

## **Changelog**

CHANGELOG entry: Added push notification support for Shield subscription payment success

## **Related issues**

Fixes SUBS-932

## **Manual testing steps**

1. Have an active Shield subscription with recurring payments enabled
2. Trigger a successful recurring payment via Stripe webhook (backend sends `platform` notification)
3. Verify the push notification is displayed with the correct title and description
4. Verify the notification appears in the notifications list with the correct template content

## **Screenshots/Recordings**

### **Before**

<!-- No payment success notification support -->

### **After**

<!-- Payment success push notification is shown with correct translation text -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a new i18n string and translation mapping for notifications; no changes to business logic, auth, or data handling.
> 
> **Overview**
> Adds client-side support for a Shield subscription *payment success* push notification by introducing a new English locale string `pushNotificationShieldSubscriptionPaymentSucceededDescriptionShort`.
> 
> Updates `shieldTranslations` in `get-notification-message.ts` to expose `ShieldSubscriptionPaymentSucceededDescriptionShort`, enabling the push notification renderer to display the new success description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a73537afc35f3451ff498a56fe17cffb204c298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->