### PR TITLE
fix: update smart account learn more links to point to specific section

### DIFF
--- a/shared/lib/ui-utils.js
+++ b/shared/lib/ui-utils.js
@@ -26,7 +26,7 @@ export const GAS_FEES_LEARN_MORE_URL =
   'https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172';
 
 export const SMART_ACCOUNT_INFO_LINK =
-  'https://support.metamask.io/configure/accounts/what-is-a-smart-account';
+  'https://support.metamask.io/configure/accounts/what-is-a-smart-account/#what-are-metamask-smart-accounts';
 
 export const VAULT_RECOVERY_LINK = `https://support.metamask.io/configure/wallet/how-to-recover-your-secret-recovery-phrase/#step-two-locate-your-vault`;
 

--- a/ui/helpers/constants/zendesk-url.js
+++ b/ui/helpers/constants/zendesk-url.js
@@ -1,6 +1,6 @@
 const ZENDESK_URLS = {
   ACCOUNT_UPGRADE:
-    'https://support.metamask.io/configure/accounts/what-is-a-smart-account',
+    'https://support.metamask.io/configure/accounts/what-is-a-smart-account/#what-are-metamask-smart-accounts',
   ADD_CUSTOM_TOKENS:
     'https://support.metamask.io/managing-my-tokens/custom-tokens/how-to-display-tokens-in-metamask/',
   ADD_SOLANA_ACCOUNTS:


### PR DESCRIPTION
## **Description**

Updates the "learn more" links for smart accounts to point to the specific section on the support page.

**What is the reason for the change?**
The current links point to the top of the support article. Users should be directed to the specific section about MetaMask smart accounts for a better support experience.

**What is the improvement/solution?**
Updated the URL from `https://support.metamask.io/configure/accounts/what-is-a-smart-account` to `https://support.metamask.io/configure/accounts/what-is-a-smart-account/#what-are-metamask-smart-accounts` in two files:
- `shared/lib/ui-utils.js` (`SMART_ACCOUNT_INFO_LINK`)
- `ui/helpers/constants/zendesk-url.js` (`ACCOUNT_UPGRADE`)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40027?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4861

## **Manual testing steps**

1. Go Accounts menu > accounts detail > smart account set up.
2. Click the "learn more" link.
3. Verify that the link navigates to `https://support.metamask.io/configure/accounts/what-is-a-smart-account/#what-are-metamask-smart-accounts` and scrolls to the correct section.


## **Screenshots/Recordings**

### **Before**

Links navigate to `https://support.metamask.io/configure/accounts/what-is-a-smart-account` (top of page).

### **After**

Links navigate to `https://support.metamask.io/configure/accounts/what-is-a-smart-account/#what-are-metamask-smart-accounts` (specific section).

<img width="1197" height="935" alt="Screenshot 2026-02-12 at 15 26 56" src="https://github.com/user-attachments/assets/718c84c0-0ea4-4170-8583-14494db16ecd" />
<img width="1195" height="929" alt="Screenshot 2026-02-12 at 15 29 30" src="https://github.com/user-attachments/assets/d732f3b0-f2b3-4375-b9b0-6490fde97741" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only URL updates with no behavior changes beyond where external links land.
> 
> **Overview**
> Updates the smart account “learn more” URLs to deep-link to the `#what-are-metamask-smart-accounts` section instead of the top of the support article.
> 
> This changes both `SMART_ACCOUNT_INFO_LINK` in `shared/lib/ui-utils.js` and `ZENDESK_URLS.ACCOUNT_UPGRADE` in `ui/helpers/constants/zendesk-url.js`, affecting any UI that opens those links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e83fc8ad0bee2b49d8402e6f066cc149b13db12c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->