### PR TITLE
fix: update `extension-port-stream` to fix an issue with large state failing to transfer on new chromium-based browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -426,7 +426,7 @@
     "eth-method-registry": "^4.0.0",
     "ethereum-cryptography": "^3.2.0",
     "ethereumjs-util": "^7.0.10",
-    "extension-port-stream": "^5.0.2",
+    "extension-port-stream": "^5.0.3",
     "fast-json-patch": "^3.1.1",
     "fast-json-stable-stringify": "^2.1.0",
     "fuse.js": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26198,14 +26198,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extension-port-stream@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "extension-port-stream@npm:5.0.2"
+"extension-port-stream@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "extension-port-stream@npm:5.0.3"
   dependencies:
     readable-stream: "npm:^3.6.2 || ^4.4.2"
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/edb942e69bcccc4924ed401a729e5e418601ace7cdc834cf262b4a00a79203d4c130273fc881ae582557008a075b6a2e625a4271eacabbea6394beaaee59952d
+  checksum: 10/3f4368e4e450cc762bc0c7cac0c09b27ccc6f3ca4e9426cf076d1bde0bff5414f842c287fbaed26d0390a734ee27b1e1aa588d3d356fdf82bd3d625fad569eb3
   languageName: node
   linkType: hard
 
@@ -33997,7 +33997,7 @@ __metadata:
     ethereum-cryptography: "npm:^3.2.0"
     ethereumjs-util: "npm:^7.0.10"
     ethers: "npm:^5.7.0"
-    extension-port-stream: "npm:^5.0.2"
+    extension-port-stream: "npm:^5.0.3"
     fake-indexeddb: "npm:^6.1.0"
     fancy-log: "npm:^1.3.3"
     fast-glob: "npm:^3.2.2"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Update `extension-port-stream` to `v5.0.3` to fix an issue with users with a lot of state who are on recent version of chromium, caused by a change in behavior in chromium.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40101?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes issue for users with a lot of state on recent chromium-based browsers

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40082
<!--
## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**

-->
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch version bump with lockfile updates; limited surface area beyond whatever behavior changed upstream in `extension-port-stream`.
> 
> **Overview**
> Updates the `extension-port-stream` dependency from `^5.0.2` to `^5.0.3`, including the corresponding `yarn.lock` resolution/checksum changes, to address a Chromium behavior change impacting users with large extension state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a91fd92a31245d711fab4e539b31008c7516996. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->