### PR TITLE
test: add unit tests for untested utility modules

### DIFF
--- a/app/scripts/lib/createLoggerMiddleware.test.js
+++ b/app/scripts/lib/createLoggerMiddleware.test.js
@@ -1,0 +1,123 @@
+import log from 'loglevel';
+import createLoggerMiddleware from './createLoggerMiddleware';
+
+jest.mock('loglevel');
+
+describe('createLoggerMiddleware', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return a middleware function', () => {
+    const middleware = createLoggerMiddleware({ origin: 'test.com' });
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should call next', () => {
+    const middleware = createLoggerMiddleware({ origin: 'test.com' });
+    const req = { method: 'eth_call' };
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(typeof next.mock.calls[0][0]).toBe('function');
+  });
+
+  it('should log error when response has error', () => {
+    const middleware = createLoggerMiddleware({ origin: 'test.com' });
+    const req = { method: 'eth_call' };
+    const res = { error: { code: -32000, message: 'execution reverted' } };
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    const callback = next.mock.calls[0][0];
+    const cb = jest.fn();
+    callback(cb);
+
+    expect(log.debug).toHaveBeenCalledWith('Error in RPC response:\n', res);
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('should not log details for metamask internal requests', () => {
+    const middleware = createLoggerMiddleware({ origin: 'metamask' });
+    const req = { method: 'eth_call', isMetamaskInternal: true };
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    const callback = next.mock.calls[0][0];
+    const cb = jest.fn();
+    callback(cb);
+
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('should log detailed info in debug mode', () => {
+    process.env.METAMASK_DEBUG = 'true';
+    const middleware = createLoggerMiddleware({ origin: 'dapp.io' });
+    const req = { method: 'eth_getBalance' };
+    const res = { result: '0x1' };
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    const callback = next.mock.calls[0][0];
+    const cb = jest.fn();
+    callback(cb);
+
+    expect(log.info).toHaveBeenCalledWith(
+      'RPC (dapp.io):',
+      req,
+      '->',
+      res,
+    );
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('should log summary info in production mode', () => {
+    delete process.env.METAMASK_DEBUG;
+    const middleware = createLoggerMiddleware({ origin: 'dapp.io' });
+    const req = { method: 'eth_chainId' };
+    const res = { result: '0x1' };
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    const callback = next.mock.calls[0][0];
+    const cb = jest.fn();
+    callback(cb);
+
+    expect(log.info).toHaveBeenCalledWith(
+      'RPC (dapp.io): eth_chainId -> success',
+    );
+  });
+
+  it('should log error status in production mode when response has error', () => {
+    delete process.env.METAMASK_DEBUG;
+    const middleware = createLoggerMiddleware({ origin: 'app.uniswap.org' });
+    const req = { method: 'eth_sendTransaction' };
+    const res = { error: { code: -32603, message: 'internal error' } };
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    const callback = next.mock.calls[0][0];
+    const cb = jest.fn();
+    callback(cb);
+
+    expect(log.info).toHaveBeenCalledWith(
+      'RPC (app.uniswap.org): eth_sendTransaction -> error',
+    );
+  });
+});

--- a/app/scripts/lib/createOriginMiddleware.test.js
+++ b/app/scripts/lib/createOriginMiddleware.test.js
@@ -1,0 +1,66 @@
+import createOriginMiddleware from './createOriginMiddleware';
+
+describe('createOriginMiddleware', () => {
+  it('should return a middleware function', () => {
+    const middleware = createOriginMiddleware({ origin: 'example.com' });
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should set the origin on the request object', () => {
+    const origin = 'https://example.metamask.io';
+    const middleware = createOriginMiddleware({ origin });
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(req.origin).toBe(origin);
+  });
+
+  it('should call next after setting origin', () => {
+    const middleware = createOriginMiddleware({ origin: 'test.com' });
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should overwrite existing origin on request', () => {
+    const middleware = createOriginMiddleware({ origin: 'new-origin.com' });
+    const req = { origin: 'old-origin.com' };
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(req.origin).toBe('new-origin.com');
+  });
+
+  it('should preserve other properties on the request object', () => {
+    const middleware = createOriginMiddleware({ origin: 'test.com' });
+    const req = { method: 'eth_call', params: ['0x1'] };
+    const res = {};
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(req.method).toBe('eth_call');
+    expect(req.params).toStrictEqual(['0x1']);
+    expect(req.origin).toBe('test.com');
+  });
+
+  it('should handle empty string origin', () => {
+    const middleware = createOriginMiddleware({ origin: '' });
+    const req = {};
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.origin).toBe('');
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/app/scripts/lib/createTabIdMiddleware.test.js
+++ b/app/scripts/lib/createTabIdMiddleware.test.js
@@ -1,0 +1,61 @@
+import createTabIdMiddleware from './createTabIdMiddleware';
+
+describe('createTabIdMiddleware', () => {
+  it('should return a middleware function', () => {
+    const middleware = createTabIdMiddleware({ tabId: 123 });
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should set the tabId on the request object', () => {
+    const tabId = 42;
+    const middleware = createTabIdMiddleware({ tabId });
+    const req = {};
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.tabId).toBe(42);
+  });
+
+  it('should call next after setting tabId', () => {
+    const middleware = createTabIdMiddleware({ tabId: 1 });
+    const req = {};
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('should overwrite existing tabId on the request', () => {
+    const middleware = createTabIdMiddleware({ tabId: 99 });
+    const req = { tabId: 1 };
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.tabId).toBe(99);
+  });
+
+  it('should preserve other properties on the request object', () => {
+    const middleware = createTabIdMiddleware({ tabId: 7 });
+    const req = { method: 'eth_sendTransaction', origin: 'dapp.com' };
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.method).toBe('eth_sendTransaction');
+    expect(req.origin).toBe('dapp.com');
+    expect(req.tabId).toBe(7);
+  });
+
+  it('should handle tabId of 0', () => {
+    const middleware = createTabIdMiddleware({ tabId: 0 });
+    const req = {};
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(req.tabId).toBe(0);
+  });
+});

--- a/app/scripts/lib/getObjStructure.test.js
+++ b/app/scripts/lib/getObjStructure.test.js
@@ -1,0 +1,150 @@
+import getObjStructure from './getObjStructure';
+
+describe('getObjStructure', () => {
+  it('should return type strings for primitive values', () => {
+    const obj = {
+      name: 'MetaMask',
+      version: 10,
+      active: true,
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      name: 'string',
+      version: 'number',
+      active: 'boolean',
+    });
+  });
+
+  it('should handle null values', () => {
+    const obj = {
+      data: null,
+      count: 5,
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      data: 'null',
+      count: 'number',
+    });
+  });
+
+  it('should handle undefined values', () => {
+    const obj = {
+      missing: undefined,
+      present: 'hello',
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      missing: 'undefined',
+      present: 'string',
+    });
+  });
+
+  it('should recursively map nested objects', () => {
+    const obj = {
+      data: {
+        CurrencyController: {
+          currentCurrency: 'usd',
+          conversionRate: 1800.5,
+        },
+      },
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      data: {
+        CurrencyController: {
+          currentCurrency: 'string',
+          conversionRate: 'number',
+        },
+      },
+    });
+  });
+
+  it('should handle deeply nested structures', () => {
+    const obj = {
+      level1: {
+        level2: {
+          level3: {
+            value: 42,
+          },
+        },
+      },
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      level1: {
+        level2: {
+          level3: {
+            value: 'number',
+          },
+        },
+      },
+    });
+  });
+
+  it('should handle an empty object', () => {
+    const result = getObjStructure({});
+    expect(result).toStrictEqual({});
+  });
+
+  it('should handle arrays within objects', () => {
+    const obj = {
+      items: [1, 2, 3],
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      items: {
+        0: 'number',
+        1: 'number',
+        2: 'number',
+      },
+    });
+  });
+
+  it('should not modify the original object', () => {
+    const obj = {
+      name: 'test',
+      nested: { value: 123 },
+    };
+
+    getObjStructure(obj);
+
+    expect(obj).toStrictEqual({
+      name: 'test',
+      nested: { value: 123 },
+    });
+  });
+
+  it('should handle mixed types in nested structures', () => {
+    const obj = {
+      config: {
+        enabled: true,
+        label: 'network',
+        chainId: 1,
+        metadata: null,
+      },
+    };
+
+    const result = getObjStructure(obj);
+
+    expect(result).toStrictEqual({
+      config: {
+        enabled: 'boolean',
+        label: 'string',
+        chainId: 'number',
+        metadata: 'null',
+      },
+    });
+  });
+});

