### PR TITLE
chore: Bump the STX controller to ^22.5.0, add a new event prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,7 +374,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/shield-controller": "^5.0.1",
     "@metamask/signature-controller": "^39.0.1",
-    "@metamask/smart-transactions-controller": "^22.4.0",
+    "@metamask/smart-transactions-controller": "^22.5.0",
     "@metamask/snaps-controllers": "^18.0.0",
     "@metamask/snaps-execution-environments": "^11.0.0",
     "@metamask/snaps-rpc-methods": "^14.3.0",

--- a/shared/modules/metametrics.test.ts
+++ b/shared/modules/metametrics.test.ts
@@ -98,6 +98,7 @@ describe('getSmartTransactionMetricsProperties', () => {
           statusMetadata: {
             cancellationFeeWei: 36777567771000,
             cancellationReason: 'not_cancelled',
+            originalTransactionStatus: 'pending',
             deadlineRatio: 0.6400288486480713,
             minedHash: txHash,
             timedOut: true,
@@ -129,6 +130,9 @@ describe('getSmartTransactionMetricsProperties', () => {
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
       // eslint-disable-next-line @typescript-eslint/naming-convention
       smart_transaction_timed_out: true,
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      stx_original_transaction_status: 'pending',
     });
   });
 

--- a/shared/modules/metametrics.ts
+++ b/shared/modules/metametrics.ts
@@ -14,6 +14,9 @@ type SmartTransactionMetricsProperties = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   smart_transaction_proxied?: boolean;
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  stx_original_transaction_status?: string;
 };
 
 export const getSmartTransactionMetricsProperties = (
@@ -43,5 +46,7 @@ export const getSmartTransactionMetricsProperties = (
   properties.smart_transaction_timed_out =
     smartTransactionStatusMetadata.timedOut;
   properties.smart_transaction_proxied = smartTransactionStatusMetadata.proxied;
+  properties.stx_original_transaction_status =
+    smartTransactionStatusMetadata.originalTransactionStatus;
   return properties;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,9 +8496,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^22.4.0":
-  version: 22.4.0
-  resolution: "@metamask/smart-transactions-controller@npm:22.4.0"
+"@metamask/smart-transactions-controller@npm:^22.5.0":
+  version: 22.5.0
+  resolution: "@metamask/smart-transactions-controller@npm:22.5.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -8532,7 +8532,7 @@ __metadata:
       optional: true
     "@metamask/gas-fee-controller":
       optional: true
-  checksum: 10/e1cad73e890c5ce2d6f9422d4ac7bd248ac853d10ecf4d96d5092ff5ae911d18db3a851ca800e492613db44c8b4f8a325543a6fe06c10aab5ae1774c75259455
+  checksum: 10/215c5fe21e5e1679e4e0bc247d4ace99d88464ae97fd8c75fcd3bb3dc8420e11752b18a8eddd481591fc97508cfa87e909f7defda6911027c95166e6f69c5ba5
   languageName: node
   linkType: hard
 
@@ -33995,7 +33995,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/shield-controller": "npm:^5.0.1"
     "@metamask/signature-controller": "npm:^39.0.1"
-    "@metamask/smart-transactions-controller": "npm:^22.4.0"
+    "@metamask/smart-transactions-controller": "npm:^22.5.0"
     "@metamask/snap-account-abstraction-keyring-site": "npm:^1.0.0"
     "@metamask/snap-simple-keyring-site": "npm:^2.0.0"
     "@metamask/snaps-controllers": "npm:^18.0.0"


### PR DESCRIPTION
## **Description**
Bumps the STX controller to ^22.5.0, add a new event prop for the original transaction status for STX.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39977?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. When a cancelled smart transaction happens, we will log this new prop in the Transaction Finalized event, which will give us more granular reason for cancellation

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive telemetry change plus a dependency patch bump; main risk is minor metrics schema drift if downstream consumers aren’t expecting the new property.
> 
> **Overview**
> Bumps `@metamask/smart-transactions-controller` from `^22.4.0` to `^22.5.0` (lockfile updated accordingly).
> 
> Extends smart-transaction MetaMetrics properties to include `stx_original_transaction_status`, sourced from STX `statusMetadata.originalTransactionStatus`, and updates unit tests to assert the new field is emitted when metadata is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e75272e4375ebd1a6925e789735a44e2f4f35b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->