### PR TITLE
refactor: multichain transaction modal props

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.test.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../../shared/constants/multichain/networks';
 import mockState from '../../../../test/data/mock-state.json';
 import configureStore from '../../../store/store';
-import { shortenAddress as utilShortenAddress } from '../../../helpers/utils/util';
 import { MultichainTransactionDetailsModal } from './multichain-transaction-details-modal';
 import {
   getAddressUrl,
@@ -130,7 +129,6 @@ const mockSwapTransaction = {
 const mockProps = {
   transaction: mockTransaction,
   onClose: jest.fn(),
-  userAddress: MOCK_ACCOUNT_SOLANA_MAINNET.address,
 };
 
 const mockStateWithBitcoin = {
@@ -141,6 +139,13 @@ const mockStateWithBitcoin = {
     remoteFeatureFlags: {
       ...mockState.metamask.remoteFeatureFlags,
       bitcoinAccounts: true,
+    },
+    internalAccounts: {
+      ...mockState.metamask.internalAccounts,
+      accounts: {
+        ...mockState.metamask.internalAccounts.accounts,
+        [MOCK_ACCOUNT_BIP122_P2WPKH.id]: MOCK_ACCOUNT_BIP122_P2WPKH,
+      },
     },
   },
 };
@@ -167,7 +172,6 @@ describe('MultichainTransactionDetailsModal', () => {
     props: {
       transaction: Transaction;
       onClose: jest.Mock;
-      userAddress: string;
     } = mockProps,
   ) => {
     const store = configureStore(mockStateWithBitcoin);
@@ -329,12 +333,9 @@ describe('MultichainTransactionDetailsModal', () => {
   });
 
   it('renders Solana swap transaction details correctly', () => {
-    const userAddress = MOCK_ACCOUNT_SOLANA_MAINNET.address;
     const swapProps = {
       transaction: mockSwapTransaction,
       onClose: jest.fn(),
-      userAddress,
-      networkConfig: MULTICHAIN_PROVIDER_CONFIGS[MultichainNetworks.SOLANA],
     };
 
     renderComponent(swapProps);
@@ -344,7 +345,7 @@ describe('MultichainTransactionDetailsModal', () => {
       '-2.5 SOL',
     );
 
-    const addressStart = userAddress.substring(0, 6);
+    const addressStart = MOCK_ACCOUNT_SOLANA_MAINNET.address.substring(0, 6);
     const addressElements = screen.getAllByText((_content, element) => {
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -368,12 +369,22 @@ describe('MultichainTransactionDetailsModal', () => {
     const btcTransaction: Transaction = {
       ...mockTransaction,
       account: MOCK_ACCOUNT_BIP122_P2WPKH.id,
+      from: [
+        {
+          address: MOCK_ACCOUNT_BIP122_P2WPKH.address,
+          asset: {
+            fungible: true,
+            type: 'native' as CaipAssetType,
+            amount: '1.0',
+            unit: 'BTC',
+          },
+        },
+      ],
     };
     const store = configureStore(mockStateWithBitcoin);
     const props = {
       transaction: btcTransaction,
       onClose: jest.fn(),
-      userAddress: MOCK_ACCOUNT_BIP122_P2WPKH.address,
     };
 
     renderWithProvider(
@@ -386,10 +397,9 @@ describe('MultichainTransactionDetailsModal', () => {
     const fromLabel = screen.getByText('from');
     expect(fromLabel).toBeInTheDocument();
 
-    const shortenedFromAddress = utilShortenAddress(
-      MOCK_ACCOUNT_BIP122_P2WPKH.address,
+    const fromAddressElement = screen.getByText(
+      MOCK_ACCOUNT_BIP122_P2WPKH.metadata.name,
     );
-    const fromAddressElement = screen.getByText(shortenedFromAddress);
     expect(fromAddressElement).toBeInTheDocument();
 
     const expectedHref = getAddressUrl(

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -45,6 +45,7 @@ import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
 import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
 import {
   getAccountName,
+  getSelectedAccount,
   getSelectedMultichainNetworkConfiguration,
 } from '../../../selectors';
 import {
@@ -66,7 +67,6 @@ import {
 export type MultichainTransactionDetailsModalProps = {
   transaction: Transaction;
   onClose: () => void;
-  userAddress: string;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -74,10 +74,10 @@ export type MultichainTransactionDetailsModalProps = {
 export function MultichainTransactionDetailsModal({
   transaction,
   onClose,
-  userAddress,
 }: MultichainTransactionDetailsModalProps) {
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
+  const userAddress = useSelector(getSelectedAccount)?.address;
   const networkConfig = useSelector(getSelectedMultichainNetworkConfiguration);
   const {
     from,

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -453,6 +453,8 @@ const TransactionListItem = (props) => {
 
 TransactionListItem.propTypes = {
   transactionGroup: PropTypes.object.isRequired,
+  isEarliestNonce: PropTypes.bool,
+  chainId: PropTypes.string,
 };
 
 export default TransactionListItem;

--- a/ui/components/app/transaction-list/transaction-list.component.js
+++ b/ui/components/app/transaction-list/transaction-list.component.js
@@ -499,7 +499,6 @@ export default function TransactionList({
             <MultichainTransactionDetailsModal
               transaction={selectedTransaction}
               onClose={() => toggleShowDetails(null)}
-              userAddress={selectedAccount.address}
             />
           ))}
 

--- a/ui/components/app/transaction-list/unified-transaction-list.component.js
+++ b/ui/components/app/transaction-list/unified-transaction-list.component.js
@@ -864,7 +864,6 @@ export default function UnifiedTransactionList({
           <MultichainTransactionDetailsModal
             transaction={selectedTransaction}
             onClose={() => toggleShowDetails(null)}
-            userAddress={selectedAccount.address}
           />
         ))}
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Move props closer to point of usage

Part of breaking down the Activity v2 PR

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40077?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI refactor that changes how the modal sources the “from” address; main risk is incorrect display if `getSelectedAccount` is unset or differs from the transaction’s actual sender.
> 
> **Overview**
> **Refactors `MultichainTransactionDetailsModal` to stop requiring a `userAddress` prop**, and instead derives the address from Redux via `getSelectedAccount`.
> 
> Updates the non‑EVM transaction list and unified transaction list to stop passing `userAddress`, and adjusts the modal test setup/expectations (including seeding `internalAccounts` so Bitcoin “from” renders as the account name rather than a shortened address).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 831696b9aebaccade3a4ada961c54cb174508808. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->