### PR TITLE
fix(perps): update perps/tutorial skip button

### DIFF
--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { PerpsTutorialStep } from '../../../../ducks/perps';
+import PerpsTutorialModal from './PerpsTutorialModal';
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+jest.mock('../../../../hooks/useTheme', () => ({
+  useTheme: () => 'light',
+}));
+
+// Mock environment type
+jest.mock('../../../../../app/scripts/lib/util', () => ({
+  getEnvironmentType: () => 'fullscreen',
+}));
+
+// Mock Rive animation component
+jest.mock('./PerpsTutorialAnimation', () => {
+  const mockComponent = ({ artboardName }: { artboardName: string }) => (
+    <div data-testid="mock-rive-animation" data-artboard={artboardName}>
+      Mock Rive Animation: {artboardName}
+    </div>
+  );
+  return mockComponent;
+});
+
+const mockStore = configureStore([]);
+
+describe('PerpsTutorialModal', () => {
+  const createStore = (
+    isOpen: boolean,
+    activeStep: PerpsTutorialStep = PerpsTutorialStep.WhatArePerps,
+  ) =>
+    mockStore({
+      perpsTutorial: {
+        tutorialModalOpen: isOpen,
+        activeStep,
+        tutorialCompleted: false,
+      },
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the modal when open', () => {
+      const store = createStore(true);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('perps-tutorial-modal')).toBeInTheDocument();
+    });
+
+    it('renders progress indicator', () => {
+      const store = createStore(true);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-progress-indicator'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders continue button', () => {
+      const store = createStore(true);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-continue-button'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders skip button on non-last step', () => {
+      const store = createStore(true, PerpsTutorialStep.WhatArePerps);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-skip-button'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders "Let\'s Go" button on last step', () => {
+      const store = createStore(true, PerpsTutorialStep.ReadyToTrade);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-lets-go-button'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render skip button on last step', () => {
+      const store = createStore(true, PerpsTutorialStep.ReadyToTrade);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.queryByTestId('perps-tutorial-skip-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('navigation', () => {
+    it('advances to next step when continue is clicked', () => {
+      const store = createStore(true, PerpsTutorialStep.WhatArePerps);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-continue-button'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'perpsTutorial/setTutorialActiveStep',
+        payload: PerpsTutorialStep.GoLongOrShort,
+      });
+    });
+
+    it('advances through all steps in correct order', () => {
+      const steps = [
+        { current: PerpsTutorialStep.WhatArePerps, next: PerpsTutorialStep.GoLongOrShort },
+        { current: PerpsTutorialStep.GoLongOrShort, next: PerpsTutorialStep.ChooseLeverage },
+        { current: PerpsTutorialStep.ChooseLeverage, next: PerpsTutorialStep.WatchLiquidation },
+        { current: PerpsTutorialStep.WatchLiquidation, next: PerpsTutorialStep.CloseAnytime },
+        { current: PerpsTutorialStep.CloseAnytime, next: PerpsTutorialStep.ReadyToTrade },
+      ];
+
+      steps.forEach(({ current, next }) => {
+        jest.clearAllMocks();
+        const store = createStore(true, current);
+        const { unmount } = render(
+          <Provider store={store}>
+            <PerpsTutorialModal />
+          </Provider>,
+        );
+
+        fireEvent.click(screen.getByTestId('perps-tutorial-continue-button'));
+
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'perpsTutorial/setTutorialActiveStep',
+          payload: next,
+        });
+
+        unmount();
+      });
+    });
+
+    it('marks tutorial completed when "Let\'s Go" is clicked on last step', () => {
+      const store = createStore(true, PerpsTutorialStep.ReadyToTrade);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-lets-go-button'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'perpsTutorial/markTutorialCompleted',
+      });
+    });
+
+    it('closes modal when skip is clicked', () => {
+      const store = createStore(true, PerpsTutorialStep.WhatArePerps);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-skip-button'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'perpsTutorial/setTutorialModalOpen',
+        payload: false,
+      });
+    });
+  });
+
+  describe('step content', () => {
+    it('renders WhatArePerps step content', () => {
+      const store = createStore(true, PerpsTutorialStep.WhatArePerps);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-what-are-perps'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders GoLongShort step content', () => {
+      const store = createStore(true, PerpsTutorialStep.GoLongOrShort);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-go-long-short'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders ReadyToTrade step content', () => {
+      const store = createStore(true, PerpsTutorialStep.ReadyToTrade);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      expect(
+        screen.getByTestId('perps-tutorial-ready-to-trade'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('close behavior', () => {
+    it('calls onClose callback when modal is closed', () => {
+      const onClose = jest.fn();
+      const store = createStore(true);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal onClose={onClose} />
+        </Provider>,
+      );
+
+      // Find and click the close button in the modal header
+      const closeButton = screen.getByTestId('perps-tutorial-modal-header').querySelector('button');
+      if (closeButton) {
+        fireEvent.click(closeButton);
+        expect(onClose).toHaveBeenCalled();
+      }
+    });
+
+    it('resets to first step when modal is closed', () => {
+      const store = createStore(true, PerpsTutorialStep.ChooseLeverage);
+      render(
+        <Provider store={store}>
+          <PerpsTutorialModal />
+        </Provider>,
+      );
+
+      const closeButton = screen.getByTestId('perps-tutorial-modal-header').querySelector('button');
+      if (closeButton) {
+        fireEvent.click(closeButton);
+
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'perpsTutorial/setTutorialActiveStep',
+          payload: PerpsTutorialStep.WhatArePerps,
+        });
+      }
+    });
+  });
+});

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
@@ -151,11 +151,26 @@ describe('PerpsTutorialModal', () => {
 
     it('advances through all steps in correct order', () => {
       const steps = [
-        { current: PerpsTutorialStep.WhatArePerps, next: PerpsTutorialStep.GoLongOrShort },
-        { current: PerpsTutorialStep.GoLongOrShort, next: PerpsTutorialStep.ChooseLeverage },
-        { current: PerpsTutorialStep.ChooseLeverage, next: PerpsTutorialStep.WatchLiquidation },
-        { current: PerpsTutorialStep.WatchLiquidation, next: PerpsTutorialStep.CloseAnytime },
-        { current: PerpsTutorialStep.CloseAnytime, next: PerpsTutorialStep.ReadyToTrade },
+        {
+          current: PerpsTutorialStep.WhatArePerps,
+          next: PerpsTutorialStep.GoLongOrShort,
+        },
+        {
+          current: PerpsTutorialStep.GoLongOrShort,
+          next: PerpsTutorialStep.ChooseLeverage,
+        },
+        {
+          current: PerpsTutorialStep.ChooseLeverage,
+          next: PerpsTutorialStep.WatchLiquidation,
+        },
+        {
+          current: PerpsTutorialStep.WatchLiquidation,
+          next: PerpsTutorialStep.CloseAnytime,
+        },
+        {
+          current: PerpsTutorialStep.CloseAnytime,
+          next: PerpsTutorialStep.ReadyToTrade,
+        },
       ];
 
       steps.forEach(({ current, next }) => {
@@ -262,11 +277,12 @@ describe('PerpsTutorialModal', () => {
       );
 
       // Find and click the close button in the modal header
-      const closeButton = screen.getByTestId('perps-tutorial-modal-header').querySelector('button');
-      if (closeButton) {
-        fireEvent.click(closeButton);
-        expect(onClose).toHaveBeenCalled();
-      }
+      const closeButton = screen
+        .getByTestId('perps-tutorial-modal-header')
+        .querySelector('button');
+      expect(closeButton).toBeInTheDocument();
+      fireEvent.click(closeButton as HTMLElement);
+      expect(onClose).toHaveBeenCalled();
     });
 
     it('resets to first step when modal is closed', () => {
@@ -277,15 +293,16 @@ describe('PerpsTutorialModal', () => {
         </Provider>,
       );
 
-      const closeButton = screen.getByTestId('perps-tutorial-modal-header').querySelector('button');
-      if (closeButton) {
-        fireEvent.click(closeButton);
+      const closeButton = screen
+        .getByTestId('perps-tutorial-modal-header')
+        .querySelector('button');
+      expect(closeButton).toBeInTheDocument();
+      fireEvent.click(closeButton as HTMLElement);
 
-        expect(mockDispatch).toHaveBeenCalledWith({
-          type: 'perpsTutorial/setTutorialActiveStep',
-          payload: PerpsTutorialStep.WhatArePerps,
-        });
-      }
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'perpsTutorial/setTutorialActiveStep',
+        payload: PerpsTutorialStep.WhatArePerps,
+      });
     });
   });
 });

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
@@ -6,6 +6,7 @@ import {
   ModalHeader,
   ModalOverlay,
   ModalContentSize,
+  ModalBody,
 } from '../../../component-library';
 import { ThemeType } from '../../../../../shared/constants/preferences';
 import {
@@ -17,6 +18,7 @@ import {
   selectTutorialActiveStep,
   setTutorialModalOpen,
   setTutorialActiveStep,
+  markTutorialCompleted,
   PerpsTutorialStep,
 } from '../../../../ducks/perps';
 import { useTheme } from '../../../../hooks/useTheme';
@@ -29,6 +31,19 @@ import ChooseLeverageStep from './steps/ChooseLeverageStep';
 import WatchLiquidationStep from './steps/WatchLiquidationStep';
 import CloseAnytimeStep from './steps/CloseAnytimeStep';
 import ReadyToTradeStep from './steps/ReadyToTradeStep';
+import TutorialFooter from './TutorialFooter';
+import ProgressIndicator from './ProgressIndicator';
+
+const TOTAL_STEPS = 6;
+
+const STEP_ORDER = [
+  PerpsTutorialStep.WhatArePerps,
+  PerpsTutorialStep.GoLongOrShort,
+  PerpsTutorialStep.ChooseLeverage,
+  PerpsTutorialStep.WatchLiquidation,
+  PerpsTutorialStep.CloseAnytime,
+  PerpsTutorialStep.ReadyToTrade,
+];
 
 type PerpsTutorialModalProps = {
   onClose?: () => void;
@@ -44,11 +59,34 @@ const PerpsTutorialModal: React.FC<PerpsTutorialModalProps> = ({ onClose }) => {
   // Use a shorter height for popup to avoid scroll
   const modalHeight = useMemo(() => (isPopup ? '580px' : '675px'), [isPopup]);
 
+  const currentStepIndex = useMemo(
+    () => STEP_ORDER.indexOf(activeStep),
+    [activeStep],
+  );
+
+  const isLastStep = useMemo(
+    () => currentStepIndex === TOTAL_STEPS - 1,
+    [currentStepIndex],
+  );
+
   const handleClose = useCallback(() => {
     dispatch(setTutorialModalOpen(false));
     dispatch(setTutorialActiveStep(PerpsTutorialStep.WhatArePerps));
     onClose?.();
   }, [dispatch, onClose]);
+
+  const handleContinue = useCallback(() => {
+    if (isLastStep) {
+      dispatch(markTutorialCompleted());
+    } else {
+      const nextStep = STEP_ORDER[currentStepIndex + 1];
+      dispatch(setTutorialActiveStep(nextStep));
+    }
+  }, [dispatch, isLastStep, currentStepIndex]);
+
+  const handleSkip = useCallback(() => {
+    dispatch(setTutorialModalOpen(false));
+  }, [dispatch]);
 
   const renderContent = useCallback(() => {
     switch (activeStep) {
@@ -103,7 +141,18 @@ const PerpsTutorialModal: React.FC<PerpsTutorialModalProps> = ({ onClose }) => {
           paddingBottom={0}
           onClose={handleClose}
         />
-        {renderContent()}
+        <ModalBody className="w-full h-full pt-6 pb-4 flex flex-col">
+          <ProgressIndicator
+            totalSteps={TOTAL_STEPS}
+            currentStep={currentStepIndex + 1}
+          />
+          {renderContent()}
+          <TutorialFooter
+            onContinue={handleContinue}
+            onSkip={handleSkip}
+            isLastStep={isLastStep}
+          />
+        </ModalBody>
       </ModalContent>
     </Modal>
   );

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
@@ -20,6 +20,7 @@ import {
   setTutorialActiveStep,
   markTutorialCompleted,
   PerpsTutorialStep,
+  TUTORIAL_STEPS_ORDER,
 } from '../../../../ducks/perps';
 import { useTheme } from '../../../../hooks/useTheme';
 // eslint-disable-next-line import/no-restricted-paths
@@ -33,17 +34,6 @@ import CloseAnytimeStep from './steps/CloseAnytimeStep';
 import ReadyToTradeStep from './steps/ReadyToTradeStep';
 import TutorialFooter from './TutorialFooter';
 import ProgressIndicator from './ProgressIndicator';
-
-const TOTAL_STEPS = 6;
-
-const STEP_ORDER = [
-  PerpsTutorialStep.WhatArePerps,
-  PerpsTutorialStep.GoLongOrShort,
-  PerpsTutorialStep.ChooseLeverage,
-  PerpsTutorialStep.WatchLiquidation,
-  PerpsTutorialStep.CloseAnytime,
-  PerpsTutorialStep.ReadyToTrade,
-];
 
 type PerpsTutorialModalProps = {
   onClose?: () => void;
@@ -60,12 +50,12 @@ const PerpsTutorialModal: React.FC<PerpsTutorialModalProps> = ({ onClose }) => {
   const modalHeight = useMemo(() => (isPopup ? '580px' : '675px'), [isPopup]);
 
   const currentStepIndex = useMemo(
-    () => STEP_ORDER.indexOf(activeStep),
+    () => TUTORIAL_STEPS_ORDER.indexOf(activeStep),
     [activeStep],
   );
 
   const isLastStep = useMemo(
-    () => currentStepIndex === TOTAL_STEPS - 1,
+    () => currentStepIndex === TUTORIAL_STEPS_ORDER.length - 1,
     [currentStepIndex],
   );
 
@@ -79,7 +69,7 @@ const PerpsTutorialModal: React.FC<PerpsTutorialModalProps> = ({ onClose }) => {
     if (isLastStep) {
       dispatch(markTutorialCompleted());
     } else {
-      const nextStep = STEP_ORDER[currentStepIndex + 1];
+      const nextStep = TUTORIAL_STEPS_ORDER[currentStepIndex + 1];
       dispatch(setTutorialActiveStep(nextStep));
     }
   }, [dispatch, isLastStep, currentStepIndex]);
@@ -143,7 +133,7 @@ const PerpsTutorialModal: React.FC<PerpsTutorialModalProps> = ({ onClose }) => {
         />
         <ModalBody className="w-full h-full pt-6 pb-4 flex flex-col">
           <ProgressIndicator
-            totalSteps={TOTAL_STEPS}
+            totalSteps={TUTORIAL_STEPS_ORDER.length}
             currentStep={currentStepIndex + 1}
           />
           {renderContent()}

--- a/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+import TutorialFooter from './TutorialFooter';
+
+describe('TutorialFooter', () => {
+  const defaultProps = {
+    onContinue: jest.fn(),
+    onSkip: jest.fn(),
+    isLastStep: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the continue button with "Continue" text when not last step', () => {
+      render(<TutorialFooter {...defaultProps} />);
+
+      const continueButton = screen.getByTestId(
+        'perps-tutorial-continue-button',
+      );
+      expect(continueButton).toBeInTheDocument();
+      expect(continueButton).toHaveTextContent('perpsTutorialContinue');
+    });
+
+    it('renders the continue button with "Let\'s Go" text when last step', () => {
+      render(<TutorialFooter {...defaultProps} isLastStep />);
+
+      const continueButton = screen.getByTestId('perps-tutorial-lets-go-button');
+      expect(continueButton).toBeInTheDocument();
+      expect(continueButton).toHaveTextContent('perpsTutorialLetsGo');
+    });
+
+    it('renders the skip button when not last step', () => {
+      render(<TutorialFooter {...defaultProps} />);
+
+      expect(
+        screen.getByTestId('perps-tutorial-skip-button'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('perpsTutorialSkip')).toBeInTheDocument();
+    });
+
+    it('does not render the skip button when last step', () => {
+      render(<TutorialFooter {...defaultProps} isLastStep />);
+
+      expect(
+        screen.queryByTestId('perps-tutorial-skip-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onContinue when continue button is clicked', () => {
+      const onContinue = jest.fn();
+      render(<TutorialFooter {...defaultProps} onContinue={onContinue} />);
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-continue-button'));
+
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onContinue when "Let\'s Go" button is clicked on last step', () => {
+      const onContinue = jest.fn();
+      render(
+        <TutorialFooter {...defaultProps} onContinue={onContinue} isLastStep />,
+      );
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-lets-go-button'));
+
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSkip when skip button is clicked', () => {
+      const onSkip = jest.fn();
+      render(<TutorialFooter {...defaultProps} onSkip={onSkip} />);
+
+      fireEvent.click(screen.getByTestId('perps-tutorial-skip-button'));
+
+      expect(onSkip).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('styling', () => {
+    it('skip button has text-default class for white text', () => {
+      render(<TutorialFooter {...defaultProps} />);
+
+      const skipButton = screen.getByTestId('perps-tutorial-skip-button');
+      expect(skipButton).toHaveClass('text-default');
+    });
+  });
+});

--- a/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import TutorialFooter from './TutorialFooter';
 
 jest.mock('../../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string) => key,
 }));
-
-import TutorialFooter from './TutorialFooter';
 
 describe('TutorialFooter', () => {
   const defaultProps = {
@@ -32,7 +31,9 @@ describe('TutorialFooter', () => {
     it('renders the continue button with "Let\'s Go" text when last step', () => {
       render(<TutorialFooter {...defaultProps} isLastStep />);
 
-      const continueButton = screen.getByTestId('perps-tutorial-lets-go-button');
+      const continueButton = screen.getByTestId(
+        'perps-tutorial-lets-go-button',
+      );
       expect(continueButton).toBeInTheDocument();
       expect(continueButton).toHaveTextContent('perpsTutorialLetsGo');
     });

--- a/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+
+type TutorialFooterProps = {
+  onContinue: () => void;
+  onSkip: () => void;
+  isLastStep: boolean;
+};
+
+const TutorialFooter: React.FC<TutorialFooterProps> = ({
+  onContinue,
+  onSkip,
+  isLastStep,
+}) => {
+  const t = useI18nContext();
+
+  return (
+    <Box className="flex flex-col gap-2 px-4">
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Lg}
+        onClick={onContinue}
+        className="w-full"
+        data-testid={
+          isLastStep
+            ? 'perps-tutorial-lets-go-button'
+            : 'perps-tutorial-continue-button'
+        }
+      >
+        {isLastStep ? t('perpsTutorialLetsGo') : t('perpsTutorialContinue')}
+      </Button>
+      {!isLastStep && (
+        <Button
+          variant={ButtonVariant.Tertiary}
+          size={ButtonSize.Lg}
+          onClick={onSkip}
+          className="w-full text-default"
+          data-testid="perps-tutorial-skip-button"
+        >
+          {t('perpsTutorialSkip')}
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default TutorialFooter;

--- a/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/TutorialFooter.tsx
@@ -38,7 +38,7 @@ const TutorialFooter: React.FC<TutorialFooterProps> = ({
       {!isLastStep && (
         <Button
           variant={ButtonVariant.Tertiary}
-          size={ButtonSize.Lg}
+          size={ButtonSize.Sm}
           onClick={onSkip}
           className="w-full text-default"
           data-testid="perps-tutorial-skip-button"

--- a/ui/components/app/perps/perps-tutorial-modal/steps/ChooseLeverageStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/ChooseLeverageStep.tsx
@@ -1,87 +1,32 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import {
-  ButtonLink,
-  ButtonLinkSize,
-  ModalBody,
-} from '../../../../component-library';
-import {
-  setTutorialActiveStep,
-  setTutorialModalOpen,
-  PerpsTutorialStep,
-} from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import ProgressIndicator from '../ProgressIndicator';
 import PerpsTutorialAnimation from '../PerpsTutorialAnimation';
 
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 3;
-
 const ChooseLeverageStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const handleNext = useCallback(() => {
-    dispatch(setTutorialActiveStep(PerpsTutorialStep.WatchLiquidation));
-  }, [dispatch]);
-
-  const handleSkip = useCallback(() => {
-    dispatch(setTutorialModalOpen(false));
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-choose-leverage"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
-
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4 pb-2">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialChooseLeverageTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialChooseLeverageDescription')}
-        </Text>
-        <Box
-          className="flex-1 flex items-center justify-center w-full"
-          data-testid="perps-tutorial-step-image"
-        >
-          <PerpsTutorialAnimation artboardName="02_Leverage" />
-        </Box>
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialChooseLeverageTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialChooseLeverageDescription')}
+      </Text>
+      <Box
+        className="flex-1 flex items-center justify-center w-full"
+        data-testid="perps-tutorial-step-image"
+      >
+        <PerpsTutorialAnimation artboardName="02_Leverage" />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleNext}
-          className="w-full"
-          data-testid="perps-tutorial-continue-button"
-        >
-          {t('perpsTutorialContinue')}
-        </Button>
-        <ButtonLink
-          size={ButtonLinkSize.Md}
-          onClick={handleSkip}
-          className="w-full justify-center"
-          data-testid="perps-tutorial-skip-button"
-        >
-          {t('perpsTutorialSkip')}
-        </ButtonLink>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/CloseAnytimeStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/CloseAnytimeStep.tsx
@@ -1,87 +1,32 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import {
-  ButtonLink,
-  ButtonLinkSize,
-  ModalBody,
-} from '../../../../component-library';
-import {
-  setTutorialActiveStep,
-  setTutorialModalOpen,
-  PerpsTutorialStep,
-} from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import ProgressIndicator from '../ProgressIndicator';
 import PerpsTutorialAnimation from '../PerpsTutorialAnimation';
 
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 5;
-
 const CloseAnytimeStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const handleNext = useCallback(() => {
-    dispatch(setTutorialActiveStep(PerpsTutorialStep.ReadyToTrade));
-  }, [dispatch]);
-
-  const handleSkip = useCallback(() => {
-    dispatch(setTutorialModalOpen(false));
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-close-anytime"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
-
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4 pb-2">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialCloseAnytimeTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialCloseAnytimeDescription')}
-        </Text>
-        <Box
-          className="flex-1 flex items-center justify-center w-full"
-          data-testid="perps-tutorial-step-image"
-        >
-          <PerpsTutorialAnimation artboardName="04_Close" />
-        </Box>
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialCloseAnytimeTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialCloseAnytimeDescription')}
+      </Text>
+      <Box
+        className="flex-1 flex items-center justify-center w-full"
+        data-testid="perps-tutorial-step-image"
+      >
+        <PerpsTutorialAnimation artboardName="04_Close" />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleNext}
-          className="w-full"
-          data-testid="perps-tutorial-continue-button"
-        >
-          {t('perpsTutorialContinue')}
-        </Button>
-        <ButtonLink
-          size={ButtonLinkSize.Md}
-          onClick={handleSkip}
-          className="w-full justify-center"
-          data-testid="perps-tutorial-skip-button"
-        >
-          {t('perpsTutorialSkip')}
-        </ButtonLink>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/GoLongShortStep.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/GoLongShortStep.test.tsx
@@ -1,23 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { PerpsTutorialStep } from '../../../../../ducks/perps';
 import GoLongShortStep from './GoLongShortStep';
-
-const mockDispatch = jest.fn();
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => mockDispatch,
-}));
 
 jest.mock('../../../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string) => key,
-}));
-
-jest.mock('../../../../../hooks/useTheme', () => ({
-  useTheme: () => 'light',
 }));
 
 // Mock Rive animation component
@@ -86,62 +74,6 @@ describe('GoLongShortStep', () => {
       const animation = screen.getByTestId('mock-rive-animation');
       expect(animation).toBeInTheDocument();
       expect(animation).toHaveAttribute('data-artboard', '01_Short_Long');
-    });
-
-    it('renders the continue button', () => {
-      render(
-        <Provider store={store}>
-          <GoLongShortStep />
-        </Provider>,
-      );
-
-      expect(
-        screen.getByTestId('perps-tutorial-continue-button'),
-      ).toBeInTheDocument();
-    });
-
-    it('renders the skip button', () => {
-      render(
-        <Provider store={store}>
-          <GoLongShortStep />
-        </Provider>,
-      );
-
-      expect(
-        screen.getByTestId('perps-tutorial-skip-button'),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('navigation', () => {
-    it('dispatches setTutorialActiveStep to ChooseLeverage when continue is clicked', () => {
-      render(
-        <Provider store={store}>
-          <GoLongShortStep />
-        </Provider>,
-      );
-
-      fireEvent.click(screen.getByTestId('perps-tutorial-continue-button'));
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'perpsTutorial/setTutorialActiveStep',
-        payload: PerpsTutorialStep.ChooseLeverage,
-      });
-    });
-
-    it('dispatches setTutorialModalOpen(false) when skip is clicked', () => {
-      render(
-        <Provider store={store}>
-          <GoLongShortStep />
-        </Provider>,
-      );
-
-      fireEvent.click(screen.getByTestId('perps-tutorial-skip-button'));
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'perpsTutorial/setTutorialModalOpen',
-        payload: false,
-      });
     });
   });
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/GoLongShortStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/GoLongShortStep.tsx
@@ -1,93 +1,38 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import {
-  ButtonLink,
-  ButtonLinkSize,
-  ModalBody,
-} from '../../../../component-library';
-import {
-  setTutorialActiveStep,
-  setTutorialModalOpen,
-  PerpsTutorialStep,
-} from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import ProgressIndicator from '../ProgressIndicator';
 import PerpsTutorialAnimation from '../PerpsTutorialAnimation';
 
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 2;
-
 const GoLongShortStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const handleNext = useCallback(() => {
-    dispatch(setTutorialActiveStep(PerpsTutorialStep.ChooseLeverage));
-  }, [dispatch]);
-
-  const handleSkip = useCallback(() => {
-    dispatch(setTutorialModalOpen(false));
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-go-long-short"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
-
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4 pb-2">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialGoLongShortTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative mb-1 w-full"
-        >
-          {t('perpsTutorialGoLongShortDescription')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialGoLongShortSubtitle')}
-        </Text>
-        <Box
-          className="flex-1 flex items-center justify-center w-full"
-          data-testid="perps-tutorial-step-image"
-        >
-          <PerpsTutorialAnimation artboardName="01_Short_Long" />
-        </Box>
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialGoLongShortTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative mb-1 w-full"
+      >
+        {t('perpsTutorialGoLongShortDescription')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialGoLongShortSubtitle')}
+      </Text>
+      <Box
+        className="flex-1 flex items-center justify-center w-full"
+        data-testid="perps-tutorial-step-image"
+      >
+        <PerpsTutorialAnimation artboardName="01_Short_Long" />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleNext}
-          className="w-full"
-          data-testid="perps-tutorial-continue-button"
-        >
-          {t('perpsTutorialContinue')}
-        </Button>
-        <ButtonLink
-          size={ButtonLinkSize.Md}
-          onClick={handleSkip}
-          className="w-full justify-center"
-          data-testid="perps-tutorial-skip-button"
-        >
-          {t('perpsTutorialSkip')}
-        </ButtonLink>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/ReadyToTradeStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/ReadyToTradeStep.tsx
@@ -1,67 +1,32 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import { ModalBody } from '../../../../component-library';
-import { markTutorialCompleted } from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import ProgressIndicator from '../ProgressIndicator';
 import PerpsTutorialAnimation from '../PerpsTutorialAnimation';
 
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 6;
-
 const ReadyToTradeStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const handleComplete = useCallback(() => {
-    dispatch(markTutorialCompleted());
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-ready-to-trade"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
-
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4 pb-2">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialReadyToTradeTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialReadyToTradeDescription')}
-        </Text>
-        <Box
-          className="flex-1 flex items-center justify-center w-full"
-          data-testid="perps-tutorial-step-image"
-        >
-          <PerpsTutorialAnimation artboardName="05_Ready" />
-        </Box>
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialReadyToTradeTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialReadyToTradeDescription')}
+      </Text>
+      <Box
+        className="flex-1 flex items-center justify-center w-full"
+        data-testid="perps-tutorial-step-image"
+      >
+        <PerpsTutorialAnimation artboardName="05_Ready" />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleComplete}
-          className="w-full"
-          data-testid="perps-tutorial-lets-go-button"
-        >
-          {t('perpsTutorialLetsGo')}
-        </Button>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/WatchLiquidationStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/WatchLiquidationStep.tsx
@@ -1,87 +1,32 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import {
-  ButtonLink,
-  ButtonLinkSize,
-  ModalBody,
-} from '../../../../component-library';
-import {
-  setTutorialActiveStep,
-  setTutorialModalOpen,
-  PerpsTutorialStep,
-} from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import ProgressIndicator from '../ProgressIndicator';
 import PerpsTutorialAnimation from '../PerpsTutorialAnimation';
 
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 4;
-
 const WatchLiquidationStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const handleNext = useCallback(() => {
-    dispatch(setTutorialActiveStep(PerpsTutorialStep.CloseAnytime));
-  }, [dispatch]);
-
-  const handleSkip = useCallback(() => {
-    dispatch(setTutorialModalOpen(false));
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-watch-liquidation"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
-
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4 pb-2">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialWatchLiquidationTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialWatchLiquidationDescription')}
-        </Text>
-        <Box
-          className="flex-1 flex items-center justify-center w-full"
-          data-testid="perps-tutorial-step-image"
-        >
-          <PerpsTutorialAnimation artboardName="03_Liquidation" />
-        </Box>
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialWatchLiquidationTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialWatchLiquidationDescription')}
+      </Text>
+      <Box
+        className="flex-1 flex items-center justify-center w-full"
+        data-testid="perps-tutorial-step-image"
+      >
+        <PerpsTutorialAnimation artboardName="03_Liquidation" />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleNext}
-          className="w-full"
-          data-testid="perps-tutorial-continue-button"
-        >
-          {t('perpsTutorialContinue')}
-        </Button>
-        <ButtonLink
-          size={ButtonLinkSize.Md}
-          onClick={handleSkip}
-          className="w-full justify-center"
-          data-testid="perps-tutorial-skip-button"
-        >
-          {t('perpsTutorialSkip')}
-        </ButtonLink>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.test.tsx
@@ -1,23 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { PerpsTutorialStep } from '../../../../../ducks/perps';
 import WhatArePerpsStep from './WhatArePerpsStep';
-
-const mockDispatch = jest.fn();
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => mockDispatch,
-}));
 
 jest.mock('../../../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string) => key,
-}));
-
-jest.mock('../../../../../hooks/useTheme', () => ({
-  useTheme: () => 'light',
 }));
 
 const mockStore = configureStore([]);
@@ -81,73 +69,17 @@ describe('WhatArePerpsStep', () => {
       );
     });
 
-    it('renders the continue button', () => {
+    it('renders decorative image with empty alt text for accessibility', () => {
       render(
         <Provider store={store}>
           <WhatArePerpsStep />
         </Provider>,
       );
 
-      expect(
-        screen.getByTestId('perps-tutorial-continue-button'),
-      ).toBeInTheDocument();
-    });
-
-    it('renders the skip button', () => {
-      render(
-        <Provider store={store}>
-          <WhatArePerpsStep />
-        </Provider>,
-      );
-
-      expect(
-        screen.getByTestId('perps-tutorial-skip-button'),
-      ).toBeInTheDocument();
-    });
-
-    it('renders the progress indicator', () => {
-      render(
-        <Provider store={store}>
-          <WhatArePerpsStep />
-        </Provider>,
-      );
-
-      // Progress indicator should be rendered
-      expect(
-        screen.getByTestId('perps-tutorial-progress-indicator'),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('navigation', () => {
-    it('dispatches setTutorialActiveStep when continue is clicked', () => {
-      render(
-        <Provider store={store}>
-          <WhatArePerpsStep />
-        </Provider>,
-      );
-
-      fireEvent.click(screen.getByTestId('perps-tutorial-continue-button'));
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'perpsTutorial/setTutorialActiveStep',
-        payload: PerpsTutorialStep.GoLongOrShort,
-      });
-    });
-
-    it('dispatches setTutorialModalOpen(false) when skip is clicked', () => {
-      render(
-        <Provider store={store}>
-          <WhatArePerpsStep />
-        </Provider>,
-      );
-
-      fireEvent.click(screen.getByTestId('perps-tutorial-skip-button'));
-
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'perpsTutorial/setTutorialModalOpen',
-        payload: false,
-      });
+      const image = screen
+        .getByTestId('perps-tutorial-step-image')
+        .querySelector('img');
+      expect(image).toHaveAttribute('alt', '');
     });
   });
 

--- a/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
@@ -11,7 +11,7 @@ const WhatArePerpsStep: React.FC = () => {
 
   return (
     <Box
-      className="flex-1 flex flex-col items-center px-6 pt-4"
+      className="flex-1 flex flex-col items-center px-6 pt-4 pb-2"
       data-testid="perps-tutorial-what-are-perps"
     >
       <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">

--- a/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
@@ -1,111 +1,56 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
-import {
-  ButtonLink,
-  ButtonLinkSize,
-  ModalBody,
-} from '../../../../component-library';
-import {
-  setTutorialActiveStep,
-  setTutorialModalOpen,
-  PerpsTutorialStep,
-} from '../../../../../ducks/perps';
+import React from 'react';
+import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 // eslint-disable-next-line import/no-restricted-paths
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../../shared/constants/app';
-import ProgressIndicator from '../ProgressIndicator';
-
-const TOTAL_STEPS = 6;
-const CURRENT_STEP = 1;
 
 const WhatArePerpsStep: React.FC = () => {
-  const dispatch = useDispatch();
   const t = useI18nContext();
   const isPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP;
 
-  const handleNext = useCallback(() => {
-    dispatch(setTutorialActiveStep(PerpsTutorialStep.GoLongOrShort));
-  }, [dispatch]);
-
-  const handleSkip = useCallback(() => {
-    dispatch(setTutorialModalOpen(false));
-  }, [dispatch]);
-
   return (
-    <ModalBody
-      className="w-full h-full pt-6 pb-4 flex flex-col"
+    <Box
+      className="flex-1 flex flex-col items-center px-6 pt-4"
       data-testid="perps-tutorial-what-are-perps"
     >
-      <ProgressIndicator totalSteps={TOTAL_STEPS} currentStep={CURRENT_STEP} />
+      <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
+        {t('perpsTutorialWhatArePerpsTitle')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full"
+      >
+        {t('perpsTutorialWhatArePerpsDescription')}
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        className="text-left text-alternative w-full mt-2"
+      >
+        {t('perpsTutorialWhatArePerpsSubtitle')}
+      </Text>
 
-      <Box className="flex-1 flex flex-col items-center px-6 pt-4">
-        <Text variant={TextVariant.HeadingLg} className="text-left mb-2 w-full">
-          {t('perpsTutorialWhatArePerpsTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full"
-        >
-          {t('perpsTutorialWhatArePerpsDescription')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-left text-alternative w-full mt-2"
-        >
-          {t('perpsTutorialWhatArePerpsSubtitle')}
-        </Text>
-
-        <Box
-          data-testid="perps-tutorial-step-image"
+      <Box
+        data-testid="perps-tutorial-step-image"
+        style={{
+          height: isPopup ? 180 : 280,
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <img
+          src="./images/perps-character.png"
+          alt=""
           style={{
+            width: isPopup ? 180 : 280,
             height: isPopup ? 180 : 280,
-            width: '100%',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
+            objectFit: 'contain',
           }}
-        >
-          <img
-            src="./images/perps-character.png"
-            alt=""
-            style={{
-              width: isPopup ? 180 : 280,
-              height: isPopup ? 180 : 280,
-              objectFit: 'contain',
-            }}
-          />
-        </Box>
+        />
       </Box>
-
-      <Box className="flex flex-col gap-2 px-4">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleNext}
-          className="w-full"
-          data-testid="perps-tutorial-continue-button"
-        >
-          {t('perpsTutorialContinue')}
-        </Button>
-        <ButtonLink
-          size={ButtonLinkSize.Md}
-          onClick={handleSkip}
-          className="w-full justify-center"
-          data-testid="perps-tutorial-skip-button"
-        >
-          {t('perpsTutorialSkip')}
-        </ButtonLink>
-      </Box>
-    </ModalBody>
+    </Box>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Refactors the Perps tutorial modal to align with the mobile implementation pattern and improves the Skip button styling.
Reason for change:

  - Skip button was using ButtonLink which is semantically incorrect (Skip is an action, not a navigation link) and had unwanted blue hover styling
  - Footer buttons (Continue/Skip) were duplicated across all 6 step components, making styling changes require edits to multiple files

Solution:
  - Created shared TutorialFooter component with Continue and Skip buttons, matching mobile's single-footer architecture
  - Changed Skip button from ButtonLink to Button with ButtonVariant.Tertiary for correct semantics
  - Applied text-default class to Skip button for white text (per designer request)
  - Moved ProgressIndicator and footer to parent PerpsTutorialModal, simplifying step components to content-only
  - Added comprehensive test coverage for TutorialFooter and PerpsTutorialModal navigation logic
  - Updated mobile Skip button to use TextColor.Default for consistency

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40174?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Refactors the Perps tutorial modal to align with the mobile implementation pattern

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask extension and navigate to a page that triggers the Perps tutorial modal
2. Verify the Skip button appears with white text (not blue) on steps 1-5
3. Hover over the Skip button and confirm it does NOT turn blue
4. Click Continue to advance through all 6 steps, verifying:
5. Progress indicator updates correctly
6. Skip button is hidden on step 6 (Ready to Trade)
7. Button text changes from "Continue" to "Let's Go" on step 6
8. Restart tutorial and click Skip - verify modal closes
9. Test in all three view modes: popup, side panel, and fullscreen
10. Verify no visual regressions to animations or layout

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/f90f60ba-2b2d-4453-be8a-9c6f46ca6711



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor consolidating tutorial navigation into the modal and adjusting button styling; main risk is minor UX/regression in step progression/closing, mitigated by added tests.
> 
> **Overview**
> Refactors the Perps tutorial modal so navigation is controlled centrally: `ProgressIndicator` and a new shared `TutorialFooter` now live in `PerpsTutorialModal`, with step components reduced to content-only.
> 
> Updates the Skip action to be a proper `Button` (`Tertiary`) with `text-default` styling, hides Skip on the last step, and changes the primary CTA to "Let’s Go" on the final step while continuing to advance steps using `TUTORIAL_STEPS_ORDER`.
> 
> Adds new unit tests for `PerpsTutorialModal` and `TutorialFooter`, and trims step tests to remove per-step button/dispatch assertions now handled by the modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b09b22fa4e88686a05e788bb08ab42dd8c5270ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->