### PR TITLE
feat: add `rpc_method_name`, `type` and `retry_reason` to `degraded` RPC endpoint Segment events

### DIFF
--- a/app/scripts/controller-init/network-controller-init.ts
+++ b/app/scripts/controller-init/network-controller-init.ts
@@ -268,13 +268,12 @@ export const NetworkControllerInit: ControllerInitFunction<
 
   initMessenger.subscribe(
     'NetworkController:rpcEndpointUnavailable',
-    async ({ chainId, endpointUrl, error, rpcMethodName }) => {
+    async ({ chainId, endpointUrl, error }) => {
       onRpcEndpointUnavailable({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
-        rpcMethodName,
         trackEvent: initMessenger.call.bind(
           initMessenger,
           'MetaMetricsController:trackEvent',

--- a/app/scripts/controller-init/network-controller-init.ts
+++ b/app/scripts/controller-init/network-controller-init.ts
@@ -268,12 +268,13 @@ export const NetworkControllerInit: ControllerInitFunction<
 
   initMessenger.subscribe(
     'NetworkController:rpcEndpointUnavailable',
-    async ({ chainId, endpointUrl, error }) => {
+    async ({ chainId, endpointUrl, error, rpcMethodName }) => {
       onRpcEndpointUnavailable({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
+        rpcMethodName,
         trackEvent: initMessenger.call.bind(
           initMessenger,
           'MetaMetricsController:trackEvent',
@@ -287,12 +288,13 @@ export const NetworkControllerInit: ControllerInitFunction<
 
   initMessenger.subscribe(
     'NetworkController:rpcEndpointDegraded',
-    async ({ chainId, endpointUrl, error }) => {
+    async ({ chainId, endpointUrl, error, rpcMethodName }) => {
       onRpcEndpointDegraded({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
+        rpcMethodName,
         trackEvent: initMessenger.call.bind(
           initMessenger,
           'MetaMetricsController:trackEvent',

--- a/app/scripts/controller-init/network-controller-init.ts
+++ b/app/scripts/controller-init/network-controller-init.ts
@@ -287,12 +287,20 @@ export const NetworkControllerInit: ControllerInitFunction<
 
   initMessenger.subscribe(
     'NetworkController:rpcEndpointDegraded',
-    async ({ chainId, endpointUrl, error, rpcMethodName }) => {
+    async ({
+      chainId,
+      endpointUrl,
+      error,
+      rpcMethodName,
+      type,
+      retryReason,
+    }) => {
       onRpcEndpointDegraded({
         chainId,
         endpointUrl,
         error,
         infuraProjectId,
+        retryReason,
         rpcMethodName,
         trackEvent: initMessenger.call.bind(
           initMessenger,
@@ -301,6 +309,7 @@ export const NetworkControllerInit: ControllerInitFunction<
         metaMetricsId: initMessenger.call(
           'MetaMetricsController:getMetaMetricsId',
         ),
+        type,
       });
     },
   );

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -37,7 +37,6 @@ describe('onRpcEndpointUnavailable', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
-      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -61,7 +60,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -76,7 +74,6 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -92,7 +89,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -108,7 +104,6 @@ describe('onRpcEndpointUnavailable', () => {
           http_status: 420,
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -124,7 +119,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://custom-endpoint.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -139,7 +133,6 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
-          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -156,7 +149,6 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
-        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -193,7 +193,7 @@ describe('onRpcEndpointDegraded', () => {
       rpcMethodName: 'eth_blockNumber',
       trackEvent,
       type: 'retries_exhausted',
-      retryReason: 'non_successful_response',
+      retryReason: 'non_successful_http_status',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -252,7 +252,7 @@ describe('onRpcEndpointDegraded', () => {
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
         type: 'retries_exhausted',
-        retryReason: 'non_successful_response',
+        retryReason: 'non_successful_http_status',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -266,7 +266,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           degraded_event_type: 'retries_exhausted',
           http_status: 420,
-          retry_reason: 'non_successful_response',
+          retry_reason: 'non_successful_http_status',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
           rpc_method_name: 'eth_blockNumber',

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -37,6 +37,7 @@ describe('onRpcEndpointUnavailable', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
+      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -60,6 +61,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -74,6 +76,7 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -89,6 +92,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -104,6 +108,7 @@ describe('onRpcEndpointUnavailable', () => {
           http_status: 420,
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -119,6 +124,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://custom-endpoint.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -133,6 +139,7 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -149,6 +156,7 @@ describe('onRpcEndpointUnavailable', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -190,6 +198,7 @@ describe('onRpcEndpointDegraded', () => {
       endpointUrl: 'https://example.com',
       error: new HttpError(420),
       infuraProjectId: 'the-infura-project-id',
+      rpcMethodName: 'eth_blockNumber',
       trackEvent,
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -213,6 +222,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -227,6 +237,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -242,6 +253,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: new HttpError(420),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -257,6 +269,7 @@ describe('onRpcEndpointDegraded', () => {
           http_status: 420,
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -272,6 +285,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://custom-endpoint.com',
         error: undefined,
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
@@ -286,6 +300,7 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
+          rpc_method_name: 'eth_blockNumber',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -302,6 +317,7 @@ describe('onRpcEndpointDegraded', () => {
         endpointUrl: 'https://example.com',
         error: new Error('some error'),
         infuraProjectId: 'the-infura-project-id',
+        rpcMethodName: 'eth_blockNumber',
         trackEvent,
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -192,6 +192,8 @@ describe('onRpcEndpointDegraded', () => {
       infuraProjectId: 'the-infura-project-id',
       rpcMethodName: 'eth_blockNumber',
       trackEvent,
+      type: 'retries_exhausted',
+      retryReason: 'non_successful_response',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -216,6 +218,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'slow_success',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -227,6 +230,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'slow_success',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -247,6 +251,8 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'retries_exhausted',
+        retryReason: 'non_successful_response',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -258,7 +264,9 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'retries_exhausted',
           http_status: 420,
+          retry_reason: 'non_successful_response',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -279,6 +287,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'slow_success',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });
@@ -290,6 +299,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
+          degraded_event_type: 'slow_success',
           rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
           rpc_method_name: 'eth_blockNumber',
@@ -311,6 +321,7 @@ describe('onRpcEndpointDegraded', () => {
         infuraProjectId: 'the-infura-project-id',
         rpcMethodName: 'eth_blockNumber',
         trackEvent,
+        type: 'retries_exhausted',
         metaMetricsId:
           '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
       });

--- a/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.test.ts
@@ -230,7 +230,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'slow_success',
+          type: 'slow_success',
           rpc_domain: 'example.com',
           rpc_endpoint_url: 'example.com',
           rpc_method_name: 'eth_blockNumber',
@@ -264,7 +264,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'retries_exhausted',
+          type: 'retries_exhausted',
           http_status: 420,
           retry_reason: 'non_successful_http_status',
           rpc_domain: 'example.com',
@@ -299,7 +299,7 @@ describe('onRpcEndpointDegraded', () => {
         event: 'RPC Service Degraded',
         properties: {
           chain_id_caip: 'eip155:11155111',
-          degraded_event_type: 'slow_success',
+          type: 'slow_success',
           rpc_domain: 'custom',
           rpc_endpoint_url: 'custom',
           rpc_method_name: 'eth_blockNumber',

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -178,7 +178,7 @@ export function trackRpcEndpointEvent(
     rpc_domain: sanitizedUrl,
     rpc_endpoint_url: sanitizedUrl, // @deprecated - Will be removed in a future release.
     ...(rpcMethodName ? { rpc_method_name: rpcMethodName } : {}),
-    ...(type ? { degraded_event_type: type } : {}),
+    ...(type ? { type } : {}),
     ...(retryReason ? { retry_reason: retryReason } : {}),
     ...(isObject(error) &&
     'httpStatus' in error &&

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -1,4 +1,8 @@
 import log from 'loglevel';
+import type {
+  DegradedEventType,
+  RetryReason,
+} from '@metamask/network-controller';
 import { type Hex, hexToNumber, isObject, isValidJson } from '@metamask/utils';
 import {
   MetaMetricsEventCategory,
@@ -69,8 +73,12 @@ export function onRpcEndpointUnavailable({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.retryReason - The category of error that was retried (only
+ * present when `type` is `'retries_exhausted'`).
  * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
+ * @param args.type - Why the endpoint became degraded (`'slow_success'` or
+ * `'retries_exhausted'`).
  */
 export function onRpcEndpointDegraded({
   chainId,
@@ -78,16 +86,20 @@ export function onRpcEndpointDegraded({
   error,
   infuraProjectId,
   metaMetricsId,
+  retryReason,
   rpcMethodName,
   trackEvent,
+  type,
 }: {
   chainId: Hex;
   endpointUrl: string;
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
+  retryReason?: RetryReason;
   rpcMethodName: string;
   trackEvent: MetaMetricsController['trackEvent'];
+  type: DegradedEventType;
 }): void {
   trackRpcEndpointEvent(MetaMetricsEventName.RpcServiceDegraded, {
     chainId,
@@ -95,8 +107,10 @@ export function onRpcEndpointDegraded({
     error,
     infuraProjectId,
     metaMetricsId,
+    retryReason,
     rpcMethodName,
     trackEvent,
+    type,
   });
 }
 
@@ -112,9 +126,13 @@ export function onRpcEndpointDegraded({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.retryReason - The category of error that was retried (only
+ * present for degraded events when `type` is `'retries_exhausted'`).
  * @param args.rpcMethodName - The JSON-RPC method that was being executed
  * (only present for degraded events).
  * @param args.trackEvent - The function that will create the Segment event.
+ * @param args.type - Why the endpoint became degraded (only present for
+ * degraded events).
  */
 export function trackRpcEndpointEvent(
   event: string,
@@ -123,16 +141,20 @@ export function trackRpcEndpointEvent(
     endpointUrl,
     error,
     infuraProjectId,
+    retryReason,
     rpcMethodName,
     trackEvent,
+    type,
     metaMetricsId,
   }: {
     chainId: Hex;
     endpointUrl: string;
     error: unknown;
     infuraProjectId: string;
+    retryReason?: RetryReason;
     rpcMethodName?: string;
     trackEvent: MetaMetricsController['trackEvent'];
+    type?: DegradedEventType;
     metaMetricsId: string | null | undefined;
   },
 ): void {
@@ -156,6 +178,8 @@ export function trackRpcEndpointEvent(
     rpc_domain: sanitizedUrl,
     rpc_endpoint_url: sanitizedUrl, // @deprecated - Will be removed in a future release.
     ...(rpcMethodName ? { rpc_method_name: rpcMethodName } : {}),
+    ...(type ? { degraded_event_type: type } : {}),
+    ...(retryReason ? { retry_reason: retryReason } : {}),
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -26,7 +26,6 @@ import { shouldCreateRpcServiceEvents } from './utils';
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
- * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointUnavailable({
@@ -35,7 +34,6 @@ export function onRpcEndpointUnavailable({
   error,
   infuraProjectId,
   metaMetricsId,
-  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -43,7 +41,6 @@ export function onRpcEndpointUnavailable({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
-  rpcMethodName: string;
   trackEvent: MetaMetricsController['trackEvent'];
 }): void {
   trackRpcEndpointEvent(MetaMetricsEventName.RpcServiceUnavailable, {
@@ -52,7 +49,6 @@ export function onRpcEndpointUnavailable({
     error,
     infuraProjectId,
     metaMetricsId,
-    rpcMethodName,
     trackEvent,
   });
 }
@@ -116,7 +112,8 @@ export function onRpcEndpointDegraded({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
- * @param args.rpcMethodName - The JSON-RPC method that was being executed.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed
+ * (only present for degraded events).
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function trackRpcEndpointEvent(
@@ -134,7 +131,7 @@ export function trackRpcEndpointEvent(
     endpointUrl: string;
     error: unknown;
     infuraProjectId: string;
-    rpcMethodName: string;
+    rpcMethodName?: string;
     trackEvent: MetaMetricsController['trackEvent'];
     metaMetricsId: string | null | undefined;
   },
@@ -158,7 +155,7 @@ export function trackRpcEndpointEvent(
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
     rpc_domain: sanitizedUrl,
     rpc_endpoint_url: sanitizedUrl, // @deprecated - Will be removed in a future release.
-    rpc_method_name: rpcMethodName,
+    ...(rpcMethodName ? { rpc_method_name: rpcMethodName } : {}),
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/app/scripts/lib/network-controller/messenger-action-handlers.ts
+++ b/app/scripts/lib/network-controller/messenger-action-handlers.ts
@@ -26,6 +26,7 @@ import { shouldCreateRpcServiceEvents } from './utils';
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointUnavailable({
@@ -34,6 +35,7 @@ export function onRpcEndpointUnavailable({
   error,
   infuraProjectId,
   metaMetricsId,
+  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -41,6 +43,7 @@ export function onRpcEndpointUnavailable({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
+  rpcMethodName: string;
   trackEvent: MetaMetricsController['trackEvent'];
 }): void {
   trackRpcEndpointEvent(MetaMetricsEventName.RpcServiceUnavailable, {
@@ -49,6 +52,7 @@ export function onRpcEndpointUnavailable({
     error,
     infuraProjectId,
     metaMetricsId,
+    rpcMethodName,
     trackEvent,
   });
 }
@@ -69,6 +73,7 @@ export function onRpcEndpointUnavailable({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function onRpcEndpointDegraded({
@@ -77,6 +82,7 @@ export function onRpcEndpointDegraded({
   error,
   infuraProjectId,
   metaMetricsId,
+  rpcMethodName,
   trackEvent,
 }: {
   chainId: Hex;
@@ -84,6 +90,7 @@ export function onRpcEndpointDegraded({
   error: unknown;
   infuraProjectId: string;
   metaMetricsId: string | null | undefined;
+  rpcMethodName: string;
   trackEvent: MetaMetricsController['trackEvent'];
 }): void {
   trackRpcEndpointEvent(MetaMetricsEventName.RpcServiceDegraded, {
@@ -92,6 +99,7 @@ export function onRpcEndpointDegraded({
     error,
     infuraProjectId,
     metaMetricsId,
+    rpcMethodName,
     trackEvent,
   });
 }
@@ -108,6 +116,7 @@ export function onRpcEndpointDegraded({
  * a request to the RPC endpoint.
  * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
+ * @param args.rpcMethodName - The JSON-RPC method that was being executed.
  * @param args.trackEvent - The function that will create the Segment event.
  */
 export function trackRpcEndpointEvent(
@@ -117,6 +126,7 @@ export function trackRpcEndpointEvent(
     endpointUrl,
     error,
     infuraProjectId,
+    rpcMethodName,
     trackEvent,
     metaMetricsId,
   }: {
@@ -124,6 +134,7 @@ export function trackRpcEndpointEvent(
     endpointUrl: string;
     error: unknown;
     infuraProjectId: string;
+    rpcMethodName: string;
     trackEvent: MetaMetricsController['trackEvent'];
     metaMetricsId: string | null | undefined;
   },
@@ -147,6 +158,7 @@ export function trackRpcEndpointEvent(
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
     rpc_domain: sanitizedUrl,
     rpc_endpoint_url: sanitizedUrl, // @deprecated - Will be removed in a future release.
+    rpc_method_name: rpcMethodName,
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,35 +1779,6 @@
       }
     },
     "@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/network-enablement-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,6 +1779,122 @@
       }
     },
     "@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/network-enablement-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2567,7 +2683,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,35 +1779,6 @@
       }
     },
     "@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/network-enablement-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,6 +1779,122 @@
       }
     },
     "@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/network-enablement-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2567,7 +2683,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,35 +1779,6 @@
       }
     },
     "@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/network-enablement-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,6 +1779,122 @@
       }
     },
     "@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/network-enablement-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2567,7 +2683,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,35 +1779,6 @@
       }
     },
     "@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1737,7 +1737,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-controller": true,
+        "@metamask/network-enablement-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1779,6 +1779,122 @@
       }
     },
     "@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/network-enablement-controller>@metamask/network-controller": {
+      "globals": {
+        "Intl.NumberFormat": true,
+        "URL": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/connectivity-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/network-controller>@metamask/eth-block-tracker": true,
+        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
+        "@metamask/eth-json-rpc-middleware": true,
+        "@metamask/eth-json-rpc-provider": true,
+        "@metamask/controller-utils>@metamask/eth-query": true,
+        "@metamask/json-rpc-engine": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/utils": true,
+        "cockatiel": true,
+        "addons-linter>deepmerge": true,
+        "eslint>fast-deep-equal": true,
+        "immer": true,
+        "lodash": true,
+        "reselect": true,
+        "uri-js": true,
+        "uuid": true
+      }
+    },
+    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2567,7 +2683,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/network-controller": true,
+        "@metamask/transaction-controller>@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@ledgerhq/hw-transport-webhid@npm:^6.31.0": "patch:@ledgerhq/hw-transport-webhid@npm%3A6.31.0#~/.yarn/patches/@ledgerhq-hw-transport-webhid-npm-6.31.0-efbecf27ab.patch",
     "fast-xml-parser": "^5.3.6",
     "@metamask/snaps-controllers": "^18.0.0",
-    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3"
+    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",

--- a/package.json
+++ b/package.json
@@ -813,5 +813,11 @@
       }
     },
     "version": "v0.3.0"
+  },
+  "previewBuilds": {
+    "@metamask/network-controller": {
+      "type": "non-breaking",
+      "previewVersion": "29.0.0-preview-33dbba4f3"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -250,8 +250,7 @@
     "@metamask/bridge-status-controller": "64.3.0",
     "@ledgerhq/hw-transport-webhid@npm:^6.31.0": "patch:@ledgerhq/hw-transport-webhid@npm%3A6.31.0#~/.yarn/patches/@ledgerhq-hw-transport-webhid-npm-6.31.0-efbecf27ab.patch",
     "fast-xml-parser": "^5.3.6",
-    "@metamask/snaps-controllers": "^18.0.0",
-    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-1821148"
+    "@metamask/snaps-controllers": "^18.0.0"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",
@@ -349,7 +348,7 @@
     "@metamask/multichain-network-controller": "^2.0.0",
     "@metamask/multichain-transactions-controller": "^6.0.0",
     "@metamask/name-controller": "^9.0.0",
-    "@metamask/network-controller": "^29.0.0",
+    "@metamask/network-controller": "^30.0.0",
     "@metamask/network-enablement-controller": "^4.1.0",
     "@metamask/notification-services-controller": "^22.0.0",
     "@metamask/object-multiplex": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "@metamask/bridge-status-controller": "64.3.0",
     "@ledgerhq/hw-transport-webhid@npm:^6.31.0": "patch:@ledgerhq/hw-transport-webhid@npm%3A6.31.0#~/.yarn/patches/@ledgerhq-hw-transport-webhid-npm-6.31.0-efbecf27ab.patch",
     "fast-xml-parser": "^5.3.6",
-    "@metamask/snaps-controllers": "^18.0.0"
+    "@metamask/snaps-controllers": "^18.0.0",
+    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",
@@ -813,11 +814,5 @@
       }
     },
     "version": "v0.3.0"
-  },
-  "previewBuilds": {
-    "@metamask/network-controller": {
-      "type": "non-breaking",
-      "previewVersion": "29.0.0-preview-33dbba4f3"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@ledgerhq/hw-transport-webhid@npm:^6.31.0": "patch:@ledgerhq/hw-transport-webhid@npm%3A6.31.0#~/.yarn/patches/@ledgerhq-hw-transport-webhid-npm-6.31.0-efbecf27ab.patch",
     "fast-xml-parser": "^5.3.6",
     "@metamask/snaps-controllers": "^18.0.0",
-    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666"
+    "@metamask/network-controller": "npm:@metamask-previews/network-controller@29.0.0-preview-1821148"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6622,7 +6622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^23.0.0, @metamask/eth-json-rpc-middleware@npm:^23.1.0":
+"@metamask/eth-json-rpc-middleware@npm:^23.1.0":
   version: 23.1.0
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.0"
   dependencies:
@@ -7063,9 +7063,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^10.0.0, @metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.0, @metamask/json-rpc-engine@npm:^10.2.1":
-  version: 10.2.1
-  resolution: "@metamask/json-rpc-engine@npm:10.2.1"
+"@metamask/json-rpc-engine@npm:^10.0.0, @metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.0.3, @metamask/json-rpc-engine@npm:^10.1.0, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.0, @metamask/json-rpc-engine@npm:^10.2.1, @metamask/json-rpc-engine@npm:^10.2.2":
+  version: 10.2.2
+  resolution: "@metamask/json-rpc-engine@npm:10.2.2"
   dependencies:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
@@ -7073,7 +7073,7 @@ __metadata:
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
     klona: "npm:^2.0.6"
-  checksum: 10/f218065b6fe2354c79f9ffc8780fd86a781f75b9a5f1a2fceb277d44d13e48a216bdcdca14e8a5be76dffa2b63cb321631bc49dc259d54bd71fe3ffeb4a593af
+  checksum: 10/e2449e80f8ca3aed58d0778c220eba6c98e0848359da2703bcb68879c1b315774a1a8a90b2a7cd8d3eb3e0f022f9d0e30503e75a2645ec32cbfc5ba2e537f807
   languageName: node
   linkType: hard
 
@@ -7676,6 +7676,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3":
+  version: 29.0.0-preview-33dbba4f3
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-33dbba4f3"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^23.1.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.2"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/bdacf157bb1c4fd6391cd0f98ccd58a881bbaf2192d3ef33a6c9b7a806ae1fcb6a5f590e1392846313cee737dfdfd7e5b7a9ee2d1af795ca904e43dc32535581
+  languageName: node
+  linkType: hard
+
 "@metamask/network-controller@npm:^27.0.0, @metamask/network-controller@npm:^27.1.0":
   version: 27.2.0
   resolution: "@metamask/network-controller@npm:27.2.0"
@@ -7700,34 +7728,6 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
-  languageName: node
-  linkType: hard
-
-"@metamask/network-controller@npm:^29.0.0":
-  version: 29.0.0
-  resolution: "@metamask/network-controller@npm:29.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/connectivity-controller": "npm:^0.1.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^23.0.0"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.1"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    immer: "npm:^9.0.6"
-    loglevel: "npm:^1.8.1"
-    reselect: "npm:^5.1.1"
-    uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/873a68a3c5012f84c925a868aac2741bd1de7c047f3696874cabd911f5632acb162e07210c345447ed9765f94a2c33e034e589ff1f59ce92b09b6e29d68c5940
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,7 +6551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^15.0.0, @metamask/eth-block-tracker@npm:^15.0.1":
+"@metamask/eth-block-tracker@npm:^15.0.1":
   version: 15.0.1
   resolution: "@metamask/eth-block-tracker@npm:15.0.1"
   dependencies:
@@ -6600,25 +6600,6 @@ __metadata:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.0.1"
   checksum: 10/164c9ef1285a0895db668f3949d9258df721d348c857c4337b964f147000221d69fd103851c6483d8dd6bfe851c76cc5299155a8818eac0b92334469c40ccaef
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-json-rpc-middleware@npm:^22.0.1":
-  version: 22.0.1
-  resolution: "@metamask/eth-json-rpc-middleware@npm:22.0.1"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.0"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.0"
-    "@metamask/message-manager": "npm:^14.1.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.8.1"
-    klona: "npm:^2.0.6"
-    pify: "npm:^5.0.0"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/1cb47dad7eaeb104b8b8a8b25e5d36cee04c40bbe0db0a8bfa41f8abb6be4602ebb061bcadf548d22d34f0df581cf3ec64e11cb1434e653fd4cc22617d41440a
   languageName: node
   linkType: hard
 
@@ -7701,33 +7682,6 @@ __metadata:
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
   checksum: 10/bdacf157bb1c4fd6391cd0f98ccd58a881bbaf2192d3ef33a6c9b7a806ae1fcb6a5f590e1392846313cee737dfdfd7e5b7a9ee2d1af795ca904e43dc32535581
-  languageName: node
-  linkType: hard
-
-"@metamask/network-controller@npm:^27.0.0, @metamask/network-controller@npm:^27.1.0":
-  version: 27.2.0
-  resolution: "@metamask/network-controller@npm:27.2.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/eth-block-tracker": "npm:^15.0.0"
-    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.2.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    fast-deep-equal: "npm:^3.1.3"
-    immer: "npm:^9.0.6"
-    loglevel: "npm:^1.8.1"
-    reselect: "npm:^5.1.1"
-    uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7657,9 +7657,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-33dbba4f3":
-  version: 29.0.0-preview-33dbba4f3
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-33dbba4f3"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666":
+  version: 29.0.0-preview-d9075b666
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-d9075b666"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
@@ -7681,7 +7681,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/bdacf157bb1c4fd6391cd0f98ccd58a881bbaf2192d3ef33a6c9b7a806ae1fcb6a5f590e1392846313cee737dfdfd7e5b7a9ee2d1af795ca904e43dc32535581
+  checksum: 10/71719a65a64f390dae1eeb62587cddbefb108c5ed1fe108fbc97fc40f7d0f949efd8c427271faa5ce28eac3b19415011a77a47a281abb8c3c6fad2a297f8cadf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,9 +6224,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.3.0":
-  version: 11.18.0
-  resolution: "@metamask/controller-utils@npm:11.18.0"
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.17.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.19.0, @metamask/controller-utils@npm:^11.3.0":
+  version: 11.19.0
+  resolution: "@metamask/controller-utils@npm:11.19.0"
   dependencies:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
@@ -6241,7 +6241,7 @@ __metadata:
     lodash: "npm:^4.17.21"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 10/0c96701e3639b887c51c02416158bfeef42bf80701a4ca0d1ad2c888a370ccd9a6f2cb4677ef075a17a341c0dc9135e91c4f3079a7d498d9368d2f5e6fdf5d1b
+  checksum: 10/d66ff170a6c2fb5726aa34c94e4870d79e96737043d3450f87d34eec8b24209b27a09df9935aad9e3e5bb685ebb3ee2c918e6d4cfbeec497c2fa823a177fc227
   languageName: node
   linkType: hard
 
@@ -6551,7 +6551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^15.0.1":
+"@metamask/eth-block-tracker@npm:^15.0.0, @metamask/eth-block-tracker@npm:^15.0.1":
   version: 15.0.1
   resolution: "@metamask/eth-block-tracker@npm:15.0.1"
   dependencies:
@@ -6603,7 +6603,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^23.1.0":
+"@metamask/eth-json-rpc-middleware@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:22.0.1"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.0"
+    "@metamask/message-manager": "npm:^14.1.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.8.1"
+    klona: "npm:^2.0.6"
+    pify: "npm:^5.0.0"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/1cb47dad7eaeb104b8b8a8b25e5d36cee04c40bbe0db0a8bfa41f8abb6be4602ebb061bcadf548d22d34f0df581cf3ec64e11cb1434e653fd4cc22617d41440a
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-middleware@npm:^23.0.0, @metamask/eth-json-rpc-middleware@npm:^23.1.0":
   version: 23.1.0
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.0"
   dependencies:
@@ -7657,13 +7676,68 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-1821148":
-  version: 29.0.0-preview-1821148
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-1821148"
+"@metamask/network-controller@npm:^27.0.0, @metamask/network-controller@npm:^27.1.0":
+  version: 27.2.0
+  resolution: "@metamask/network-controller@npm:27.2.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.0"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^22.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/52f9523b30d1136c3a8cd466bf81bbf0ca5e9399ecc8b256054a09597940b1bddecb2bc117ba8f1872ba0b0dc55537521d2cbf2fb1b4c1aa741322879b2f7ba8
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@metamask/network-controller@npm:29.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
     "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^23.0.0"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.2.1"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/swappable-obj-proxy": "npm:^2.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    reselect: "npm:^5.1.1"
+    uri-js: "npm:^4.4.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/873a68a3c5012f84c925a868aac2741bd1de7c047f3696874cabd911f5632acb162e07210c345447ed9765f94a2c33e034e589ff1f59ce92b09b6e29d68c5940
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^30.0.0":
+  version: 30.0.0
+  resolution: "@metamask/network-controller@npm:30.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/eth-block-tracker": "npm:^15.0.1"
     "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
     "@metamask/eth-json-rpc-middleware": "npm:^23.1.0"
@@ -7681,7 +7755,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/17137c892c948750f21d94e98a33518e089fdc63f9a431e577cef0d8d50687595ca223070d72bec75029a7103283ccc5151a25b3c02757cd960b68b5d1a93901
+  checksum: 10/3f16a1be8f35995147580c23d5fa977c7ac5e231662ac43a75ea8bedea6b2039261bcfaac399a1a9f3dc310eed1f1f4896dcb0ff634add2597da519432789710
   languageName: node
   linkType: hard
 
@@ -33709,7 +33783,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^2.0.0"
     "@metamask/multichain-transactions-controller": "npm:^6.0.0"
     "@metamask/name-controller": "npm:^9.0.0"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/network-enablement-controller": "npm:^4.1.0"
     "@metamask/notification-services-controller": "npm:^22.0.0"
     "@metamask/object-multiplex": "npm:^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7657,9 +7657,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-d9075b666":
-  version: 29.0.0-preview-d9075b666
-  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-d9075b666"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@29.0.0-preview-1821148":
+  version: 29.0.0-preview-1821148
+  resolution: "@metamask-previews/network-controller@npm:29.0.0-preview-1821148"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
@@ -7681,7 +7681,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/71719a65a64f390dae1eeb62587cddbefb108c5ed1fe108fbc97fc40f7d0f949efd8c427271faa5ce28eac3b19415011a77a47a281abb8c3c6fad2a297f8cadf
+  checksum: 10/17137c892c948750f21d94e98a33518e089fdc63f9a431e577cef0d8d50687595ca223070d72bec75029a7103283ccc5151a25b3c02757cd960b68b5d1a93901
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add `rpc_method_name`, `type` and `retry_reason` to the `RPC Service Degraded` Segment events. This lets us identify which JSON-RPC methods produce the most slow requests or retry exhaustions, enabling better debugging of RPC endpoint health issues.

Consumes the new `rpcMethodName`, `type` and `retryReason` field added to `NetworkController:rpcEndpointDegraded` events in `@metamask/network-controller` (core PR [#7954](https://github.com/MetaMask/core/pull/7954), [#7988](https://github.com/MetaMask/core/pull/7988)).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40176?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-441

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily telemetry/schema changes, but the `@metamask/network-controller` major-version bump plus LavaMoat policy updates could affect runtime behavior or bundling if any dependency allowances are incorrect.
> 
> **Overview**
> `NetworkController:rpcEndpointDegraded` handling is updated to consume new event fields and emit richer `RPC Service Degraded` Segment properties: `rpc_method_name`, degradation `type` (e.g. slow success vs retries exhausted), and optional `retry_reason`.
> 
> This bumps `@metamask/network-controller` to `^30.0.0` (with related lockfile updates) and updates LavaMoat policies to reflect the new dependency graph/package nesting; tests are adjusted to assert the new telemetry properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1861770baf7a18150ccf0fbf0dcb6f101774f660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->