### PR TITLE
fix(39724): fix QR infinite loader on firefox

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1526,6 +1526,9 @@
       "Reselect: Identity function warnings": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/bridge/hooks/useDestinationAccount.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -313,4 +313,95 @@ describe('AwaitingSignatures', () => {
       expect(mockUseNavigate).not.toHaveBeenCalled();
     });
   });
+
+  describe('navigation on fullscreen-initiated failure', () => {
+    it('navigates to activity when QR scan is cleared in fullscreen mode (activeQuote still present)', async () => {
+      const requestId = 'test-request-id-fullscreen';
+      const pathname = `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`;
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      // Create initial state with QR scan active and activeQuote present (fullscreen mode)
+      // In fullscreen mode, activeQuote doesn't get cleared when transaction fails
+      const initialBridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+        bridgeStateOverrides: {
+          activeQuote: {
+            quote: {
+              requestId,
+            },
+            sentAmount: {
+              amount: '100',
+            },
+          },
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: {
+            type: 'sign',
+            request: {
+              requestId: 'qr-request-id',
+            },
+          },
+        },
+      });
+
+      // Create real store with custom reducer to allow state updates
+      const store = configureStore(initialBridgeMockStore);
+
+      // Custom reducer to handle state updates
+      const reducer: Reducer<MetaMaskReduxState, AnyAction> = (
+        reduxState,
+        action,
+      ) => {
+        const storeState = reduxState ?? store.getState();
+
+        if (action.type === 'TEST_UPDATE_QR_SCAN_REQUEST') {
+          return {
+            ...storeState,
+            metamask: {
+              ...storeState.metamask,
+              activeQrCodeScanRequest: action.payload,
+            },
+          };
+        }
+        return storeState;
+      };
+
+      store.replaceReducer(reducer);
+
+      // Render with initial state (QR scan active, activeQuote present)
+      renderWithProvider(<AwaitingSignatures />, store, pathname);
+
+      // Wait for initial render to complete and refs to be set
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Update store to clear QR scan request (simulating failure in fullscreen)
+      // Note: activeQuote remains present in fullscreen mode (unlike popup mode)
+      await act(async () => {
+        store.dispatch({
+          type: 'TEST_UPDATE_QR_SCAN_REQUEST',
+          payload: null,
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          `${DEFAULT_ROUTE}?tab=activity`,
+          {
+            replace: true,
+            state: { stayOnHomePage: true },
+          },
+        );
+      });
+    });
+  });
 });

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -3,7 +3,7 @@ import { act, waitFor } from '@testing-library/react';
 import { Reducer, AnyAction } from 'redux';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import configureStore from '../../../store/store';
