### PR TITLE
refactor: resolve rive wasm via import.meta.url

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -36,6 +36,18 @@ module.exports = function (api) {
             /^@metamask\/([^/]+)\/dist\/preinstalled-snap\.json(\.gz)?$/u,
           rootPath: '/snaps/',
         },
+        'import-meta-url-snaps',
+      ],
+      [
+        path.resolve(
+          __dirname,
+          'development/build/transforms/import-meta-url.js',
+        ),
+        {
+          pattern: /^@rive-app\/canvas\/(rive)\.wasm$/u,
+          rootPath: '/images/',
+        },
+        'import-meta-url-rive',
       ],
     ],
     presets: [

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -124,7 +124,7 @@ function getCopyTargets(
     },
     {
       src: getPathInsideNodeModules('@rive-app/canvas', 'rive.wasm'),
-      dest: `images/riv_animations/rive.wasm`,
+      dest: 'images/rive.wasm',
       pattern: '',
     },
     {

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -166,11 +166,6 @@ const plugins: WebpackPluginInstance[] = [
       // misc images
       // TODO: fix overlap between this folder and automatically bundled assets
       { from: join(context, 'images'), to: 'images' },
-      // Copy rive.wasm for Rive animations
-      {
-        from: join(nodeModules, '@rive-app/canvas/rive.wasm'),
-        to: 'images/riv_animations/rive.wasm',
-      },
       // snaps MV3 needs the offscreen document
       ...(MANIFEST_VERSION === 3
         ? [

--- a/development/webpack/webpack.integration.tests.config.ts
+++ b/development/webpack/webpack.integration.tests.config.ts
@@ -30,7 +30,7 @@ const plugins: WebpackPluginInstance[] = [
       // Copy rive.wasm for Rive animations
       {
         from: join(nodeModules, '@rive-app/canvas/rive.wasm'),
-        to: 'images/riv_animations/rive.wasm',
+        to: 'images/rive.wasm',
       },
     ],
   }),

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -906,30 +906,6 @@ async function setupMocking(
     };
   });
 
-  // Mock Rive animation files to prevent loading errors in e2e tests
-  // These animations are loaded during onboarding flow
-  await server
-    .forGet(/.*\/images\/riv_animations\/rive\.wasm/u)
-    .thenCallback(() => {
-      // Return empty ArrayBuffer for WASM file
-      return {
-        statusCode: 200,
-        headers: { 'content-type': 'application/wasm' },
-        body: Buffer.alloc(0),
-      };
-    });
-
-  await server
-    .forGet(/.*\/images\/riv_animations\/.*\.riv/u)
-    .thenCallback(() => {
-      // Return empty binary for .riv animation files
-      return {
-        statusCode: 200,
-        headers: { 'content-type': 'application/octet-stream' },
-        body: Buffer.alloc(0),
-      };
-    });
-
   // Price API: Spot prices for native token (ETH)
   // Uses zero address (0x0000000000000000000000000000000000000000) to represent native token
   // API format: v3/spot-prices?assetIds={assetIds}&vsCurrency=usd&includeMarketData=true

--- a/ui/contexts/rive-wasm/index.tsx
+++ b/ui/contexts/rive-wasm/index.tsx
@@ -6,9 +6,11 @@ import { RuntimeLoader } from '@rive-app/react-canvas';
 import React, { createContext, useCallback, useContext, useState } from 'react';
 import { useAsyncResult } from '../../hooks/useAsync';
 
-// WASM file URL - the file is copied to dist/chrome/images/ by the build process
-// We don't import it as a module to avoid browserify resolution issues
-const RIVE_WASM_URL = './images/riv_animations/rive.wasm';
+const RIVE_WASM_URL = new URL(
+  '@rive-app/canvas/rive.wasm',
+  // @ts-expect-error TS1470: 'import.meta' is not allowed in CommonJS
+  import.meta.url,
+);
 
 export const useRiveWasmReady = () => {
   const [isWasmReady, setIsWasmReady] = useState(false);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Rive was previously integrated into MM by copying its assets to the build output folder explicitly, this PR makes it part of the build process (for webpack), and adapts the old system to use the same "magic".

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40070?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build asset resolution/packaging for a WASM dependency; misconfiguration could break onboarding animations or tests, but changes are localized to Rive asset paths.
> 
> **Overview**
> Rive’s `rive.wasm` is now resolved via `new URL('@rive-app/canvas/rive.wasm', import.meta.url)` and a Babel `import-meta-url` transform, instead of relying on a hardcoded `./images/riv_animations/rive.wasm` path.
> 
> Build/test packaging is adjusted to match: the WASM is copied to `images/rive.wasm` (and the explicit webpack copy step is removed in the main config), and the E2E mock that intercepted `images/riv_animations/*` Rive asset requests is dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d01319448fb832ef71654ee9991dfd591f5f74b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->