### PR TITLE
fix(rewards): reward flag not used to render discover menu item

### DIFF
--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -80,7 +80,6 @@ import {
   getShieldSubscription,
   getSubscriptionPaymentData,
 } from '../../../../shared/lib/shield';
-import { selectRewardsEnabled } from '../../../ducks/rewards/selectors';
 import { useSubscriptionMetrics } from '../../../hooks/shield/metrics/useSubscriptionMetrics';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import type { GlobalMenuSection } from '../global-menu/global-menu-list.types';
@@ -104,7 +103,6 @@ export function useGlobalMenuSections(
   const navigate = useNavigate();
 
   const basicFunctionality = useSelector(getUseExternalServices);
-  const rewardsEnabled = useSelector(selectRewardsEnabled);
   const { notificationsUnreadCount } = useUnreadNotificationsCounter();
   const { notificationsReadCount } = useReadNotificationsCounter();
   const isMetamaskNotificationFeatureSeen = useSelector(
@@ -327,29 +325,27 @@ export function useGlobalMenuSections(
       items: [],
     };
 
-    if (rewardsEnabled) {
-      section2.items.push({
-        id: 'discover',
-        iconName: IconName.Export,
-        label: t('discover'),
-        onClick: () => {
-          const url = getPortfolioUrl(
-            'explore/tokens',
-            'ext_portfolio_button',
-            metaMetricsId,
-            isMetaMetricsEnabled,
-            isMarketingEnabled,
-          );
-          global.platform.openTab({ url });
-          trackEvent({
-            category: MetaMetricsEventCategory.Navigation,
-            event: MetaMetricsEventName.PortfolioLinkClicked,
-            properties: { location: METRICS_LOCATION, text: 'Portfolio' },
-          });
-          onClose();
-        },
-      });
-    }
+    section2.items.push({
+      id: 'discover',
+      iconName: IconName.Export,
+      label: t('discover'),
+      onClick: () => {
+        const url = getPortfolioUrl(
+          'explore/tokens',
+          'ext_portfolio_button',
+          metaMetricsId,
+          isMetaMetricsEnabled,
+          isMarketingEnabled,
+        );
+        global.platform.openTab({ url });
+        trackEvent({
+          category: MetaMetricsEventCategory.Navigation,
+          event: MetaMetricsEventName.PortfolioLinkClicked,
+          properties: { location: METRICS_LOCATION, text: 'Portfolio' },
+        });
+        onClose();
+      },
+    });
 
     if (isPopup || isSidepanel) {
       section2.items.push({
@@ -526,7 +522,6 @@ export function useGlobalMenuSections(
   }, [
     t,
     basicFunctionality,
-    rewardsEnabled,
     isPopup,
     isSidepanel,
     hasUnapprovedTransactions,

--- a/ui/components/multichain/global-menu/global-menu.tsx
+++ b/ui/components/multichain/global-menu/global-menu.tsx
@@ -96,7 +96,6 @@ import {
   getShieldSubscription,
   getSubscriptionPaymentData,
 } from '../../../../shared/lib/shield';
-import { selectRewardsEnabled } from '../../../ducks/rewards/selectors';
 import { useSubscriptionMetrics } from '../../../hooks/shield/metrics/useSubscriptionMetrics';
 
 const METRICS_LOCATION = 'Global Menu';
@@ -118,7 +117,6 @@ export const GlobalMenu = ({
   const { captureCommonExistingShieldSubscriptionEvents } =
     useSubscriptionMetrics();
   const basicFunctionality = useSelector(getUseExternalServices);
-  const rewardsEnabled = useSelector(selectRewardsEnabled);
 
   const navigate = useNavigate();
 
@@ -405,12 +403,10 @@ export const GlobalMenu = ({
           ></Box>
         </>
       )}
-      {rewardsEnabled && (
-        <DiscoverMenuItem
-          metricsLocation={METRICS_LOCATION}
-          closeMenu={closeMenu}
-        />
-      )}
+      <DiscoverMenuItem
+        metricsLocation={METRICS_LOCATION}
+        closeMenu={closeMenu}
+      />
 
       {(isPopup || isSidepanel) && (
         <MenuItem


### PR DESCRIPTION
## **Description**

The discover menu button was conditionally being rendered based on the rewards feature flag. This should always be rendered now, regardless of whether rewards is flagged on or off.

## **Changelog**

CHANGELOG entry: discover menu button always rendered

## **Screenshots/Recordings**

### **After**

<img width="1714" height="1304" alt="Screenshot from 2026-02-12 16-38-44" src="https://github.com/user-attachments/assets/758b2d13-4f1b-4804-98d2-dad3a2e45c02" />

<img width="1714" height="1304" alt="Screenshot from 2026-02-12 16-41-15" src="https://github.com/user-attachments/assets/03349ad6-e5c8-4bc0-bf4e-984af200780c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-logic change that only affects visibility of a menu item and removes a feature-flag check; no auth, data writes, or security-sensitive logic touched.
> 
> **Overview**
> The `Discover` menu entry is now **always rendered**, removing its dependency on the rewards feature flag.
> 
> This updates both the popover `GlobalMenu` and the drawer `useGlobalMenuSections` hook by deleting the `selectRewardsEnabled` selector usage and unconditionalizing the `Discover` item while keeping the existing portfolio URL + MetaMetrics tracking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4572fbf3fa68aec366d5c5eca3d9d556ad4ba25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->