### PR TITLE
poc: middleware for transforming Tempo txs

### DIFF
--- a/app/scripts/lib/createTempoTransactionTransformMiddleware.ts
+++ b/app/scripts/lib/createTempoTransactionTransformMiddleware.ts
@@ -1,0 +1,187 @@
+/**
+ * Detects and transforms Tempo 0x76 transactions sent via eth_sendTransaction:
+ * - Removes `params[0].type` ('0x76') and sets the method to 'wallet_sendCalls'
+ * - Converts `params[0].calls` to a EIP-5792 compatible `calls`
+ * - Removes 'params[0]?.feeToken' to set `params[0].capabilities.feeToken.address`
+ * See: https://eips.ethereum.org/EIPS/eip-5792
+ */
+
+import { JsonRpcEngineNextCallback } from '@metamask/json-rpc-engine';
+import {
+  Json,
+  JsonRpcError,
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+type Hex = `0x${string}`;
+
+type TempoCall = {
+  to: Hex;
+  // In our tests we see '0x' (probably to signal no native token),
+  // However '0x' is invalid as a value and we use '0x0' when transforming.
+  value: Hex | '0x';
+  data: Hex;
+};
+
+type TempoTransactionRequest = {
+  from: Hex;
+  chainId: Hex;
+  type: '0x76';
+  calls: TempoCall[];
+  feeToken?: Hex;
+};
+
+type TempoSendTransactionRequest = {
+  id: number;
+  jsonrpc: '2.0';
+  method: 'wallet_sendTransaction';
+  params: [TempoTransactionRequest];
+};
+
+// TODO: Check for existing types instead of creating new ones
+type WalletSendCallsRequest = {
+  id: number | string;
+  jsonrpc: '2.0';
+  method: 'wallet_sendCalls';
+  params: [
+    {
+      version: '2.0.0';
+      from: Hex;
+      chainId: Hex;
+      atomicRequired?: boolean;
+      calls: {
+        to?: Hex;
+        value?: Hex;
+        data?: Hex;
+      }[];
+      capabilities?: {
+        feeToken?: { address: Hex; optional: true };
+      };
+    },
+  ];
+};
+
+const TEMPO_TRANSACTION_TYPE: Hex = '0x76';
+
+// This could be in a flag/env var or other mechanism that allows per-chain enable/disable.
+// Could also have one default fee token per chain. Keeping it simple for the PoC.
+const ENABLED_TEMPO_CHAIN_IDS_HEX = [
+  '0xa5bd', // Tempo older Testnet
+  '0xa5bf', // Tempo Moderato Testnet
+];
+const DEFAULT_FEE_TOKEN_ADDRESS: Hex =
+  '0x20c0000000000000000000000000000000000000';
+
+function isTempoTransaction(
+  req: JsonRpcRequest,
+): req is TempoSendTransactionRequest {
+  const firstParam = Array.isArray(req.params) ? req.params[0] : null;
+  return (
+    firstParam !== null &&
+    typeof firstParam === 'object' &&
+    !Array.isArray(firstParam) &&
+    'type' in firstParam &&
+    firstParam.type === TEMPO_TRANSACTION_TYPE
+  );
+}
+
+function transformToEIP7702Transaction(
+  req: TempoSendTransactionRequest | WalletSendCallsRequest,
+): asserts req is WalletSendCallsRequest {
+  const tempoRequest = req as TempoSendTransactionRequest;
+  req.method = 'wallet_sendCalls';
+  const { from, chainId, feeToken } = tempoRequest.params[0];
+  req.params = [
+    {
+      version: '2.0.0',
+      atomicRequired: false,
+      from,
+      chainId,
+      calls: tempoRequest.params[0].calls.map(({ data, to }) => ({
+        data,
+        to,
+        value: '0x0',
+      })),
+      capabilities: {
+        // 'feeToken' is not part of any standard, but the "capabilities"
+        // is part of EIP-5792. The idea is to carry this parameter down
+        // until it reaches the part of the code where we turn it into "gasFeeToken".
+        feeToken: {
+          address: feeToken || DEFAULT_FEE_TOKEN_ADDRESS,
+          optional: true,
+        },
+      },
+    },
+  ];
+}
+
+function isSupportEnabledForChainId(chainId: Hex): boolean {
+  return chainId && ENABLED_TEMPO_CHAIN_IDS_HEX.includes(chainId);
+}
+
+export default function createTempoTransactionTransformMiddleware() {
+  return function originThrottlingMiddleware(
+    req: JsonRpcRequest,
+    _res: JsonRpcResponse<Json | JsonRpcError>,
+    next: JsonRpcEngineNextCallback,
+  ) {
+    const { method } = req;
+    if (method === 'eth_sendTransaction' && isTempoTransaction(req)) {
+      console.warn('TEMPO TRANSACTION DETECTED', cloneDeep(req));
+      const { chainId } = req.params[0];
+      if (!isSupportEnabledForChainId(chainId)) {
+        next((callback: () => void) => {
+          // TODO: Proper error propagation
+          console.error(
+            `Tempo Transactions are not supported for chain ${chainId}`,
+          );
+          callback();
+        });
+        return;
+      }
+      transformToEIP7702Transaction(req);
+      console.warn('TRANSFORMED TEMPO REQUEST:', req);
+    }
+    next();
+  };
+}
+
+// Tempo request example for reference (what dApps built on Viem will send to MetaMask)
+// {
+//    "enabled":true,
+//    "req":{
+//       "method":"wallet_sendTransaction",
+//       "params":[
+//          {
+//             "from":"0x1e3abc74428056924cEeE2F45f060879c3F063ed",
+//             "chainId":"0xa5bf",
+//             "type":"0x76",
+//             "calls":[
+//                {
+//                   "to":"0x20C0000000000000000000000008f1fB6c965249",
+//                   "value":"0x",
+//                   "data":"0x2f2ff15d114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa1220000000000000000000000001e3abc74428056924ceee2f45f060879c3f063ed"
+//                },
+//                {
+//                   "to":"0x20C0000000000000000000000008f1fB6c965249",
+//                   "value":"0x",
+//                   "data":"0x2f2ff15d139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d0000000000000000000000001e3abc74428056924ceee2f45f060879c3f063ed"
+//                },
+//                {
+//                   "to":"0x20C0000000000000000000000008f1fB6c965249",
+//                   "value":"0x",
+//                   "data":"0x2f2ff15d265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae0000000000000000000000001e3abc74428056924ceee2f45f060879c3f063ed"
+//                },
+//                {
+//                   "to":"0x20C0000000000000000000000008f1fB6c965249",
+//                   "value":"0x",
+//                   "data":"0x2f2ff15d7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae0000000000000000000000001e3abc74428056924ceee2f45f060879c3f063ed"
+//                }
+//             ],
+//             "feeToken":"0x20c0000000000000000000000000000000000001"
+//          }
+//       ]
+//    }
+// };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -437,6 +437,7 @@ import {
 } from './controller-init/claims';
 import { ProfileMetricsControllerInit } from './controller-init/profile-metrics-controller-init';
 import { ProfileMetricsServiceInit } from './controller-init/profile-metrics-service-init';
