### PR TITLE
fix: Only reject approvals if subject has `endowment:caip25` permission revoked

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
@@ -151,7 +151,7 @@ describe('revokePermissionsHandler', () => {
       ...baseRequest,
       params: [
         {
-          "eth_accounts": {},
+          [RestrictedMethods.eth_accounts]: {},
           otherPermission: {},
         },
       ],

--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts
@@ -151,7 +151,7 @@ describe('revokePermissionsHandler', () => {
       ...baseRequest,
       params: [
         {
-          [Caip25EndowmentPermissionName]: {},
+          "eth_accounts": {},
           otherPermission: {},
         },
       ],

--- a/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.ts
@@ -82,7 +82,10 @@ function revokePermissionsImplementation(
   }
 
   revokePermissionsForOrigin(relevantPermissionKeys);
-  rejectApprovalRequestsForOrigin();
+
+  if (relevantPermissionKeys.includes(Caip25EndowmentPermissionName)) {
+    rejectApprovalRequestsForOrigin();
+  }
 
   res.result = null;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Rejecting all approvals caused strange behavior when installing Snaps from the Snaps Directory because the directory page uses `wallet_revokePermissions`. This PR fixes it by only rejecting pending approvals from the origin if the revoked permission is `endowment:caip25`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40139?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where approvals would be closed too soon

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40112

## **Manual testing steps**

See attached issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in RPC middleware behavior with targeted test update; low risk aside from potential behavioral differences in edge cases around permission key selection.
> 
> **Overview**
> Updates `wallet_revokePermissions` so it only calls `rejectApprovalRequestsForOrigin` when the revoke set includes `endowment:caip25`, instead of rejecting approvals for any permission revocation.
> 
> Adjusts the corresponding unit test to trigger approval rejection via a CAIP-25-equivalent permission (`eth_accounts`) rather than an explicit `endowment:caip25` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5caae2835b6518dcf74b8b29fa7bde2786965d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->