### PR TITLE
test: added total time to benchmark tests

### DIFF
--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -66,7 +66,9 @@ function convertSummaryToResults(
   mean.total = summary.timers.reduce((acc, t) => acc + t.mean, 0);
   min.total = summary.timers.reduce((acc, t) => acc + t.min, 0);
   max.total = summary.timers.reduce((acc, t) => acc + t.max, 0);
-  stdDev.total = summary.timers.reduce((acc, t) => acc + t.stdDev, 0);
+  stdDev.total = Math.sqrt(
+    summary.timers.reduce((acc, t) => acc + t.stdDev * t.stdDev, 0),
+  );
   p75.total = summary.timers.reduce((acc, t) => acc + t.p75, 0);
   p95.total = summary.timers.reduce((acc, t) => acc + t.p95, 0);
 

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -63,6 +63,13 @@ function convertSummaryToResults(
     p95[timer.id] = timer.p95;
   }
 
+  mean.total = summary.timers.reduce((acc, t) => acc + t.mean, 0);
+  min.total = summary.timers.reduce((acc, t) => acc + t.min, 0);
+  max.total = summary.timers.reduce((acc, t) => acc + t.max, 0);
+  stdDev.total = summary.timers.reduce((acc, t) => acc + t.stdDev, 0);
+  p75.total = summary.timers.reduce((acc, t) => acc + t.p75, 0);
+  p95.total = summary.timers.reduce((acc, t) => acc + t.p95, 0);
+
   return {
     testTitle,
     persona,

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -63,15 +63,6 @@ function convertSummaryToResults(
     p95[timer.id] = timer.p95;
   }
 
-  mean.total = summary.timers.reduce((acc, t) => acc + t.mean, 0);
-  min.total = summary.timers.reduce((acc, t) => acc + t.min, 0);
-  max.total = summary.timers.reduce((acc, t) => acc + t.max, 0);
-  stdDev.total = Math.sqrt(
-    summary.timers.reduce((acc, t) => acc + t.stdDev * t.stdDev, 0),
-  );
-  p75.total = summary.timers.reduce((acc, t) => acc + t.p75, 0);
-  p95.total = summary.timers.reduce((acc, t) => acc + t.p95, 0);
-
   return {
     testTitle,
     persona,

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -14,6 +14,7 @@ import {
   calculateTimerStatistics,
   checkExclusionRate,
   MAX_EXCLUSION_RATE,
+  MAX_TOTAL_DURATION_MS,
   validateThresholds,
 } from './statistics';
 import type {
@@ -142,7 +143,9 @@ export async function runBenchmarkWithIterations(
     }
   }
   if (perRunTotalDurations.length > 0) {
-    const totalStats = calculateTimerStatistics('total', perRunTotalDurations);
+    const totalStats = calculateTimerStatistics('total', perRunTotalDurations, {
+      maxDurationMs: MAX_TOTAL_DURATION_MS,
+    });
     timerStats.push(totalStats);
   }
 

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -132,6 +132,20 @@ export async function runBenchmarkWithIterations(
     }
   }
 
+  // Compute per-run total durations and derive total statistics from them
+  // (min/max/percentiles are not additive across timers from different runs)
+  const perRunTotalDurations: number[] = [];
+  for (const result of allResults) {
+    if (result.success && result.timers.length > 0) {
+      const runTotal = result.timers.reduce((acc, t) => acc + t.duration, 0);
+      perRunTotalDurations.push(runTotal);
+    }
+  }
+  if (perRunTotalDurations.length > 0) {
+    const totalStats = calculateTimerStatistics('total', perRunTotalDurations);
+    timerStats.push(totalStats);
+  }
+
   // Check overall run exclusion rate
   const overallExclusionCheck = checkExclusionRate(
     iterations,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added "total" field to the final report so Sentry can take this data easily

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40100?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/benchmark reporting-only change that adds a new derived metric and a configurable sanity-check threshold; no production logic or security-sensitive paths affected.
> 
> **Overview**
> Adds a derived `total` timer metric to e2e benchmark summaries by summing all timer durations per successful run and computing statistics (mean/min/max/percentiles) over those per-run totals.
> 
> Extends `calculateTimerStatistics` to accept an optional max-duration override and introduces `MAX_TOTAL_DURATION_MS` (10 minutes) so the new aggregated total metric is sanity-checked with a higher ceiling than individual timers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69670eea53561c197a1c20ba81278a600475d444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->