### PR TITLE
feat: added icons for sidepanel and popup view in drawer component

### DIFF
--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -376,9 +376,7 @@ export function useGlobalMenuSections(
     ) {
       section2.items.push({
         id: 'global-menu-toggle-view',
-        // TODO: Add back the correct icon name when the design system is updated
-        // iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
-        iconName: IconName.Expand,
+        iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
         label: isSidepanel ? t('switchToPopup') : t('switchToSidePanel'),
         onClick: async () => {
           await toggleDefaultView();


### PR DESCRIPTION
This PR adds the correct icons for sidepanel and popup in global menu drawer component

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: icon update

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to app-header-unlocked componet
2. Comment the global-menu component in app-header-unlocked
3. Add this code

<GlobalMenuDrawerWithList
isOpen={accountOptionsMenuOpen}
onClose={() => setAccountOptionsMenuOpen(false)}
anchorElement={menuRef.current}
/>
4. Run with yarn start
5. Check the global-menu drawer in extension and the icons for sidepanel and popup view are correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

NA
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only icon change in a single menu item with no impact on navigation logic, state, or data handling.
> 
> **Overview**
> Updates the Global Menu drawer “toggle view” action to show the correct icon depending on current viewport: `IconName.PopUp` when in sidepanel and `IconName.SidePanel` when in popup (replacing the temporary `IconName.Expand`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 077d76b725d98657559ef8be926a12c375d713ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->