+import createTempoTransactionTransformMiddleware from './lib/createTempoTransactionTransformMiddleware';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -7295,6 +7296,8 @@ export default class MetamaskController extends EventEmitter {
     engine.push(this.permissionLogController.createMiddleware());
 
     engine.push(createTracingMiddleware());
+
+    engine.push(createTempoTransactionTransformMiddleware());
 
     engine.push(
       createOriginThrottlingMiddleware({

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@metamask/address-book-controller": "^7.0.1",
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^8.0.0",
-    "@metamask/assets-controllers": "^99.0.0",
+    "@metamask/assets-controllers": "^99.3.1",
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.10.0",
     "@metamask/bridge-controller": "^64.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6009,9 +6009,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^99.0.0":
-  version: 99.1.0
-  resolution: "@metamask/assets-controllers@npm:99.1.0"
+"@metamask/assets-controllers@npm:^99.3.1":
+  version: 99.3.1
+  resolution: "@metamask/assets-controllers@npm:99.3.1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -6026,7 +6026,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/core-backend": "npm:^5.0.0"
+    "@metamask/core-backend": "npm:5.0.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/keyring-api": "npm:^21.0.0"
     "@metamask/keyring-controller": "npm:^25.1.0"
@@ -6038,14 +6038,14 @@ __metadata:
     "@metamask/permission-controller": "npm:^12.2.0"
     "@metamask/phishing-controller": "npm:^16.1.0"
     "@metamask/polling-controller": "npm:^16.0.2"
-    "@metamask/preferences-controller": "npm:^22.0.0"
-    "@metamask/profile-sync-controller": "npm:^27.0.0"
+    "@metamask/preferences-controller": "npm:^22.1.0"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/snaps-controllers": "npm:^17.2.0"
     "@metamask/snaps-sdk": "npm:^10.3.0"
     "@metamask/snaps-utils": "npm:^11.7.0"
-    "@metamask/storage-service": "npm:^0.0.1"
-    "@metamask/transaction-controller": "npm:^62.11.0"
+    "@metamask/storage-service": "npm:^1.0.0"
+    "@metamask/transaction-controller": "npm:^62.15.0"
     "@metamask/utils": "npm:^11.9.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/uuid": "npm:^8.3.0"
@@ -6061,7 +6061,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/01e9e33f50d5207817264c969ee37ad534399756d580ff1ebb965018cba0c669a181ba70273ba6901e5c71c2f5acd7506b2ff12432c9b218cfa778e3d12c59b7
+  checksum: 10/b69b63f034f1b49a814233c968d84bd82edb7ea113037980e8b7cb40248a8695f821f37b7bd9b0e082a127b8edb4ac29a090964498e2a9b7525808f573919758
   languageName: node
   linkType: hard
 
@@ -6397,7 +6397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^5.0.0":
+"@metamask/core-backend@npm:5.0.0, @metamask/core-backend@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/core-backend@npm:5.0.0"
   dependencies:
@@ -8142,6 +8142,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/preferences-controller@npm:^22.1.0":
+  version: 22.1.0
+  resolution: "@metamask/preferences-controller@npm:22.1.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+  checksum: 10/bdb6a727cd88313b29b66dfd10308accc8c8bf52830bd7950a5afa7c832554958b94d207ed46ba4b7c8645cd05697e4601ee18194f988416d8dec0bbd2977516
+  languageName: node
+  linkType: hard
+
 "@metamask/preinstalled-example-snap@npm:^0.7.2":
   version: 0.7.2
   resolution: "@metamask/preinstalled-example-snap@npm:0.7.2"
@@ -8773,16 +8785,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/storage-service@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@metamask/storage-service@npm:0.0.1"
-  dependencies:
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-  checksum: 10/ba2443e4bab7a4ef64bf3e0a10403ef94d50225e5ae5931a6fd32a21bfa8e276916ab6dc377d2db30c15c50acaeaee74a3c0b418a563311da9f98b9172fba300
-  languageName: node
-  linkType: hard
-
 "@metamask/storage-service@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/storage-service@npm:1.0.0"
@@ -8962,6 +8964,45 @@ __metadata:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
   checksum: 10/949150f95a68186b9c919876c9c70ba2c8e6a072e3bb504624a650b8bd161931126fc50d5112c3d1fd58d541ca762a788116376b6325a19d2ee8e9d9ac0e3a4a
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@npm:^62.15.0":
+  version: 62.16.0
+  resolution: "@metamask/transaction-controller@npm:62.16.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/core-backend": "npm:5.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.2"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/b0152b51e538b72969960ae18be576945ea768ece8a92c25bcb7cf4f33735eb69816722086b8cf427d9c37711e87451a449a0f662366736b9181eba5fc295d5c
   languageName: node
   linkType: hard
 
@@ -33766,7 +33807,7 @@ __metadata:
     "@metamask/announcement-controller": "npm:^8.0.0"
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/assets-controllers": "npm:^99.0.0"
+    "@metamask/assets-controllers": "npm:^99.3.1"
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39981?quickstart=1)

Context: With current Viem implementation of Tempo, we can see that some dApps will try to call `eth_sendTransaction` with `{ type: '0x76', feeToken: '0x000...' }` which both type `0x76` and `feeToken` field are not standard.
Approach: Turn those transactions into `eth_sendCalls` to preserve support of batching and dApp-set fee token. 

Middleware Input (from dApp / Viem Tempo implementation):
```
{
  "id": 4208624703,
  "jsonrpc": "2.0",
  "mainFrameOrigin": "http://localhost:5173",
  "method": "eth_sendTransaction",
  "networkClientId": "b36ed464-d916-4299-b982-c7db44f961b7",
  "origin": "http://localhost:5173",
  "params": [
    {
      "calls": [
        {
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x",
          "data": "0x2f2ff15d114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa1220000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff"
        },
        {
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x",
          "data": "0x2f2ff15d139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff"
        },
        {
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x",
          "data": "0x2f2ff15d265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff"
        },
        {
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x",
          "data": "0x2f2ff15d7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff"
        }
      ],
      "chainId": "0xa5bf",
      "feeToken": "0x20c0000000000000000000000000000000000001",
      "from": "0x2367E6eCA6E1fCc2d112133c896e3bddad375Aff",
      "type": "0x76"
    }
  ]
}

```

Middleware After transform:
```
{
  "id": 4208624703,
  "jsonrpc": "2.0",
  "mainFrameOrigin": "http://localhost:5173",
  "method": "wallet_sendCalls",
  "networkClientId": "b36ed464-d916-4299-b982-c7db44f961b7",
  "origin": "http://localhost:5173",
  "params": [
    {
      "atomicRequired": false,
      "calls": [
        {
          "data": "0x2f2ff15d114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa1220000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x0"
        },
        {
          "data": "0x2f2ff15d139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x0"
        },
        {
          "data": "0x2f2ff15d265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x0"
        },
        {
          "data": "0x2f2ff15d7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
          "to": "0x20C000000000000000000000527F687b8Fc500FC",
          "value": "0x0"
        }
      ],
      "capabilities": {
        "feeToken": {
          "address": "0x20c0000000000000000000000000000000000001",
          "optional": true
        }
      },
      "chainId": "0xa5bf",
      "from": "0x2367E6eCA6E1fCc2d112133c896e3bddad375Aff",
      "version": "2.0.0"
    }
  ]
}
```

Note that since `feeToken` doesn't exist as part as any standard, we move it to `capabilities.feeToken.address` so the controllers that the transaction pass through will have the information "this gas fee token has been set". The idea would be that it works the same way as gasless txs, except that when this token is set directly from the dApp, the user cannot "switch" the gas token (or a dropdown of 1 with only that token, depending on existing behavior).

The goal then if I understand correctly, is to have this `feeToken` address be set as `gasFeeToken` when calling the final `addTransaction`. The tracing below tries to follow when the tx goes from the dApp to the "show transaction to the user step".

Tracing where this tx goes - NOTE this is when modifying `transaction-controller` and `eip-5792-middleware` locally (+ feature flags mocks) to go as far as possible in the flow and try to understand it before 7702 is enabled :
- [core/eip-5792-middleware] [validateAndNormalizeKeyholder](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/eip-5792-middleware/src/utils.ts#L52C23-L52C52) - modified locally to not throw.
- [core/eip-5792-middleware] [processSendCalls](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/eip-5792-middleware/src/hooks/processSendCalls.ts#L75) - modified locally to set add an extra `gasFeeToken` parameter when calling [processMultipleTransaction](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/eip-5792-middleware/src/hooks/processSendCalls.ts#L130C21-L130C39). The `gasFeeToken` is obtained from `params.capabilities?.feeToken` previously added in `capabilities when transforming the original `0x76` transaction.

- [core/transaction-controller] [addTransationBatch](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/transaction-controller/src/TransactionController.ts#L1200-L1202) is called with `gasFeeToken` set among other params:
```
{
  "publicKeyEIP7702": "0x3c7a1cCCe462e96D186B8ca9a1BCB2010C3dABa3",
  "publishBatchHook": "async _request => {...}",
  "publishTransaction": "(ethQuery, transactionMeta) => {...}",
  "request": {
    "from": "0x2367e6eca6e1fcc2d112133c896e3bddad375aff",
    "gasFeeToken": "0x20c0000000000000000000000000000000000001", // the param we managed to "pass down"
    "gasLimit7702": "0x124f80", // added for testing because this was automatically set too low
    "networkClientId": "b36ed464-d916-4299-b982-c7db44f961b7",
    "origin": "http://localhost:5173",
    "requestId": "1675194481",
    "requiredAssets": null,
    "securityAlertId": "048e23a3-ab82-448f-814e-2d281a9c2782",
    "transactions": [
      { "params": {...} },
      { "params": {...} },
      { "params": {...} },
      { "params": {...} }
    ]
  },
  "validateSecurity": "ƒ validateSecurity()"
}
``` 
- [core/transaction-controller] [addTransactionBatchWith7702](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/transaction-controller/src/utils/batch.ts#L285) is called with the same param as above.
- [core/transaction-controller] [addTransaction](https://github.com/MetaMask/core/blob/e899692d5b4a9f3cb7b53949c3d59af4c67a8e00/packages/transaction-controller/src/TransactionController.ts#L1266) is called with:
```
{
  "options": {
    "batchId": "0xdf1a2a26b11c47369157517e2798259b",
    "gasFeeToken": "0x20c0000000000000000000000000000000000001",
    "isGasFeeIncluded": null,
    "isGasFeeSponsored": null,
    "nestedTransactions": [
      {
        "data": "0x2f2ff15d114e74f6ea3bd819998f78687bfcb11b140da08e…0000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
        "to": "0x20C000000000000000000000A60F2958A84f05DA",
        "value": "0x0",
        "type": "contractInteraction"
      },
      {
        "data": "0x2f2ff15d139c2898040ef16910dc9f44dc697df79363da76…0000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
        "to": "0x20C000000000000000000000A60F2958A84f05DA",
        "value": "0x0",
        "type": "contractInteraction"
      },
      {
        "data": "0x2f2ff15d265b220c5a8891efdd9e1b1b7fa72f257bd5169f…0000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
        "to": "0x20C000000000000000000000A60F2958A84f05DA",
        "value": "0x0",
        "type": "contractInteraction"
      },
      {
        "data": "0x2f2ff15d7408fdc0d31c7bcb349eab611f5d1168acd43035…0000000002367e6eca6e1fcc2d112133c896e3bddad375aff",
        "to": "0x20C000000000000000000000A60F2958A84f05DA",
        "value": "0x0",
        "type": "contractInteraction"
      }
    ],
    "networkClientId": "b36ed464-d916-4299-b982-c7db44f961b7",
    "origin": "http://localhost:5173",
    "requestId": "1675194481",
    "requireApproval": null,
    "requiredAssets": null,
    "securityAlertResponse": {
      "securityAlertId": "048e23a3-ab82-448f-814e-2d281a9c2782"
    },
    "skipInitialGasEstimate": null,
    "type": "batch"
  },
  "txParams": {
    "data": "0xe9ae5c5301000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000240000000000000000000000000000000000000000000000000000000000000032000000000000000000000000020c000000000000000000000a60f2958a84f05da0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000442f2ff15d114e74f6ea3bd819998f78687bfcb11b140da08e9b7d222fa9c1f1ba1f2aa1220000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff0000000000000000000000000000000000000000000000000000000000000000000000000000000020c000000000000000000000a60f2958a84f05da0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000442f2ff15d139c2898040ef16910dc9f44dc697df79363da767d8bc92f2e310312b816e46d0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff0000000000000000000000000000000000000000000000000000000000000000000000000000000020c000000000000000000000a60f2958a84f05da0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000442f2ff15d265b220c5a8891efdd9e1b1b7fa72f257bd5169f8d87e319cf3dad6ff52b94ae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff0000000000000000000000000000000000000000000000000000000000000000000000000000000020c000000000000000000000a60f2958a84f05da0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000442f2ff15d7408fdc0d31c7bcb349eab611f5d1168acd4303574993f8cdc98b1cd18c41cae0000000000000000000000002367e6eca6e1fcc2d112133c896e3bddad375aff00000000000000000000000000000000000000000000000000000000",
    "from": "0x2367e6eca6e1fcc2d112133c896e3bddad375aff",
    "gas": "0x124f80",
    "maxFeePerGas": null,
    "maxPriorityFeePerGas": null,
    "to": "0x2367e6eca6e1fcc2d112133c896e3bddad375aff"
  }
}
```
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
