### PR TITLE
fix: wait for bridge tx submission before navigating to activity log

### DIFF
--- a/ui/ducks/bridge-status/actions.ts
+++ b/ui/ducks/bridge-status/actions.ts
@@ -30,14 +30,14 @@ const callBridgeStatusControllerMethod = <T extends unknown[]>(
  * @param context
  * @returns
  */
-export const submitBridgeTx = (
+export const submitBridgeTx = async (
   accountAddress: string,
   quote: QuoteResponse & QuoteMetadata,
   isStxSupportedInClient: boolean,
   context: RequiredEventContextFromClient[UnifiedSwapBridgeEventName.QuotesReceived],
 ) => {
   return async (dispatch: MetaMaskReduxDispatch) => {
-    return dispatch(
+    return await dispatch(
       callBridgeStatusControllerMethod<
         [
           string,

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -146,7 +146,9 @@ export default function useSubmitBridgeTransaction() {
         dispatch(setWasTxDeclined(true));
         navigate(`${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`);
       } else {
-        navigate(`${DEFAULT_ROUTE}?tab=activity`);
+        navigate(`${DEFAULT_ROUTE}?tab=activity`, {
+          state: { stayOnHomePage: true },
+        });
       }
       return;
     }

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -107,7 +107,7 @@ export default function useSubmitBridgeTransaction() {
       if (isNonEvmSource) {
         // Submit the transaction first, THEN navigate
         await dispatch(
-          submitBridgeTx(
+          await submitBridgeTx(
             fromAccount.address,
             quoteResponse,
             false,
@@ -127,7 +127,7 @@ export default function useSubmitBridgeTransaction() {
       }
 
       await dispatch(
-        submitBridgeTx(
+        await submitBridgeTx(
           fromAccount.address,
           quoteResponse,
           smartTransactionsEnabled,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is what currently happens when a user submits a swap/bridge tx
1. Publish submission metrics 
2. Add transaction to the background state
3. Route to the Activity log while the transaction is pending
4. Reset bridge controller state on page unload

Since the async `submitTx` handler is not awaited, #4 can happen before steps 1-3, which causes the tracking error described in the bug ticket. This scenario is only possible if the user submits the trade right after they receive it and their network connection is slow

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
5. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40173?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: swap tx submission fails if page navigates to Activity log before QuotesReceived event is published

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4060 , https://github.com/MetaMask/metamask-extension/issues/39871

## **Manual testing steps**

1. Open dev console
1. Request a swap quote
2. Submit right when first quote appears
6. Check if console logs include request cancellation logs (to verify that the edge case was hit). Otherwise repeat prior steps again
7. Verify that tx got submitted
8. Verify in network tab that a "Quotes Received" event was published

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change to await an existing async submission before navigation; low risk but could affect perceived UI timing if the background call is slow.
> 
> **Overview**
> Ensures bridge/swap submissions fully complete before routing the user to the Activity tab to avoid losing side effects (e.g., metrics/state updates) on page unload.
> 
> This makes `submitBridgeTx` async and updates `useSubmitBridgeTransaction` to await the thunk creation and dispatch for both non-EVM and EVM flows. It also makes error navigation to Activity consistent by passing `state: { stayOnHomePage: true }` when redirecting after failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e21743798fbb4b2f6e8bdf421499ad60cd6643f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->