### PR TITLE
release: temporarily increase the E2E timeout to 40 minutes

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -25,7 +25,7 @@ on:
         description: The run ID to get builds from
       test-timeout-minutes:
         type: number
-        default: 30
+        default: 40
         description: The timeout in minutes for the test command
       matrix-index:
         type: number
@@ -49,7 +49,7 @@ jobs:
   run-e2e:
     name: ${{ inputs.test-suite-name }}${{ inputs.matrix-total > 1 && format(' ({0})', inputs.matrix-index) || '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     container:
       image: ghcr.io/metamask/metamask-extension-e2e-image:v24.13.0
       credentials:


### PR DESCRIPTION
## **Description**

We can't get a release out because:

1. Download `test-runs-for-splitting` is failing (maybe it's because we don't have any recent runs on branch `main` that have `status:success`, but I'm not sure)
2. `test/e2e/tests/deep-link/deep-link.spec.ts` on `firefox-webpack` runs incredibly long (I've talked about this recently)
3. It's not splitting intelligently, and it's hitting the timeout of 30 minutes

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that lengthens E2E job/test execution timeouts; no product code or security-sensitive logic is modified.
> 
> **Overview**
> Increases the `run-e2e` GitHub Actions workflow timeout from **30 to 40 minutes**, both at the job level (`timeout-minutes`) and the default for the `test-timeout-minutes` workflow input used by the test step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf042917e5fba2b992eb8243d2d2c2ede08b5547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->