### PR TITLE
chore: Ignore `ajv` advisory

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -37,6 +37,12 @@ npmAuditIgnoreAdvisories:
   # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
   - 1110857
 
+  # Issue: ajv has ReDoS when using `$data` option
+  # A lot of our linting tooling relies on old versions of ajv, which proves hard to deal with
+  # For now, we are ignoring this to unblock CI
+  # URL: https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
+  - 1113214
+
   ### Package Deprecations:
 
   # React-tippy brings in popper.js and react-tippy has not been updated in


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ignore `ajv` ReDoS advisory since we have a lot of linting tooling relying on old versions of it. Since `ajv` is strictly a dev dependency, this vuln does not impact production.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40199?quickstart=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/audit configuration change only; it reduces visibility of a known advisory (primarily affecting dev tooling) but does not change runtime code paths.
> 
> **Overview**
> Updates `.yarnrc.yml` to ignore the `ajv` ReDoS advisory (`1113214` / `GHSA-2g4f-4pwh-qvx6`) in `npmAuditIgnoreAdvisories`, with comments noting this is to unblock CI due to older lint tooling dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52e70c11b504c4bae12d25f006ef4b9eeb348bc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->