### PR TITLE
refactor: remove BIP-44 flag from `SnapUIAvatar` and `useDisplayName`

### DIFF
--- a/ui/components/app/snaps/snap-ui-avatar/snap-ui-avatar.tsx
+++ b/ui/components/app/snaps/snap-ui-avatar/snap-ui-avatar.tsx
@@ -4,7 +4,6 @@ import { AvatarAccountSize } from '@metamask/design-system-react';
 import { CaipAccountId, parseCaipAccountId } from '@metamask/utils';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { PreferredAvatar } from '../../preferred-avatar';
-import { getIsMultichainAccountsState2Enabled } from '../../../../selectors/multichain-accounts';
 import { getAccountGroupsByAddress } from '../../../../selectors/multichain-accounts/account-tree';
 import { MultichainAccountsState } from '../../../../selectors/multichain-accounts/account-tree.types';
 
@@ -22,8 +21,6 @@ export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
     return parseCaipAccountId(caipAddress as CaipAccountId);
   }, [caipAddress]);
 
-  const useAccountGroups = useSelector(getIsMultichainAccountsState2Enabled);
-
   const accountGroups = useSelector((state: MultichainAccountsState) =>
     getAccountGroupsByAddress(state, [address]),
   );
@@ -33,8 +30,7 @@ export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
   )?.address;
 
   // Display the account group address if it exists as the default.
-  const displayAddress =
-    useAccountGroups && accountGroupAddress ? accountGroupAddress : caipAddress;
+  const displayAddress = accountGroupAddress ?? caipAddress;
 
   return <PreferredAvatar address={displayAddress} size={size} />;
 };

--- a/ui/hooks/snaps/useDisplayName.ts
+++ b/ui/hooks/snaps/useDisplayName.ts
@@ -14,7 +14,6 @@ import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import { decimalToHex } from '../../../shared/modules/conversion.utils';
 import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
 import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
-import { getIsMultichainAccountsState2Enabled } from '../../selectors';
 
 export type UseDisplayNameParams = {
   chain: {
@@ -44,10 +43,6 @@ export const useDisplayName = (
 
   const parsedAddress = isEip155 ? toChecksumHexAddress(address) : address;
 
-  const showAccountGroupName = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-
   const accountGroups = useSelector((state: MultichainAccountsState) =>
     getAccountGroupsByAddress(state, [parsedAddress]),
   );
@@ -68,7 +63,7 @@ export const useDisplayName = (
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return (
-    (showAccountGroupName && accountGroupName) ||
+    accountGroupName ||
     accountName ||
     (isEip155 && addressBookEntry?.name) ||
     undefined


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR is part of a series to remove the legacy code after BIP-44 was shipped, several components, hooks, views, etc. still uses the remote feature flag for BIP-44 causing an unnecessary overcomplexity that can be easily removed.

The changes include updating the component `SnapUIAvatar` and the hook `useDisplayName`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40107?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1454

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

### **Before**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing a feature-flag branch; behavior only changes in cases where account-group data exists but the flag was previously off.
> 
> **Overview**
> `SnapUIAvatar` no longer checks `getIsMultichainAccountsState2Enabled`; it always uses the first EVM account in the resolved account group (if present) as the avatar address fallback instead of gating on a feature flag.
> 
> `useDisplayName` similarly drops the feature-flag condition and always prefers `accountGroupName` ahead of per-account names/address-book entries when an account group is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd07ee4d0a57df5aa9284fcad24e149611133d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->