### PR TITLE
fix: race conditions with stale build artifact in the update-fixture script

### DIFF
--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -87,8 +87,10 @@ jobs:
 
       - name: Find and download dist artifact
         run: |
+          COMMIT_SHA_FULL=$(git rev-parse HEAD)
+
           # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion --limit 1 --jq 'first')
+          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion,headSha --limit 1 --jq 'first')
 
           if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
             echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
@@ -98,12 +100,29 @@ jobs:
           RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
           RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
           RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
+          RUN_HEAD_SHA=$(echo "$RUN_INFO" | jq -r '.headSha')
 
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}"
-          echo "Attempting to download latest dist artifact..."
+          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}, headSha: ${RUN_HEAD_SHA}"
+          echo "Current PR HEAD commit: ${COMMIT_SHA_FULL}"
+
+          if [ "${RUN_HEAD_SHA}" != "${COMMIT_SHA_FULL}" ]; then
+            echo "::error::The latest 'Main' workflow run (commit ${RUN_HEAD_SHA}) does not match the current PR HEAD (commit ${COMMIT_SHA_FULL}). Please ensure the Main workflow has run for the latest commit on this branch."
+            exit 1
+          fi
+
+          if [ "${RUN_STATUS}" != "completed" ]; then
+            echo "::error::The latest 'Main' workflow run is still in progress (status: ${RUN_STATUS}). Please wait for it to complete before updating fixtures."
+            exit 1
+          fi
+
+          if [ "${RUN_CONCLUSION}" != "success" ]; then
+            echo "::warning::The latest 'Main' workflow run concluded with '${RUN_CONCLUSION}'. The build artifact may still be available, proceeding with download attempt."
+          fi
+
+          echo "Attempting to download dist artifact..."
 
           if ! gh run download "${RUN_ID}" -n build-dist-browserify -D build-dist-browserify; then
-            echo "::error::Failed to download the 'build-dist-browserify' artifact. The build job may not have completed yet, may have failed. Please ensure the build-dist-browserify job has completed successfully."
+            echo "::error::Failed to download the 'build-dist-browserify' artifact. The build job may not have completed yet, or may have failed. Please ensure the build-dist-browserify job has completed successfully."
             exit 1
           fi
 

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -111,11 +111,8 @@ jobs:
           fi
 
           if [ "${RUN_STATUS}" != "completed" ]; then
-            echo "::error::The latest 'Main' workflow run is still in progress (status: ${RUN_STATUS}). Please wait for it to complete before updating fixtures."
-            exit 1
-          fi
-
-          if [ "${RUN_CONCLUSION}" != "success" ]; then
+            echo "::notice::The latest 'Main' workflow run is still in progress (status: ${RUN_STATUS}). Attempting to download the dist artifact anyway."
+          elif [ "${RUN_CONCLUSION}" != "success" ]; then
             echo "::warning::The latest 'Main' workflow run concluded with '${RUN_CONCLUSION}'. The build artifact may still be available, proceeding with download attempt."
           fi
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Issue pointed by @Gudahtt  +Cursor here: https://github.com/MetaMask/metamask-extension/pull/40120#discussion_r2806423381 

Changes: 
- Stale artifact (commit mismatch): compare RUN_HEAD_SHA against COMMIT_SHA_FULL (the current PR HEAD). If the latest Main run is from an older commit, it hard-fails with a clear error.

Preserved: 
- No need to wait for all of Main processes to complete: only log a ::notice:: (not an error) when the Main workflow is still running, then falls through to attempt the download. If the build-dist-browserify job has finished and uploaded its artifact, the download succeeds. If it hasn't finished yet, gh run download fails naturally with a descriptive error. No hard gate on the overall Main workflow completing.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40163?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1451
 
## **Manual testing steps**

Verify my tests in a fork (or create a fork yourself following these steps)



### Test : Stale artifact detection (commit mismatch)
1. After build dist completes for any commit, push a new trivial commit (e.g., add a comment to a file).
2. Immediately comment @metamaskbot update-e2e-fixture -- before the Main workflow finishes for the new commit.
3. Open the triggered "Update E2E fixtures" run in Actions.
4. The "Find and download dist artifact" step should fail with: `The latest 'Main' workflow run (commit <old>) does not match the current PR HEAD (commit <new>)`

<img width="920" height="362" alt="image" src="https://github.com/user-attachments/assets/6d494a4e-9bde-49b1-aa44-57e7cb6fcbbc" />

https://github.com/seaona/metamask-extension/actions/runs/22106590200

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that add validation/logging around artifact selection; primary risk is increased CI failures if run metadata or SHA expectations differ.
> 
> **Overview**
> Tightens the `update-e2e-fixtures` GitHub Actions workflow to avoid updating fixtures from a **stale `build-dist-browserify` artifact**.
> 
> The download step now fetches the latest `Main` run’s `headSha` and compares it to the current PR HEAD (full SHA), failing with a clear error when they differ; it also emits notices/warnings for non-completed or non-success runs while still attempting the artifact download, and improves the download-failure message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0ebd99c328a10bd41d9825f0f76d78eafaec23c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->