### PR TITLE
refactor: remove BIP-44 flag from wallet overview

### DIFF
--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.test.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.test.tsx
@@ -3,7 +3,6 @@ import configureMockStore from 'redux-mock-store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { TextColor } from '../../../../helpers/constants/design-system';
-import { getIsMultichainAccountsState2Enabled } from '../../../../selectors';
 import { AccountGroupBalanceChange } from './account-group-balance-change';
 import { useAccountGroupBalanceDisplay } from './useAccountGroupBalanceDisplay';
 
@@ -22,16 +21,11 @@ describe('AccountGroupBalanceChange', () => {
   });
 
   const arrange = () => {
-    const mockGetIsMultichainAccountsState2Enabled = jest
-      .mocked(getIsMultichainAccountsState2Enabled)
-      .mockReturnValue(true);
-
     const mockUseAccountGroupBalanceDisplay = jest
       .mocked(useAccountGroupBalanceDisplay)
       .mockReturnValue(createBalanceDisplayData());
 
     return {
-      mockGetIsMultichainAccountsState2Enabled,
       mockUseAccountGroupBalanceDisplay,
     };
   };
@@ -75,12 +69,5 @@ describe('AccountGroupBalanceChange', () => {
       value: '••••••••••',
       percent: '••••••••••',
     });
-  });
-
-  it('returns null when feature flag is disabled', () => {
-    const mocks = arrange();
-    mocks.mockGetIsMultichainAccountsState2Enabled.mockReturnValue(false);
-    const { container } = renderComponent();
-    expect(container.firstChild).toBeNull();
   });
 });

--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -7,10 +7,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
-import {
-  getIsMultichainAccountsState2Enabled,
-  selectAnyEnabledNetworksAreAvailable,
-} from '../../../../selectors';
+import { selectAnyEnabledNetworksAreAvailable } from '../../../../selectors';
 import { Box, SensitiveText } from '../../../component-library';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { Skeleton } from '../../../component-library/skeleton';
@@ -68,14 +65,4 @@ const AccountGroupBalanceChangeComponent: React.FC<
 
 export const AccountGroupBalanceChange: React.FC<
   AccountGroupBalanceChangeProps
-> = (props) => {
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-
-  if (!isMultichainAccountsState2Enabled) {
-    return null;
-  }
-
-  return <AccountGroupBalanceChangeComponent {...props} />;
-};
+> = (props) => <AccountGroupBalanceChangeComponent {...props} />;

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -27,7 +27,6 @@ import {
   getNetworkConfigurationIdByChainId,
   getSwapsDefaultToken,
 } from '../../../selectors';
