### PR TITLE
chore: add cursor rule for test i18n usage patterns

### DIFF
--- a/.cursor/rules/e2e-testing-guidelines/RULE.md
+++ b/.cursor/rules/e2e-testing-guidelines/RULE.md
@@ -6,6 +6,8 @@ alwaysApply: false
 
 Reference: [MetaMask Extension E2E Test Guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/e2e/extension-e2e-guidelines.md)
 
+**See also:** [Test i18n Usage Guidelines](../test-i18n-usage/RULE.md) - For i18n patterns in test assertions
+
 # MetaMask Extension E2E Testing Guidelines
 
 ## Core Principles

--- a/.cursor/rules/test-i18n-usage/RULE.md
+++ b/.cursor/rules/test-i18n-usage/RULE.md
@@ -145,6 +145,7 @@ A fitness function test (`test/unit-global/locale-query-mismatch.test.ts`) preve
    - Baseline allowlist exists for legacy exceptions
 
 If the fitness function fails, either:
+
 - Fix the test to use i18n references
 - Fix the component to use i18n (preferred)
 - Add to baseline only if legacy code

--- a/.cursor/rules/test-i18n-usage/RULE.md
+++ b/.cursor/rules/test-i18n-usage/RULE.md
@@ -1,0 +1,231 @@
+---
+description: i18n Usage Guidelines for Test Files
+globs: '*.test.*'
+alwaysApply: false
+---
+
+Reference: [PR #39859 - Replace hardcoded strings with i18n message references](https://github.com/MetaMask/metamask-extension/pull/39859)
+
+# Test i18n Usage Guidelines
+
+## Import i18n Messages from Test Helpers
+
+### ALWAYS Use enLocale from Test Helpers
+
+- **Import locale messages from `test/lib/i18n-helpers`**, not directly from `app/_locales/en/messages.json`
+- Use the alias `enLocale as messages` for consistency
+- This prevents tests from breaking when translations change
+- Eliminates need for `eslint-disable-next-line import/no-restricted-paths`
+
+```typescript
+✅ CORRECT:
+import { enLocale as messages } from '../../../test/lib/i18n-helpers';
+
+❌ WRONG:
+// eslint-disable-next-line import/no-restricted-paths
+import enMessages from '../../../app/_locales/en/messages.json';
+```
+
+## Use i18n Keys in Test Assertions
+
+### Reference Locale Messages in Queries
+
+- **ALWAYS use `messages.<key>.message`** instead of hardcoded strings
+- Makes tests resilient to translation changes
+- Self-documenting - shows which i18n key is being used
+- Caught by fitness function test that prevents locale query mismatches
+
+```typescript
+✅ CORRECT:
+import { enLocale as messages } from '../../../test/lib/i18n-helpers';
+
+it('displays cancel button', () => {
+  render(<MyComponent />);
+  expect(screen.getByText(messages.cancel.message)).toBeInTheDocument();
+});
+
+it('finds button by role and name', () => {
+  render(<MyComponent />);
+  const button = screen.getByRole('button', { name: messages.confirm.message });
+  expect(button).toBeInTheDocument();
+});
+
+❌ WRONG:
+it('displays cancel button', () => {
+  render(<MyComponent />);
+  expect(screen.getByText('Cancel')).toBeInTheDocument(); // Hardcoded string
+});
+
+it('finds button by role and name', () => {
+  render(<MyComponent />);
+  const button = screen.getByRole('button', { name: 'Confirm' }); // Hardcoded string
+  expect(button).toBeInTheDocument();
+});
+```
+
+## Handle Parameterized i18n Strings
+
+### Use String Replace for Placeholders
+
+- **ALWAYS use `.replace()` for parameterized locale strings**
+- i18n strings with placeholders like `$1`, `$2` need runtime replacement
+- Chain multiple `.replace()` calls for multiple parameters
+
+```typescript
+✅ CORRECT:
+import { enLocale as messages } from '../../../test/lib/i18n-helpers';
+
+it('displays token with symbol', () => {
+  render(<TokenDisplay symbol="DAI" />);
+  const expectedText = messages.tokenBalance.message.replace('$1', 'DAI');
+  expect(screen.getByText(expectedText)).toBeInTheDocument();
+});
+
+it('displays message with multiple parameters', () => {
+  render(<TransferMessage from="Alice" to="Bob" />);
+  const expectedText = messages.transferFrom.message
+    .replace('$1', 'Alice')
+    .replace('$2', 'Bob');
+  expect(screen.getByText(expectedText)).toBeInTheDocument();
+});
+
+❌ WRONG:
+it('displays token with symbol', () => {
+  render(<TokenDisplay symbol="DAI" />);
+  expect(screen.getByText('Balance: DAI')).toBeInTheDocument(); // Hardcoded
+});
+
+it('displays message with placeholders', () => {
+  render(<TransferMessage from="Alice" to="Bob" />);
+  // This will fail - placeholders not replaced
+  expect(screen.getByText(messages.transferFrom.message)).toBeInTheDocument();
+});
+```
+
+## Import Testing Library Utilities Directly
+
+### Import fireEvent from @testing-library/react
+
+- **Import `fireEvent` directly from `@testing-library/react`**
+- Don't import from `test/jest` re-exports
+- Apply to all @testing-library utilities (screen, render, waitFor, etc.)
+
+```typescript
+✅ CORRECT:
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+it('handles click event', () => {
+  render(<MyButton onClick={mockFn} />);
+  fireEvent.click(screen.getByRole('button'));
+  expect(mockFn).toHaveBeenCalled();
+});
+
+❌ WRONG:
+import { fireEvent } from '../../../test/jest';
+import { render, screen } from '@testing-library/react';
+
+it('handles click event', () => {
+  render(<MyButton onClick={mockFn} />);
+  fireEvent.click(screen.getByRole('button'));
+  expect(mockFn).toHaveBeenCalled();
+});
+```
+
+## Fitness Function Protection
+
+### Quality Gate for Locale Query Mismatches
+
+A fitness function test (`test/unit-global/locale-query-mismatch.test.ts`) prevents:
+
+1. **Querying via locale keys when component renders hardcoded text**
+   - If component has hardcoded JSX text, test shouldn't query via i18n key
+
+2. **Introducing new hardcoded query strings that match existing locale values**
+   - New tests must use `messages.<key>.message` pattern
+   - Baseline allowlist exists for legacy exceptions
+
+If the fitness function fails, either:
+- Fix the test to use i18n references
+- Fix the component to use i18n (preferred)
+- Add to baseline only if legacy code
+
+## Complete Example
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react';
+import { enLocale as messages } from '../../../test/lib/i18n-helpers';
+import { TokenApproval } from './token-approval';
+
+describe('TokenApproval', () => {
+  const mockProps = {
+    tokenSymbol: 'USDC',
+    spenderName: 'Uniswap',
+    onApprove: jest.fn(),
+    onReject: jest.fn(),
+  };
+
+  it('displays approval message with token and spender', () => {
+    render(<TokenApproval {...mockProps} />);
+
+    const expectedMessage = messages.approveTokenSpender.message
+      .replace('$1', 'USDC')
+      .replace('$2', 'Uniswap');
+
+    expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+  });
+
+  it('calls onApprove when confirm button is clicked', () => {
+    render(<TokenApproval {...mockProps} />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
+
+    fireEvent.click(confirmButton);
+
+    expect(mockProps.onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onReject when cancel button is clicked', () => {
+    render(<TokenApproval {...mockProps} />);
+
+    const cancelButton = screen.getByRole('button', {
+      name: messages.cancel.message,
+    });
+
+    fireEvent.click(cancelButton);
+
+    expect(mockProps.onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables confirm button when loading', () => {
+    render(<TokenApproval {...mockProps} isLoading />);
+
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
+
+    expect(confirmButton).toBeDisabled();
+  });
+});
+```
+
+## Benefits of This Approach
+
+1. **Resilient to translation changes** - Tests won't break when copy changes
+2. **Self-documenting** - Clear which i18n keys are being tested
+3. **Enforced by automation** - Fitness function prevents regressions
+4. **Consistent patterns** - All tests follow same i18n approach
+5. **Better refactoring** - Can safely update translations without test failures
+
+## Checklist
+
+Before submitting tests:
+
+- [ ] Import `enLocale as messages` from `test/lib/i18n-helpers`
+- [ ] No direct imports from `app/_locales/en/messages.json`
+- [ ] All string queries use `messages.<key>.message` pattern
+- [ ] Parameterized strings use `.replace()` for placeholders
+- [ ] Import testing utilities directly from `@testing-library/react`
+- [ ] No hardcoded English strings in assertions
+- [ ] Fitness function test passes

--- a/.cursor/rules/test-i18n-usage/RULE.md
+++ b/.cursor/rules/test-i18n-usage/RULE.md
@@ -1,6 +1,6 @@
 ---
-description: i18n Usage Guidelines for Test Files
-globs: '*.test.*'
+description: i18n Usage Guidelines for Unit and E2E Test Files
+globs: '{*.test.*,*.spec.*}'
 alwaysApply: false
 ---
 

--- a/.cursor/rules/unit-testing-guidelines/RULE.md
+++ b/.cursor/rules/unit-testing-guidelines/RULE.md
@@ -6,6 +6,8 @@ alwaysApply: false
 
 Reference: [MetaMask Unit Testing Guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/unit-testing.md)
 
+**See also:** [Test i18n Usage Guidelines](../test-i18n-usage/RULE.md) - For i18n patterns in test assertions
+
 # MetaMask Extension - Cursor Rules
 
 ## Unit Testing Guidelines


### PR DESCRIPTION
## **Description**

This PR adds a new Cursor rule based on the standards established in [PR #39859](https://github.com/MetaMask/metamask-extension/pull/39859).

### What is the reason for the change?

PR #39859 introduced a major improvement to our testing practices by replacing hardcoded strings with i18n message references. This makes tests more resilient to translation changes and self-documenting. 

### What is the improvement/solution?

Created a new Cursor rule at `.cursor/rules/test-i18n-usage/RULE.md` that:

- **Enforces importing locale messages** from `test/lib/i18n-helpers` instead of direct locale file imports
- **Requires using `messages.<key>.message` pattern** in test assertions instead of hardcoded strings
- **Documents parameterized string handling** with `.replace()` for i18n strings with placeholders
- **Guides proper testing library imports** directly from `@testing-library/react`
- **Explains the fitness function** quality gate that prevents locale query mismatches

The rule follows [Cursor's best practices](https://cursor.com/docs/context/rules):
- Focused and actionable guidance
- Auto-applies only to test files via `globs: '*.test.*'`
- Includes clear ✅ CORRECT and ❌ WRONG examples
- Provides a checklist for quick reference
- Under 500 lines and concise

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/39995?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

Related: #39859

## **Manual testing steps**

1. Open a test file in Cursor (e.g., `ui/components/app/alert-system/alert-modal/alert-modal.test.tsx`)
2. Try writing a test with a hardcoded string like `getByText('Cancel')`
3. Cursor should suggest using `messages.cancel.message` pattern based on the new rule
4. Verify the rule documentation is clear and helpful

## **Screenshots/Recordings**

### **Before**

No Cursor rule for test i18n patterns - developers might continue using hardcoded strings in tests.

### **After**

New Cursor rule provides guidance on proper i18n usage in tests, helping maintain the standards from PR #39859.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation only)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A - markdown documentation)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Cursor rule additions/links; no runtime or test logic changes.
> 
> **Overview**
> Adds a new Cursor rule, `.cursor/rules/test-i18n-usage/RULE.md`, to standardize how tests reference locale strings (importing `enLocale` from `test/lib/i18n-helpers`, asserting via `messages.<key>.message`, handling placeholder replacement, and importing Testing Library utilities directly).
> 
> Updates the existing `.cursor` unit and E2E testing guideline rules to **cross-reference** this new i18n rule for consistent test assertion patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281789062ce793fa4f857211c2c22733a027e76e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->