### PR TITLE
fix: onboarding completion page guard

### DIFF
--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.test.tsx
@@ -7,6 +7,7 @@ import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import {
   DEFAULT_ROUTE,
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
+  ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
 import CreationSuccessful from './creation-successful';
 
@@ -51,6 +52,8 @@ describe('Wallet Ready Page', () => {
       ],
       firstTimeFlowType: FirstTimeFlowType.create,
       seedPhraseBackedUp: true,
+      isInitialized: true,
+      isUnlocked: true,
     },
     appState: {
       externalServicesOnboardingToggleState: true,
@@ -97,6 +100,21 @@ describe('Wallet Ready Page', () => {
     fireEvent.click(doneButton);
     await waitFor(() => {
       expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    });
+  });
+
+  it('redirects to welcome page when wallet is not initialized', () => {
+    const mockStore = configureMockStore([thunk])({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        isInitialized: false,
+        isUnlocked: false,
+      },
+    });
+    renderWithProvider(<CreationSuccessful />, mockStore);
+    expect(mockUseNavigate).toHaveBeenCalledWith(ONBOARDING_WELCOME_ROUTE, {
+      replace: true,
     });
   });
 });

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -38,6 +38,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
+  ONBOARDING_WELCOME_ROUTE,
   DEFAULT_ROUTE,
   SECURITY_ROUTE,
 } from '../../../helpers/constants/routes';
@@ -55,6 +56,7 @@ import {
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import {
   getCompletedOnboarding,
+  getIsInitialized,
   getIsPrimarySeedPhraseBackedUp,
 } from '../../../ducks/metamask/metamask';
 import {
@@ -87,6 +89,8 @@ export default function CreationSuccessful() {
   const isOnboardingCompleted = useSelector(getCompletedOnboarding);
   const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
 
+  const isInitialized = useSelector(getIsInitialized);
+
   const learnMoreLink =
     'https://support.metamask.io/stay-safe/safety-in-web3/basic-safety-and-security-tips-for-metamask/';
 
@@ -96,6 +100,17 @@ export default function CreationSuccessful() {
   const isFromSettingsSRPBackup = isWalletReady && isFromReminder;
 
   const [isSidePanelOpen, setIsSidePanelOpen] = useState<boolean>(false);
+
+  // Guard: redirect if wallet is not properly set up.
+  // Prevents users from skipping onboarding steps by navigating directly to the completion route.
+  useEffect(() => {
+    if (isFromReminder) {
+      return;
+    }
+    if (!isInitialized) {
+      navigate(ONBOARDING_WELCOME_ROUTE, { replace: true });
+    }
+  }, [isInitialized, isFromReminder, navigate]);
 
   useEffect(() => {
     const browserWithSidePanel = browser as BrowserWithSidePanel;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Users can bypass the entire onboarding flow by navigating directly to the completion route (`#/onboarding/completion`), rendering the `CreationSuccessful` component without having created a wallet. Clicking "Open wallet" then calls `completeOnboarding()`, marking onboarding as complete even though the KeyringController vault was never created. This leads to an inconsistent state where the extension appears onboarded but has no wallet, causing errors when trying to unlock.

This PR adds a guard to the `CreationSuccessful` component that checks whether the wallet has been initialized (`isInitialized`). If the wallet is not initialized and the user is not arriving from a settings reminder, they are redirected back to the onboarding welcome page. This prevents users from skipping mandatory onboarding steps by directly manipulating route URLs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40012?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a security issue where users could skip onboarding by navigating directly to the completion route

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/37079

## **Manual testing steps**

1. Load the extension in Chrome and begin a fresh onboarding (clear extension data if needed)
2. Instead of going through the onboarding flow, navigate directly to `chrome-extension://<extension-id>/home.html#/onboarding/completion`
3. Verify that you are redirected back to the onboarding welcome page instead of seeing the "Your wallet is ready!" screen
4. Complete the normal onboarding flow (create password, back up SRP, etc.)
5. Verify the completion screen renders correctly after proper onboarding
6. After onboarding, go to Settings → Security & Privacy → Reveal Secret Recovery Phrase → back up SRP again
7. Verify the completion screen renders correctly when arriving from the settings reminder flow (`?isFromReminder=true`)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Navigating directly to `#/onboarding/completion` shows the "Your wallet is ready!" screen and allows completing onboarding without a wallet -->

### **After**

<!-- Navigating directly to `#/onboarding/completion` redirects to the welcome page -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.