### PR TITLE
fix: flaky test `Shield Plan Stripe Integration Shield Claims displays error when transaction is not eligible`

### DIFF
--- a/test/e2e/tests/shield/shield-subscription-management.spec.ts
+++ b/test/e2e/tests/shield/shield-subscription-management.spec.ts
@@ -437,7 +437,7 @@ describe('Shield Plan Stripe Integration', function () {
             });
           },
           ignoredConsoleErrors: [
-            'SubmitClaimError: This transaction is not done within MetaMask, hence it is not eligible for claims',
+            'SubmitClaimError: A claim has already been submitted for this transaction hash.',
           ],
         },
         async ({ driver }) => {

--- a/test/e2e/tests/shield/shield-subscription-management.spec.ts
+++ b/test/e2e/tests/shield/shield-subscription-management.spec.ts
@@ -377,6 +377,9 @@ describe('Shield Plan Stripe Integration', function () {
               claimErrorCode: 'E102', // TRANSACTION_NOT_ELIGIBLE
             });
           },
+          ignoredConsoleErrors: [
+            'SubmitClaimError: This transaction is not done within MetaMask, hence it is not eligible for claims',
+          ],
         },
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/shield/shield-subscription-management.spec.ts
+++ b/test/e2e/tests/shield/shield-subscription-management.spec.ts
@@ -436,6 +436,9 @@ describe('Shield Plan Stripe Integration', function () {
               claimErrorCode: 'E203', // DUPLICATE_CLAIM_EXISTS
             });
           },
+          ignoredConsoleErrors: [
+            'SubmitClaimError: This transaction is not done within MetaMask, hence it is not eligible for claims',
+          ],
         },
         async ({ driver }) => {
           await loginWithBalanceValidation(driver);

--- a/test/e2e/tests/shield/shield-subscription-management.spec.ts
+++ b/test/e2e/tests/shield/shield-subscription-management.spec.ts
@@ -378,6 +378,7 @@ describe('Shield Plan Stripe Integration', function () {
             });
           },
           ignoredConsoleErrors: [
+            'Failed to submit shield claim',
             'SubmitClaimError: This transaction is not done within MetaMask, hence it is not eligible for claims',
           ],
         },
@@ -437,6 +438,7 @@ describe('Shield Plan Stripe Integration', function () {
             });
           },
           ignoredConsoleErrors: [
+            'Failed to submit shield claim',
             'SubmitClaimError: A claim has already been submitted for this transaction hash.',
           ],
         },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The spec sometimes fails as it appears a console error (if there is enough time). This console error is expected as we are testing that specific error, so we can ignore it (either duplicated tx, or tx not elegible)

<img width="845" height="298" alt="image" src="https://github.com/user-attachments/assets/7cf73152-e03d-42af-8665-760383ed8b46" />


<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/51b4052f-135e-44e9-8e07-fbfaddc50a92" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39987?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that relaxes console-error assertions for specific, expected failures; minimal product risk but could mask unexpected regressions if error strings change.
> 
> **Overview**
> Fixes flakiness in Shield E2E claim error scenarios by adding `ignoredConsoleErrors` filters to the two negative tests (`TRANSACTION_NOT_ELIGIBLE` and `DUPLICATE_CLAIM_EXISTS`).
> 
> This prevents expected “Failed to submit shield claim” console output from failing the suite while still asserting the user-facing error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98abfa0cb3fb261b9cc92fcf8ece050fd24871e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->