### PR TITLE
fix: flaky bridge test

### DIFF
--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -363,6 +363,7 @@ exports[`BridgeInputGroup should render destination networks 3`] = `
 [
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:e92eb8d31dccb497e712b982d787222dae4d9f3503cca3569c7a96bbd5bb2f35",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:c6ab4b1f41996afda9220fbe8503fa6985c2f54e14bec5b7ed8a9530938f06db",
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
@@ -373,6 +374,18 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Client-Id": "extension",
+      },
+      "method": "POST",
+      "signal": AbortSignal {},
+    },
+  ],
+  [
+    "https://bridge.api.cx.metamask.io/getTokens/search",
+    {
+      "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
         "Content-Type": "application/json",
         "X-Client-Id": "extension",
@@ -648,6 +661,7 @@ exports[`BridgeInputGroup should render source networks 3`] = `
 [
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:503dca807bc28c124ddd2340e17a335eb411cc81363589c7a73716053f469fd3",
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:d4ebccd5f98957b00ea939fb0c1fccbdb21ab61290f7557e3f96855866f19789",
   "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
@@ -658,6 +672,18 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Client-Id": "extension",
+      },
+      "method": "POST",
+      "signal": AbortSignal {},
+    },
+  ],
+  [
+    "https://bridge.api.cx.metamask.io/getTokens/search",
+    {
+      "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
         "Content-Type": "application/json",
         "X-Client-Id": "extension",

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -405,6 +405,14 @@ describe('BridgeInputGroup', () => {
 
       const networkPicker = getByTestId('multichain-asset-picker__network');
       await fillSearchInput('SD');
+      // Wait for the debounced search fetch to fire before clicking the
+      // network picker, which unmounts the asset list and cancels the debounce
+      await waitFor(() => {
+        expect(mockHandleFetch).toHaveBeenCalledWith(
+          expect.stringContaining('search'),
+          expect.anything(),
+        );
+      });
       await act(async () => {
         await networkPicker.click();
       });

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -422,7 +422,7 @@ describe('BridgeInputGroup', () => {
       );
       await waitFor(() => {
         expect(networkPickerPopover).toBeVisible();
-        expect(abortSpy).toHaveBeenCalledTimes(4);
+        expect(abortSpy).toHaveBeenCalledTimes(5);
       });
 
       expect(networkPickerPopover).toMatchSnapshot();
@@ -437,8 +437,8 @@ describe('BridgeInputGroup', () => {
       });
       await waitFor(() => {
         expect(networkPickerPopover).not.toBeVisible();
-        expect(abortSpy).toHaveBeenCalledTimes(7);
-        expect(mockHandleFetch).toHaveBeenCalledTimes(3);
+        expect(abortSpy).toHaveBeenCalledTimes(8);
+        expect(mockHandleFetch).toHaveBeenCalledTimes(4);
       });
 
       expect(await localforage.keys()).toMatchSnapshot();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a flaky test in bridge-input-group.test.tsx ("should render destination/source networks").

Context: The test types a search query then immediately clicks the network picker. The search fetch is debounced by 300ms (useTokenSearchResults), and clicking the network picker unmounts BridgeAssetList, which cancels the debounce. Depending on system load/timing, the debounced search may or may not fire before the unmount — causing the localforage.keys() snapshot to non-deterministically include or exclude the search cache key.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39989?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust timing/expectations to make snapshots deterministic; no production logic is modified.
> 
> **Overview**
> Fixes flakiness in `BridgeInputGroup`'s "render source/destination networks" test by explicitly `waitFor`-ing the debounced token search `handleFetch` call to occur before clicking the network picker (which unmounts the list and cancels the debounce).
> 
> Updates expectations accordingly: abort counts increase and the snapshots now consistently include the `getTokens/search` request and resulting `localforage` cache keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d63607d6d0e5d8ce55452fc17a5a634f9fd5fcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->