--- a/ui/helpers/utils/formatters.test.js
+++ b/ui/helpers/utils/formatters.test.js
@@ -1,0 +1,35 @@
+import { formatETHFee } from './formatters';
+
+describe('formatETHFee', () => {
+  it('should format fee with default ETH symbol', () => {
+    expect(formatETHFee('0.005')).toBe('0.005 ETH');
+  });
+
+  it('should format fee with a custom currency symbol', () => {
+    expect(formatETHFee('1.25', 'BNB')).toBe('1.25 BNB');
+  });
+
+  it('should format fee with MATIC symbol', () => {
+    expect(formatETHFee('100', 'MATIC')).toBe('100 MATIC');
+  });
+
+  it('should handle zero fee', () => {
+    expect(formatETHFee('0')).toBe('0 ETH');
+  });
+
+  it('should handle very small fee amounts', () => {
+    expect(formatETHFee('0.000000001')).toBe('0.000000001 ETH');
+  });
+
+  it('should handle empty string fee', () => {
+    expect(formatETHFee('')).toBe(' ETH');
+  });
+
+  it('should handle numeric input', () => {
+    expect(formatETHFee(0.01)).toBe('0.01 ETH');
+  });
+
+  it('should use empty string as currency symbol when passed', () => {
+    expect(formatETHFee('5', '')).toBe('5 ');
+  });
+});

