### PR TITLE
refactor: replace hardcoded selector with POM method in handleSidepanelPostOnboarding

### DIFF
--- a/test/e2e/page-objects/flows/onboarding.flow.ts
+++ b/test/e2e/page-objects/flows/onboarding.flow.ts
@@ -10,6 +10,7 @@ import OnboardingCompletePage from '../pages/onboarding/onboarding-complete-page
 import OnboardingPrivacySettingsPage from '../pages/onboarding/onboarding-privacy-settings-page';
 import { WALLET_PASSWORD } from '../../constants';
 import { E2E_SRP } from '../../fixtures/default-fixture';
+import HeaderNavbar from '../pages/header-navbar';
 import HomePage from '../pages/home/homepage';
 import LoginPage from '../pages/login-page';
 import TermsOfUseUpdateModal from '../pages/dialog/terms-of-use-update-modal';
@@ -41,7 +42,8 @@ export const handleSidepanelPostOnboarding = async (
   await driver.driver.get(`${driver.extensionUrl}/home.html`);
 
   // Wait for the home page to fully load
-  await driver.waitForSelector('[data-testid="account-menu-icon"]');
+  const headerNavbar = new HeaderNavbar(driver);
+  await headerNavbar.checkPageIsLoaded();
 };
 
 /**


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace hardcoded `[data-testid="account-menu-icon"]` selector in `handleSidepanelPostOnboarding` with `HeaderNavbar.checkPageIsLoaded()` POM method, aligning with the project's Page Object Model patterns.


- Imported `HeaderNavbar` in `onboarding.flow.ts`
- Replaced `driver.waitForSelector('[data-testid="account-menu-icon"]')` with `new HeaderNavbar(driver).checkPageIsLoaded()`


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39976?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: [MMQA1417](https://consensyssoftware.atlassian.net/browse/MMQA-1417?atlOrigin=eyJpIjoiNDU4ZGMzODY5YTljNGZlYmJlMDA3MzQyZWFiMTJlNGEiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that changes how the home page load is detected, with minimal product impact and low risk beyond potential e2e flakiness if `HeaderNavbar.checkPageIsLoaded()` is too strict.
> 
> **Overview**
> Refactors `handleSidepanelPostOnboarding` in `onboarding.flow.ts` to replace the hardcoded wait on `[data-testid="account-menu-icon"]` with the `HeaderNavbar.checkPageIsLoaded()` Page Object Model method when navigating to `home.html` in sidepanel-enabled (Chrome) runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db65c4f9780285e9d6f47ea9ebdff7b00a567419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->