-import { getIsMultichainAccountsState2Enabled } from '../../../selectors/multichain-accounts/feature-flags';
 import { getSelectedAccountGroup } from '../../../selectors/multichain-accounts/account-tree';
 import Tooltip from '../../ui/tooltip';
 import {
@@ -121,11 +120,6 @@ const CoinButtons = ({
     string
   >;
   const currentChainId = useSelector(getCurrentChainId);
-
-  // Multichain accounts feature flag and selected account group
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
   const selectedAccountGroup = useSelector(getSelectedAccountGroup);
 
   const defaultSwapsToken = useSelector((state) =>
@@ -236,11 +230,7 @@ const CoinButtons = ({
   const { openBridgeExperience } = useBridging();
 
   const setCorrectChain = useCallback(async () => {
-    if (
-      currentChainId !== chainId &&
-      multichainChainId !== chainId &&
-      !isMultichainAccountsState2Enabled
-    ) {
+    if (currentChainId !== chainId && multichainChainId !== chainId) {
       try {
         const networkConfigurationId = networks[chainId];
         await dispatch(setActiveNetworkWithError(networkConfigurationId));
@@ -255,14 +245,7 @@ const CoinButtons = ({
         throw err;
       }
     }
-  }, [
-    isMultichainAccountsState2Enabled,
-    currentChainId,
-    multichainChainId,
-    chainId,
-    networks,
-    dispatch,
-  ]);
+  }, [currentChainId, multichainChainId, chainId, networks, dispatch]);
 
   const handleSendOnClick = useCallback(async () => {
     trackEvent(
@@ -360,7 +343,7 @@ const CoinButtons = ({
       },
     });
 
-    if (isMultichainAccountsState2Enabled && selectedAccountGroup) {
+    if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
       navigate(
         `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedAccountGroup)}?${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
@@ -369,14 +352,7 @@ const CoinButtons = ({
       // Show the traditional receive modal
       setShowReceiveModal(true);
     }
-  }, [
-    isMultichainAccountsState2Enabled,
-    selectedAccountGroup,
-    navigate,
-    trackEvent,
-    trackingLocation,
-    chainId,
-  ]);
+  }, [selectedAccountGroup, navigate, trackEvent, trackingLocation, chainId]);
 
   return (
     <Box

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -207,8 +207,13 @@ export const CoinOverview = ({
   const hasBalance = useSelector(selectAccountGroupBalanceForEmptyState);
   const isTestnet = useSelector(getMultichainIsTestnet);
 
+  // Only show empty state when Receive can act (selectedAccountGroup exists);
+  // otherwise the Receive button would be a no-op.
   const shouldShowBalanceEmptyState =
-    !isTestnet && !balanceIsCached && !hasBalance;
+    Boolean(selectedAccountGroup) &&
+    !isTestnet &&
+    !balanceIsCached &&
+    !hasBalance;
 
   const handleSensitiveToggle = () => {
     dispatch(setPrivacyMode(!privacyMode));

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -6,7 +6,6 @@ import { CaipChainId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Box, ButtonLink, IconName } from '../../component-library';
 import { TextVariant } from '../../../helpers/constants/design-system';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
@@ -29,7 +28,6 @@ import { trace, TraceName } from '../../../../shared/lib/trace';
 import {
   getPreferences,
   getShouldHideZeroBalanceTokens,
-  getTokensMarketData,
   getIsTestnet,
   getIsTokenNetworkFilterEqualCurrentNetwork,
   getChainIdsToPoll,
@@ -37,16 +35,13 @@ import {
   getMetaMetricsId,
   getParticipateInMetaMetrics,
   getEnabledNetworksByNamespace,
-  getIsMultichainAccountsState2Enabled,
   selectAnyEnabledNetworksAreAvailable,
 } from '../../../selectors';
 
-import { PercentageAndAmountChange } from '../../multichain/token-list-item/price/percentage-and-amount-change/percentage-and-amount-change';
 import { AccountGroupBalance } from '../assets/account-group-balance/account-group-balance';
 import { AccountGroupBalanceChange } from '../assets/account-group-balance-change/account-group-balance-change';
 
 import {
-  getMultichainIsEvm,
   getMultichainShouldShowFiat,
   getMultichainIsTestnet,
 } from '../../../selectors/multichain';
@@ -56,7 +51,6 @@ import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountT
 
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
-import { AggregatedBalance } from '../../ui/aggregated-balance/aggregated-balance';
 import { Skeleton } from '../../component-library/skeleton';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
 import { RewardsPointsBalance } from '../rewards/RewardsPointsBalance';
@@ -66,11 +60,6 @@ import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/asset
 import { getSelectedAccountGroup } from '../../../selectors/multichain-accounts/account-tree';
 import WalletOverview from './wallet-overview';
 import CoinButtons from './coin-buttons';
-import {
-  AggregatedMultichainPercentageOverview,
-  AggregatedPercentageOverview,
-} from './aggregated-percentage-overview';
-import { AggregatedPercentageOverviewCrossChains } from './aggregated-percentage-overview-cross-chains';
 
 export type CoinOverviewProps = {
   account: InternalAccount;
@@ -198,8 +187,6 @@ export const CoinOverview = ({
   isSwapsChain,
   isSigningEnabled,
 }: CoinOverviewProps) => {
-  const enabledNetworks = useSelector(getEnabledNetworksByNamespace);
-
   const t: ReturnType<typeof useI18nContext> = useContext(I18nContext);
 
   const { trackEvent } = useContext(MetaMetricsContext);
@@ -211,35 +198,17 @@ export const CoinOverview = ({
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const { privacyMode, showNativeTokenAsMainBalance } =
-    useSelector(getPreferences);
+  const { privacyMode } = useSelector(getPreferences);
 
   const selectedAccountGroup = useSelector(getSelectedAccountGroup);
 
-  const isTokenNetworkFilterEqualCurrentNetwork = useSelector(
-    getIsTokenNetworkFilterEqualCurrentNetwork,
-  );
-
-  const isEvm = useSelector(getMultichainIsEvm);
-
-  const tokensMarketData = useSelector(getTokensMarketData);
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-
-  const anyEnabledNetworksAreAvailable = useSelector(
-    selectAnyEnabledNetworksAreAvailable,
-  );
   const isRewardsEnabled = useSelector(selectRewardsEnabled);
 
   const hasBalance = useSelector(selectAccountGroupBalanceForEmptyState);
   const isTestnet = useSelector(getMultichainIsTestnet);
 
   const shouldShowBalanceEmptyState =
-    isMultichainAccountsState2Enabled &&
-    !isTestnet &&
-    !balanceIsCached &&
-    !hasBalance;
+    !isTestnet && !balanceIsCached && !hasBalance;
 
   const handleSensitiveToggle = () => {
     dispatch(setPrivacyMode(!privacyMode));
@@ -278,19 +247,13 @@ export const CoinOverview = ({
       },
     });
 
-    if (isMultichainAccountsState2Enabled && selectedAccountGroup) {
+    if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
       navigate(
         `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedAccountGroup)}?${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
       );
     }
-  }, [
-    isMultichainAccountsState2Enabled,
-    selectedAccountGroup,
-    navigate,
-    trackEvent,
-    chainId,
-  ]);
+  }, [selectedAccountGroup, navigate, trackEvent, chainId]);
 
   const renderPercentageAndAmountChange = () => {
     const renderPercentageAndAmountChangeTrail = () => {
@@ -310,97 +273,26 @@ export const CoinOverview = ({
       );
     };
 
-    const renderNativeTokenView = () => {
-      const value =
-        tokensMarketData?.[getNativeTokenAddress(chainId as Hex)]
-          ?.pricePercentChange1d;
-      return (
-        <Skeleton
-          isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(value)}
-        >
-          <Box className="wallet-overview__currency-wrapper">
-            <PercentageAndAmountChange value={value} />
-            {renderPercentageAndAmountChangeTrail()}
-          </Box>
-        </Skeleton>
-      );
-    };
-
-    const renderAggregatedView = () => (
+    return (
       <Box className="wallet-overview__currency-wrapper">
-        {isTokenNetworkFilterEqualCurrentNetwork ? (
-          <AggregatedPercentageOverview
-            trailingChild={renderPercentageAndAmountChangeTrail}
-          />
-        ) : (
-          <AggregatedPercentageOverviewCrossChains
-            trailingChild={renderPercentageAndAmountChangeTrail}
-          />
-        )}
-      </Box>
-    );
-
-    const renderNonEvmView = () => (
-      <Box className="wallet-overview__currency-wrapper">
-        <AggregatedMultichainPercentageOverview
-          privacyMode={privacyMode}
+        <AccountGroupBalanceChange
+          period="1d"
           trailingChild={renderPercentageAndAmountChangeTrail}
         />
       </Box>
     );
-
-    // Early exit for state2 unified view
-    if (isMultichainAccountsState2Enabled) {
-      return (
-        <Box className="wallet-overview__currency-wrapper">
-          <AccountGroupBalanceChange
-            period="1d"
-            trailingChild={renderPercentageAndAmountChangeTrail}
-          />
-        </Box>
-      );
-    }
-
-    if (!isEvm) {
-      return renderNonEvmView();
-    }
-
-    return showNativeTokenAsMainBalance &&
-      Object.keys(enabledNetworks).length === 1
-      ? renderNativeTokenView()
-      : renderAggregatedView();
   };
 
-  let balanceSection: React.ReactNode;
-  if (isMultichainAccountsState2Enabled) {
-    balanceSection = (
-      <AccountGroupBalance
-        classPrefix={classPrefix}
-        balanceIsCached={balanceIsCached}
-        handleSensitiveToggle={handleSensitiveToggle}
-        balance={balance}
-        chainId={chainId}
-      />
-    );
-  } else if (isEvm) {
-    balanceSection = (
-      <LegacyAggregatedBalance
-        classPrefix={classPrefix}
-        account={account}
-        balance={balance}
-        balanceIsCached={balanceIsCached}
-        handleSensitiveToggle={handleSensitiveToggle}
-      />
-    );
-  } else {
-    balanceSection = (
-      <AggregatedBalance
-        classPrefix={classPrefix}
-        balanceIsCached={balanceIsCached}
-        handleSensitiveToggle={handleSensitiveToggle}
-      />
-    );
-  }
+  const balanceSection: React.ReactNode = (
+    <AccountGroupBalance
+      classPrefix={classPrefix}
+      balanceIsCached={balanceIsCached}
+      handleSensitiveToggle={handleSensitiveToggle}
+      balance={balance}
+      chainId={chainId}
+    />
+  );
+
   return (
     <WalletOverview
       balance={

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -39,6 +39,7 @@ jest.mock('../../../hooks/useIsOriginalNativeTokenSymbol', () => {
 });
 
 jest.mock('../../../ducks/locale/locale', () => ({
+  ...jest.requireActual('../../../ducks/locale/locale'),
   getIntlLocale: jest.fn(),
 }));
 
@@ -73,6 +74,7 @@ describe('EthOverview', () => {
     options: {},
     methods: ETH_EOA_METHODS,
     type: EthAccountType.Eoa,
+    scopes: ['eip155:0'],
   };
 
   const mockEvmAccount2 = {
@@ -87,17 +89,40 @@ describe('EthOverview', () => {
     options: {},
     methods: ETH_EOA_METHODS,
     type: EthAccountType.Eoa,
+    scopes: ['eip155:0'],
   };
 
   const mockStore = {
     appState: {
       confirmationExchangeRates: {},
     },
+    localeMessages: {
+      currentLocale: 'en-US',
+    },
     metamask: {
       ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
       accountTree: {
-        wallets: {},
-        selectedAccountGroup: null,
+        wallets: {
+          'entropy:wallet1': {
+            id: 'entropy:wallet1',
+            groups: {
+              'entropy:wallet1/group1': {
+                id: 'entropy:wallet1/group1',
+                type: 'multichain-account',
+                accounts: [mockEvmAccount1.id],
+                metadata: {
+                  name: 'Account 1',
+                  hidden: false,
+                  pinned: false,
+                },
+              },
+            },
+          },
+        },
+        selectedAccountGroup: 'entropy:wallet1/group1',
+      },
+      tokenBalances: {
+        [CHAIN_IDS.MAINNET]: {},
       },
       remoteFeatureFlags: {
         bridgeConfig: {
@@ -224,7 +249,7 @@ describe('EthOverview', () => {
 
       const primaryBalance = queryByTestId(ETH_OVERVIEW_PRIMARY_CURRENCY);
       expect(primaryBalance).toBeInTheDocument();
-      expect(primaryBalance).toHaveTextContent('<0.000001ETH');
+      expect(primaryBalance).toHaveTextContent('0 ETH');
       expect(queryByText('*')).not.toBeInTheDocument();
     });
 
@@ -256,7 +281,7 @@ describe('EthOverview', () => {
 
       const primaryBalance = queryByTestId(ETH_OVERVIEW_PRIMARY_CURRENCY);
       expect(primaryBalance).toBeInTheDocument();
-      expect(primaryBalance).toHaveTextContent('0.0104ETH');
+      expect(primaryBalance).toHaveTextContent('0.0104 ETH');
       expect(queryByText('*')).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR is part of a series to remove the legacy code after BIP-44 was shipped, several components, hooks, views, etc. still uses the remote feature flag for BIP-44 causing an unnecessary overcomplexity that can be easily removed.

The changes included updating the components relevant for the "Wallet Overview".

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40029?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1451

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing wallet overview rendering and receive/chain-switch preconditions by removing a gating feature flag, which could expose edge cases for accounts without a valid `selectedAccountGroup` or incomplete account-tree state.
> 
> **Overview**
> Wallet Overview no longer branches on the BIP-44/multichain state2 feature flag: `CoinOverview` always renders `AccountGroupBalance` and `AccountGroupBalanceChange`, and `AccountGroupBalanceChange` no longer returns `null` when the flag is off.
> 
> `CoinButtons` and the balance-empty-state receive handler now route to the multichain address list whenever `selectedAccountGroup` exists (and chain-switching no longer depends on the flag), simplifying behavior and removing legacy paths. Tests were updated accordingly (new `accountTree` fixtures, formatting expectations like `0.0104 ETH`, and removal of flag-disabled assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5422b6daaef462357bb0caf8766dbabb88f86ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->