### PR TITLE
refactor: move network config prop

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
@@ -131,7 +131,18 @@ const mockProps = {
   transaction: mockTransaction,
   onClose: jest.fn(),
   userAddress: MOCK_ACCOUNT_SOLANA_MAINNET.address,
-  networkConfig: MULTICHAIN_PROVIDER_CONFIGS[MultichainNetworks.BITCOIN],
+};
+
+const mockStateWithBitcoin = {
+  ...mockState,
+  metamask: {
+    ...mockState.metamask,
+    isEvmSelected: false,
+    remoteFeatureFlags: {
+      ...mockState.metamask.remoteFeatureFlags,
+      bitcoinAccounts: true,
+    },
+  },
 };
 
 describe('MultichainTransactionDetailsModal', () => {
@@ -159,7 +170,7 @@ describe('MultichainTransactionDetailsModal', () => {
       userAddress: string;
     } = mockProps,
   ) => {
-    const store = configureStore(mockState.metamask);
+    const store = configureStore(mockStateWithBitcoin);
     return renderWithProvider(
       <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
         <MultichainTransactionDetailsModal {...props} />
@@ -354,31 +365,15 @@ describe('MultichainTransactionDetailsModal', () => {
   });
 
   it('displays the correct from address for Bitcoin send transaction', () => {
-    const btcTransaction = {
+    const btcTransaction: Transaction = {
       ...mockTransaction,
       account: MOCK_ACCOUNT_BIP122_P2WPKH.id,
     };
-
-    const modifiedMockState = {
-      ...mockState,
-      metamask: {
-        ...mockState.metamask,
-        internalAccounts: {
-          ...mockState.metamask.internalAccounts,
-          accounts: {
-            ...mockState.metamask.internalAccounts.accounts,
-            [MOCK_ACCOUNT_BIP122_P2WPKH.id]: MOCK_ACCOUNT_BIP122_P2WPKH,
-          },
-        },
-      },
-    };
-
-    const store = configureStore(modifiedMockState.metamask);
+    const store = configureStore(mockStateWithBitcoin);
     const props = {
       transaction: btcTransaction,
       onClose: jest.fn(),
       userAddress: MOCK_ACCOUNT_BIP122_P2WPKH.address,
-      networkConfig: MULTICHAIN_PROVIDER_CONFIGS[MultichainNetworks.BITCOIN],
     };
 
     renderWithProvider(

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
@@ -16,7 +16,6 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MULTICHAIN_PROVIDER_CONFIGS,
   MultichainNetworks,
-  MultichainProviderConfig,
   SOLANA_BLOCK_EXPLORER_URL,
 } from '../../../../shared/constants/multichain/networks';
 import mockState from '../../../../test/data/mock-state.json';
@@ -158,7 +157,6 @@ describe('MultichainTransactionDetailsModal', () => {
       transaction: Transaction;
       onClose: jest.Mock;
       userAddress: string;
-      networkConfig: MultichainProviderConfig;
     } = mockProps,
   ) => {
     const store = configureStore(mockState.metamask);

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -43,12 +43,14 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
 import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
-import { getAccountName } from '../../../selectors';
+import {
+  getAccountName,
+  getSelectedMultichainNetworkConfiguration,
+} from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
 } from '../../../hooks/useMultichainTransactionDisplay';
-import { MultichainProviderConfig } from '../../../../shared/constants/multichain/networks';
 import {
   getInternalAccounts,
   getInternalAccountsObject,
@@ -65,7 +67,6 @@ export type MultichainTransactionDetailsModalProps = {
   transaction: Transaction;
   onClose: () => void;
   userAddress: string;
-  networkConfig: MultichainProviderConfig;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -74,11 +75,10 @@ export function MultichainTransactionDetailsModal({
   transaction,
   onClose,
   userAddress,
-  networkConfig,
 }: MultichainTransactionDetailsModalProps) {
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
-
+  const networkConfig = useSelector(getSelectedMultichainNetworkConfiguration);
   const {
     from,
     to,

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -500,7 +500,6 @@ export default function TransactionList({
               transaction={selectedTransaction}
               onClose={() => toggleShowDetails(null)}
               userAddress={selectedAccount.address}
-              networkConfig={multichainNetworkConfig}
             />
           ))}
 

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -865,7 +865,6 @@ export default function UnifiedTransactionList({
             transaction={selectedTransaction}
             onClose={() => toggleShowDetails(null)}
             userAddress={selectedAccount.address}
-            networkConfig={multichainNetworkConfig}
           />
         ))}
 

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -6,10 +6,10 @@ import {
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { MULTICHAIN_NETWORK_DECIMAL_PLACES } from '@metamask/multichain-network-controller';
 import { useSelector } from 'react-redux';
+import type { CaipChainId } from '@metamask/utils';
 import { formatWithThreshold } from '../components/app/assets/util/formatWithThreshold';
 import { getIntlLocale } from '../ducks/locale/locale';
 import { TransactionGroupStatus } from '../../shared/constants/transaction';
-import type { MultichainProviderConfig } from '../../shared/constants/multichain/networks';
 import { useI18nContext } from './useI18nContext';
 
 export const KEYRING_TRANSACTION_STATUS_KEY = {
@@ -39,7 +39,7 @@ type AggregatedMovement = {
 
 export function useMultichainTransactionDisplay(
   transaction: Transaction,
-  networkConfig: MultichainProviderConfig,
+  networkConfig: { chainId: CaipChainId },
 ) {
   const locale = useSelector(getIntlLocale);
   const { chainId } = networkConfig;

--- a/ui/selectors/multichain-transactions.test.ts
+++ b/ui/selectors/multichain-transactions.test.ts
@@ -1,8 +1,6 @@
 import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
 import type { Transaction } from '@metamask/keyring-api';
-import type { DefaultRootState } from 'react-redux';
-import type { MultichainState } from './multichain';
-import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
+import type { MetaMaskReduxState } from '../store/store';
 import { getSelectedAccountGroupMultichainTransactions } from './multichain-transactions';
 
 // Mock account-tree selectors used by the selector under test
@@ -18,16 +16,15 @@ describe('getSelectedAccountGroupMultichainTransactions', () => {
   const SOLANA_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
   const SOLANA_DEVNET = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
 
-  type RootState = MultichainState & MultichainAccountsState & DefaultRootState;
   type NonEvmTransactionsMap =
     MultichainTransactionsControllerState['nonEvmTransactions'];
 
-  function buildState(nonEvmTransactions: unknown): RootState {
+  function buildState(nonEvmTransactions: unknown): MetaMaskReduxState {
     return {
       metamask: {
         nonEvmTransactions: nonEvmTransactions as NonEvmTransactionsMap,
       },
-    } as unknown as RootState;
+    } as unknown as MetaMaskReduxState;
   }
 
   it('returns empty transactions when nonEvmChainIds is undefined', () => {

--- a/ui/selectors/multichain-transactions.ts
+++ b/ui/selectors/multichain-transactions.ts
@@ -1,5 +1,4 @@
 import { Transaction } from '@metamask/keyring-api';
-import type { DefaultRootState } from 'react-redux';
 import type { MultichainState } from './multichain';
 import {
   getAccountGroupWithInternalAccounts,
@@ -9,6 +8,7 @@ import type {
   MultichainAccountsState,
   AccountGroupWithInternalAccounts,
 } from './multichain-accounts/account-tree.types';
+import { MetaMaskReduxState } from '.';
 
 // Lightweight shape for nonEvmTransactions state map
 // accountId -> chainId -> TransactionStateEntry
@@ -20,10 +20,8 @@ type NonEvmTransactionsMap = Record<
   >
 >;
 
-type RootState = MultichainState & MultichainAccountsState & DefaultRootState;
-
 export function getSelectedAccountGroupMultichainTransactions(
-  state: RootState,
+  state: MetaMaskReduxState,
   nonEvmChainIds?: string[],
 ): { transactions: Transaction[] } {
   const nonEvmTransactionsByAccount = (state as MultichainState).metamask


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Moving the network config prop closer to where it's needed

Part of breaking down the Activity v2 PR work

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40007?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a prop-to-selector refactor, but it changes where the modal gets network context, which could affect explorer links/amount formatting if the selected network state doesn’t match the transaction’s chain.
> 
> **Overview**
> `MultichainTransactionDetailsModal` no longer accepts a `networkConfig` prop; it now reads the selected multichain network configuration via `getSelectedMultichainNetworkConfiguration` and passes it into `useMultichainTransactionDisplay`.
> 
> Call sites in both `transaction-list.component.js` and `unified-transaction-list.component.js` stop threading `multichainNetworkConfig` into the modal. Supporting types and tests are updated: `useMultichainTransactionDisplay` now only requires `{ chainId }`, modal tests build a store state with Bitcoin feature flags enabled, and `getSelectedAccountGroupMultichainTransactions` is retyped to accept `MetaMaskReduxState` (with matching test updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966ccca6c789b0e0c01179ea8aba10359c1de78a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->