### PR TITLE
feat: added drawer component with list

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3133,6 +3133,9 @@
   "hardwareWalletsMsg": {
     "message": "Select a hardware wallet you would like to use with MetaMask."
   },
+  "helpAndSettings": {
+    "message": "HELP AND SETTINGS"
+  },
   "here": {
     "message": "here",
     "description": "as in -click here- for more information (goes with troubleTokenBalances)"
@@ -3782,6 +3785,9 @@
   "makeSureNoOneWatching": {
     "message": "Make sure nobody is looking",
     "description": "Warning to users to be care while creating and saving their new Secret Recovery Phrase"
+  },
+  "manage": {
+    "message": "MANAGE"
   },
   "manageDefaultSettings": {
     "message": "Manage default settings"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3718,6 +3718,9 @@
   "lockTimeInvalid": {
     "message": "Lock time must be a number between 0 and 10080"
   },
+  "logOut": {
+    "message": "Log out"
+  },
   "loginErrorConnectButton": {
     "message": "Try again"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3134,7 +3134,7 @@
     "message": "Select a hardware wallet you would like to use with MetaMask."
   },
   "helpAndSettings": {
-    "message": "HELP AND SETTINGS"
+    "message": "Help and settings"
   },
   "here": {
     "message": "here",
@@ -3787,7 +3787,7 @@
     "description": "Warning to users to be care while creating and saving their new Secret Recovery Phrase"
   },
   "manage": {
-    "message": "MANAGE"
+    "message": "Manage"
   },
   "manageDefaultSettings": {
     "message": "Manage default settings"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3133,6 +3133,9 @@
   "hardwareWalletsMsg": {
     "message": "Select a hardware wallet you would like to use with MetaMask."
   },
+  "helpAndSettings": {
+    "message": "HELP AND SETTINGS"
+  },
   "here": {
     "message": "here",
     "description": "as in -click here- for more information (goes with troubleTokenBalances)"
@@ -3782,6 +3785,9 @@
   "makeSureNoOneWatching": {
     "message": "Make sure nobody is looking",
     "description": "Warning to users to be care while creating and saving their new Secret Recovery Phrase"
+  },
+  "manage": {
+    "message": "MANAGE"
   },
   "manageDefaultSettings": {
     "message": "Manage default settings"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3718,6 +3718,9 @@
   "lockTimeInvalid": {
     "message": "Lock time must be a number between 0 and 10080"
   },
+  "logOut": {
+    "message": "Log out"
+  },
   "loginErrorConnectButton": {
     "message": "Try again"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3134,7 +3134,7 @@
     "message": "Select a hardware wallet you would like to use with MetaMask."
   },
   "helpAndSettings": {
-    "message": "HELP AND SETTINGS"
+    "message": "Help and settings"
   },
   "here": {
     "message": "here",
@@ -3787,7 +3787,7 @@
     "description": "Warning to users to be care while creating and saving their new Secret Recovery Phrase"
   },
   "manage": {
-    "message": "MANAGE"
+    "message": "Manage"
   },
   "manageDefaultSettings": {
     "message": "Manage default settings"

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer-with-list.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer-with-list.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { GlobalMenuList } from '../global-menu/global-menu-list';
+import { useGlobalMenuSections } from './useGlobalMenuSections';
+import { GlobalMenuDrawer } from './global-menu-drawer';
+import type { GlobalMenuDrawerProps } from './global-menu-drawer.types';
+
+export const GlobalMenuDrawerWithList = ({
+  isOpen,
+  onClose,
+  ...drawerProps
+}: Omit<GlobalMenuDrawerProps, 'children'>) => {
+  const sections = useGlobalMenuSections(onClose);
+
+  return (
+    <GlobalMenuDrawer isOpen={isOpen} onClose={onClose} {...drawerProps}>
+      <GlobalMenuList sections={sections} />
+    </GlobalMenuDrawer>
+  );
+};

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.stories.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.stories.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
+import { Provider } from 'react-redux';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button, Text, TextVariant } from '@metamask/design-system-react';
 import { GlobalMenuDrawer } from './global-menu-drawer';
+import { GlobalMenuDrawerWithList } from './global-menu-drawer-with-list';
+import configureStore from '../../../store/store';
+import testData from '../../../../.storybook/test-data';
 
 const meta: Meta<typeof GlobalMenuDrawer> = {
   title: 'Components/Multichain/GlobalMenuDrawer',
@@ -105,4 +109,24 @@ const CustomWidthWrapper = () => {
 
 export const CustomWidth: Story = {
   render: CustomWidthWrapper,
+};
+
+const store = configureStore(testData);
+
+const WithGlobalMenuListWrapper = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Provider store={store}>
+      <Button onClick={() => setIsOpen(true)}>Open Menu Drawer</Button>
+      <GlobalMenuDrawerWithList
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </Provider>
+  );
+};
+
+export const WithGlobalMenuList: Story = {
+  render: WithGlobalMenuListWrapper,
 };

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -6,6 +6,7 @@ import {
   BoxBackgroundColor,
   BoxFlexDirection,
   ButtonIcon,
+  ButtonIconSize,
   IconName,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -298,6 +299,7 @@ export const GlobalMenuDrawer = ({
                     <Box className="flex flex-row items-center justify-start p-4 w-full overflow-hidden">
                       <ButtonIcon
                         iconName={IconName.ArrowLeft}
+                        size={ButtonIconSize.Lg}
                         ariaLabel={title || t('close')}
                         onClick={onClose}
                         data-testid="drawer-close-button"

--- a/ui/components/multichain/global-menu-drawer/index.ts
+++ b/ui/components/multichain/global-menu-drawer/index.ts
@@ -1,2 +1,4 @@
 export { GlobalMenuDrawer } from './global-menu-drawer';
+export { GlobalMenuDrawerWithList } from './global-menu-drawer-with-list';
+export { useGlobalMenuSections } from './useGlobalMenuSections';
 export type { GlobalMenuDrawerProps } from './global-menu-drawer.types';

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -12,11 +12,15 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { useUnreadNotificationsCounter } from '../../../hooks/metamask-notifications/useCounter';
+import {
+  useReadNotificationsCounter,
+  useUnreadNotificationsCounter,
+} from '../../../hooks/metamask-notifications/useCounter';
 import { NotificationsTagCounter } from '../notifications-tag-counter';
 import { NewFeatureTag } from '../../../pages/notifications/NewFeatureTag';
 import {
   SETTINGS_ROUTE,
+  DEFAULT_ROUTE,
   NOTIFICATIONS_ROUTE,
   SNAPS_ROUTE,
   PERMISSIONS,
@@ -102,6 +106,7 @@ export function useGlobalMenuSections(
   const basicFunctionality = useSelector(getUseExternalServices);
   const rewardsEnabled = useSelector(selectRewardsEnabled);
   const { notificationsUnreadCount } = useUnreadNotificationsCounter();
+  const { notificationsReadCount } = useReadNotificationsCounter();
   const isMetamaskNotificationFeatureSeen = useSelector(
     selectIsMetamaskNotificationsFeatureSeen,
   );
@@ -178,6 +183,9 @@ export function useGlobalMenuSections(
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
         // eslint-disable-next-line @typescript-eslint/naming-convention
         unread_count: notificationsUnreadCount,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        read_count: notificationsReadCount,
       },
     });
     navigate(NOTIFICATIONS_ROUTE);
@@ -191,6 +199,7 @@ export function useGlobalMenuSections(
     onClose,
     navigate,
     notificationsUnreadCount,
+    notificationsReadCount,
   ]);
 
   const handleSupportMenuClick = useCallback(() => {
@@ -390,7 +399,7 @@ export function useGlobalMenuSections(
 
     const section2Manage: GlobalMenuSection = {
       id: 'global-menu-section-manage',
-      title: 'MANAGE',
+      title: t('manage'),
       items: [
         {
           id: 'global-menu-connected-sites',
@@ -431,7 +440,7 @@ export function useGlobalMenuSections(
 
     const section3HelpAndSettings: GlobalMenuSection = {
       id: 'global-menu-section-help-settings',
-      title: 'HELP AND SETTINGS',
+      title: t('helpAndSettings'),
       items: [
         {
           id: 'global-menu-settings',
@@ -489,6 +498,7 @@ export function useGlobalMenuSections(
           textColor: TextColor.ErrorDefault,
           label: t('logOut'),
           onClick: () => {
+            navigate(DEFAULT_ROUTE);
             dispatch(lockMetamask(t('lockMetaMaskLoadingMessage')));
             trackEvent({
               category: MetaMetricsEventCategory.Navigation,
@@ -523,6 +533,7 @@ export function useGlobalMenuSections(
     snapsUpdatesAvailable,
     showPriorityTag,
     notificationsUnreadCount,
+    notificationsReadCount,
     isMetamaskNotificationFeatureSeen,
     onClose,
     navigate,

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -1,0 +1,541 @@
+import React, { useCallback, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import browser from 'webextension-polyfill';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  IconColor,
+  IconName,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { useUnreadNotificationsCounter } from '../../../hooks/metamask-notifications/useCounter';
+import { NotificationsTagCounter } from '../notifications-tag-counter';
+import { NewFeatureTag } from '../../../pages/notifications/NewFeatureTag';
+import {
+  SETTINGS_ROUTE,
+  NOTIFICATIONS_ROUTE,
+  SNAPS_ROUTE,
+  PERMISSIONS,
+  GATOR_PERMISSIONS,
+} from '../../../helpers/constants/routes';
+import {
+  lockMetamask,
+  setShowSupportDataConsentModal,
+  showConfirmTurnOnMetamaskNotifications,
+  toggleNetworkMenu,
+  setUseSidePanelAsDefault,
+} from '../../../store/actions';
+import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../shared/modules/environment';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';
+import { useBrowserSupportsSidePanel } from '../../../hooks/useBrowserSupportsSidePanel';
+import {
+  selectIsMetamaskNotificationsEnabled,
+  selectIsMetamaskNotificationsFeatureSeen,
+} from '../../../selectors/metamask-notifications/metamask-notifications';
+import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity/backup-and-sync';
+import { Tag } from '../../component-library';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+  PLATFORM_FIREFOX,
+} from '../../../../shared/constants/app';
+import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+import { SUPPORT_LINK } from '../../../../shared/lib/ui-utils';
+///: BEGIN:ONLY_INCLUDE_IF(build-beta,build-flask)
+import { SUPPORT_REQUEST_LINK } from '../../../helpers/constants/common';
+///: END:ONLY_INCLUDE_IF
+
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsContextProp,
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+
+import {
+  getUnapprovedTransactions,
+  getAnySnapUpdateAvailable,
+  getThirdPartyNotifySnaps,
+  getUseExternalServices,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+  getDataCollectionForMarketing,
+} from '../../../selectors';
+import { useUserSubscriptions } from '../../../hooks/subscription/useSubscription';
+import {
+  getIsShieldSubscriptionActive,
+  getIsShieldSubscriptionPaused,
+  getShieldSubscription,
+  getSubscriptionPaymentData,
+} from '../../../../shared/lib/shield';
+import { selectRewardsEnabled } from '../../../ducks/rewards/selectors';
+import { useSubscriptionMetrics } from '../../../hooks/shield/metrics/useSubscriptionMetrics';
+import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
+import type { GlobalMenuSection } from '../global-menu/global-menu-list.types';
+
+const METRICS_LOCATION = 'Global Menu';
+
+/**
+ * Hook that returns menu sections with the same data and behavior as GlobalMenu.
+ * Use with GlobalMenuList inside GlobalMenuDrawer to render the menu in a drawer.
+ *
+ * @param onClose - Callback to close the drawer/menu when an action is taken
+ */
+export function useGlobalMenuSections(
+  onClose: () => void,
+): GlobalMenuSection[] {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const { captureCommonExistingShieldSubscriptionEvents } =
+    useSubscriptionMetrics();
+  const navigate = useNavigate();
+
+  const basicFunctionality = useSelector(getUseExternalServices);
+  const rewardsEnabled = useSelector(selectRewardsEnabled);
+  const { notificationsUnreadCount } = useUnreadNotificationsCounter();
+  const isMetamaskNotificationFeatureSeen = useSelector(
+    selectIsMetamaskNotificationsFeatureSeen,
+  );
+  const isMetamaskNotificationsEnabled = useSelector(
+    selectIsMetamaskNotificationsEnabled,
+  );
+  const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
+  const unapprovedTransactions = useSelector(getUnapprovedTransactions);
+  const hasUnapprovedTransactions =
+    Object.keys(unapprovedTransactions).length > 0;
+  let hasThirdPartyNotifySnaps = false;
+  const snapsUpdatesAvailable = useSelector(getAnySnapUpdateAvailable);
+  hasThirdPartyNotifySnaps = useSelector(getThirdPartyNotifySnaps).length > 0;
+
+  const isSidePanelEnabled = useSidePanelEnabled();
+  const browserSupportsSidePanel = useBrowserSupportsSidePanel();
+  const currentEnvironment = getEnvironmentType();
+  const isSidepanel = currentEnvironment === ENVIRONMENT_TYPE_SIDEPANEL;
+  const isPopup = currentEnvironment === ENVIRONMENT_TYPE_POPUP;
+
+  const { subscriptions } = useUserSubscriptions();
+  const isActiveShieldSubscription =
+    getIsShieldSubscriptionActive(subscriptions);
+  const isPausedShieldSubscription =
+    getIsShieldSubscriptionPaused(subscriptions);
+  const showPriorityTag = useMemo(
+    () =>
+      (isActiveShieldSubscription || isPausedShieldSubscription) &&
+      basicFunctionality,
+    [
+      isActiveShieldSubscription,
+      isPausedShieldSubscription,
+      basicFunctionality,
+    ],
+  );
+
+  const metaMetricsId = useSelector(getMetaMetricsId);
+  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
+
+  let supportText = t('support');
+  let supportLink = SUPPORT_LINK || '';
+  ///: BEGIN:ONLY_INCLUDE_IF(build-beta,build-flask)
+  supportText = t('needHelpSubmitTicket');
+  supportLink = SUPPORT_REQUEST_LINK || '';
+  ///: END:ONLY_INCLUDE_IF
+
+  const handleNotificationsClick = useCallback(() => {
+    const shouldShowEnableModal =
+      !hasThirdPartyNotifySnaps && !isMetamaskNotificationsEnabled;
+
+    if (shouldShowEnableModal) {
+      trackEvent({
+        category: MetaMetricsEventCategory.NotificationsActivationFlow,
+        event: MetaMetricsEventName.NotificationsActivated,
+        properties: {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          action_type: 'started',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_profile_syncing_enabled: isBackupAndSyncEnabled,
+        },
+      });
+      dispatch(showConfirmTurnOnMetamaskNotifications());
+      onClose();
+      return;
+    }
+
+    trackEvent({
+      category: MetaMetricsEventCategory.NotificationInteraction,
+      event: MetaMetricsEventName.NotificationsMenuOpened,
+      properties: {
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        unread_count: notificationsUnreadCount,
+      },
+    });
+    navigate(NOTIFICATIONS_ROUTE);
+    onClose();
+  }, [
+    hasThirdPartyNotifySnaps,
+    isMetamaskNotificationsEnabled,
+    trackEvent,
+    isBackupAndSyncEnabled,
+    dispatch,
+    onClose,
+    navigate,
+    notificationsUnreadCount,
+  ]);
+
+  const handleSupportMenuClick = useCallback(() => {
+    dispatch(setShowSupportDataConsentModal(true));
+    trackEvent(
+      {
+        category: MetaMetricsEventCategory.Home,
+        event: MetaMetricsEventName.SupportLinkClicked,
+        properties: {
+          url: supportLink,
+          location: METRICS_LOCATION,
+        },
+      },
+      {
+        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
+      },
+    );
+    if (showPriorityTag) {
+      const shieldSubscription = getShieldSubscription(subscriptions);
+      const { cryptoPaymentChain, cryptoPaymentCurrency } =
+        getSubscriptionPaymentData(shieldSubscription);
+      if (shieldSubscription) {
+        captureCommonExistingShieldSubscriptionEvents(
+          {
+            subscriptionStatus: shieldSubscription.status,
+            paymentType: shieldSubscription.paymentMethod.type,
+            billingInterval: shieldSubscription.interval,
+            cryptoPaymentChain,
+            cryptoPaymentCurrency,
+          },
+          MetaMetricsEventName.ShieldPrioritySupportClicked,
+        );
+      }
+    }
+    onClose();
+  }, [
+    dispatch,
+    trackEvent,
+    supportLink,
+    showPriorityTag,
+    subscriptions,
+    captureCommonExistingShieldSubscriptionEvents,
+    onClose,
+  ]);
+
+  const toggleDefaultView = useCallback(async () => {
+    if (!isSidePanelEnabled) {
+      return;
+    }
+
+    try {
+      if (isSidepanel) {
+        await dispatch(setUseSidePanelAsDefault(false));
+        window.close();
+        return;
+      }
+
+      if (isPopup) {
+        const browserWithSidePanel = browser as typeof browser & {
+          sidePanel?: {
+            open: (options: { windowId: number }) => Promise<void>;
+          };
+        };
+
+        if (!browserWithSidePanel?.sidePanel?.open) {
+          return;
+        }
+
+        const tabs = await browser.tabs.query({
+          active: true,
+          currentWindow: true,
+        });
+
+        if (tabs && tabs.length > 0 && tabs[0].windowId) {
+          await browserWithSidePanel.sidePanel.open({
+            windowId: tabs[0].windowId,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 500));
+
+          const contexts = await chrome.runtime.getContexts({
+            contextTypes: ['SIDE_PANEL' as chrome.runtime.ContextType],
+          });
+
+          if (!contexts || contexts.length === 0) {
+            return;
+          }
+
+          await dispatch(setUseSidePanelAsDefault(true));
+          window.close();
+        }
+      }
+    } catch (error) {
+      console.error('Error toggling default view:', error);
+    }
+  }, [isSidePanelEnabled, isSidepanel, isPopup, dispatch]);
+
+  return useMemo(() => {
+    const section1: GlobalMenuSection = {
+      id: 'global-menu-section-1',
+      items: [],
+    };
+
+    if (basicFunctionality) {
+      section1.items.push({
+        id: 'notifications-menu-item',
+        iconName: IconName.Notification,
+        label: (
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+          >
+            {t('notifications')}
+            {notificationsUnreadCount === 0 &&
+              !isMetamaskNotificationFeatureSeen && <NewFeatureTag />}
+            <NotificationsTagCounter />
+          </Box>
+        ),
+        onClick: handleNotificationsClick,
+      });
+    }
+
+    const section2: GlobalMenuSection = {
+      id: 'global-menu-section-2',
+      items: [],
+    };
+
+    if (rewardsEnabled) {
+      section2.items.push({
+        id: 'discover',
+        iconName: IconName.Export,
+        label: t('discover'),
+        onClick: () => {
+          const url = getPortfolioUrl(
+            'explore/tokens',
+            'ext_portfolio_button',
+            metaMetricsId,
+            isMetaMetricsEnabled,
+            isMarketingEnabled,
+          );
+          global.platform.openTab({ url });
+          trackEvent({
+            category: MetaMetricsEventCategory.Navigation,
+            event: MetaMetricsEventName.PortfolioLinkClicked,
+            properties: { location: METRICS_LOCATION, text: 'Portfolio' },
+          });
+          onClose();
+        },
+      });
+    }
+
+    if (isPopup || isSidepanel) {
+      section2.items.push({
+        id: 'global-menu-expand-view',
+        iconName: IconName.Expand,
+        label: t('openFullScreen'),
+        onClick: () => {
+          global?.platform?.openExtensionInBrowser?.();
+          trackEvent({
+            event: MetaMetricsEventName.AppWindowExpanded,
+            category: MetaMetricsEventCategory.Navigation,
+            properties: { location: METRICS_LOCATION },
+          });
+          onClose();
+        },
+      });
+    }
+
+    if (
+      getBrowserName() !== PLATFORM_FIREFOX &&
+      browserSupportsSidePanel === true &&
+      isSidePanelEnabled &&
+      (isPopup || isSidepanel)
+    ) {
+      section2.items.push({
+        id: 'global-menu-toggle-view',
+        // TODO: Add back the correct icon name when the design system is updated
+        // iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
+        iconName: IconName.Expand,
+        label: isSidepanel ? t('switchToPopup') : t('switchToSidePanel'),
+        onClick: async () => {
+          await toggleDefaultView();
+          trackEvent({
+            event: MetaMetricsEventName.ViewportSwitched,
+            category: MetaMetricsEventCategory.Navigation,
+            properties: {
+              location: METRICS_LOCATION,
+              to: isSidepanel
+                ? ENVIRONMENT_TYPE_POPUP
+                : ENVIRONMENT_TYPE_SIDEPANEL,
+            },
+          });
+          onClose();
+        },
+      });
+    }
+
+    const section2Manage: GlobalMenuSection = {
+      id: 'global-menu-section-manage',
+      title: 'MANAGE',
+      items: [
+        {
+          id: 'global-menu-connected-sites',
+          iconName: IconName.SecurityTick,
+          label: t('allPermissions'),
+          to: isGatorPermissionsRevocationFeatureEnabled()
+            ? GATOR_PERMISSIONS
+            : PERMISSIONS,
+          onClick: () => {
+            trackEvent({
+              event: MetaMetricsEventName.NavPermissionsOpened,
+              category: MetaMetricsEventCategory.Navigation,
+              properties: { location: METRICS_LOCATION },
+            });
+            onClose();
+          },
+          disabled: hasUnapprovedTransactions,
+        },
+        {
+          id: 'global-menu-networks',
+          iconName: IconName.Hierarchy,
+          label: t('networks'),
+          onClick: () => {
+            dispatch(toggleNetworkMenu());
+            onClose();
+          },
+        },
+        {
+          id: 'global-menu-snaps',
+          iconName: IconName.Snaps,
+          label: t('snaps'),
+          to: SNAPS_ROUTE,
+          onClick: onClose,
+          showInfoDot: snapsUpdatesAvailable,
+        },
+      ],
+    };
+
+    const section3HelpAndSettings: GlobalMenuSection = {
+      id: 'global-menu-section-help-settings',
+      title: 'HELP AND SETTINGS',
+      items: [
+        {
+          id: 'global-menu-settings',
+          iconName: IconName.Setting,
+          label: t('settings'),
+          to: SETTINGS_ROUTE,
+          onClick: () => {
+            trackEvent({
+              category: MetaMetricsEventCategory.Navigation,
+              event: MetaMetricsEventName.NavSettingsOpened,
+              properties: { location: METRICS_LOCATION },
+            });
+            onClose();
+          },
+          disabled: hasUnapprovedTransactions,
+        },
+        {
+          id: 'global-menu-support',
+          iconName: IconName.MessageQuestion,
+          label: (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
+            >
+              {supportText}
+              {showPriorityTag && (
+                <Tag
+                  label={t('priority')}
+                  textVariant={TextVariant.BodySm}
+                  className="rounded-lg border-0 bg-success-muted"
+                  labelProps={{
+                    className: 'text-success-default',
+                  }}
+                  iconName={IconName.Sparkle}
+                  startIconProps={{
+                    className: 'text-success-default',
+                  }}
+                />
+              )}
+            </Box>
+          ),
+          onClick: handleSupportMenuClick,
+        },
+      ],
+    };
+
+    const section4LogOut: GlobalMenuSection = {
+      id: 'global-menu-section-log-out',
+      items: [
+        {
+          id: 'global-menu-lock',
+          iconName: IconName.Lock,
+          iconColor: IconColor.ErrorDefault,
+          textColor: TextColor.ErrorDefault,
+          label: t('logOut'),
+          onClick: () => {
+            dispatch(lockMetamask(t('lockMetaMaskLoadingMessage')));
+            trackEvent({
+              category: MetaMetricsEventCategory.Navigation,
+              event: MetaMetricsEventName.AppLocked,
+              properties: { location: METRICS_LOCATION },
+            });
+            onClose();
+          },
+        },
+      ],
+    };
+
+    const sections: GlobalMenuSection[] = [];
+    if (section1.items.length > 0) {
+      sections.push(section1);
+    }
+    if (section2.items.length > 0) {
+      sections.push(section2);
+    }
+    sections.push(section2Manage);
+    sections.push(section3HelpAndSettings);
+    sections.push(section4LogOut);
+
+    return sections;
+  }, [
+    t,
+    basicFunctionality,
+    rewardsEnabled,
+    isPopup,
+    isSidepanel,
+    hasUnapprovedTransactions,
+    snapsUpdatesAvailable,
+    showPriorityTag,
+    notificationsUnreadCount,
+    isMetamaskNotificationFeatureSeen,
+    onClose,
+    navigate,
+    dispatch,
+    trackEvent,
+    metaMetricsId,
+    isMetaMetricsEnabled,
+    isMarketingEnabled,
+    browserSupportsSidePanel,
+    isSidePanelEnabled,
+    supportText,
+    handleNotificationsClick,
+    handleSupportMenuClick,
+    toggleDefaultView,
+  ]);
+}


### PR DESCRIPTION
This PR is to combine global-menu list with the drawer component

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [https://consensyssoftware.atlassian.net/browse/CEUX-862](https://consensyssoftware.atlassian.net/browse/CEUX-862)

## **Manual testing steps**

1. Go to app-header-unlocked componet
2. Comment the global-menu component in app-header-unlocked
3. Add this code         

```
<GlobalMenuDrawerWithList
isOpen={accountOptionsMenuOpen}
onClose={() => setAccountOptionsMenuOpen(false)}
anchorElement={menuRef.current}
/>
```
4. Run with yarn start
5. Check the global-menu drawer in extension

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
![Screenshot 2026-02-11 at 10 56 26 AM](https://github.com/user-attachments/assets/43cb4e9f-38fb-41b7-b3a6-dcdfeaf2cbc3)


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new navigation/action wiring (including sidepanel/popup switching and logout) and metrics events in a new shared hook; issues would primarily surface as broken menu behavior or mis-tracking rather than data integrity problems.
> 
> **Overview**
> Adds `GlobalMenuDrawerWithList`, which composes `GlobalMenuDrawer` with `GlobalMenuList` via a new `useGlobalMenuSections` hook so the global menu can be rendered inside a drawer.
> 
> `useGlobalMenuSections` builds the menu sections (notifications, discover/fullscreen/viewport toggle, manage, help & settings, logout) and wires up navigation, Redux actions (e.g. lock, toggle network menu, notifications enable flow), and MetaMetrics tracking; Storybook gains a new `WithGlobalMenuList` story. Also updates the drawer close icon to use `ButtonIconSize.Lg` and introduces new i18n strings (`helpAndSettings`, `manage`, `logOut`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3541e3917c2e48a7a070c5156c553fbb7e9b9c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->