### PR TITLE
refactor: replace deprecated CheckBox with Checkbox component-library

### DIFF
--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -18,11 +18,11 @@ import {
 import { isExtensionUrl, getURLHost } from '../../../../helpers/utils/util';
 import Popover from '../../../ui/popover';
 
-import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
+  Checkbox,
   Icon,
   IconName,
   Text,
@@ -72,9 +72,9 @@ const UnconnectedAccountAlert = () => {
         <div className="unconnected-account-alert__checkbox-wrapper">
           <Checkbox
             id="unconnectedAccount_dontShowThisAgain"
-            checked={dontShowThisAgain}
+            isChecked={dontShowThisAgain}
             className="unconnected-account-alert__checkbox"
-            onClick={() => setDontShowThisAgain((checked) => !checked)}
+            onChange={() => setDontShowThisAgain((checked) => !checked)}
           />
           <label
             className="unconnected-account-alert__checkbox-label"

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
@@ -219,4 +219,50 @@ describe('Unconnected Account Alert', () => {
       'unconnectedAccount/disableAlertSucceeded',
     );
   });
+
+  it('renders the checkbox as unchecked by default', () => {
+    const store = configureMockStore()(mockState);
+
+    const { getByRole } = renderWithProvider(
+      <UnconnectedAccountAlert />,
+      store,
+    );
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('toggles checkbox checked state on multiple clicks', () => {
+    const store = configureMockStore()(mockState);
+
+    const { getByRole } = renderWithProvider(
+      <UnconnectedAccountAlert />,
+      store,
+    );
+
+    const checkbox = getByRole('checkbox');
+
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('dismisses without disabling when checkbox is not checked', () => {
+    const store = configureMockStore()(mockState);
+
+    const { getByText } = renderWithProvider(
+      <UnconnectedAccountAlert />,
+      store,
+    );
+
+    const dismissButton = getByText(/Dismiss/u);
+    fireEvent.click(dismissButton);
+
+    const dispatchedActions = store.getActions();
+    expect(dispatchedActions[0].type).toStrictEqual(
+      'unconnectedAccount/dismissAlert',
+    );
+  });
 });

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -1,8 +1,13 @@
 import React, { useState } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { Button, ButtonVariant, Icon, IconName } from '../../component-library';
-import Checkbox from '../../ui/check-box';
+import {
+  Button,
+  ButtonVariant,
+  Checkbox,
+  Icon,
+  IconName,
+} from '../../component-library';
 import Tooltip from '../../ui/tooltip';
 import { IconColor } from '../../../helpers/constants/design-system';
 
@@ -22,9 +27,9 @@ const HomeNotification = ({
   const checkboxElement = checkboxText && (
     <Checkbox
       id="homeNotification_checkbox"
-      checked={checkboxState}
+      isChecked={checkboxState}
       className="home-notification__checkbox"
-      onClick={() => setCheckBoxState((checked) => !checked)}
+      onChange={() => setCheckBoxState((checked) => !checked)}
     />
   );
 

--- a/ui/components/app/home-notification/home-notification.test.js
+++ b/ui/components/app/home-notification/home-notification.test.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import HomeNotification from './home-notification.component';
+
+describe('HomeNotification', () => {
+  const defaultProps = {
+    descriptionText: 'Test notification description',
+  };
+
+  it('renders the description text', () => {
+    const { getByText } = render(<HomeNotification {...defaultProps} />);
+    expect(getByText('Test notification description')).toBeInTheDocument();
+  });
+
+  it('renders accept button when acceptText and onAccept are provided', () => {
+    const onAccept = jest.fn();
+    const { getByText } = render(
+      <HomeNotification
+        {...defaultProps}
+        acceptText="Accept"
+        onAccept={onAccept}
+      />,
+    );
+
+    const acceptButton = getByText('Accept');
+    expect(acceptButton).toBeInTheDocument();
+    fireEvent.click(acceptButton);
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render accept button when acceptText is missing', () => {
+    const onAccept = jest.fn();
+    const { queryByText } = render(
+      <HomeNotification {...defaultProps} onAccept={onAccept} />,
+    );
+    expect(queryByText('Accept')).toBeNull();
+  });
+
+  it('renders ignore button when ignoreText and onIgnore are provided', () => {
+    const onIgnore = jest.fn();
+    const { getByText } = render(
+      <HomeNotification
+        {...defaultProps}
+        ignoreText="Dismiss"
+        onIgnore={onIgnore}
+      />,
+    );
+
+    const ignoreButton = getByText('Dismiss');
+    expect(ignoreButton).toBeInTheDocument();
+    fireEvent.click(ignoreButton);
+    expect(onIgnore).toHaveBeenCalledTimes(1);
+    // Default checkbox state is false
+    expect(onIgnore).toHaveBeenCalledWith(false);
+  });
+
+  it('does not render ignore button when ignoreText is missing', () => {
+    const onIgnore = jest.fn();
+    const { queryByText } = render(
+      <HomeNotification {...defaultProps} onIgnore={onIgnore} />,
+    );
+    expect(queryByText('Dismiss')).toBeNull();
+  });
+
+  it('renders checkbox when checkboxText is provided', () => {
+    const onIgnore = jest.fn();
+    const { getByRole, getByText } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+        ignoreText="Dismiss"
+        onIgnore={onIgnore}
+      />,
+    );
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(getByText("Don't show again")).toBeInTheDocument();
+  });
+
+  it('toggles checkbox state when clicked', () => {
+    const onIgnore = jest.fn();
+    const { getByRole } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+        ignoreText="Dismiss"
+        onIgnore={onIgnore}
+      />,
+    );
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('passes checkbox state to onIgnore handler', () => {
+    const onIgnore = jest.fn();
+    const { getByRole, getByText } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+        ignoreText="Dismiss"
+        onIgnore={onIgnore}
+      />,
+    );
+
+    const checkbox = getByRole('checkbox');
+    const ignoreButton = getByText('Dismiss');
+
+    // Click ignore without checking checkbox
+    fireEvent.click(ignoreButton);
+    expect(onIgnore).toHaveBeenCalledWith(false);
+
+    // Check the checkbox, then click ignore
+    fireEvent.click(checkbox);
+    fireEvent.click(ignoreButton);
+    expect(onIgnore).toHaveBeenCalledWith(true);
+  });
+
+  it('does not render checkbox when checkboxText is not provided', () => {
+    const { queryByRole } = render(<HomeNotification {...defaultProps} />);
+    expect(queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders with custom classNames', () => {
+    const { container } = render(
+      <HomeNotification
+        {...defaultProps}
+        classNames={['custom-class-1', 'custom-class-2']}
+      />,
+    );
+
+    const notification = container.firstChild;
+    expect(notification).toHaveClass('home-notification');
+    expect(notification).toHaveClass('custom-class-1');
+    expect(notification).toHaveClass('custom-class-2');
+  });
+
+  it('renders info tooltip when infoText is provided', () => {
+    const { container } = render(
+      <HomeNotification {...defaultProps} infoText="Helpful info" />,
+    );
+
+    const tooltipWrapper = container.querySelector(
+      '.home-notification__tooltip-wrapper',
+    );
+    expect(tooltipWrapper).toBeInTheDocument();
+  });
+
+  it('does not render info tooltip when infoText is not provided', () => {
+    const { container } = render(<HomeNotification {...defaultProps} />);
+
+    const tooltipWrapper = container.querySelector(
+      '.home-notification__tooltip-wrapper',
+    );
+    expect(tooltipWrapper).toBeNull();
+  });
+
+  it('renders checkbox with tooltip when checkboxTooltipText is provided', () => {
+    const { container } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+        checkboxTooltipText="This will permanently dismiss"
+      />,
+    );
+
+    const tooltipWrapper = container.querySelector(
+      '.home-notification__checkbox-label-tooltip',
+    );
+    expect(tooltipWrapper).toBeInTheDocument();
+  });
+
+  it('renders checkbox without tooltip when checkboxTooltipText is not provided', () => {
+    const { container } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+      />,
+    );
+
+    const tooltipWrapper = container.querySelector(
+      '.home-notification__checkbox-label-tooltip',
+    );
+    expect(tooltipWrapper).toBeNull();
+  });
+
+  it('uses Checkbox from component-library with isChecked prop', () => {
+    const { getByRole } = render(
+      <HomeNotification
+        {...defaultProps}
+        checkboxText="Don't show again"
+      />,
+    );
+
+    const checkbox = getByRole('checkbox');
+    // The new Checkbox component from component-library renders
+    // with the mm-checkbox CSS class structure
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox.checked).toBe(false);
+  });
+});

--- a/ui/components/app/home-notification/index.scss
+++ b/ui/components/app/home-notification/index.scss
@@ -48,9 +48,6 @@
   }
 
   &__checkbox {
-    height: 13px;
-    width: 13px;
-    font-size: 16px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
## **Description**

Migrates `home-notification` and `unconnected-account-alert` components from the deprecated `CheckBox` (`ui/components/ui/check-box`) to the new `Checkbox` from `ui/components/component-library`. Updates prop names (`checked` → `isChecked`, `onClick` → `onChange`) to match the new component API and adds comprehensive tests.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40106?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #19553

## **Manual testing steps**

1. Navigate to a dapp that triggers the unconnected account alert
2. Verify the "Don't show this again" checkbox renders and toggles correctly
3. Navigate to a page that displays a home notification with a checkbox
4. Verify the checkbox renders and toggles correctly
5. Run tests: `npx jest --testPathPattern="home-notification|unconnected-account-alert"`

## **Screenshots/Recordings**

### **Before**

N/A - No visual changes, only import source changed

### **After**

N/A - Behavior is identical, components sourced from component-library instead of deprecated check-box

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.