+import configureStore, { MetaMaskReduxState } from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import {
   createBridgeMockStore,
@@ -136,17 +136,19 @@ describe('AwaitingSignatures', () => {
 
       // Create real store with custom reducer to allow state updates
       const store = configureStore(initialBridgeMockStore);
-      const originalReducer = store.replaceReducer;
 
       // Custom reducer to handle state updates
-      const reducer: Reducer = (reduxState, action: AnyAction) => {
+      const reducer: Reducer<MetaMaskReduxState, AnyAction> = (
+        reduxState,
+        action,
+      ) => {
         const storeState = reduxState ?? store.getState();
 
         if (action.type === 'TEST_UPDATE_QR_SCAN_REQUEST') {
           return {
             ...storeState,
             metamask: {
-              ...(storeState as any).metamask,
+              ...storeState.metamask,
               activeQrCodeScanRequest: action.payload,
             },
           };
@@ -160,11 +162,7 @@ describe('AwaitingSignatures', () => {
       store.replaceReducer(reducer);
 
       // Render with initial state (QR scan active)
-      renderWithProvider(
-        <AwaitingSignatures />,
-        store,
-        pathname,
-      );
+      renderWithProvider(<AwaitingSignatures />, store, pathname);
 
       // Wait for initial render to complete and ref to be set
       await act(async () => {
@@ -248,6 +246,43 @@ describe('AwaitingSignatures', () => {
         `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
       );
 
+      expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when between approval and bridge steps in two-step flow', () => {
+      const requestId = 'test-request-id-two-step';
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {
+            'tx-meta-id-approval': {
+              quote: {
+                requestId,
+              },
+              approvalTxId: 'approval-tx-id-123',
+              account: MOCK_EVM_ACCOUNT.address,
+            },
+          },
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: null,
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
+      );
+
+      // Should not navigate because we're between approval and bridge steps
       expect(mockUseNavigate).not.toHaveBeenCalled();
     });
 

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -328,11 +328,14 @@ describe('AwaitingSignatures', () => {
 
       // Create initial state with QR scan active and activeQuote present (fullscreen mode)
       // In fullscreen mode, activeQuote doesn't get cleared when transaction fails
+      // Note: activeQuote is computed by selector from bridge controller state
       const initialBridgeMockStore = createBridgeMockStore({
         bridgeStatusStateOverrides: {
           txHistory: {},
         },
         bridgeStateOverrides: {
+          // activeQuote is a computed property from the bridge controller selector
+          // We need to set it for the test, using Record to allow the property
           activeQuote: {
             quote: {
               requestId,
@@ -341,7 +344,7 @@ describe('AwaitingSignatures', () => {
               amount: '100',
             },
           },
-        },
+        } as Record<string, unknown>,
         metamaskStateOverrides: {
           activeQrCodeScanRequest: {
             type: 'sign',

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -51,6 +51,11 @@ describe('AwaitingSignatures', () => {
                 requestId,
               },
               account: MOCK_EVM_ACCOUNT.address,
+              status: {
+                srcChain: {
+                  txHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+                },
+              },
             },
           },
         },

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import {
+  createBridgeMockStore,
+  MOCK_EVM_ACCOUNT,
+} from '../../../../test/data/bridge/mock-bridge-store';
+import {
+  AWAITING_SIGNATURES_ROUTE,
+  DEFAULT_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+} from '../../../helpers/constants/routes';
+import AwaitingSignatures from './awaiting-signatures';
+
+const mockUseNavigate = jest.fn();
+const mockUseLocation = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  return {
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockUseNavigate,
+    useLocation: () => mockUseLocation(),
+  };
+});
+
+const middleware = [thunk];
+
+describe('AwaitingSignatures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({
+      pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+      search: '',
+      hash: '',
+      state: null,
+    });
+  });
+
+  describe('navigation on successful transaction', () => {
+    it('navigates to activity when transaction is in bridge history', async () => {
+      const requestId = 'test-request-id-123';
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {
+            'tx-meta-id-123': {
+              quote: {
+                requestId,
+              },
+              account: MOCK_EVM_ACCOUNT.address,
+            },
+          },
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
+      );
+
+      await waitFor(() => {
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          `${DEFAULT_ROUTE}?tab=activity`,
+          {
+            replace: true,
+            state: { stayOnHomePage: true },
+          },
+        );
+      });
+    });
+
+    it('does not navigate when transaction is not in history', () => {
+      const requestId = 'test-request-id-456';
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
+      );
+
+      expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation on QR scan cancellation', () => {
+    // Note: Testing QR scan cancellation state transition requires complex store updates.
+    // The cancellation logic is covered by:
+    // 1. Integration/E2E tests (fullscreen QR flow)
+    // 2. Manual testing
+    // The negative cases below ensure we don't navigate prematurely
+
+    it('does not navigate when QR scan is still active', () => {
+      const requestId = 'test-request-id-abc';
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: {
+            type: 'sign',
+            request: {
+              requestId: 'qr-request-id',
+            },
+          },
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
+      );
+
+      expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate on initial load when QR scan was never active', () => {
+      const requestId = 'test-request-id-def';
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: null,
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`,
+      );
+
+      expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when there is no requestId in URL', () => {
+      const bridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: null,
+        },
+      });
+      const store = configureMockStore(middleware)(bridgeMockStore);
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+      );
+
+      expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -53,7 +53,8 @@ describe('AwaitingSignatures', () => {
               account: MOCK_EVM_ACCOUNT.address,
               status: {
                 srcChain: {
-                  txHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+                  txHash:
+                    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
                 },
               },
             },

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
+import { Reducer, AnyAction } from 'redux';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import {
   createBridgeMockStore,
@@ -106,11 +108,87 @@ describe('AwaitingSignatures', () => {
   });
 
   describe('navigation on QR scan cancellation', () => {
-    // Note: Testing QR scan cancellation state transition requires complex store updates.
-    // The cancellation logic is covered by:
-    // 1. Integration/E2E tests (fullscreen QR flow)
-    // 2. Manual testing
-    // The negative cases below ensure we don't navigate prematurely
+    it('navigates to activity when QR scan is cancelled', async () => {
+      const requestId = 'test-request-id-789';
+      const pathname = `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(requestId)}`;
+
+      mockUseLocation.mockReturnValue({
+        pathname: `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
+        search: `?requestId=${encodeURIComponent(requestId)}`,
+        hash: '',
+        state: null,
+      });
+
+      // Create initial state with QR scan active
+      const initialBridgeMockStore = createBridgeMockStore({
+        bridgeStatusStateOverrides: {
+          txHistory: {},
+        },
+        metamaskStateOverrides: {
+          activeQrCodeScanRequest: {
+            type: 'sign',
+            request: {
+              requestId: 'qr-request-id',
+            },
+          },
+        },
+      });
+
+      // Create real store with custom reducer to allow state updates
+      const store = configureStore(initialBridgeMockStore);
+      const originalReducer = store.replaceReducer;
+
+      // Custom reducer to handle state updates
+      const reducer: Reducer = (reduxState, action: AnyAction) => {
+        const storeState = reduxState ?? store.getState();
+
+        if (action.type === 'TEST_UPDATE_QR_SCAN_REQUEST') {
+          return {
+            ...storeState,
+            metamask: {
+              ...(storeState as any).metamask,
+              activeQrCodeScanRequest: action.payload,
+            },
+          };
+        }
+        // For other actions, use the original reducer logic
+        // Since we can't easily access the original reducer, we'll just return current state
+        // This is acceptable for this test since we only need to test the QR scan cancellation
+        return storeState;
+      };
+
+      store.replaceReducer(reducer);
+
+      // Render with initial state (QR scan active)
+      renderWithProvider(
+        <AwaitingSignatures />,
+        store,
+        pathname,
+      );
+
+      // Wait for initial render to complete and ref to be set
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Update store to clear QR scan request (simulating cancellation)
+      await act(async () => {
+        store.dispatch({
+          type: 'TEST_UPDATE_QR_SCAN_REQUEST',
+          payload: null,
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          `${DEFAULT_ROUTE}?tab=activity`,
+          {
+            replace: true,
+            state: { stayOnHomePage: true },
+          },
+        );
+      });
+    });
 
     it('does not navigate when QR scan is still active', () => {
       const requestId = 'test-request-id-abc';

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { isCrossChain } from '@metamask/bridge-controller';
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import {
   isHardwareWallet,
   getHardwareWalletType,
+  getActiveQrCodeScanRequest,
 } from '../../../selectors/selectors';
 import PulseLoader from '../../../components/ui/pulse-loader';
 import {
@@ -52,8 +53,10 @@ export default function AwaitingSignatures() {
   const bridgeHistory = useSelector(selectBridgeHistoryForAccountGroup);
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
+  const activeQrCodeScanRequest = useSelector(getActiveQrCodeScanRequest);
   const needsTwoConfirmations = Boolean(activeQuote?.approval);
   const { trackEvent } = useContext(MetaMetricsContext);
+  const prevQrScanRequestRef = useRef<typeof activeQrCodeScanRequest>(null);
 
   // Use requestId from URL when popup state is lost (QR fullscreen flow).
   const requestIdFromLocation = useMemo(() => {
@@ -73,16 +76,40 @@ export default function AwaitingSignatures() {
     );
   }, [activeQuote?.quote?.requestId, bridgeHistory, requestIdFromLocation]);
 
+  // Navigate away when transaction completes (success or cancellation)
   useEffect(() => {
-    if (!hasSubmittedBridgeTx) {
+    // Success: Transaction is in bridge history
+    if (hasSubmittedBridgeTx) {
+      navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+        replace: true,
+        state: { stayOnHomePage: true },
+      });
       return;
     }
 
-    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-      replace: true,
-      state: { stayOnHomePage: true },
-    });
-  }, [hasSubmittedBridgeTx, navigate]);
+    // Cancellation: QR scan was active, then cleared (fallback if error handler doesn't fire)
+    const prevQrScanRequest = prevQrScanRequestRef.current;
+    prevQrScanRequestRef.current = activeQrCodeScanRequest;
+
+    const qrScanWasCancelled =
+      prevQrScanRequest !== null &&
+      activeQrCodeScanRequest === null &&
+      requestIdFromLocation &&
+      !activeQuote;
+
+    if (qrScanWasCancelled) {
+      navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+        replace: true,
+        state: { stayOnHomePage: true },
+      });
+    }
+  }, [
+    hasSubmittedBridgeTx,
+    activeQrCodeScanRequest,
+    requestIdFromLocation,
+    activeQuote,
+    navigate,
+  ]);
 
   useEffect(() => {
     trackEvent({

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -1,7 +1,8 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { isCrossChain } from '@metamask/bridge-controller';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
   isHardwareWallet,
@@ -32,22 +33,55 @@ import {
   getToToken,
   getToChain,
 } from '../../../ducks/bridge/selectors';
+import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function AwaitingSignatures() {
   const t = useI18nContext();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { activeQuote } = useSelector(getBridgeQuotes, shallowEqual);
   const fromAmount = activeQuote?.sentAmount?.amount;
   const fromToken = useSelector(getFromToken, isEqual);
   const toToken = useSelector(getToToken, isEqual);
   const fromChain = useSelector(getFromChain, isEqual);
   const toChain = useSelector(getToChain, isEqual);
+  const bridgeHistory = useSelector(selectBridgeHistoryForAccountGroup);
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
   const needsTwoConfirmations = Boolean(activeQuote?.approval);
   const { trackEvent } = useContext(MetaMetricsContext);
+
+  // Use requestId from URL when popup state is lost (QR fullscreen flow).
+  const requestIdFromLocation = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('requestId') || undefined;
+  }, [location.search]);
+
+  const hasSubmittedBridgeTx = useMemo(() => {
+    const requestId =
+      activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined;
+    if (!requestId) {
+      return false;
+    }
+
+    return Object.values(bridgeHistory).some(
+      (historyItem) => historyItem?.quote?.requestId === requestId,
+    );
+  }, [activeQuote?.quote?.requestId, bridgeHistory, requestIdFromLocation]);
+
+  useEffect(() => {
+    if (!hasSubmittedBridgeTx) {
+      return;
+    }
+
+    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      state: { stayOnHomePage: true },
+    });
+  }, [hasSubmittedBridgeTx, navigate]);
 
   useEffect(() => {
     trackEvent({

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -1,19 +1,11 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { isCrossChain } from '@metamask/bridge-controller';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
   isHardwareWallet,
   getHardwareWalletType,
-  getActiveQrCodeScanRequest,
 } from '../../../selectors/selectors';
 import PulseLoader from '../../../components/ui/pulse-loader';
 import {
@@ -40,164 +32,27 @@ import {
   getToToken,
   getToChain,
 } from '../../../ducks/bridge/selectors';
-import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useBridgeTransactionNavigation } from '../hooks/useBridgeTransactionNavigation';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function AwaitingSignatures() {
   const t = useI18nContext();
-  const navigate = useNavigate();
-  const location = useLocation();
   const { activeQuote } = useSelector(getBridgeQuotes, shallowEqual);
   const fromAmount = activeQuote?.sentAmount?.amount;
   const fromToken = useSelector(getFromToken, isEqual);
   const toToken = useSelector(getToToken, isEqual);
   const fromChain = useSelector(getFromChain, isEqual);
   const toChain = useSelector(getToChain, isEqual);
-  const bridgeHistory = useSelector(selectBridgeHistoryForAccountGroup);
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);
-  const activeQrCodeScanRequest = useSelector(getActiveQrCodeScanRequest);
   const needsTwoConfirmations = Boolean(activeQuote?.approval);
   const { trackEvent } = useContext(MetaMetricsContext);
-  // Refs to track state transitions for navigation logic
-  const prevQrScanRequestRef = useRef<typeof activeQrCodeScanRequest>(null);
   const hasTrackedEventRef = useRef(false);
-  const hasSeenQrScanActiveRef = useRef<boolean>(false);
-  const hasSeenRequestIdRef = useRef<boolean>(false);
-  const hasSeenActiveQuoteRef = useRef<boolean>(false);
 
-  // Extract requestId from URL params (used when popup state is lost in QR fullscreen flow)
-  const requestIdFromLocation = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('requestId') || undefined;
-  }, [location.search]);
-
-  // Resolve requestId from activeQuote (popup mode) or URL params (fullscreen mode)
-  const requestId = useMemo(
-    () => activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined,
-    [activeQuote?.quote?.requestId, requestIdFromLocation],
-  );
-
-  // Find bridge history item for this requestId
-  const historyItem = useMemo(() => {
-    if (!requestId) {
-      return undefined;
-    }
-
-    return Object.values(bridgeHistory).find(
-      (item) => item?.quote?.requestId === requestId,
-    );
-  }, [bridgeHistory, requestId]);
-
-  // Check if the bridge transaction has been submitted to the network
-  // In two-step flows, a history item with approvalTxId means we're between steps
-  const hasSubmittedBridgeTx = useMemo(() => {
-    if (!historyItem) {
-      return false;
-    }
-
-    // History item with approvalTxId means approval is done but bridge tx not submitted yet
-    if (historyItem.approvalTxId !== undefined) {
-      return false;
-    }
-
-    // No approvalTxId means this is the final bridge transaction
-    return true;
-  }, [historyItem]);
-
-  // Check if we're between approval and bridge steps in a two-step flow
-  const isBetweenApprovalAndBridgeSteps = useMemo(() => {
-    return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
-  }, [historyItem, hasSubmittedBridgeTx]);
-
-  // Navigate to activity tab with consistent options
-  const navigateToActivity = useCallback(() => {
-    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-      replace: true,
-      state: { stayOnHomePage: true },
-    });
-  }, [navigate]);
-
-  // Navigate away when transaction completes (success or cancellation/failure)
-  useEffect(() => {
-    // Success: Transaction is in bridge history
-    if (hasSubmittedBridgeTx) {
-      navigateToActivity();
-      return;
-    }
-
-    // Don't navigate if we're between approval and bridge steps in two-step flow
-    if (isBetweenApprovalAndBridgeSteps) {
-      return;
-    }
-
-    // Track if we've seen a requestId (indicates transaction was initiated)
-    if (requestId) {
-      hasSeenRequestIdRef.current = true;
-    }
-
-    // Track if we've seen activeQuote (indicates transaction was actually started)
-    if (activeQuote !== null && activeQuote !== undefined) {
-      hasSeenActiveQuoteRef.current = true;
-    }
-
-    // Track QR scan state transitions
-    const prevQrScanRequest = prevQrScanRequestRef.current;
-
-    // Mark QR scan as seen when it becomes active (truthy object)
-    if (activeQrCodeScanRequest !== null && activeQrCodeScanRequest !== false) {
-      hasSeenQrScanActiveRef.current = true;
-    }
-
-    prevQrScanRequestRef.current = activeQrCodeScanRequest;
-
-    // Detect cancellation/failure scenarios:
-    // 1. QR scan cancellation: QR scan was active, then cleared, and no activeQuote
-    //    (handles popup-initiated cancellations where activeQuote gets cleared)
-    const qrScanWasCancelled =
-      prevQrScanRequest !== null &&
-      activeQrCodeScanRequest === null &&
-      requestId &&
-      !activeQuote;
-
-    // 2. Fullscreen-initiated failure: QR scan was active then cleared, but activeQuote
-    //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
-    const qrScanWasActiveThenCleared =
-      hasSeenQrScanActiveRef.current && activeQrCodeScanRequest === null;
-    const fullscreenInitiatedFailure =
-      requestIdFromLocation !== undefined &&
-      hasSeenRequestIdRef.current &&
-      !hasSubmittedBridgeTx &&
-      qrScanWasActiveThenCleared &&
-      !isBetweenApprovalAndBridgeSteps;
-
-    // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
-    //    (activeQuote gets cleared in popup mode when transaction fails)
-    //    Only trigger if we've actually seen the transaction start (activeQuote was present)
-    const transactionFailed =
-      hasSeenActiveQuoteRef.current &&
-      requestId &&
-      !activeQuote &&
-      !historyItem &&
-      !activeQrCodeScanRequest;
-
-    // Navigate on any failure/cancellation scenario
-    if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
-      navigateToActivity();
-    }
-  }, [
-    hasSubmittedBridgeTx,
-    activeQrCodeScanRequest,
-    requestId,
-    requestIdFromLocation,
-    activeQuote,
-    historyItem,
-    isBetweenApprovalAndBridgeSteps,
-    navigateToActivity,
-  ]);
+  // Handle navigation logic for transaction success, cancellation, and failure
+  useBridgeTransactionNavigation();
 
   useEffect(() => {
     // Only track the event once on mount to avoid duplicate events when dependencies change

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -79,6 +79,7 @@ export default function AwaitingSignatures() {
     }
 
     navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      replace: true,
       state: { stayOnHomePage: true },
     });
   }, [hasSubmittedBridgeTx, navigate]);

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -35,7 +35,11 @@ import {
   getToChain,
 } from '../../../ducks/bridge/selectors';
 import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import {
+  DEFAULT_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+  PREPARE_SWAP_ROUTE,
+} from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -76,6 +80,29 @@ export default function AwaitingSignatures() {
     );
   }, [activeQuote?.quote?.requestId, bridgeHistory, requestIdFromLocation]);
 
+  // Check if we're between approval and bridge steps in a two-step flow
+  const isBetweenApprovalAndBridgeSteps = useMemo(() => {
+    const requestId =
+      activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined;
+    if (!requestId) {
+      return false;
+    }
+
+    // Find bridge history item for this requestId
+    const historyItem = Object.values(bridgeHistory).find(
+      (item) => item?.quote?.requestId === requestId,
+    );
+
+    // If history item exists with approvalTxId but bridge hasn't been submitted,
+    // we're between the approval and bridge steps
+    return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
+  }, [
+    bridgeHistory,
+    activeQuote?.quote?.requestId,
+    requestIdFromLocation,
+    hasSubmittedBridgeTx,
+  ]);
+
   // Navigate away when transaction completes (success or cancellation)
   useEffect(() => {
     // Success: Transaction is in bridge history
@@ -98,7 +125,7 @@ export default function AwaitingSignatures() {
       requestIdFromLocation &&
       !activeQuote &&
       // Don't navigate if we're between approval and bridge steps in two-step flow
-      (!needsTwoConfirmations || hasSubmittedBridgeTx);
+      !isBetweenApprovalAndBridgeSteps;
 
     if (qrScanWasCancelled) {
       navigate(`${DEFAULT_ROUTE}?tab=activity`, {
@@ -111,7 +138,7 @@ export default function AwaitingSignatures() {
     activeQrCodeScanRequest,
     requestIdFromLocation,
     activeQuote,
-    needsTwoConfirmations,
+    isBetweenApprovalAndBridgeSteps,
     navigate,
   ]);
 

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -52,6 +52,7 @@ export default function AwaitingSignatures() {
   const hasTrackedEventRef = useRef(false);
 
   // Handle navigation logic for transaction success, cancellation, and failure
+  // (encapsulates refs, detection logic, and navigation)
   useBridgeTransactionNavigation();
 
   useEffect(() => {

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -88,6 +88,7 @@ export default function AwaitingSignatures() {
     }
 
     // Cancellation: QR scan was active, then cleared (fallback if error handler doesn't fire)
+    // Only navigate if we're not in the middle of a two-step approval flow
     const prevQrScanRequest = prevQrScanRequestRef.current;
     prevQrScanRequestRef.current = activeQrCodeScanRequest;
 
@@ -95,7 +96,9 @@ export default function AwaitingSignatures() {
       prevQrScanRequest !== null &&
       activeQrCodeScanRequest === null &&
       requestIdFromLocation &&
-      !activeQuote;
+      !activeQuote &&
+      // Don't navigate if we're between approval and bridge steps in two-step flow
+      (!needsTwoConfirmations || hasSubmittedBridgeTx);
 
     if (qrScanWasCancelled) {
       navigate(`${DEFAULT_ROUTE}?tab=activity`, {
@@ -108,6 +111,7 @@ export default function AwaitingSignatures() {
     activeQrCodeScanRequest,
     requestIdFromLocation,
     activeQuote,
+    needsTwoConfirmations,
     navigate,
   ]);
 

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -99,8 +99,6 @@ export default function AwaitingSignatures() {
     });
   }, [
     activeQuote,
-    activeQuote?.quote?.destTokenAmount,
-    activeQuote?.quote?.srcTokenAmount,
     fromToken?.symbol,
     hardwareWalletType,
     hardwareWalletUsed,

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -65,18 +65,25 @@ export default function AwaitingSignatures() {
     return params.get('requestId') || undefined;
   }, [location.search]);
 
-  const hasSubmittedBridgeTx = useMemo(() => {
-    const requestId =
-      activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined;
+  // Resolve requestId from activeQuote or URL params
+  const requestId = useMemo(
+    () => activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined,
+    [activeQuote?.quote?.requestId, requestIdFromLocation],
+  );
+
+  // Find bridge history item for this requestId (shared lookup for both booleans)
+  const historyItem = useMemo(() => {
     if (!requestId) {
-      return false;
+      return undefined;
     }
 
-    // Find bridge history item for this requestId
-    const historyItem = Object.values(bridgeHistory).find(
+    return Object.values(bridgeHistory).find(
       (item) => item?.quote?.requestId === requestId,
     );
+  }, [bridgeHistory, requestId]);
 
+  // Check if the bridge transaction has been submitted
+  const hasSubmittedBridgeTx = useMemo(() => {
     if (!historyItem) {
       return false;
     }
@@ -91,30 +98,14 @@ export default function AwaitingSignatures() {
 
     // If no approvalTxId, the history item represents a submitted bridge transaction
     return true;
-  }, [activeQuote?.quote?.requestId, bridgeHistory, requestIdFromLocation]);
+  }, [historyItem]);
 
   // Check if we're between approval and bridge steps in a two-step flow
   const isBetweenApprovalAndBridgeSteps = useMemo(() => {
-    const requestId =
-      activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined;
-    if (!requestId) {
-      return false;
-    }
-
-    // Find bridge history item for this requestId
-    const historyItem = Object.values(bridgeHistory).find(
-      (item) => item?.quote?.requestId === requestId,
-    );
-
     // If history item exists with approvalTxId but bridge hasn't been submitted,
     // we're between the approval and bridge steps
     return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
-  }, [
-    bridgeHistory,
-    activeQuote?.quote?.requestId,
-    requestIdFromLocation,
-    hasSubmittedBridgeTx,
-  ]);
+  }, [historyItem, hasSubmittedBridgeTx]);
 
   // Navigate away when transaction completes (success or cancellation)
   useEffect(() => {

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -35,11 +35,7 @@ import {
   getToChain,
 } from '../../../ducks/bridge/selectors';
 import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
-import {
-  DEFAULT_ROUTE,
-  CROSS_CHAIN_SWAP_ROUTE,
-  PREPARE_SWAP_ROUTE,
-} from '../../../helpers/constants/routes';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -75,9 +71,25 @@ export default function AwaitingSignatures() {
       return false;
     }
 
-    return Object.values(bridgeHistory).some(
-      (historyItem) => historyItem?.quote?.requestId === requestId,
+    // Find bridge history item for this requestId
+    const historyItem = Object.values(bridgeHistory).find(
+      (item) => item?.quote?.requestId === requestId,
     );
+
+    if (!historyItem) {
+      return false;
+    }
+
+    // In a two-step flow, a history item is created after approval with approvalTxId.
+    // If the history item has approvalTxId, it means approval is done but the bridge
+    // transaction hasn't been submitted yet (we're between steps).
+    // In that case, hasSubmittedBridgeTx should be false.
+    if (historyItem.approvalTxId !== undefined) {
+      return false;
+    }
+
+    // If no approvalTxId, the history item represents a submitted bridge transaction
+    return true;
   }, [activeQuote?.quote?.requestId, bridgeHistory, requestIdFromLocation]);
 
   // Check if we're between approval and bridge steps in a two-step flow
@@ -172,7 +184,16 @@ export default function AwaitingSignatures() {
         token_to_amount: activeQuote?.quote?.destTokenAmount ?? '',
       },
     });
-  }, []);
+  }, [
+    activeQuote?.quote?.destTokenAmount,
+    activeQuote?.quote?.srcTokenAmount,
+    fromToken?.symbol,
+    hardwareWalletType,
+    hardwareWalletUsed,
+    needsTwoConfirmations,
+    toToken?.symbol,
+    trackEvent,
+  ]);
 
   const isSwap =
     fromChain && !isCrossChain(fromChain.chainId, toChain?.chainId);

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -57,6 +57,7 @@ export default function AwaitingSignatures() {
   const needsTwoConfirmations = Boolean(activeQuote?.approval);
   const { trackEvent } = useContext(MetaMetricsContext);
   const prevQrScanRequestRef = useRef<typeof activeQrCodeScanRequest>(null);
+  const hasTrackedEventRef = useRef(false);
 
   // Use requestId from URL when popup state is lost (QR fullscreen flow).
   const requestIdFromLocation = useMemo(() => {
@@ -155,6 +156,18 @@ export default function AwaitingSignatures() {
   ]);
 
   useEffect(() => {
+    // Only track the event once on mount to avoid duplicate events when dependencies change
+    // (e.g., when activeQuote becomes null during popup-to-fullscreen transition)
+    if (hasTrackedEventRef.current) {
+      return;
+    }
+
+    // Only fire if we have valid quote data to avoid sending empty values
+    if (!activeQuote) {
+      return;
+    }
+
+    hasTrackedEventRef.current = true;
     trackEvent({
       event: 'Awaiting Signature(s) on a HW wallet',
       category: MetaMetricsEventCategory.Swaps,
@@ -185,6 +198,7 @@ export default function AwaitingSignatures() {
       },
     });
   }, [
+    activeQuote,
     activeQuote?.quote?.destTokenAmount,
     activeQuote?.quote?.srcTokenAmount,
     fromToken?.symbol,

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { isCrossChain } from '@metamask/bridge-controller';
@@ -56,22 +62,26 @@ export default function AwaitingSignatures() {
   const activeQrCodeScanRequest = useSelector(getActiveQrCodeScanRequest);
   const needsTwoConfirmations = Boolean(activeQuote?.approval);
   const { trackEvent } = useContext(MetaMetricsContext);
+  // Refs to track state transitions for navigation logic
   const prevQrScanRequestRef = useRef<typeof activeQrCodeScanRequest>(null);
   const hasTrackedEventRef = useRef(false);
+  const hasSeenQrScanActiveRef = useRef<boolean>(false);
+  const hasSeenRequestIdRef = useRef<boolean>(false);
+  const hasSeenActiveQuoteRef = useRef<boolean>(false);
 
-  // Use requestId from URL when popup state is lost (QR fullscreen flow).
+  // Extract requestId from URL params (used when popup state is lost in QR fullscreen flow)
   const requestIdFromLocation = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('requestId') || undefined;
   }, [location.search]);
 
-  // Resolve requestId from activeQuote or URL params
+  // Resolve requestId from activeQuote (popup mode) or URL params (fullscreen mode)
   const requestId = useMemo(
     () => activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined,
     [activeQuote?.quote?.requestId, requestIdFromLocation],
   );
 
-  // Find bridge history item for this requestId (shared lookup for both booleans)
+  // Find bridge history item for this requestId
   const historyItem = useMemo(() => {
     if (!requestId) {
       return undefined;
@@ -82,68 +92,111 @@ export default function AwaitingSignatures() {
     );
   }, [bridgeHistory, requestId]);
 
-  // Check if the bridge transaction has been submitted
+  // Check if the bridge transaction has been submitted to the network
+  // In two-step flows, a history item with approvalTxId means we're between steps
   const hasSubmittedBridgeTx = useMemo(() => {
     if (!historyItem) {
       return false;
     }
 
-    // In a two-step flow, a history item is created after approval with approvalTxId.
-    // If the history item has approvalTxId, it means approval is done but the bridge
-    // transaction hasn't been submitted yet (we're between steps).
-    // In that case, hasSubmittedBridgeTx should be false.
+    // History item with approvalTxId means approval is done but bridge tx not submitted yet
     if (historyItem.approvalTxId !== undefined) {
       return false;
     }
 
-    // If no approvalTxId, the history item represents a submitted bridge transaction
+    // No approvalTxId means this is the final bridge transaction
     return true;
   }, [historyItem]);
 
   // Check if we're between approval and bridge steps in a two-step flow
   const isBetweenApprovalAndBridgeSteps = useMemo(() => {
-    // If history item exists with approvalTxId but bridge hasn't been submitted,
-    // we're between the approval and bridge steps
     return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
   }, [historyItem, hasSubmittedBridgeTx]);
 
-  // Navigate away when transaction completes (success or cancellation)
+  // Navigate to activity tab with consistent options
+  const navigateToActivity = useCallback(() => {
+    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      replace: true,
+      state: { stayOnHomePage: true },
+    });
+  }, [navigate]);
+
+  // Navigate away when transaction completes (success or cancellation/failure)
   useEffect(() => {
     // Success: Transaction is in bridge history
     if (hasSubmittedBridgeTx) {
-      navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-        replace: true,
-        state: { stayOnHomePage: true },
-      });
+      navigateToActivity();
       return;
     }
 
-    // Cancellation: QR scan was active, then cleared (fallback if error handler doesn't fire)
-    // Only navigate if we're not in the middle of a two-step approval flow
+    // Don't navigate if we're between approval and bridge steps in two-step flow
+    if (isBetweenApprovalAndBridgeSteps) {
+      return;
+    }
+
+    // Track if we've seen a requestId (indicates transaction was initiated)
+    if (requestId) {
+      hasSeenRequestIdRef.current = true;
+    }
+
+    // Track if we've seen activeQuote (indicates transaction was actually started)
+    if (activeQuote !== null && activeQuote !== undefined) {
+      hasSeenActiveQuoteRef.current = true;
+    }
+
+    // Track QR scan state transitions
     const prevQrScanRequest = prevQrScanRequestRef.current;
+
+    // Mark QR scan as seen when it becomes active (truthy object)
+    if (activeQrCodeScanRequest !== null && activeQrCodeScanRequest !== false) {
+      hasSeenQrScanActiveRef.current = true;
+    }
+
     prevQrScanRequestRef.current = activeQrCodeScanRequest;
 
+    // Detect cancellation/failure scenarios:
+    // 1. QR scan cancellation: QR scan was active, then cleared, and no activeQuote
+    //    (handles popup-initiated cancellations where activeQuote gets cleared)
     const qrScanWasCancelled =
       prevQrScanRequest !== null &&
       activeQrCodeScanRequest === null &&
-      requestIdFromLocation &&
-      !activeQuote &&
-      // Don't navigate if we're between approval and bridge steps in two-step flow
+      requestId &&
+      !activeQuote;
+
+    // 2. Fullscreen-initiated failure: QR scan was active then cleared, but activeQuote
+    //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
+    const qrScanWasActiveThenCleared =
+      hasSeenQrScanActiveRef.current && activeQrCodeScanRequest === null;
+    const fullscreenInitiatedFailure =
+      requestIdFromLocation !== undefined &&
+      hasSeenRequestIdRef.current &&
+      !hasSubmittedBridgeTx &&
+      qrScanWasActiveThenCleared &&
       !isBetweenApprovalAndBridgeSteps;
 
-    if (qrScanWasCancelled) {
-      navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-        replace: true,
-        state: { stayOnHomePage: true },
-      });
+    // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
+    //    (activeQuote gets cleared in popup mode when transaction fails)
+    //    Only trigger if we've actually seen the transaction start (activeQuote was present)
+    const transactionFailed =
+      hasSeenActiveQuoteRef.current &&
+      requestId &&
+      !activeQuote &&
+      !historyItem &&
+      !activeQrCodeScanRequest;
+
+    // Navigate on any failure/cancellation scenario
+    if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
+      navigateToActivity();
     }
   }, [
     hasSubmittedBridgeTx,
     activeQrCodeScanRequest,
+    requestId,
     requestIdFromLocation,
     activeQuote,
+    historyItem,
     isBetweenApprovalAndBridgeSteps,
-    navigate,
+    navigateToActivity,
   ]);
 
   useEffect(() => {

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -52,24 +52,23 @@ export function useBridgeTransactionNavigation(): void {
   }, [bridgeHistory, requestId]);
 
   // Check if the bridge transaction has been submitted to the network
-  // In two-step flows, a history item with approvalTxId means we're between steps
+  // Use status.srcChain.txHash to detect submission, as approvalTxId can remain
+  // present even after the bridge transaction is submitted/completed
   const hasSubmittedBridgeTx = useMemo(() => {
     if (!historyItem) {
       return false;
     }
 
-    // History item with approvalTxId means approval is done but bridge tx not submitted yet
-    if (historyItem.approvalTxId !== undefined) {
-      return false;
-    }
-
-    // No approvalTxId means this is the final bridge transaction
-    return true;
+    // status.srcChain.txHash indicates the bridge transaction has been submitted
+    return Boolean(historyItem.status?.srcChain?.txHash);
   }, [historyItem]);
 
   // Check if we're between approval and bridge steps in a two-step flow
+  // This is true when approvalTxId exists but bridge tx hasn't been submitted yet
   const isBetweenApprovalAndBridgeSteps = useMemo(() => {
-    return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
+    return (
+      historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx
+    );
   }, [historyItem, hasSubmittedBridgeTx]);
 
   // Navigate to activity tab with consistent options

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -162,6 +162,5 @@ export function useBridgeTransactionNavigation(): void {
     historyItem,
     isBetweenApprovalAndBridgeSteps,
     navigateToActivity,
-    location.pathname,
   ]);
 }

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -7,6 +7,20 @@ import { getBridgeQuotes } from '../../../ducks/bridge/selectors';
 import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
+// Helper to check if QR scan request is cleared (null or undefined)
+function isQrScanCleared(
+  value: ReturnType<typeof getActiveQrCodeScanRequest>,
+): boolean {
+  return value === null || value === undefined;
+}
+
+// Helper to check if QR scan request was previously active (not null, undefined, or false)
+function wasQrScanActive(
+  value: ReturnType<typeof getActiveQrCodeScanRequest>,
+): boolean {
+  return value !== null && value !== undefined && value !== false;
+}
+
 /**
  * Hook to handle navigation logic for bridge transaction awaiting signatures page.
  * Encapsulates refs, detection logic, and navigation for transaction success, cancellation, and failure.
@@ -90,50 +104,6 @@ export function useBridgeTransactionNavigation(): void {
     prevQrScanRequestRef.current = activeQrCodeScanRequest;
   }, [requestId, activeQuote, activeQrCodeScanRequest]);
 
-  // Helper to check if QR scan request is cleared (null or undefined)
-  const isQrScanCleared = (value: typeof activeQrCodeScanRequest): boolean => {
-    return value === null || value === undefined;
-  };
-
-  // Helper to check if QR scan request was previously active (not null, undefined, or false)
-  const wasQrScanActive = (value: typeof activeQrCodeScanRequest): boolean => {
-    return value !== null && value !== undefined && value !== false;
-  };
-
-  // Detect cancellation/failure scenarios:
-  // 1. QR scan cancellation: QR scan was active, then cleared (null or undefined), and no activeQuote
-  //    (handles popup-initiated cancellations where activeQuote gets cleared)
-  const qrScanWasCancelled = Boolean(
-    wasQrScanActive(prevQrScanRequestRef.current) &&
-      isQrScanCleared(activeQrCodeScanRequest) &&
-      requestId &&
-      !activeQuote,
-  );
-
-  // 2. Fullscreen-initiated failure: QR scan was active then cleared (null or undefined), but activeQuote
-  //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
-  //    Note: We detect this even when between approval and bridge steps, as it indicates
-  //    the user cancelled the bridge transaction QR scan (not the approval)
-  const qrScanWasActiveThenCleared =
-    hasSeenQrScanActiveRef.current && isQrScanCleared(activeQrCodeScanRequest);
-  const fullscreenInitiatedFailure = Boolean(
-    requestIdFromLocation !== undefined &&
-      hasSeenRequestIdRef.current &&
-      !hasSubmittedBridgeTx &&
-      qrScanWasActiveThenCleared,
-  );
-
-  // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
-  //    (activeQuote gets cleared in popup mode when transaction fails)
-  //    Only trigger if we've actually seen the transaction start (activeQuote was present)
-  const transactionFailed = Boolean(
-    hasSeenActiveQuoteRef.current &&
-      requestId &&
-      !activeQuote &&
-      !historyItem &&
-      isQrScanCleared(activeQrCodeScanRequest),
-  );
-
   // Navigate to activity tab with consistent options
   const navigateToActivity = useCallback(() => {
     navigate(`${DEFAULT_ROUTE}?tab=activity`, {
@@ -150,6 +120,42 @@ export function useBridgeTransactionNavigation(): void {
       return;
     }
 
+    // Detect cancellation/failure scenarios:
+    // 1. QR scan cancellation: QR scan was active, then cleared (null or undefined), and no activeQuote
+    //    (handles popup-initiated cancellations where activeQuote gets cleared)
+    const qrScanWasCancelled = Boolean(
+      wasQrScanActive(prevQrScanRequestRef.current) &&
+        isQrScanCleared(activeQrCodeScanRequest) &&
+        requestId &&
+        !activeQuote,
+    );
+
+    // 2. Fullscreen-initiated failure: QR scan was active then cleared (null or undefined), but activeQuote
+    //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
+    //    Note: We exclude the case where we're between approval and bridge steps, as the QR scan
+    //    can be temporarily cleared during the transition from approval QR to bridge QR
+    const qrScanWasActiveThenCleared =
+      hasSeenQrScanActiveRef.current &&
+      isQrScanCleared(activeQrCodeScanRequest);
+    const fullscreenInitiatedFailure = Boolean(
+      requestIdFromLocation !== undefined &&
+        hasSeenRequestIdRef.current &&
+        !hasSubmittedBridgeTx &&
+        !isBetweenApprovalAndBridgeSteps &&
+        qrScanWasActiveThenCleared,
+    );
+
+    // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
+    //    (activeQuote gets cleared in popup mode when transaction fails)
+    //    Only trigger if we've actually seen the transaction start (activeQuote was present)
+    const transactionFailed = Boolean(
+      hasSeenActiveQuoteRef.current &&
+        requestId &&
+        !activeQuote &&
+        !historyItem &&
+        isQrScanCleared(activeQrCodeScanRequest),
+    );
+
     // Navigate on any failure/cancellation scenario
     // Even if we're between approval and bridge steps, we should navigate on cancellation
     if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
@@ -164,9 +170,11 @@ export function useBridgeTransactionNavigation(): void {
     }
   }, [
     hasSubmittedBridgeTx,
-    qrScanWasCancelled,
-    fullscreenInitiatedFailure,
-    transactionFailed,
+    activeQrCodeScanRequest,
+    requestId,
+    requestIdFromLocation,
+    activeQuote,
+    historyItem,
     isBetweenApprovalAndBridgeSteps,
     navigateToActivity,
   ]);

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { shallowEqual } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 
 import { getActiveQrCodeScanRequest } from '../../../selectors/selectors';
 import { getBridgeQuotes } from '../../../ducks/bridge/selectors';
@@ -12,8 +11,6 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
  * Hook to handle navigation logic for bridge transaction awaiting signatures page.
  * Encapsulates refs and detection logic for transaction success, cancellation, and failure.
  * The refs are tightly coupled with the navigation logic, so they're kept together.
- *
- * @returns void - Navigation is handled internally via useEffect
  */
 export function useBridgeTransactionNavigation(): void {
   const navigate = useNavigate();
@@ -66,9 +63,7 @@ export function useBridgeTransactionNavigation(): void {
   // Check if we're between approval and bridge steps in a two-step flow
   // This is true when approvalTxId exists but bridge tx hasn't been submitted yet
   const isBetweenApprovalAndBridgeSteps = useMemo(() => {
-    return (
-      historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx
-    );
+    return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
   }, [historyItem, hasSubmittedBridgeTx]);
 
   // Navigate to activity tab with consistent options
@@ -84,11 +79,6 @@ export function useBridgeTransactionNavigation(): void {
     // Success: Transaction is in bridge history
     if (hasSubmittedBridgeTx) {
       navigateToActivity();
-      return;
-    }
-
-    // Don't navigate if we're between approval and bridge steps in two-step flow
-    if (isBetweenApprovalAndBridgeSteps) {
       return;
     }
 
@@ -130,14 +120,15 @@ export function useBridgeTransactionNavigation(): void {
 
     // 2. Fullscreen-initiated failure: QR scan was active then cleared, but activeQuote
     //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
+    //    Note: We detect this even when between approval and bridge steps, as it indicates
+    //    the user cancelled the bridge transaction QR scan (not the approval)
     const qrScanWasActiveThenCleared =
       hasSeenQrScanActiveRef.current && activeQrCodeScanRequest === null;
     const fullscreenInitiatedFailure =
       requestIdFromLocation !== undefined &&
       hasSeenRequestIdRef.current &&
       !hasSubmittedBridgeTx &&
-      qrScanWasActiveThenCleared &&
-      !isBetweenApprovalAndBridgeSteps;
+      qrScanWasActiveThenCleared;
 
     // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
     //    (activeQuote gets cleared in popup mode when transaction fails)
@@ -150,8 +141,16 @@ export function useBridgeTransactionNavigation(): void {
       !activeQrCodeScanRequest;
 
     // Navigate on any failure/cancellation scenario
+    // Even if we're between approval and bridge steps, we should navigate on cancellation
     if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
       navigateToActivity();
+      return;
+    }
+
+    // Don't navigate if we're between approval and bridge steps in two-step flow
+    // (but only if we haven't detected a cancellation above)
+    if (isBetweenApprovalAndBridgeSteps) {
+      // Wait for bridge transaction to be submitted
     }
   }, [
     hasSubmittedBridgeTx,

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -162,6 +162,9 @@ export function useBridgeTransactionNavigation(): void {
     // Even if we're between approval and bridge steps, we should navigate on cancellation
     if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
       navigateToActivity();
+      // Update ref even on failure/cancellation to prevent re-triggering
+      // if component doesn't unmount immediately
+      prevQrScanRequestRef.current = activeQrCodeScanRequest;
       return;
     }
 
@@ -169,9 +172,13 @@ export function useBridgeTransactionNavigation(): void {
     // (but only if we haven't detected a cancellation above)
     if (isBetweenApprovalAndBridgeSteps) {
       // Wait for bridge transaction to be submitted
+      // Update ref to track current state
+      prevQrScanRequestRef.current = activeQrCodeScanRequest;
+      return;
     }
 
     // Update ref AFTER all checks to preserve previous value for next render
+    // This ensures the ref is always updated, preventing repeated navigation triggers
     prevQrScanRequestRef.current = activeQrCodeScanRequest;
   }, [
     hasSubmittedBridgeTx,

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { shallowEqual } from 'react-redux';
+
+import { getActiveQrCodeScanRequest } from '../../../selectors/selectors';
+import { getBridgeQuotes } from '../../../ducks/bridge/selectors';
+import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+
+/**
+ * Hook to handle navigation logic for bridge transaction awaiting signatures page.
+ * Encapsulates refs and detection logic for transaction success, cancellation, and failure.
+ * The refs are tightly coupled with the navigation logic, so they're kept together.
+ *
+ * @returns void - Navigation is handled internally via useEffect
+ */
+export function useBridgeTransactionNavigation(): void {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { activeQuote } = useSelector(getBridgeQuotes, shallowEqual);
+  const bridgeHistory = useSelector(selectBridgeHistoryForAccountGroup);
+  const activeQrCodeScanRequest = useSelector(getActiveQrCodeScanRequest);
+
+  // Refs to track state transitions for navigation logic
+  const prevQrScanRequestRef = useRef<typeof activeQrCodeScanRequest>(null);
+  const hasSeenQrScanActiveRef = useRef<boolean>(false);
+  const hasSeenRequestIdRef = useRef<boolean>(false);
+  const hasSeenActiveQuoteRef = useRef<boolean>(false);
+
+  // Extract requestId from URL params (used when popup state is lost in QR fullscreen flow)
+  const requestIdFromLocation = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('requestId') || undefined;
+  }, [location.search]);
+
+  // Resolve requestId from activeQuote (popup mode) or URL params (fullscreen mode)
+  const requestId = useMemo(
+    () => activeQuote?.quote?.requestId ?? requestIdFromLocation ?? undefined,
+    [activeQuote?.quote?.requestId, requestIdFromLocation],
+  );
+
+  // Find bridge history item for this requestId
+  const historyItem = useMemo(() => {
+    if (!requestId) {
+      return undefined;
+    }
+
+    return Object.values(bridgeHistory).find(
+      (item) => item?.quote?.requestId === requestId,
+    );
+  }, [bridgeHistory, requestId]);
+
+  // Check if the bridge transaction has been submitted to the network
+  // In two-step flows, a history item with approvalTxId means we're between steps
+  const hasSubmittedBridgeTx = useMemo(() => {
+    if (!historyItem) {
+      return false;
+    }
+
+    // History item with approvalTxId means approval is done but bridge tx not submitted yet
+    if (historyItem.approvalTxId !== undefined) {
+      return false;
+    }
+
+    // No approvalTxId means this is the final bridge transaction
+    return true;
+  }, [historyItem]);
+
+  // Check if we're between approval and bridge steps in a two-step flow
+  const isBetweenApprovalAndBridgeSteps = useMemo(() => {
+    return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
+  }, [historyItem, hasSubmittedBridgeTx]);
+
+  // Navigate to activity tab with consistent options
+  const navigateToActivity = useCallback(() => {
+    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      replace: true,
+      state: { stayOnHomePage: true },
+    });
+  }, [navigate]);
+
+  // Navigate away when transaction completes (success or cancellation/failure)
+  useEffect(() => {
+    // Success: Transaction is in bridge history
+    if (hasSubmittedBridgeTx) {
+      navigateToActivity();
+      return;
+    }
+
+    // Don't navigate if we're between approval and bridge steps in two-step flow
+    if (isBetweenApprovalAndBridgeSteps) {
+      return;
+    }
+
+    // Track if we've seen a requestId (indicates transaction was initiated)
+    if (requestId) {
+      hasSeenRequestIdRef.current = true;
+    }
+
+    // Track if we've seen activeQuote (indicates transaction was actually started)
+    if (activeQuote !== null && activeQuote !== undefined) {
+      hasSeenActiveQuoteRef.current = true;
+    }
+
+    // Track QR scan state transitions
+    const prevQrScanRequest = prevQrScanRequestRef.current;
+
+    // Mark QR scan as seen when it becomes active (truthy object)
+    if (activeQrCodeScanRequest !== null && activeQrCodeScanRequest !== false) {
+      hasSeenQrScanActiveRef.current = true;
+    }
+
+    prevQrScanRequestRef.current = activeQrCodeScanRequest;
+
+    // Detect cancellation/failure scenarios:
+    // 1. QR scan cancellation: QR scan was active, then cleared, and no activeQuote
+    //    (handles popup-initiated cancellations where activeQuote gets cleared)
+    const qrScanWasCancelled =
+      prevQrScanRequest !== null &&
+      activeQrCodeScanRequest === null &&
+      requestId &&
+      !activeQuote;
+
+    // 2. Fullscreen-initiated failure: QR scan was active then cleared, but activeQuote
+    //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
+    const qrScanWasActiveThenCleared =
+      hasSeenQrScanActiveRef.current && activeQrCodeScanRequest === null;
+    const fullscreenInitiatedFailure =
+      requestIdFromLocation !== undefined &&
+      hasSeenRequestIdRef.current &&
+      !hasSubmittedBridgeTx &&
+      qrScanWasActiveThenCleared &&
+      !isBetweenApprovalAndBridgeSteps;
+
+    // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
+    //    (activeQuote gets cleared in popup mode when transaction fails)
+    //    Only trigger if we've actually seen the transaction start (activeQuote was present)
+    const transactionFailed =
+      hasSeenActiveQuoteRef.current &&
+      requestId &&
+      !activeQuote &&
+      !historyItem &&
+      !activeQrCodeScanRequest;
+
+    // Navigate on any failure/cancellation scenario
+    if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
+      navigateToActivity();
+    }
+  }, [
+    hasSubmittedBridgeTx,
+    activeQrCodeScanRequest,
+    requestId,
+    requestIdFromLocation,
+    activeQuote,
+    historyItem,
+    isBetweenApprovalAndBridgeSteps,
+    navigateToActivity,
+    location.pathname,
+  ]);
+}

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -106,7 +106,12 @@ export function useBridgeTransactionNavigation(): void {
     const prevQrScanRequest = prevQrScanRequestRef.current;
 
     // Mark QR scan as seen when it becomes active (truthy object)
-    if (activeQrCodeScanRequest !== null && activeQrCodeScanRequest !== false) {
+    // Exclude null, undefined, and false to ensure we only mark actual active scans
+    if (
+      activeQrCodeScanRequest !== null &&
+      activeQrCodeScanRequest !== undefined &&
+      activeQrCodeScanRequest !== false
+    ) {
       hasSeenQrScanActiveRef.current = true;
     }
 
@@ -115,8 +120,10 @@ export function useBridgeTransactionNavigation(): void {
     // Detect cancellation/failure scenarios:
     // 1. QR scan cancellation: QR scan was active, then cleared, and no activeQuote
     //    (handles popup-initiated cancellations where activeQuote gets cleared)
+    // Exclude undefined from prevQrScanRequest to avoid false positives
     const qrScanWasCancelled =
       prevQrScanRequest !== null &&
+      prevQrScanRequest !== undefined &&
       activeQrCodeScanRequest === null &&
       requestId &&
       !activeQuote;

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -79,8 +79,20 @@ export function useBridgeTransactionNavigation(): void {
     return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
   }, [historyItem, hasSubmittedBridgeTx]);
 
+  // Navigate to activity tab with consistent options
+  const navigateToActivity = useCallback(() => {
+    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      replace: true,
+      state: { stayOnHomePage: true },
+    });
+  }, [navigate]);
+
   // Track state transitions and detect navigation scenarios
   useEffect(() => {
+    // Read previous QR scan request BEFORE updating the ref
+    // This ensures we can detect transitions (e.g., active -> cleared)
+    const prevQrScanRequest = prevQrScanRequestRef.current;
+
     // Track if we've seen a requestId (indicates transaction was initiated)
     if (requestId) {
       hasSeenRequestIdRef.current = true;
@@ -101,30 +113,20 @@ export function useBridgeTransactionNavigation(): void {
       hasSeenQrScanActiveRef.current = true;
     }
 
-    prevQrScanRequestRef.current = activeQrCodeScanRequest;
-  }, [requestId, activeQuote, activeQrCodeScanRequest]);
-
-  // Navigate to activity tab with consistent options
-  const navigateToActivity = useCallback(() => {
-    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-      replace: true,
-      state: { stayOnHomePage: true },
-    });
-  }, [navigate]);
-
-  // Navigate away when transaction completes (success or cancellation/failure)
-  useEffect(() => {
     // Success: Transaction is in bridge history
     if (hasSubmittedBridgeTx) {
       navigateToActivity();
+      // Update ref after navigation check
+      prevQrScanRequestRef.current = activeQrCodeScanRequest;
       return;
     }
 
     // Detect cancellation/failure scenarios:
     // 1. QR scan cancellation: QR scan was active, then cleared (null or undefined), and no activeQuote
     //    (handles popup-initiated cancellations where activeQuote gets cleared)
+    //    Note: We read prevQrScanRequest BEFORE updating the ref to detect transitions
     const qrScanWasCancelled = Boolean(
-      wasQrScanActive(prevQrScanRequestRef.current) &&
+      wasQrScanActive(prevQrScanRequest) &&
         isQrScanCleared(activeQrCodeScanRequest) &&
         requestId &&
         !activeQuote,
@@ -168,6 +170,9 @@ export function useBridgeTransactionNavigation(): void {
     if (isBetweenApprovalAndBridgeSteps) {
       // Wait for bridge transaction to be submitted
     }
+
+    // Update ref AFTER all checks to preserve previous value for next render
+    prevQrScanRequestRef.current = activeQrCodeScanRequest;
   }, [
     hasSubmittedBridgeTx,
     activeQrCodeScanRequest,

--- a/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
+++ b/ui/pages/bridge/hooks/useBridgeTransactionNavigation.ts
@@ -9,8 +9,7 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
 /**
  * Hook to handle navigation logic for bridge transaction awaiting signatures page.
- * Encapsulates refs and detection logic for transaction success, cancellation, and failure.
- * The refs are tightly coupled with the navigation logic, so they're kept together.
+ * Encapsulates refs, detection logic, and navigation for transaction success, cancellation, and failure.
  */
 export function useBridgeTransactionNavigation(): void {
   const navigate = useNavigate();
@@ -66,6 +65,75 @@ export function useBridgeTransactionNavigation(): void {
     return historyItem?.approvalTxId !== undefined && !hasSubmittedBridgeTx;
   }, [historyItem, hasSubmittedBridgeTx]);
 
+  // Track state transitions and detect navigation scenarios
+  useEffect(() => {
+    // Track if we've seen a requestId (indicates transaction was initiated)
+    if (requestId) {
+      hasSeenRequestIdRef.current = true;
+    }
+
+    // Track if we've seen activeQuote (indicates transaction was actually started)
+    if (activeQuote !== null && activeQuote !== undefined) {
+      hasSeenActiveQuoteRef.current = true;
+    }
+
+    // Mark QR scan as seen when it becomes active (truthy object)
+    // Exclude null, undefined, and false to ensure we only mark actual active scans
+    if (
+      activeQrCodeScanRequest !== null &&
+      activeQrCodeScanRequest !== undefined &&
+      activeQrCodeScanRequest !== false
+    ) {
+      hasSeenQrScanActiveRef.current = true;
+    }
+
+    prevQrScanRequestRef.current = activeQrCodeScanRequest;
+  }, [requestId, activeQuote, activeQrCodeScanRequest]);
+
+  // Helper to check if QR scan request is cleared (null or undefined)
+  const isQrScanCleared = (value: typeof activeQrCodeScanRequest): boolean => {
+    return value === null || value === undefined;
+  };
+
+  // Helper to check if QR scan request was previously active (not null, undefined, or false)
+  const wasQrScanActive = (value: typeof activeQrCodeScanRequest): boolean => {
+    return value !== null && value !== undefined && value !== false;
+  };
+
+  // Detect cancellation/failure scenarios:
+  // 1. QR scan cancellation: QR scan was active, then cleared (null or undefined), and no activeQuote
+  //    (handles popup-initiated cancellations where activeQuote gets cleared)
+  const qrScanWasCancelled = Boolean(
+    wasQrScanActive(prevQrScanRequestRef.current) &&
+      isQrScanCleared(activeQrCodeScanRequest) &&
+      requestId &&
+      !activeQuote,
+  );
+
+  // 2. Fullscreen-initiated failure: QR scan was active then cleared (null or undefined), but activeQuote
+  //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
+  //    Note: We detect this even when between approval and bridge steps, as it indicates
+  //    the user cancelled the bridge transaction QR scan (not the approval)
+  const qrScanWasActiveThenCleared =
+    hasSeenQrScanActiveRef.current && isQrScanCleared(activeQrCodeScanRequest);
+  const fullscreenInitiatedFailure = Boolean(
+    requestIdFromLocation !== undefined &&
+      hasSeenRequestIdRef.current &&
+      !hasSubmittedBridgeTx &&
+      qrScanWasActiveThenCleared,
+  );
+
+  // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
+  //    (activeQuote gets cleared in popup mode when transaction fails)
+  //    Only trigger if we've actually seen the transaction start (activeQuote was present)
+  const transactionFailed = Boolean(
+    hasSeenActiveQuoteRef.current &&
+      requestId &&
+      !activeQuote &&
+      !historyItem &&
+      isQrScanCleared(activeQrCodeScanRequest),
+  );
+
   // Navigate to activity tab with consistent options
   const navigateToActivity = useCallback(() => {
     navigate(`${DEFAULT_ROUTE}?tab=activity`, {
@@ -82,64 +150,6 @@ export function useBridgeTransactionNavigation(): void {
       return;
     }
 
-    // Track if we've seen a requestId (indicates transaction was initiated)
-    if (requestId) {
-      hasSeenRequestIdRef.current = true;
-    }
-
-    // Track if we've seen activeQuote (indicates transaction was actually started)
-    if (activeQuote !== null && activeQuote !== undefined) {
-      hasSeenActiveQuoteRef.current = true;
-    }
-
-    // Track QR scan state transitions
-    const prevQrScanRequest = prevQrScanRequestRef.current;
-
-    // Mark QR scan as seen when it becomes active (truthy object)
-    // Exclude null, undefined, and false to ensure we only mark actual active scans
-    if (
-      activeQrCodeScanRequest !== null &&
-      activeQrCodeScanRequest !== undefined &&
-      activeQrCodeScanRequest !== false
-    ) {
-      hasSeenQrScanActiveRef.current = true;
-    }
-
-    prevQrScanRequestRef.current = activeQrCodeScanRequest;
-
-    // Detect cancellation/failure scenarios:
-    // 1. QR scan cancellation: QR scan was active, then cleared, and no activeQuote
-    //    (handles popup-initiated cancellations where activeQuote gets cleared)
-    // Exclude undefined from prevQrScanRequest to avoid false positives
-    const qrScanWasCancelled =
-      prevQrScanRequest !== null &&
-      prevQrScanRequest !== undefined &&
-      activeQrCodeScanRequest === null &&
-      requestId &&
-      !activeQuote;
-
-    // 2. Fullscreen-initiated failure: QR scan was active then cleared, but activeQuote
-    //    doesn't get cleared in fullscreen mode (fallback when error handler doesn't fire)
-    //    Note: We detect this even when between approval and bridge steps, as it indicates
-    //    the user cancelled the bridge transaction QR scan (not the approval)
-    const qrScanWasActiveThenCleared =
-      hasSeenQrScanActiveRef.current && activeQrCodeScanRequest === null;
-    const fullscreenInitiatedFailure =
-      requestIdFromLocation !== undefined &&
-      hasSeenRequestIdRef.current &&
-      !hasSubmittedBridgeTx &&
-      qrScanWasActiveThenCleared;
-
-    // 3. Popup-initiated failure: Transaction was initiated (we saw activeQuote) but now cleared
-    //    (activeQuote gets cleared in popup mode when transaction fails)
-    //    Only trigger if we've actually seen the transaction start (activeQuote was present)
-    const transactionFailed =
-      hasSeenActiveQuoteRef.current &&
-      requestId &&
-      !activeQuote &&
-      !historyItem &&
-      !activeQrCodeScanRequest;
-
     // Navigate on any failure/cancellation scenario
     // Even if we're between approval and bridge steps, we should navigate on cancellation
     if (qrScanWasCancelled || fullscreenInitiatedFailure || transactionFailed) {
@@ -154,11 +164,9 @@ export function useBridgeTransactionNavigation(): void {
     }
   }, [
     hasSubmittedBridgeTx,
-    activeQrCodeScanRequest,
-    requestId,
-    requestIdFromLocation,
-    activeQuote,
-    historyItem,
+    qrScanWasCancelled,
+    fullscreenInitiatedFailure,
+    transactionFailed,
     isBetweenApprovalAndBridgeSteps,
     navigateToActivity,
   ]);

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
@@ -204,6 +204,7 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
       expect(mockUseNavigate).toHaveBeenCalledWith(
         `${DEFAULT_ROUTE}?tab=activity`,
         {
+          replace: true,
           state: { stayOnHomePage: true },
         },
       );

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
@@ -10,8 +10,13 @@ import {
   DummyQuotesNoApproval,
   DummyQuotesWithApproval,
 } from '../../../../test/data/bridge/dummy-quotes';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import {
+  AWAITING_SIGNATURES_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../../helpers/constants/routes';
 import { setBackgroundConnection } from '../../../store/background-connection';
+import * as sharedSelectors from '../../../../shared/modules/selectors';
 import useSubmitBridgeTransaction from './useSubmitBridgeTransaction';
 
 const mockUseNavigate = jest.fn();
@@ -80,6 +85,14 @@ jest.mock('../../../../shared/modules/selectors/networks', () => {
         ],
       },
     })),
+  };
+});
+
+jest.mock('../../../../shared/modules/selectors', () => {
+  const original = jest.requireActual('../../../../shared/modules/selectors');
+  return {
+    ...original,
+    isHardwareWallet: jest.fn(),
   };
 });
 
@@ -193,6 +206,30 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
         {
           state: { stayOnHomePage: true },
         },
+      );
+    });
+
+    it('routes to awaiting signatures with requestId for hardware wallets', async () => {
+      (sharedSelectors.isHardwareWallet as jest.Mock).mockReturnValue(true);
+      const store = makeMockStore();
+      const { result } = renderHook(() => useSubmitBridgeTransaction(), {
+        wrapper: makeWrapper(store),
+      });
+
+      // Execute
+      await result.current.submitBridgeTransaction(
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0] as any,
+      );
+
+      const {
+        quote: { requestId },
+      } = DummyQuotesWithApproval.ETH_11_USDC_TO_ARB[0];
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(
+          requestId,
+        )}`,
       );
     });
   });

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -130,6 +130,7 @@ export default function useSubmitBridgeTransaction() {
           ),
         );
         navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+          replace: true,
           state: { stayOnHomePage: true },
         });
         return;

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -159,6 +159,7 @@ export default function useSubmitBridgeTransaction() {
       } else {
         navigate(`${DEFAULT_ROUTE}?tab=activity`, {
           replace: true,
+          state: { stayOnHomePage: true },
         });
       }
       return;

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -96,7 +96,16 @@ export default function useSubmitBridgeTransaction() {
     }
 
     if (hardwareWalletUsed) {
-      navigate(`${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`);
+      const {
+        quote: { requestId },
+      } = quoteResponse;
+      // Preserve requestId across popup -> fullscreen transitions (QR flow).
+      const awaitingUrl = requestId
+        ? `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}?requestId=${encodeURIComponent(
+            requestId,
+          )}`
+        : `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`;
+      navigate(awaitingUrl);
     }
 
     // Execute transaction(s)

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -153,10 +153,12 @@ export default function useSubmitBridgeTransaction() {
       captureException(e);
       if (hardwareWalletUsed && isHardwareWalletUserRejection(e)) {
         dispatch(setWasTxDeclined(true));
-        navigate(`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`);
+        navigate(`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`, {
+          replace: true,
+        });
       } else {
         navigate(`${DEFAULT_ROUTE}?tab=activity`, {
-          state: { stayOnHomePage: true },
+          replace: true,
         });
       }
       return;

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -165,6 +165,7 @@ export default function useSubmitBridgeTransaction() {
     }
 
     navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+      replace: true,
       state: { stayOnHomePage: true },
     });
   };


### PR DESCRIPTION
## **Description**

This PR fixes an issue where users using QR hardware wallets in popup mode would encounter an infinite loader after successfully signing a bridge/swap transaction. The problem occurred because when the user clicked "Get signature", MetaMask would transition from popup mode to fullscreen mode, causing the popup state to be lost. The `AwaitingSignatures` component could no longer track the active quote, leaving users stuck on the loading screen even after the transaction was successfully submitted.

**The solution:**
1. **Preserve requestId in URL**: When navigating to the awaiting signatures page for hardware wallets, we now include the `requestId` as a URL query parameter. This allows the component to track the transaction even when popup state is lost during the popup-to-fullscreen transition.
2. **Detect completed transactions**: The component now checks the bridge history to determine if a transaction with the matching `requestId` has been submitted. It uses the `requestId` from either the active quote (when available) or from the URL parameters (when popup state is lost).
3. **Auto-navigate on completion**: Once the transaction is detected in the bridge history, the component automatically navigates the user to the home page with the activity tab, providing a smooth user experience.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40014?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed infinite loader when using QR hardware wallets in popup mode after signing bridge transactions

## **Related issues**

Fixes: #39724

## **Manual testing steps**

1. Open MetaMask in Firefox in popup mode
2. Connect MetaMask with a QR hardware wallet
3. Initiate a bridge/swap transaction
4. Click "Get signature" and notice the transition to fullscreen mode in a new tab
5. Proceed with signing the transaction on the hardware wallet
6. Verify that after the transaction is successfully signed, the user is automatically taken to the main MetaMask screen (home page with activity tab) instead of being stuck on an infinite loader
7. Verify that the transaction appears in the activity tab

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/96988011-5533-4f3d-87d4-988f8ff365f5
User would see infinite loader with "Confirm with your hardware wallet" message even after successful transaction.

### **After**

https://github.com/user-attachments/assets/04372124-46f2-40d6-842d-8e4e4e1dd20c
User is automatically navigated to home page with activity tab showing the completed transaction.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge/swaps hardware-wallet navigation and auto-redirect logic based on URL params, QR scan state, and bridge history; regressions could mis-route users during two-step flows or on failure/cancel paths.
> 
> **Overview**
> Fixes the QR hardware-wallet popup→fullscreen transition getting stuck on the `AwaitingSignatures` loader by **persisting `requestId` in the awaiting-signatures URL** and using it to recover state when the popup store is lost.
> 
> Adds `useBridgeTransactionNavigation` to `AwaitingSignatures` to auto-navigate to `home?tab=activity` when the matching bridge tx appears in history, and to also navigate away on QR cancellation/failure while avoiding false positives between approval and bridge steps. Updates `useSubmitBridgeTransaction` to include `requestId` in the HW-wallet awaiting URL and to use `replace: true` on activity/prepare redirects, with new unit tests and console baseline updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74a1c07ce4281a386a4ec6d71e79d8889af4389a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->