### PR TITLE
refactor: remove BIP-44 flag from asset components

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import type { NetworkConfiguration } from '@metamask/network-controller';
 import { fireEvent } from '../../../../../../test/jest';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../../test/data/mock-state.json';
 import * as actions from '../../../../../store/actions';
 import { SECURITY_ROUTE } from '../../../../../helpers/constants/routes';
-import { createMockInternalAccount } from '../../../../../../test/jest/mocks';
 import AssetListControlBar from './asset-list-control-bar';
 
 type TooltipProps = {
@@ -44,11 +42,6 @@ const createMockState = () => ({
   metamask: {
     ...mockState.metamask,
     selectedNetworkClientId: 'selectedNetworkClientId',
-    enabledNetworkMap: {
-      eip155: {
-        '0x1': true,
-      },
-    },
     networkConfigurationsByChainId: {
       '0x1': {
         chainId: '0x1',
@@ -60,17 +53,7 @@ const createMockState = () => ({
         ],
       },
     } as unknown as Record<string, NetworkConfiguration>,
-    multichainNetworkConfigurationsByChainId:
-      AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-    selectedMultichainNetworkChainId: 'eip155:1',
-    isEvmSelected: true,
     useNftDetection: true,
-    internalAccounts: {
-      selectedAccount: 'selectedAccount',
-      accounts: {
-        selectedAccount: createMockInternalAccount(),
-      },
-    },
   },
 });
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -8,17 +8,12 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import {
-  isStrictHexString,
-  KnownCaipNamespace,
-  parseCaipChainId,
-} from '@metamask/utils';
+import { isStrictHexString } from '@metamask/utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import {
   getAllChainsToPoll,
   getIsLineaMainnet,
   getIsMainnet,
-  getIsMultichainAccountsState2Enabled,
   getTokenNetworkFilter,
   getUseNftDetection,
 } from '../../../../../selectors';
@@ -26,7 +21,6 @@ import { selectAccountSupportsEnabledNetworks } from '../../../../../selectors/a
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
-  getSelectedMultichainNetworkChainId,
 } from '../../../../../selectors/multichain/networks';
 import {
   getAllNetworkConfigurationsByCaipChainId,
@@ -123,10 +117,6 @@ const AssetListControlBar = ({
 
   const { collections } = useNftsCollections();
 
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-
   const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
   const allEnabledNetworksForAllNamespaces = useSelector(
     getAllEnabledNetworksForAllNamespaces,
@@ -136,11 +126,6 @@ const AssetListControlBar = ({
   const [isImportTokensPopoverOpen, setIsImportTokensPopoverOpen] =
     useState(false);
   const [isImportNftPopoverOpen, setIsImportNftPopoverOpen] = useState(false);
-
-  const currentMultichainChainId = useSelector(
-    getSelectedMultichainNetworkChainId,
-  );
-  const { namespace } = parseCaipChainId(currentMultichainChainId);
 
   const allNetworkClientIds = useMemo(() => {
     return Object.keys(tokenNetworkFilter).flatMap((chainId) => {
@@ -290,41 +275,8 @@ const AssetListControlBar = ({
       checkAndUpdateAllNftsOwnershipStatus(networkClientId);
     });
   };
+
   const networkButtonText = useMemo(() => {
-    if (currentNamespaceNetworkCount === 1) {
-      const chainId = Object.keys(enabledNetworksByNamespace)[0];
-      return isStrictHexString(chainId)
-        ? (allNetworks[chainId]?.name ?? t('currentNetwork'))
-        : (currentMultichainNetwork.network.nickname ?? t('currentNetwork'));
-    }
-
-    if (
-      namespace !== KnownCaipNamespace.Eip155 &&
-      currentNamespaceNetworkCount > 1
-    ) {
-      return currentMultichainNetwork.network.nickname ?? t('currentNetwork');
-    }
-
-    // > 1 network selected, show "all networks"
-    if (currentNamespaceNetworkCount > 1) {
-      return t('allNetworks');
-    }
-
-    if (currentNamespaceNetworkCount === 0) {
-      return t('noNetworksSelected');
-    }
-
-    return t('popularNetworks');
-  }, [
-    enabledNetworksByNamespace,
-    currentNamespaceNetworkCount,
-    currentMultichainNetwork.network.nickname,
-    t,
-    allNetworks,
-    namespace,
-  ]);
-
-  const networkButtonTextEnabledAccountState2 = useMemo(() => {
     if (totalEnabledNetworkCount === 1) {
       const chainId = allEnabledNetworksForAllNamespaces[0];
       const caipChainId = isStrictHexString(chainId)
@@ -387,9 +339,7 @@ const AssetListControlBar = ({
               />
             )}
             <Text variant={TextVariant.bodySmMedium} ellipsis>
-              {isMultichainAccountsState2Enabled
-                ? networkButtonTextEnabledAccountState2
-                : networkButtonText}
+              {networkButtonText}
             </Text>
           </Box>
         </ButtonBase>

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -4,7 +4,6 @@ import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { isCaipChainId } from '@metamask/utils';
 import {
   getEnabledNetworksByNamespace,
-  getIsMultichainAccountsState2Enabled,
   getShowFiatInTestnets,
   getTokenList,
   selectERC20TokensByChain,
@@ -44,9 +43,6 @@ export const useTokenDisplayInfo = ({
     getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId),
   );
 
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
   const showFiat = useMultichainSelector(
     makeGetMultichainShouldShowFiatByChainId(token.chainId),
     selectedAccount,
@@ -127,9 +123,7 @@ export const useTokenDisplayInfo = ({
   // TODO BIP44 Refactor: type for secondary is wrongly set as number | null, when it is a string | null
   // Just changing it causes a number of errors all over the codebase
   // When BIP44 flag is enabled and stable, this can be refactored to use the type from the new selector
-  const nonEvmSecondary = isMultichainAccountsState2Enabled
-    ? (secondary as unknown as number)
-    : token.secondary;
+  const nonEvmSecondary = secondary as unknown as number;
 
   // TODO non-evm assets. this is only the native token
   return {

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -122,7 +122,7 @@ export const useTokenDisplayInfo = ({
 
   // TODO BIP44 Refactor: type for secondary is wrongly set as number | null, when it is a string | null
   // Just changing it causes a number of errors all over the codebase
-  // When BIP44 flag is enabled and stable, this can be refactored to use the type from the new selector
+  // The BIP44 flag is enabled and stable, so this can be refactored to use the type from the new selector
   const nonEvmSecondary = secondary as unknown as number;
 
   // TODO non-evm assets. this is only the native token

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -5,8 +5,6 @@ import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
 import TokenCell from '../token-cell';
 import { ASSET_CELL_HEIGHT } from '../constants';
 import {
-  getEnabledNetworksByNamespace,
-  getIsMultichainAccountsState2Enabled,
   getPreferences,
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
@@ -15,9 +13,6 @@ import {
 } from '../../../../selectors';
 import { endTrace, TraceName } from '../../../../../shared/lib/trace';
 import { type TokenWithFiatAmount } from '../types';
-import { filterAssets } from '../util/filter';
-import { sortAssets } from '../util/sort';
-import useMultiChainAssets from '../hooks/useMultichainAssets';
 import {
   getSelectedMultichainNetworkConfiguration,
   getIsEvmMultichainNetworkSelected,
@@ -25,7 +20,6 @@ import {
 } from '../../../../selectors/multichain/networks';
 import {
   getAssetsBySelectedAccountGroup,
-  getTokenBalancesEvm,
   selectAccountGroupBalanceForEmptyState,
 } from '../../../../selectors/assets';
 import {
@@ -54,9 +48,6 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
   const { privacyMode } = useSelector(getPreferences);
   const tokenSortConfig = useSelector(getTokenSortConfig);
   const selectedAccount = useSelector(getSelectedAccount);
-  const evmBalances = useSelector((state) =>
-    getTokenBalancesEvm(state, selectedAccount.address),
-  );
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
   );
@@ -65,15 +56,6 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
 
   const accountGroupIdAssets = useSelector(getAssetsBySelectedAccountGroup);
 
-  const multichainAssets = useMultiChainAssets();
-
-  // network filter to determine which tokens to show in list
-  const networksToShow = useSelector(getEnabledNetworksByNamespace);
-
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-
   const useExternalServices = useSelector(getUseExternalServices);
 
   const allEnabledNetworksForAllNamespaces = useSelector(
@@ -81,28 +63,6 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
   );
 
   const sortedFilteredTokens = useMemo(() => {
-    if (!isMultichainAccountsState2Enabled) {
-      const balances = isEvm ? evmBalances : multichainAssets;
-      const filteredAssets = filterAssets(balances as TokenWithFiatAmount[], [
-        {
-          key: 'chainId',
-          opts: isEvm ? networksToShow : { [currentNetwork.chainId]: true },
-          filterCallback: 'inclusive',
-        },
-      ]);
-
-      // Filter out non-EVM assets when basic functionality toggle is OFF
-      // Exception: Keep assets for the currently selected non-EVM chain
-      const finalAssets = useExternalServices
-        ? filteredAssets
-        : filteredAssets.filter(
-            (asset) =>
-              isEvmChainId(asset.chainId) ||
-              (!isEvm && asset.chainId === currentNetwork.chainId),
-          );
-
-      return sortAssets([...finalAssets], tokenSortConfig);
-    }
     const accountAssetsPreSort = Object.entries(accountGroupIdAssets).flatMap(
       ([chainId, assets]) => {
         if (!allEnabledNetworksForAllNamespaces.includes(chainId)) {
@@ -151,12 +111,8 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
     });
   }, [
     isEvm,
-    evmBalances,
-    multichainAssets,
-    networksToShow,
     currentNetwork.chainId,
     tokenSortConfig,
-    isMultichainAccountsState2Enabled,
     accountGroupIdAssets,
     allEnabledNetworksForAllNamespaces,
     shouldHideZeroBalanceTokens,

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -6,7 +6,6 @@ import TokenCell from '../token-cell';
 import { ASSET_CELL_HEIGHT } from '../constants';
 import {
   getPreferences,
-  getSelectedAccount,
   getShouldHideZeroBalanceTokens,
   getTokenSortConfig,
   getUseExternalServices,
@@ -47,7 +46,6 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
   const currentNetwork = useSelector(getSelectedMultichainNetworkConfiguration);
   const { privacyMode } = useSelector(getPreferences);
   const tokenSortConfig = useSelector(getTokenSortConfig);
-  const selectedAccount = useSelector(getSelectedAccount);
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
   );

--- a/ui/components/app/modals/confirm-delete-network/confirm-delete-network.component.js
+++ b/ui/components/app/modals/confirm-delete-network/confirm-delete-network.component.js
@@ -13,7 +13,6 @@ export default class ConfirmDeleteNetwork extends PureComponent {
     chainId: PropTypes.string.isRequired,
     isChainToDeleteSelected: PropTypes.bool,
     switchToEthereumNetwork: PropTypes.func,
-    isMultichainAccountsFeatureEnabled: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -28,7 +27,6 @@ export default class ConfirmDeleteNetwork extends PureComponent {
       removeNetwork,
       isChainToDeleteSelected,
       switchToEthereumNetwork,
-      isMultichainAccountsFeatureEnabled,
     } = this.props;
 
     // NOTE: We only support EVM networks removal, so the conversion is safe here.
@@ -36,7 +34,7 @@ export default class ConfirmDeleteNetwork extends PureComponent {
 
     // NOTE: ensure that we are not deleting a selected evm chain
     if (isChainToDeleteSelected) {
-      await switchToEthereumNetwork?.(isMultichainAccountsFeatureEnabled);
+      await switchToEthereumNetwork?.(true);
     }
 
     await removeNetwork(caipChainId);

--- a/ui/components/app/modals/confirm-delete-network/confirm-delete-network.component.js
+++ b/ui/components/app/modals/confirm-delete-network/confirm-delete-network.component.js
@@ -34,7 +34,7 @@ export default class ConfirmDeleteNetwork extends PureComponent {
 
     // NOTE: ensure that we are not deleting a selected evm chain
     if (isChainToDeleteSelected) {
-      await switchToEthereumNetwork?.(true);
+      await switchToEthereumNetwork?.();
     }
 
     await removeNetwork(caipChainId);

--- a/ui/components/app/modals/confirm-delete-network/confirm-delete-network.container.js
+++ b/ui/components/app/modals/confirm-delete-network/confirm-delete-network.container.js
@@ -6,13 +6,10 @@ import {
   getNetworkConfigurationsByChainId,
   getProviderConfig,
 } from '../../../../../shared/modules/selectors/networks';
-import { getIsMultichainAccountsState2Enabled } from '../../../../selectors';
 import ConfirmDeleteNetwork from './confirm-delete-network.component';
 
 const mapStateToProps = (state, ownProps) => {
   const networks = getNetworkConfigurationsByChainId(state);
-  const isMultichainAccountsFeatureEnabled =
-    getIsMultichainAccountsState2Enabled(state);
 
   let selectedEvmChainId;
   try {
@@ -26,7 +23,6 @@ const mapStateToProps = (state, ownProps) => {
     chainId,
     networkNickname,
     isChainToDeleteSelected,
-    isMultichainAccountsFeatureEnabled,
   };
 };
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -83,8 +83,7 @@ import AssetChart from './chart/asset-chart';
 import TokenButtons from './token-buttons';
 import { TronDailyResources } from './tron-daily-resources';
 
-// TODO BIP44 Refactor: This page needs a significant refactor after BIP44 is enabled to remove confusing branching logic
-// A page representing a native or token asset
+// TODO BIP44 Refactor: BIP-44 has been enabled and is stable, this page needs a significant refactor to remove confusing branching logic
 const AssetPage = ({
   asset,
   optionsButton,

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -9,7 +9,6 @@ import {
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   type CaipAssetType,
-  type Hex,
   isCaipChainId,
   parseCaipAssetType,
 } from '@metamask/utils';
@@ -21,14 +20,11 @@ import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/modules/conversion.utils';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
-import useMultiChainAssets from '../../../components/app/assets/hooks/useMultichainAssets';
 import TokenCell from '../../../components/app/assets/token-cell';
 import {
   TokenFiatDisplayInfo,
   type TokenWithFiatAmount,
 } from '../../../components/app/assets/types';
-import { calculateTokenBalance } from '../../../components/app/assets/util/calculateTokenBalance';
-import TransactionList from '../../../components/app/transaction-list';
 import UnifiedTransactionList from '../../../components/app/transaction-list/unified-transaction-list.component';
 import CoinButtons from '../../../components/app/wallet-overview/coin-buttons';
 import {
@@ -58,15 +54,12 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
-import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import {
   getDataCollectionForMarketing,
   getIsBridgeChain,
-  getIsMultichainAccountsState2Enabled,
   getIsSwapsChain,
   getMetaMetricsId,
   getParticipateInMetaMetrics,
-  getSelectedAccountNativeTokenCachedBalanceByChainId,
   getShowFiatInTestnets,
 } from '../../../selectors';
 import {
@@ -106,9 +99,6 @@ const AssetPage = ({
   const isEvm = isEvmChainId(asset.chainId);
   // TODO BIP44 Refactor: This selector does not work with BIP44 enabled, pass the information in the asset object
   const nativeAssetType = useSelector(getMultichainNativeAssetType);
-  const isMultichainAccountsState2Enabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
   const accountGroupIdAssets = useSelector(getAssetsBySelectedAccountGroup);
   const caipChainId = isCaipChainId(asset.chainId)
     ? asset.chainId
@@ -121,9 +111,7 @@ const AssetPage = ({
     endTrace({ name: TraceName.AssetDetails });
   }, []);
 
-  const { chainId, type, symbol, name, image, decimals } = asset;
-
-  const isNative = type === AssetType.native;
+  const { chainId, type, symbol, name, image } = asset;
 
   const isSwapsChain = useSelector((state) => getIsSwapsChain(state, chainId));
   const isBridgeChain = useSelector((state) =>
@@ -144,48 +132,6 @@ const AssetPage = ({
   const showFiatInTestnets = useSelector(getShowFiatInTestnets);
   const showFiat =
     shouldShowFiat && (isMainnet || (isTestnet && showFiatInTestnets));
-
-  const nativeBalances: Record<Hex, Hex> = useSelector(
-    getSelectedAccountNativeTokenCachedBalanceByChainId,
-  ) as Record<Hex, Hex>;
-
-  const { tokenBalances } = useTokenBalances({ chainIds: [chainId] });
-
-  const selectedAccountTokenBalancesAcrossChains =
-    tokenBalances[selectedAccount.address as Hex];
-
-  const multiChainAssets = useMultiChainAssets();
-  const mutichainTokenWithFiatAmount = multiChainAssets
-    .filter((item) => item.chainId === chainId && item.address !== undefined)
-    .find((item) => {
-      switch (type) {
-        case AssetType.native:
-          return item.isNative;
-        case AssetType.token:
-          return item.address === asset.address;
-        default:
-          return false;
-      }
-    }) ?? {
-    // TODO: remove the fallback case where the mutichainTokenWithFiatAmount is undefined
-    // Root cause: There is a race condition where when switching from a non-EVM network
-    // to an EVM network, the mutichainTokenWithFiatAmount is undefined
-    // This is a workaround to avoid the error
-    // Look into the isEvm selector
-    // We might be switching network before account.
-    address: '',
-    chainId: '',
-    symbol: '',
-    title: '',
-    image: '',
-    tokenFiatAmount: 0,
-    string: '',
-    decimals: 0,
-    aggregators: [],
-    isNative: false,
-    balance: 0,
-    secondary: 0,
-  };
 
   const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
@@ -211,56 +157,27 @@ const AssetPage = ({
 
   const { currentPrice } = useCurrentPrice(asset);
 
-  let balance, tokenFiatAmount, assetId, updatedAsset;
-  if (isMultichainAccountsState2Enabled) {
-    const assetWithBalance = accountGroupIdAssets[chainId]?.find(
-      (item) =>
-        item.assetId.toLowerCase() === address.toLowerCase() ||
-        // TODO: This is a workaround for non-evm native assets, as the address that is received here is blank
-        (!address && !isEvm && item.isNative),
-    );
+  const assetWithBalance = accountGroupIdAssets[chainId]?.find(
+    (item) =>
+      item.assetId.toLowerCase() === address.toLowerCase() ||
+      // TODO: This is a workaround for non-evm native assets, as the address that is received here is blank
+      (!address && !isEvm && item.isNative),
+  );
 
-    assetId = assetWithBalance?.assetId || '';
-    address = assetWithBalance?.assetId || '';
-    balance = assetWithBalance?.balance ?? '0';
-    tokenFiatAmount = assetWithBalance?.fiat?.balance ?? 0;
-    const tokenHexBalance = assetWithBalance?.rawBalance as string;
+  address = assetWithBalance?.assetId || '';
+  const assetId = assetWithBalance?.assetId || '';
+  const balance = assetWithBalance?.balance ?? '0';
+  const tokenFiatAmount = assetWithBalance?.fiat?.balance ?? 0;
+  const tokenHexBalance = assetWithBalance?.rawBalance as string;
 
-    updatedAsset = {
-      ...asset,
-      balance: {
-        value: hexToDecimal(tokenHexBalance),
-        display: balance,
-        fiat: String(tokenFiatAmount),
-      },
-    };
-  } else {
-    const tokenHexBalance =
-      selectedAccountTokenBalancesAcrossChains?.[chainId]?.[address as Hex];
-
-    balance = calculateTokenBalance({
-      isNative,
-      chainId,
-      address: address as Hex,
-      decimals,
-      nativeBalances,
-      selectedAccountTokenBalancesAcrossChains,
-    });
-
-    tokenFiatAmount = currentPrice
-      ? currentPrice * parseFloat(String(balance))
-      : 0;
-
-    // this is needed in order to assign the correct balances to TokenButtons before navigating to send/swap screens
-    updatedAsset = {
-      ...asset,
-      balance: {
-        value: hexToDecimal(tokenHexBalance),
-        display: String(balance),
-        fiat: String(tokenFiatAmount),
-      },
-    };
-  }
+  const updatedAsset = {
+    ...asset,
+    balance: {
+      value: hexToDecimal(tokenHexBalance),
+      display: balance,
+      fiat: String(tokenFiatAmount),
+    },
+  };
 
   const shouldShowSpendingCaps = isEvm;
   const portfolioSpendingCapsUrl = useMemo(
@@ -290,38 +207,24 @@ const AssetPage = ({
 
   const bip44Asset = useSelector((state) => getAsset(state, address, chainId));
 
-  const tokenWithFiatAmount =
-    isEvm || isMultichainAccountsState2Enabled
-      ? {
-          address: isEvm ? address : assetId,
-          chainId,
-          symbol,
-          image,
-          title: name ?? symbol,
-          tokenFiatAmount: showFiat ? tokenFiatAmount : null,
-          string: balance ? balance.toString() : '',
-          decimals: asset.decimals,
-          aggregators:
-            type === AssetType.token && asset.aggregators
-              ? asset.aggregators
-              : [],
-          isNative: type === AssetType.native,
-          balance,
-          secondary: balance ? Number(balance) : 0,
-          accountType: bip44Asset?.accountType,
-          assetId: bip44Asset?.assetId ?? assetId,
-        }
-      : {
-          ...mutichainTokenWithFiatAmount,
-          accountType: bip44Asset?.accountType,
-        };
-
+  const tokenWithFiatAmount = {
+    address: isEvm ? address : assetId,
+    chainId,
+    symbol,
+    image,
+    title: name ?? symbol,
+    tokenFiatAmount: showFiat ? tokenFiatAmount : null,
+    string: balance ? balance.toString() : '',
+    decimals: asset.decimals,
+    aggregators:
+      type === AssetType.token && asset.aggregators ? asset.aggregators : [],
+    isNative: type === AssetType.native,
+    balance,
+    secondary: balance ? Number(balance) : 0,
+    accountType: bip44Asset?.accountType,
+    assetId: bip44Asset?.assetId ?? assetId,
+  };
   const { safeChains } = useSafeChains();
-
-  const isBIP44FeatureFlagEnabled = useSelector(
-    getIsMultichainAccountsState2Enabled,
-  );
-  const showUnifiedTransactionList = isBIP44FeatureFlagEnabled;
 
   // Check if we should show Tron resources
   const isTron = useMultichainSelector(getMultichainIsTron, selectedAccount);
@@ -526,19 +429,11 @@ const AssetPage = ({
             <Text paddingInline={4} variant={TextVariant.headingSm}>
               {t('yourActivity')}
             </Text>
-            {showUnifiedTransactionList ? (
-              <UnifiedTransactionList
-                tokenAddress={address}
-                hideNetworkFilter
-                tokenChainIdOverride={chainId}
-              />
-            ) : (
-              <TransactionList
-                tokenAddress={address}
-                hideNetworkFilter
-                overrideFilterForCurrentChain={type === AssetType.native}
-              />
-            )}
+            <UnifiedTransactionList
+              tokenAddress={address}
+              hideNetworkFilter
+              tokenChainIdOverride={chainId}
+            />
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR is part of a series to remove the legacy code after BIP-44 was shipped, several components, hooks, views, etc. still uses the remote feature flag for BIP-44 causing an unnecessary overcomplexity that can be easily removed.

The changes include updating the component for the assets scope.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40107?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1455

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

### **Before**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes legacy code paths and network-switching behavior across core asset UI (token list, asset details, token actions), which could change which balances/transactions are shown and how send/swap behave on certain networks.
> 
> **Overview**
> Removes BIP-44 feature-flag branching from asset-related UI so the app consistently uses the account-group (BIP-44) asset sources and multichain network selection.
> 
> This simplifies `TokenList`, `AssetPage`, `TokenButtons`, and `AssetListControlBar` by deleting legacy balance/network-filter logic, always using `UnifiedTransactionList`, and updating the network delete modal to switch back to Ethereum without passing the removed flag parameter. Tests and display helpers are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9819adfdc20addd7a395e120fec4ed6756100b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->