--- a/ui/helpers/utils/portfolio.test.js
+++ b/ui/helpers/utils/portfolio.test.js
@@ -1,0 +1,98 @@
+import { getPortfolioUrl } from './portfolio';
+
+describe('getPortfolioUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PORTFOLIO_URL: 'https://portfolio.metamask.io' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return base URL with default parameters', () => {
+    const url = getPortfolioUrl();
+
+    expect(url).toContain('https://portfolio.metamask.io');
+    expect(url).toContain('metamaskEntry=');
+    expect(url).toContain('metametricsId=');
+    expect(url).toContain('metricsEnabled=false');
+    expect(url).toContain('marketingEnabled=false');
+  });
+
+  it('should append the endpoint to the base URL', () => {
+    const url = getPortfolioUrl('/swap');
+
+    expect(url).toContain('https://portfolio.metamask.io/swap');
+  });
+
+  it('should include metamaskEntry parameter', () => {
+    const url = getPortfolioUrl('', 'ext_portfolio_button');
+
+    expect(url).toContain('metamaskEntry=ext_portfolio_button');
+  });
+
+  it('should include metametricsId parameter', () => {
+    const url = getPortfolioUrl('', '', 'abc-123');
+
+    expect(url).toContain('metametricsId=abc-123');
+  });
+
+  it('should set metricsEnabled to true when provided', () => {
+    const url = getPortfolioUrl('', '', '', true);
+
+    expect(url).toContain('metricsEnabled=true');
+  });
+
+  it('should set marketingEnabled to true when provided', () => {
+    const url = getPortfolioUrl('', '', '', false, true);
+
+    expect(url).toContain('marketingEnabled=true');
+  });
+
+  it('should include accountAddress when provided', () => {
+    const address = '0x1234567890abcdef1234567890abcdef12345678';
+    const url = getPortfolioUrl('', '', '', false, false, address);
+
+    expect(url).toContain(`accountAddress=${address}`);
+  });
+
+  it('should not include accountAddress when not provided', () => {
+    const url = getPortfolioUrl('', '', '', false, false);
+
+    expect(url).not.toContain('accountAddress');
+  });
+
+  it('should include tab parameter when provided', () => {
+    const url = getPortfolioUrl('', '', '', false, false, undefined, 'activity');
+
+    expect(url).toContain('tab=activity');
+  });
+
+  it('should not include tab parameter when not provided', () => {
+    const url = getPortfolioUrl('', '', '', false, false, '0xabc');
+
+    expect(url).not.toContain('tab=');
+  });
+
+  it('should include all parameters together', () => {
+    const url = getPortfolioUrl(
+      '/bridge',
+      'ext_bridge',
+      'metrics-id-456',
+      true,
+      true,
+      '0xdeadbeef',
+      'tokens',
+    );
+
+    expect(url).toContain('/bridge');
+    expect(url).toContain('metamaskEntry=ext_bridge');
+    expect(url).toContain('metametricsId=metrics-id-456');
+    expect(url).toContain('metricsEnabled=true');
+    expect(url).toContain('marketingEnabled=true');
+    expect(url).toContain('accountAddress=0xdeadbeef');
+    expect(url).toContain('tab=tokens');
+  });
+});


### PR DESCRIPTION
Add comprehensive unit test coverage for the following previously untested modules:

- createOriginMiddleware: tests origin assignment and request preservation
- createTabIdMiddleware: tests tabId assignment and edge cases
- createLoggerMiddleware: tests debug/production logging, error handling, and internal request filtering
- getObjStructure: tests recursive type mapping, null handling, nested objects, and immutability of source objects
- formatETHFee: tests default and custom currency symbols, edge cases
- getPortfolioUrl: tests URL construction with all parameter combinations

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40149?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t alter production behavior; risk is limited to potential brittleness if logging/output formats or environment handling change.
> 
> **Overview**
> Adds new Jest unit tests for several previously untested utilities and middlewares.
> 
> The new coverage validates request mutation behavior in `createOriginMiddleware` and `createTabIdMiddleware`, logging behavior/branching in `createLoggerMiddleware` (debug vs prod, internal request suppression, error logging), recursive type-shape mapping and immutability in `getObjStructure`, simple formatting in `formatETHFee`, and querystring construction across parameter combinations in `getPortfolioUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 453fa6a4593ef27dd151590ff4a0ecdbaa4da8df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->