### PR TITLE
release: fix three issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -542,8 +542,7 @@ jobs:
     #
     # Requirements:
     # - For most jobs: result must be `success` or `skipped` (supports the builds-from-run shortcut).
-    # - For benchmark jobs: result may be `success`, `skipped`, or `failure` (failure does not block prerelease),
-    #   but statuses like `cancelled`, `timed_out`, or `action_required` will block.
+    # - For benchmark jobs: result can be anything (failure does not block prerelease),
     if: >-
       ${{
         !cancelled() &&
@@ -558,8 +557,6 @@ jobs:
         contains(fromJson('["success","skipped"]'), needs.build-test-mv2-browserify.result) &&
         contains(fromJson('["success","skipped"]'), needs.build-test-flask-browserify.result) &&
         contains(fromJson('["success","skipped"]'), needs.build-test-flask-mv2-browserify.result) &&
-        contains(fromJson('["success","skipped","failure"]'), needs.run-benchmarks.result) &&
-        contains(fromJson('["success","skipped","failure"]'), needs.page-load-benchmark.result) &&
         contains(fromJson('["success","skipped"]'), needs.bundle-size.result) &&
         contains(fromJson('["success","skipped"]'), needs.build-storybook.result) &&
         contains(fromJson('["success","skipped"]'), needs.build-ts-migration-dashboard.result) &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - main
       - stable
       - release/*
+      - '!release/*-Changelog'
       - trigger-ci-*
   pull_request:
     types:
@@ -535,7 +536,26 @@ jobs:
 
   publish-prerelease:
     name: Publish prerelease
-    if: ${{ needs.get-requirements.outputs.needs-releases == 'true' }}
+    # This job requires an incredibly complicated `if` condition, because we want to meet the following requirements:
+    # - Only run when releases are needed
+    # - Still run when benchmarks are not needed
+    # - Must not run if any `needs` job has failed, been cancelled, timed out, or requires action
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.get-requirements.outputs.needs-releases == 'true' &&
+        !contains(needs.*.result, 'failure') &&
+        !contains(needs.*.result, 'cancelled') &&
+        !contains(needs.*.result, 'timed_out') &&
+        !contains(needs.*.result, 'action_required') &&
+        (
+          needs.get-requirements.outputs.needs-benchmarks != 'true' ||
+          (
+            needs.run-benchmarks.result == 'success' &&
+            needs.page-load-benchmark.result == 'success'
+          )
+        )
+      }}
     needs:
       - get-requirements
       - build-dist-browserify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -536,25 +536,35 @@ jobs:
 
   publish-prerelease:
     name: Publish prerelease
-    # This job requires an incredibly complicated `if` condition, because we want to meet the following requirements:
-    # - Only run when releases are needed
-    # - Still run when benchmarks are not needed
-    # - Must not run if any `needs` job has failed, been cancelled, timed out, or requires action
+    # publish-prerelease when releases are enabled.
+    #
+    # This job is sequenced after *all* jobs in `needs`, including benchmarks.
+    #
+    # Requirements:
+    # - For most jobs: result must be `success` or `skipped` (supports the builds-from-run shortcut).
+    # - For benchmark jobs: result may be `success`, `skipped`, or `failure` (failure does not block prerelease),
+    #   but statuses like `cancelled`, `timed_out`, or `action_required` will block.
     if: >-
       ${{
         !cancelled() &&
         needs.get-requirements.outputs.needs-releases == 'true' &&
-        !contains(needs.*.result, 'failure') &&
-        !contains(needs.*.result, 'cancelled') &&
-        !contains(needs.*.result, 'timed_out') &&
-        !contains(needs.*.result, 'action_required') &&
-        (
-          needs.get-requirements.outputs.needs-benchmarks != 'true' ||
-          (
-            needs.run-benchmarks.result == 'success' &&
-            needs.page-load-benchmark.result == 'success'
-          )
-        )
+        contains(fromJson('["success","skipped"]'), needs.build-dist-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-dist-mv2-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-beta-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-beta-mv2-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-flask-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-flask-mv2-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-test-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-test-mv2-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-test-flask-browserify.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-test-flask-mv2-browserify.result) &&
+        contains(fromJson('["success","skipped","failure"]'), needs.run-benchmarks.result) &&
+        contains(fromJson('["success","skipped","failure"]'), needs.page-load-benchmark.result) &&
+        contains(fromJson('["success","skipped"]'), needs.bundle-size.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-storybook.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-ts-migration-dashboard.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-source-map-explorer.result) &&
+        contains(fromJson('["success","skipped"]'), needs.build-lavamoat-viz.result)
       }}
     needs:
       - get-requirements

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ on:
       - main
       - stable
       - release/*
-      - '!release/*-Changelog'
       - trigger-ci-*
   pull_request:
     types:

--- a/.github/workflows/prep-e2e.yml
+++ b/.github/workflows/prep-e2e.yml
@@ -5,9 +5,6 @@ on:
 
 jobs:
   prep-e2e:
-    # For a `pull_request` event, the branch is `github.head_ref``.
-    # For a `push` event, the branch is `github.ref_name`.
-    if: ${{ (github.head_ref || github.ref_name) != 'stable' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -25,9 +22,13 @@ jobs:
           use-yarn-hydrate: true
 
       - name: Get changed files with git diff
+        # On branch `stable`, there's no reason to do a diff
+        if: ${{ (github.head_ref || github.ref_name) != 'stable' }}
         run: yarn tsx .github/scripts/git-diff-default-branch.ts
 
       - name: Upload changed files artifact
+        # On branch `stable`, there's no reason to do a diff
+        if: ${{ (github.head_ref || github.ref_name) != 'stable' }}
         uses: actions/upload-artifact@v6
         with:
           name: changed-files

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Download page load benchmark results
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: page-load-benchmark-results

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -8,8 +8,7 @@ name: Update Release Changelog PR
 on:
   push:
     branches:
-      - 'release/[0-9]*.[0-9]*.[0-9]*'
-      - '!release/[0-9]*.[0-9]*.[0-9]*-Changelog' # this is necessary right now, but should be removable soon
+      - 'release/[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
   group: update-release-changelog-${{ github.ref }}

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'release/[0-9]*.[0-9]*.[0-9]*'
+      - '!release/[0-9]*.[0-9]*.[0-9]*-Changelog' # this is necessary right now, but should be removable soon
 
 concurrency:
   group: update-release-changelog-${{ github.ref }}

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -1,47 +1,22 @@
 # On every push to a release branch (release/x.y.z format), this workflow rebuilds the matching
 # changelog branch, re-runs the auto-changelog script, and either updates or recreates the changelog PR.
-# Note: This workflow validates the branch name to ensure it matches the semantic versioning pattern
-# (release/x.y.z) and skips execution for other branch names like release/x.y.z-Changelog.
+#
+# Note: GitHub Actions branch filters are glob-based (not regex), so we approximate SemVer by requiring
+# three dot-separated segments that each start with a digit.
 name: Update Release Changelog PR
 
 on:
   push:
     branches:
-      - 'release/*'
+      - 'release/[0-9]*.[0-9]*.[0-9]*'
 
 concurrency:
   group: update-release-changelog-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  validate-branch:
-    name: Validate release branch format
-    runs-on: ubuntu-latest
-    outputs:
-      is-valid-release: ${{ steps.check.outputs.is-valid }}
-      version: ${{ steps.check.outputs.version }}
-    steps:
-      - name: Check if branch matches release/x.y.z pattern
-        id: check
-        run: |
-          BRANCH_NAME="${{ github.ref_name }}"
-          echo "Checking branch: $BRANCH_NAME"
-
-          # Validate branch matches release/x.y.z format (semantic versioning)
-          if [[ "$BRANCH_NAME" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            VERSION="${BRANCH_NAME#release/}"
-            echo "Valid release branch detected: $BRANCH_NAME (version: $VERSION)"
-            echo "is-valid=true" >> "$GITHUB_OUTPUT"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          else
-            echo "Branch '$BRANCH_NAME' does not match release/x.y.z pattern. Skipping changelog update."
-            echo "is-valid=false" >> "$GITHUB_OUTPUT"
-          fi
-
   refresh-changelog:
     name: Update changelog
-    needs: validate-branch
-    if: needs.validate-branch.outputs.is-valid-release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## **Description**

Fixes three issues we just discovered during the most recent release cycle:

1. On a changelog branch, like `release/13.19.0-Changelog`, the workflow ran twice, on both `push` and `pull_request`
   - This was changed to be fixed in MetaMask/github-tools#217
   - Then I simplified `.github/workflows/update-release-changelog.yml`
2. The release branch was not running job `publish-prerelease` because `needs-benchmarks == 'false'` and the benchmarks were prereqs
3. `prep-e2e` had the gate `if: ${{ (github.head_ref || github.ref_name) != 'stable' }}` on the whole job, which prevented it from generating `test-runs-for-splitting`.  Changed to gating just the diff steps.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to CI/release automation; main risk is accidentally skipping/triggering release jobs due to updated job conditions and branch filters.
> 
> **Overview**
> Fixes release-cycle GitHub Actions behavior.
> 
> `publish-prerelease` in `main.yml` is now explicitly gated to run when releases are enabled and **not cancelled**, requiring all non-benchmark prerequisite jobs to be `success`/`skipped` so benchmarks no longer block prereleases.
> 
> `prep-e2e.yml` now runs on `stable`, but skips the diff/artifact steps there so it still produces `test-runs-for-splitting`. `publish-prerelease.yml` makes downloading `page-load-benchmark-results` non-blocking (`continue-on-error`). `update-release-changelog.yml` is simplified by narrowing the push branch filter to semver-like `release/x.y.z` and removing the extra branch-validation job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b4e3620398eef3fa1d142bb22b823f59662b87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->