### PR TITLE
fix: flaky tests due to change in Menu sliding on from the side

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -101,7 +101,7 @@ class HeaderNavbar {
 
   async openGlobalNetworksMenu(): Promise<void> {
     console.log('Open global menu');
-    await this.driver.clickElement(this.threeDotMenuButton);
+    await this.openThreeDotMenu();
     await this.driver.clickElement(this.globalNetworksMenu);
   }
 
@@ -111,15 +111,17 @@ class HeaderNavbar {
       state: 'enabled',
     });
     await this.driver.clickElement(this.threeDotMenuButton);
+    await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 
   async mouseClickOnThreeDotMenu(): Promise<void> {
     console.log('Clicking three dot menu using mouse move');
     await this.driver.clickElementUsingMouseMove(this.threeDotMenuButton);
+    await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 
   async clickDrawerBackButton(): Promise<void> {
-    await this.driver.clickElement(this.drawerBackButton);
+    await this.driver.clickElementAndWaitToDisappear(this.drawerBackButton);
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The method for open and closing the menu has become flaky as the behaviour has changed (see [related PR](https://github.com/MetaMask/metamask-extension/pull/39991)). It slides from the side both for opening and closing, causing the clicks to take no effect if the element is moving.
This PR mitigates the flakiness by waiting for the menu to stop moving

Extra note: I've seen a flaky test related to locking the wallet in this branch, due to an error appearing in the console. It could be that due to different timing, now this issue is exposed more or it might be unrelated. 
I was hesitant to try to add a fix here, but if it's non-blocking I'll investigate this separately, as it's a different issue.

```
-----Received an error from Chrome-----
KeyringController - The operation cannot be completed while the controller is locked.
getSessionProfile - unable to proceed, wallet is locked
[getSubscriptions] error -32603, undefined, Failed to get authorization header. getBearerToken - unable to proceed, wallet is locked
----------End of Chrome error----------
```




[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40157?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/2137728a-7552-446e-9f73-1338f7a7c5ff



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization changes; risk is limited to potential new waits/timeouts affecting E2E runtime or masking real UI regressions.
> 
> **Overview**
> Stabilizes E2E tests around the header account options (three-dot) drawer now that the menu slides in/out and can ignore clicks while moving.
> 
> `openThreeDotMenu` and `mouseClickOnThreeDotMenu` now wait for the drawer close button to stop moving after opening, `openGlobalNetworksMenu` reuses the shared open helper, and `clickDrawerBackButton` now clicks and waits for the drawer to disappear to avoid racey close interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6966ac48571d6c44df255cc705eda020faaf1e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->