### PR TITLE
fix: fire banner display event on active slide only

### DIFF
--- a/ui/components/multichain/carousel/__tests__/carousel.test.tsx
+++ b/ui/components/multichain/carousel/__tests__/carousel.test.tsx
@@ -61,7 +61,7 @@ describe('Carousel', () => {
     isLoading: false,
     onSlideClose: jest.fn(),
     onSlideClick: jest.fn(),
-    onRenderSlides: jest.fn(),
+    onActiveSlideChange: jest.fn(),
     className: '',
   };
 
@@ -106,11 +106,16 @@ describe('Carousel', () => {
     expect(container.firstChild).toHaveClass(customClass);
   });
 
-  it('calls onRenderSlides when slides are provided', () => {
-    const onRenderSlidesMock = jest.fn();
-    render(<Carousel {...defaultProps} onRenderSlides={onRenderSlidesMock} />);
+  it('calls onActiveSlideChange with the current slide when slides are provided', () => {
+    const onActiveSlideChangeMock = jest.fn();
+    render(
+      <Carousel
+        {...defaultProps}
+        onActiveSlideChange={onActiveSlideChangeMock}
+      />,
+    );
 
-    expect(onRenderSlidesMock).toHaveBeenCalledWith(mockSlides);
+    expect(onActiveSlideChangeMock).toHaveBeenCalledWith(mockSlides[0]);
   });
 
   it('filters out dismissed slides', () => {

--- a/ui/components/multichain/carousel/carousel.tsx
+++ b/ui/components/multichain/carousel/carousel.tsx
@@ -20,7 +20,7 @@ export const Carousel = React.forwardRef(
       isLoading = false,
       onSlideClose,
       onSlideClick,
-      onRenderSlides,
+      onActiveSlideChange,
       onEmptyState,
       className = '',
       ...props
@@ -113,17 +113,12 @@ export const Carousel = React.forwardRef(
       state.hasTriggeredEmptyState,
     ]);
 
-    // Render slides callback
+    // Notify parent when the active slide changes
     useEffect(() => {
-      if (
-        visibleSlides &&
-        visibleSlides.length > 0 &&
-        onRenderSlides &&
-        !isLoading
-      ) {
-        onRenderSlides(visibleSlides);
+      if (currentSlide && onActiveSlideChange && !isLoading) {
+        onActiveSlideChange(currentSlide);
       }
-    }, [visibleSlides, onRenderSlides, isLoading]);
+    }, [currentSlide, onActiveSlideChange, isLoading]);
 
     const handleSlideClose = (slideId: string, isLastSlide: boolean) => {
       transitionToNextCard(slideId, isLastSlide);

--- a/ui/components/multichain/carousel/types.ts
+++ b/ui/components/multichain/carousel/types.ts
@@ -24,7 +24,7 @@ export type CarouselProps = {
   onSlideClick?: (slideId: string, navigation?: NavigationAction) => void;
   onEmptyState?: () => void;
   onSlideClose?: (slideId: string, isLastSlide: boolean) => void;
-  onRenderSlides?: (slides: CarouselSlide[]) => void;
+  onActiveSlideChange?: (slide: CarouselSlide) => void;
 };
 
 // Carousel state management


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Currently, Banner Display events are fired for all slides of the carousel when MetaMask is opened, leading in unreliable stats.

This PR fixes this bug to correctly fire Banner Display when the banners are actually shown to the user. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40142?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-113

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI analytics callback semantics and associated tests; low risk aside from potential analytics behavior changes if other callers relied on `onRenderSlides`.
> 
> **Overview**
> Fixes banner impression tracking so `BannerDisplay` is emitted **per slide when it becomes the active card**, rather than for all carousel slides on initial render.
> 
> This replaces the `onRenderSlides(slides[])` callback with `onActiveSlideChange(slide)` in the multichain carousel, updates the account overview integration to de-dupe impressions via a `Set` of displayed slide IDs, and updates unit tests to assert the new callback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5f41d6bc8002b6fe3244f06c4a31204d8aea0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->