### PR TITLE
ci: Set GH token correctly when deploying Storybook

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -41,5 +41,5 @@ jobs:
         env:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |
-          git remote add storybook "https://${STORYBOOK_TOKEN}@github.com/MetaMask/metamask-storybook.git"
+          git remote add storybook "https://x-access-token:${STORYBOOK_TOKEN}@github.com/MetaMask/metamask-storybook.git"
           yarn storybook:deploy

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -11,7 +11,6 @@ jobs:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
@@ -37,7 +36,7 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
+        if: ${{ env.STORYBOOK_TOKEN }}
         env:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -11,6 +11,7 @@ jobs:
     name: Build storybook
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
@@ -36,7 +37,7 @@ jobs:
           path: storybook-build
 
       - name: Deploy storybook
-        if: ${{ env.STORYBOOK_TOKEN }}
+        if: ${{ env.BRANCH == 'main' && env.STORYBOOK_TOKEN }}
         env:
           STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
         run: |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Deploy Storybook" workflow still does not work. This workflow is using a new GitHub app token, *not* a personal access token, to authenticate the push. When using a GitHub app token, the syntax to configure a repo URL looks a bit different.

Read more: <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40073?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

(N/A)

## **Manual testing steps**

No manual testing steps, but I temporarily allowed pull requests to trigger the workflow. Here is the passing workflow: https://github.com/MetaMask/metamask-extension/actions/runs/21995079720/job/63552737288

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change that adjusts Git authentication syntax; risk is limited to the Storybook deployment step failing if misconfigured.
> 
> **Overview**
> Fixes Storybook deployment in CI by updating the `git remote add storybook` URL to use the `x-access-token:` format required for GitHub App installation tokens.
> 
> No build logic changes; only the authentication syntax for pushing to `MetaMask/metamask-storybook` is adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fe454f3127854c5147f067298826b74914e9770. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->