### PR TITLE
fix: Network fee fiat fallback when conversion rate is missing

### DIFF
--- a/test/e2e/tests/transaction/gas-estimates.spec.ts
+++ b/test/e2e/tests/transaction/gas-estimates.spec.ts
@@ -23,6 +23,16 @@ const SPOT_PRICES_MOCK = {
     marketCap: 382623505141,
     pricePercentChange1d: 0,
   },
+  'eip155:56/slip44:714': {
+    price: 300,
+    marketCap: 85000000000,
+    pricePercentChange1d: 0,
+  },
+  'eip155:56/slip44:60': {
+    price: 300,
+    marketCap: 85000000000,
+    pricePercentChange1d: 0,
+  },
 };
 
 /**

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -109,8 +109,8 @@ describe('useFeeCalculations', () => {
     expect(resultOnBNB.current).toMatchInlineSnapshot(`
       {
         "calculateGasEstimate": [Function],
-        "estimatedFeeFiat": "< $0.01",
-        "estimatedFeeFiatWith18SignificantDigits": "0.000065843",
+        "estimatedFeeFiat": "",
+        "estimatedFeeFiatWith18SignificantDigits": null,
         "estimatedFeeNative": "0.0001",
         "estimatedFeeNativeHex": "0x3be226d2d900",
         "l1FeeFiat": "",
@@ -119,8 +119,8 @@ describe('useFeeCalculations', () => {
         "l2FeeFiat": "",
         "l2FeeFiatWith18SignificantDigits": "",
         "l2FeeNative": "",
-        "maxFeeFiat": "< $0.01",
-        "maxFeeFiatWith18SignificantDigits": "0.000125347",
+        "maxFeeFiat": "",
+        "maxFeeFiatWith18SignificantDigits": null,
         "maxFeeNative": "0.0001",
       }
     `);

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -41,6 +41,8 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   const conversionRate = useSelector((state) =>
     selectConversionRateByChainId(state, chainId),
   );
+  const hasValidConversionRate =
+    Number.isFinite(conversionRate) && Number(conversionRate) > 0;
 
   let quotedGasLimit;
   if (isQuotedSwapDisplayedInInfo) {
@@ -72,6 +74,15 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
           numberOfDecimals: 4,
         }) || 0
       }`;
+
+      if (!hasValidConversionRate) {
+        return {
+          currentCurrencyFee: EMPTY_FEE,
+          currentCurrencyFeeWith18SignificantDigits: null,
+          hexFee,
+          nativeCurrencyFee,
+        };
+      }
 
       const decimalCurrentCurrencyFee = Number(
         getValueFromWeiHex({
@@ -105,7 +116,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
         nativeCurrencyFee,
       };
     },
-    [conversionRate, currentCurrency, fiatFormatter],
+    [conversionRate, currentCurrency, fiatFormatter, hasValidConversionRate],
   );
 
   const { maxFeePerGas, maxPriorityFeePerGas } =
@@ -209,8 +220,8 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     layer1GasFee,
     maxFeePerGas,
     maxPriorityFeePerGas,
+    optimizedGasLimit,
     supportsEIP1559,
-    transactionMeta,
   ]);
 
   const calculateGasEstimateCallback = useCallback(

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -28,10 +28,14 @@ function render({
   chainId = CHAIN_IDS.GOERLI,
   gasFeeTokens,
   selectedGasFeeToken,
+  fiatFee = '$1',
+  nativeFee = '0.001 ETH',
 }: {
   chainId?: Hex;
   gasFeeTokens?: GasFeeToken[];
   selectedGasFeeToken?: Hex;
+  fiatFee?: string;
+  nativeFee?: string;
 } = {}) {
   const state = getMockConfirmStateForTransaction(
     genUnapprovedContractInteractionConfirmation({
@@ -45,8 +49,8 @@ function render({
 
   return renderWithConfirmContextProvider(
     <EditGasFeesRow
-      fiatFee="$1"
-      nativeFee="0.001 ETH"
+      fiatFee={fiatFee}
+      nativeFee={nativeFee}
       fiatFeeWith18SignificantDigits="0.001234"
     />,
     mockStore,

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -55,6 +55,7 @@ export const EditGasFeesRow = ({
   const gasFeeToken = useSelectedGasFeeToken();
   const showFiat = useShowFiat(chainId);
   const fiatValue = gasFeeToken?.amountFiat || fiatFee;
+  const hasFiatValue = Boolean(fiatValue);
   const tokenValue = gasFeeToken ? gasFeeToken.amountFormatted : nativeFee;
   const metamaskFeeFiat = gasFeeToken?.metamaskFeeFiat;
   const nativeTokenSymbol = useTransactionNativeTicker() ?? '';
@@ -76,6 +77,8 @@ export const EditGasFeesRow = ({
 
   const isGasFeeEditable =
     !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;
+  const shouldShowPrimaryFiatValue =
+    showFiat && hasFiatValue && !showAdvancedDetails && !isGasFeeSponsored;
 
   return (
     <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
@@ -107,13 +110,13 @@ export const EditGasFeesRow = ({
               </Text>
             )}
             {isGasFeeEditable && <EditGasIconButton />}
-            {showFiat && !showAdvancedDetails && !isGasFeeSponsored && (
+            {shouldShowPrimaryFiatValue && (
               <FiatValue
                 fullValue={fiatFeeWith18SignificantDigits}
                 roundedValue={fiatValue}
               />
             )}
-            {!(showFiat && !showAdvancedDetails) && !isGasFeeSponsored && (
+            {!shouldShowPrimaryFiatValue && !isGasFeeSponsored && (
               <TokenValue roundedValue={tokenValue} />
             )}
             {!isGasFeeSponsored && <SelectedGasFeeToken />}
@@ -138,7 +141,7 @@ export const EditGasFeesRow = ({
                 : ' '}
             </Text>
           </Box>
-          {showAdvancedDetails && (
+          {showAdvancedDetails && hasFiatValue && (
             <FiatValue
               fullValue={fiatFeeWith18SignificantDigits}
               roundedValue={fiatValue}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.tsx
@@ -62,6 +62,7 @@ export const GasFeesRow = ({
           {nativeFee}
         </Text>
         {(!isTestnet || showFiatInTestnets) &&
+          fiatFee &&
           (fiatFeeWith18SignificantDigits ? (
             <Tooltip title={fiatFeeWith18SignificantDigits}>
               <Text color={TextColor.textAlternative}>{fiatFee}</Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On PulseChain, confirmation could show a fiat value for **Network fee** even when fiat conversion is unavailable elsewhere in the app (home for example). This happened when the chain conversion rate was missing/null and fee formatting still produced a fiat-like fallback (`< $0.01`).

## Problem

`useFeeCalculations` was generating fiat display values even when conversion rate was invalid/missing, creating inconsistent behavior across surfaces.

## Solution

- Require a valid conversion rate (`finite && > 0`) before producing gas fee fiat values.
- If conversion rate is unavailable, return empty fiat values from fee calculations instead of `"< $0.01"`.
- Update confirmation fee rows to render fiat only when a fiat value actually exists:
  - `EditGasFeesRow` now falls back to native fee display when fiat is unavailable.
  - `GasFeesRow` skips rendering fiat text when fiat is empty.
- Remove temporary debug/console logging.
- Update affected unit tests for the new expected behavior.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/39836

## **Manual testing steps**

1. Use PulseChain account with PLS balance.
2. Confirm home/send views show no fiat conversion for PLS.
3. Start a send and proceed to confirmation.
4. Verify **Network fee** no longer shows fiat when conversion rate is unavailable, and shows native-only fee consistently.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/formatting logic changes limited to fee display when conversion rates are missing; no transaction signing or fee computation semantics change beyond suppressing fiat output.
> 
> **Overview**
> Confirmation fee calculations now require a *valid* chain conversion rate (finite and > 0) before producing fiat-formatted gas fees; otherwise fiat outputs are returned empty instead of the `"< $0.01"` fallback.
> 
> Confirmation UI fee rows (`EditGasFeesRow`, `GasFeesRow`) now only render fiat amounts when a non-empty fiat value exists, falling back to native-only display when conversion data is unavailable. Tests and mocks are updated accordingly (including expanded spot price mocks for BSC in the gas estimates e2e spec).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76351a248a9c095ff2f7a28bdfd5b5674bc2fd01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->