### PR TITLE
feat(rewards): hardware wallet support

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Erneut versuchen"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Hardware-Wallet-Konten sind noch nicht zum Empfang von Belohnungen berechtigt. Bitte wechseln Sie zu einem anderen Konto, um fortzufahren."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Konto wird nicht unterstützt"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Erneut versuchen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Επανάληψη"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Οι λογαριασμοί με πορτοφόλι υλικού δεν είναι ακόμη επιλέξιμοι για ανταμοιβές. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Ο λογαριασμός δεν υποστηρίζεται"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Επανάληψη"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6291,9 +6291,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Retry"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Retry"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6294,9 +6294,6 @@
   "rewardsOnboardingIntroHardwareWalletDescription": {
     "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
   },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Account not supported"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Retry"
   },
@@ -6401,8 +6398,16 @@
   "rewardsQRCodeTitle": {
     "message": "Get the mobile app"
   },
+  "rewardsSignInToViewPoints": {
+    "message": "Sign in to view points",
+    "description": "Text shown when user needs to sign in to view their rewards points"
+  },
   "rewardsSignUp": {
     "message": "Sign up for Rewards"
+  },
+  "rewardsSigningIn": {
+    "message": "Signing in...",
+    "description": "Text shown while the user is signing in to view their rewards points"
   },
   "rpcNameOptional": {
     "message": "RPC Name (Optional)"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6291,12 +6291,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Retry"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Account not supported"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Retry"
   },
@@ -6401,8 +6395,16 @@
   "rewardsQRCodeTitle": {
     "message": "Get the mobile app"
   },
+  "rewardsSignInToViewPoints": {
+    "message": "Sign in to view points",
+    "description": "Text shown when user needs to sign in to view their rewards points"
+  },
   "rewardsSignUp": {
     "message": "Sign up for Rewards"
+  },
+  "rewardsSigningIn": {
+    "message": "Signing in...",
+    "description": "Text shown while the user is signing in to view their rewards points"
   },
   "rpcNameOptional": {
     "message": "RPC Name (Optional)"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Reintentar"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Las cuentas de billeteras físicas aún no pueden recibir recompensas. Cambia a otra cuenta para continuar."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Cuenta no admitida"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Reintentar"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Réessayer"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Les comptes de portefeuille matériel ne sont pas encore autorisés à recevoir des récompenses. Veuillez passer à un autre compte pour continuer."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Compte non pris en charge"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Réessayer"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "फिर से प्रयास करें"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "हार्डवेयर वॉलेट एकाउंट्स अभी रिवॉर्ड्स प्राप्त करने के लिए योग्य नहीं हैं। जारी रखने के लिए कृपया किसी अन्य अकाउंट का उपयोग करें।"
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "अकाउंट सपोर्टेड नहीं है"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "फिर से प्रयास करें"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Coba lagi"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Akun dompet perangkat keras belum memenuhi syarat untuk menerima reward. Beralih ke akun lain untuk melanjutkan."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Akun tidak didukung"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Coba lagi"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -5886,12 +5886,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "再試行"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "ハードウェアウォレットのアカウントは、現時点ではリワードを受け取ることはできません。別のアカウントに切り替えてください。"
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "サポートされていないアカウントです"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "再試行"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "다시 시도"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "아직은 하드웨어 지갑 계정으로 보상을 받을 수 없습니다. 다른 계정으로 변경하여 계속 진행하세요."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "지원되지 않는 계정입니다"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "다시 시도"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Tentar novamente"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Contas de carteira de hardware ainda não são qualificadas para receber recompensas. Mude para uma conta diferente para continuar."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Não há suporte para esta conta"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Tentar novamente"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -5886,12 +5886,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Повтор"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Счета аппаратных кошельков пока не могут быть использованы для получения вознаграждений. Чтобы продолжить, перейдите в другой счет."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Счет не поддерживается"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Повтор"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Subukang muli"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Ang mga account na hardware wallet ay hindi pa kwalipikadong tumanggap ng mga reward. Lumipat sa ibang account upang magpatuloy."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Hindi sinusuportahan ang account"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Subukang muli"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -5886,12 +5886,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Tekrar Dene"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Donanım cüzdanı hesapları henüz ödül almaya uygun değil. Devam etmek için lütfen farklı bir hesaba geçin."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Hesap desteklenmiyor"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Tekrar Dene"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "Thử lại"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "Tài khoản ví cứng hiện chưa đủ điều kiện nhận phần thưởng. Vui lòng chuyển sang tài khoản khác để tiếp tục."
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "Tài khoản không được hỗ trợ"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "Thử lại"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -5862,12 +5862,6 @@
   "rewardsOnboardingIntroGeoCheckRetry": {
     "message": "重试"
   },
-  "rewardsOnboardingIntroHardwareWalletDescription": {
-    "message": "硬件钱包账户暂不符合奖励领取资格。请切换至其他账户继续操作。"
-  },
-  "rewardsOnboardingIntroHardwareWalletTitle": {
-    "message": "账户不受支持"
-  },
   "rewardsOnboardingIntroRewardsAuthFailRetry": {
     "message": "重试"
   },

--- a/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/rewards-controller-messenger.ts
@@ -25,12 +25,15 @@ import {
   RewardsDataServiceEstimatePointsAction,
   RewardsDataServiceGetSeasonStatusAction,
   RewardsDataServiceLoginAction,
+  RewardsDataServiceSiweLoginAction,
   RewardsDataServiceMobileJoinAction,
+  RewardsDataServiceSiweJoinAction,
   RewardsDataServiceMobileOptinAction,
   RewardsDataServiceValidateReferralCodeAction,
   RewardsDataServiceFetchGeoLocationAction,
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetDiscoverSeasonsAction,
+  RewardsDataServiceGenerateChallengeAction,
 } from '../../controllers/rewards/rewards-data-service-types';
 import {
   RewardsControllerState,
@@ -91,15 +94,18 @@ type AllowedActions =
   | AccountsControllerListMultichainAccountsAction
   | KeyringControllerSignPersonalMessageAction
   | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
   | RewardsDataServiceEstimatePointsAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceFetchGeoLocationAction
   | RewardsDataServiceMobileOptinAction
   | RewardsDataServiceValidateReferralCodeAction
   | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceGetSeasonMetadataAction
   | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGenerateChallengeAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | HandleSnapRequest;
 
@@ -136,15 +142,18 @@ export function getRewardsControllerMessenger(
       'AccountsController:listMultichainAccounts',
       'KeyringController:signPersonalMessage',
       'RewardsDataService:login',
+      'RewardsDataService:siweLogin',
       'RewardsDataService:estimatePoints',
       'RewardsDataService:getSeasonStatus',
       'RewardsDataService:fetchGeoLocation',
       'RewardsDataService:mobileOptin',
       'RewardsDataService:validateReferralCode',
       'RewardsDataService:mobileJoin',
+      'RewardsDataService:siweJoin',
       'RewardsDataService:getOptInStatus',
       'RewardsDataService:getSeasonMetadata',
       'RewardsDataService:getDiscoverSeasons',
+      'RewardsDataService:generateChallenge',
       'SnapController:handleRequest',
     ],
     events: [

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -26,10 +26,7 @@ import {
   RECURRING_INTERVALS,
   RecurringInterval,
 } from '@metamask/subscription-controller';
-import {
-  HardwareDeviceNames,
-  HardwareKeyringType,
-} from '../../../../shared/constants/hardware-wallets';
+import { HardwareKeyringType } from '../../../../shared/constants/hardware-wallets';
 import {
   RewardsControllerActions,
   RewardsControllerEvents,
@@ -559,7 +556,7 @@ describe('RewardsController', () => {
           metadata: {
             ...MOCK_INTERNAL_ACCOUNT.metadata,
             keyring: {
-              type: HardwareDeviceNames.ledger,
+              type: HardwareKeyringType.ledger,
             },
           },
         };
@@ -3712,7 +3709,7 @@ describe('RewardsController', () => {
           metadata: {
             ...MOCK_INTERNAL_ACCOUNT.metadata,
             keyring: {
-              type: HardwareDeviceNames.ledger,
+              type: HardwareKeyringType.ledger,
             },
           },
         };
@@ -5941,7 +5938,7 @@ describe('Hardware Wallet Support for Rewards', () => {
 
           expect(capturedRequest).toMatchObject({
             from: MOCK_ACCOUNT_ADDRESS,
-            data: expect.any(String),
+            data: expect.stringMatching(/^0x[0-9a-f]+$/u),
             siwe: expect.objectContaining({
               isSIWEMessage: expect.any(Boolean),
             }),

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -26,7 +26,10 @@ import {
   RECURRING_INTERVALS,
   RecurringInterval,
 } from '@metamask/subscription-controller';
-import { HardwareDeviceNames } from '../../../../shared/constants/hardware-wallets';
+import {
+  HardwareDeviceNames,
+  HardwareKeyringType,
+} from '../../../../shared/constants/hardware-wallets';
 import {
   RewardsControllerActions,
   RewardsControllerEvents,
@@ -52,6 +55,7 @@ import type {
   SeasonMetadataDto,
   SeasonStateDto,
   SubscriptionDto,
+  ChallengeDto,
 } from './rewards-controller.types';
 import {
   InvalidTimestampError,
@@ -70,6 +74,9 @@ import {
   RewardsDataServiceMobileJoinAction,
   RewardsDataServiceMobileOptinAction,
   RewardsDataServiceValidateReferralCodeAction,
+  RewardsDataServiceGenerateChallengeAction,
+  RewardsDataServiceSiweLoginAction,
+  RewardsDataServiceSiweJoinAction,
 } from './rewards-data-service-types';
 
 type AllActions = MessengerActions<RewardsControllerMessenger>;
@@ -222,6 +229,9 @@ async function withController<ReturnValue>(
     | RewardsDataServiceGetOptInStatusAction
     | RewardsDataServiceGetSeasonMetadataAction
     | RewardsDataServiceGetDiscoverSeasonsAction
+    | RewardsDataServiceGenerateChallengeAction
+    | RewardsDataServiceSiweLoginAction
+    | RewardsDataServiceSiweJoinAction
     | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
     | HandleSnapRequest;
 
@@ -251,6 +261,9 @@ async function withController<ReturnValue>(
       'RewardsDataService:getOptInStatus',
       'RewardsDataService:mobileOptin',
       'RewardsDataService:mobileJoin',
+      'RewardsDataService:siweLogin',
+      'RewardsDataService:siweJoin',
+      'RewardsDataService:generateChallenge',
       'RewardsDataService:getSeasonStatus',
       'RewardsDataService:fetchGeoLocation',
       'RewardsDataService:validateReferralCode',
@@ -539,7 +552,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should return false for hardware wallet accounts', async () => {
+    it('should return true for hardware wallet accounts (EVM)', async () => {
       await withController({ isDisabled: false }, ({ controller }) => {
         const hardwareAccount: InternalAccount = {
           ...MOCK_INTERNAL_ACCOUNT,
@@ -551,9 +564,10 @@ describe('RewardsController', () => {
           },
         };
 
+        // Hardware wallets are now supported for opt-in via SIWE flow
         const result = controller.isOptInSupported(hardwareAccount);
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
     });
 
@@ -1142,6 +1156,9 @@ describe('RewardsController', () => {
                 sids: [MOCK_SUBSCRIPTION_ID],
               });
             }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT];
+            }
             return undefined;
           });
 
@@ -1468,6 +1485,219 @@ describe('RewardsController', () => {
             ois: [true],
             sids: [MOCK_SUBSCRIPTION_ID],
           });
+        },
+      );
+    });
+
+    it('should store subscriptionId in state for non-hardware accounts', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.getOptInStatus({
+            addresses: [MOCK_ACCOUNT_ADDRESS],
+          });
+
+          // Non-hardware accounts should have subscriptionId stored in state
+          expect(
+            controller.state.rewardsAccounts[MOCK_CAIP_ACCOUNT]?.subscriptionId,
+          ).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+
+    it('should NOT store subscriptionId in state for hardware accounts without subscription token', async () => {
+      const hardwareAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        metadata: {
+          ...MOCK_INTERNAL_ACCOUNT.metadata,
+          keyring: {
+            type: HardwareKeyringType.ledger,
+          },
+        },
+      };
+
+      const hardwareCaipAccount =
+        `eip155:1:${hardwareAccount.address}` as CaipAccountId;
+
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [hardwareAccount];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.getOptInStatus({
+            addresses: [hardwareAccount.address],
+          });
+
+          // Hardware accounts without subscription token should NOT have subscriptionId stored
+          expect(
+            controller.state.rewardsAccounts[hardwareCaipAccount]
+              ?.subscriptionId,
+          ).toBeNull();
+        },
+      );
+    });
+
+    it('should store subscriptionId in state for hardware accounts WITH subscription token', async () => {
+      const hardwareAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        metadata: {
+          ...MOCK_INTERNAL_ACCOUNT.metadata,
+          keyring: {
+            type: HardwareKeyringType.ledger,
+          },
+        },
+      };
+
+      const hardwareCaipAccount =
+        `eip155:1:${hardwareAccount.address}` as CaipAccountId;
+
+      // Pre-populate state with subscription token for the subscription ID
+      const state: Partial<RewardsControllerState> = {
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [hardwareAccount];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.getOptInStatus({
+            addresses: [hardwareAccount.address],
+          });
+
+          // Hardware accounts WITH subscription token SHOULD have subscriptionId stored
+          expect(
+            controller.state.rewardsAccounts[hardwareCaipAccount]
+              ?.subscriptionId,
+          ).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+
+    it('should update existing rewardsActiveAccount subscriptionId based on canUseSubscriptionId', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: false,
+          subscriptionId: null,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.getOptInStatus({
+            addresses: [MOCK_ACCOUNT_ADDRESS],
+          });
+
+          // rewardsActiveAccount should also be updated with subscriptionId
+          expect(controller.state.rewardsActiveAccount?.subscriptionId).toBe(
+            MOCK_SUBSCRIPTION_ID,
+          );
+        },
+      );
+    });
+
+    it('should NOT update rewardsActiveAccount subscriptionId for hardware account without token', async () => {
+      const hardwareAccount: InternalAccount = {
+        ...MOCK_INTERNAL_ACCOUNT,
+        metadata: {
+          ...MOCK_INTERNAL_ACCOUNT.metadata,
+          keyring: {
+            type: HardwareKeyringType.ledger,
+          },
+        },
+      };
+
+      const hardwareCaipAccount =
+        `eip155:1:${hardwareAccount.address}` as CaipAccountId;
+
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: hardwareCaipAccount,
+          hasOptedIn: false,
+          subscriptionId: null,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [hardwareAccount];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.getOptInStatus({
+            addresses: [hardwareAccount.address],
+          });
+
+          // Hardware account active account should NOT have subscriptionId updated without token
+          expect(controller.state.rewardsActiveAccount?.subscriptionId).toBe(
+            null,
+          );
         },
       );
     });
@@ -2146,6 +2376,7 @@ describe('RewardsController', () => {
               endDate: new Date('2024-12-31'),
             },
             next: null,
+            previous: null,
           };
 
           mockMessengerCall.mockImplementation((actionType) => {
@@ -3339,10 +3570,142 @@ describe('RewardsController', () => {
         expect(result.addressesNeedingFresh).toEqual([MOCK_ACCOUNT_ADDRESS]);
       });
     });
+
+    it('should force fresh check for opted-in accounts WITHOUT subscriptionId checked more than 60 minutes ago', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: null, // Opted in but missing subscriptionId
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 61, // 61 minutes ago (exceeds 60 minute threshold)
+          },
+        },
+      };
+
+      await withController({ state, isDisabled: false }, ({ controller }) => {
+        const addressToAccountMap = new Map<string, InternalAccount>();
+        addressToAccountMap.set(
+          MOCK_ACCOUNT_ADDRESS.toLowerCase(),
+          MOCK_INTERNAL_ACCOUNT,
+        );
+
+        const result = controller.checkOptInStatusAgainstCache(
+          [MOCK_ACCOUNT_ADDRESS],
+          addressToAccountMap,
+        );
+
+        // Should force fresh check because opted-in but no subscriptionId and stale cache
+        expect(result.cachedOptInResults).toEqual([null]);
+        expect(result.cachedSubscriptionIds).toEqual([null]);
+        expect(result.addressesNeedingFresh).toEqual([MOCK_ACCOUNT_ADDRESS]);
+      });
+    });
+
+    it('should use cached data for opted-in accounts WITHOUT subscriptionId checked within 60 minutes', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: null, // Opted in but missing subscriptionId
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 30, // 30 minutes ago (within 60 minute threshold)
+          },
+        },
+      };
+
+      await withController({ state, isDisabled: false }, ({ controller }) => {
+        const addressToAccountMap = new Map<string, InternalAccount>();
+        addressToAccountMap.set(
+          MOCK_ACCOUNT_ADDRESS.toLowerCase(),
+          MOCK_INTERNAL_ACCOUNT,
+        );
+
+        const result = controller.checkOptInStatusAgainstCache(
+          [MOCK_ACCOUNT_ADDRESS],
+          addressToAccountMap,
+        );
+
+        // Should use cached data because recently checked (within threshold)
+        expect(result.cachedOptInResults).toEqual([true]);
+        expect(result.cachedSubscriptionIds).toEqual([null]);
+        expect(result.addressesNeedingFresh).toEqual([]);
+      });
+    });
+
+    it('should use cached data for opted-in accounts WITH subscriptionId regardless of lastFreshOptInStatusCheck', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID, // Has subscriptionId
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 120, // 2 hours ago (very stale)
+          },
+        },
+      };
+
+      await withController({ state, isDisabled: false }, ({ controller }) => {
+        const addressToAccountMap = new Map<string, InternalAccount>();
+        addressToAccountMap.set(
+          MOCK_ACCOUNT_ADDRESS.toLowerCase(),
+          MOCK_INTERNAL_ACCOUNT,
+        );
+
+        const result = controller.checkOptInStatusAgainstCache(
+          [MOCK_ACCOUNT_ADDRESS],
+          addressToAccountMap,
+        );
+
+        // Should use cached data because opted-in WITH subscriptionId (no need for fresh check)
+        expect(result.cachedOptInResults).toEqual([true]);
+        expect(result.cachedSubscriptionIds).toEqual([MOCK_SUBSCRIPTION_ID]);
+        expect(result.addressesNeedingFresh).toEqual([]);
+      });
+    });
+
+    it('should force fresh check for opted-in accounts WITHOUT subscriptionId and no lastFreshOptInStatusCheck', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: null, // Opted in but missing subscriptionId
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+            lastFreshOptInStatusCheck: undefined, // Never checked fresh
+          },
+        },
+      };
+
+      await withController({ state, isDisabled: false }, ({ controller }) => {
+        const addressToAccountMap = new Map<string, InternalAccount>();
+        addressToAccountMap.set(
+          MOCK_ACCOUNT_ADDRESS.toLowerCase(),
+          MOCK_INTERNAL_ACCOUNT,
+        );
+
+        const result = controller.checkOptInStatusAgainstCache(
+          [MOCK_ACCOUNT_ADDRESS],
+          addressToAccountMap,
+        );
+
+        // Should force fresh check because opted-in without subscriptionId and never checked fresh
+        expect(result.cachedOptInResults).toEqual([null]);
+        expect(result.cachedSubscriptionIds).toEqual([null]);
+        expect(result.addressesNeedingFresh).toEqual([MOCK_ACCOUNT_ADDRESS]);
+      });
+    });
   });
 
   describe('shouldSkipSilentAuth', () => {
-    it('should skip for hardware accounts', async () => {
+    it('should not skip for hardware accounts (they are now supported via SIWE)', async () => {
       await withController({ isDisabled: false }, ({ controller }) => {
         const hardwareAccount: InternalAccount = {
           ...MOCK_INTERNAL_ACCOUNT,
@@ -3354,12 +3717,14 @@ describe('RewardsController', () => {
           },
         };
 
+        // Hardware wallets are now supported via SIWE, so shouldSkipSilentAuth returns false
+        // (meaning silent auth should NOT be skipped, though it will require interactive signing)
         const result = controller.shouldSkipSilentAuth(
           MOCK_CAIP_ACCOUNT,
           hardwareAccount,
         );
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
     });
 
@@ -4599,6 +4964,7 @@ describe('Additional RewardsController edge cases', () => {
           const mockDiscoverSeasons: DiscoverSeasonsDto = {
             current: null,
             next: null,
+            previous: null,
           };
 
           mockMessengerCall.mockImplementation((actionType) => {
@@ -4834,6 +5200,1196 @@ describe('Additional RewardsController edge cases', () => {
 
         expect(result).toBe(false);
       });
+    });
+  });
+});
+
+// Hardware wallet test constants
+const MOCK_LEDGER_ACCOUNT: InternalAccount = {
+  id: 'ledger-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Ledger Account',
+    keyring: {
+      type: HardwareKeyringType.ledger,
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_QR_ACCOUNT: InternalAccount = {
+  id: 'qr-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'QR Wallet Account',
+    keyring: {
+      type: HardwareKeyringType.qr,
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_CHALLENGE: ChallengeDto = {
+  id: 'challenge-123',
+  address: MOCK_ACCOUNT_ADDRESS,
+  domain: 'rewards.metamask.io',
+  nonce: BigInt(123456789),
+  issuedAt: new Date().toISOString(),
+  expirationTime: new Date(Date.now() + 3600000).toISOString(),
+  message: `rewards.metamask.io wants you to sign in with your Ethereum account:\n${MOCK_ACCOUNT_ADDRESS}\n\nSign in to MetaMask Rewards\n\nURI: https://rewards.metamask.io\nVersion: 1\nChain ID: 1\nNonce: 123456789\nIssued At: ${new Date().toISOString()}`,
+};
+
+describe('Hardware Wallet Support for Rewards', () => {
+  describe('optIn with hardware wallets', () => {
+    it('should opt in with Ledger account using SIWE flow', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmockhardwaresignature');
+            }
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [false],
+                sids: [null],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          const result = await controller.optIn([MOCK_LEDGER_ACCOUNT]);
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:generateChallenge',
+            { address: MOCK_ACCOUNT_ADDRESS },
+          );
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweLogin',
+            expect.objectContaining({
+              challengeId: MOCK_CHALLENGE.id,
+              signature: '0xmockhardwaresignature',
+            }),
+          );
+        },
+      );
+    });
+
+    it('should opt in with QR hardware wallet using SIWE flow', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmockqrsignature');
+            }
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [false],
+                sids: [null],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_QR_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          const result = await controller.optIn([MOCK_QR_ACCOUNT]);
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:generateChallenge',
+            { address: MOCK_ACCOUNT_ADDRESS },
+          );
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweLogin',
+            expect.objectContaining({
+              challengeId: MOCK_CHALLENGE.id,
+              signature: '0xmockqrsignature',
+            }),
+          );
+        },
+      );
+    });
+
+    it('should pass referral code to siweLogin for hardware wallet opt-in', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const referralCode = 'REF456';
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({ ois: [false], sids: [null] });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          await controller.optIn([MOCK_LEDGER_ACCOUNT], referralCode);
+
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweLogin',
+            expect.objectContaining({
+              challengeId: MOCK_CHALLENGE.id,
+              referralCode,
+            }),
+          );
+        },
+      );
+    });
+
+    it('should handle challenge generation failure for hardware wallet', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.reject(new Error('Challenge generation failed'));
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          await expect(controller.optIn([MOCK_LEDGER_ACCOUNT])).rejects.toThrow(
+            'Failed to opt in any account from the account group',
+          );
+        },
+      );
+    });
+
+    it('should handle hardware wallet signing failure', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.reject(new Error('User rejected the request'));
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          await expect(controller.optIn([MOCK_LEDGER_ACCOUNT])).rejects.toThrow(
+            'Failed to opt in any account from the account group',
+          );
+        },
+      );
+    });
+
+    it('should handle SIWE login failure for hardware wallet', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.reject(new Error('SIWE login failed'));
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          await expect(controller.optIn([MOCK_LEDGER_ACCOUNT])).rejects.toThrow(
+            'Failed to opt in any account from the account group',
+          );
+        },
+      );
+    });
+
+    it('should opt in with mixed account group (software + hardware)', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          let optInCallCount = 0;
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve(MOCK_CHALLENGE);
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:mobileOptin') {
+              optInCallCount += 1;
+              // Software wallet succeeds
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:siweJoin') {
+              // Ledger links via siweJoin
+              return Promise.resolve(MOCK_SUBSCRIPTION);
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [false, false],
+                sids: [null, null],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          // Software wallet should be tried first and succeed
+          const result = await controller.optIn([
+            MOCK_INTERNAL_ACCOUNT,
+            MOCK_LEDGER_ACCOUNT,
+          ]);
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(optInCallCount).toBe(1);
+        },
+      );
+    });
+  });
+
+  describe('linkAccountToSubscriptionCandidate with hardware wallets', () => {
+    it('should link Ledger account using SIWE join flow', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsSubscriptions: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const ledgerAccountAlt: InternalAccount = {
+            ...MOCK_LEDGER_ACCOUNT,
+            id: 'ledger-account-2',
+            address: MOCK_ACCOUNT_ADDRESS_ALT,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve({
+                ...MOCK_CHALLENGE,
+                address: MOCK_ACCOUNT_ADDRESS_ALT,
+              });
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmockhardwaresignature');
+            }
+            if (actionType === 'RewardsDataService:siweJoin') {
+              return Promise.resolve({
+                ...MOCK_SUBSCRIPTION,
+                accounts: [
+                  ...MOCK_SUBSCRIPTION.accounts,
+                  { address: MOCK_ACCOUNT_ADDRESS_ALT, chainId: 1 },
+                ],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, ledgerAccountAlt];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, false],
+                sids: [MOCK_SUBSCRIPTION_ID, null],
+              });
+            }
+            return undefined;
+          });
+
+          const result =
+            await controller.linkAccountToSubscriptionCandidate(
+              ledgerAccountAlt,
+            );
+
+          expect(result).toBe(true);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:generateChallenge',
+            { address: MOCK_ACCOUNT_ADDRESS_ALT },
+          );
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweJoin',
+            expect.objectContaining({
+              challengeId: expect.any(String),
+              signature: '0xmockhardwaresignature',
+            }),
+            MOCK_SESSION_TOKEN,
+          );
+        },
+      );
+    });
+
+    it('should link QR wallet account using SIWE join flow', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsSubscriptions: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const qrAccountAlt: InternalAccount = {
+            ...MOCK_QR_ACCOUNT,
+            id: 'qr-account-2',
+            address: MOCK_ACCOUNT_ADDRESS_ALT,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve({
+                ...MOCK_CHALLENGE,
+                address: MOCK_ACCOUNT_ADDRESS_ALT,
+              });
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmockqrsignature');
+            }
+            if (actionType === 'RewardsDataService:siweJoin') {
+              return Promise.resolve({
+                ...MOCK_SUBSCRIPTION,
+                accounts: [
+                  ...MOCK_SUBSCRIPTION.accounts,
+                  { address: MOCK_ACCOUNT_ADDRESS_ALT, chainId: 1 },
+                ],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, qrAccountAlt];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, false],
+                sids: [MOCK_SUBSCRIPTION_ID, null],
+              });
+            }
+            return undefined;
+          });
+
+          const result =
+            await controller.linkAccountToSubscriptionCandidate(qrAccountAlt);
+
+          expect(result).toBe(true);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweJoin',
+            expect.objectContaining({
+              challengeId: expect.any(String),
+              signature: '0xmockqrsignature',
+            }),
+            MOCK_SESSION_TOKEN,
+          );
+        },
+      );
+    });
+
+    it('should handle hardware wallet link failure gracefully', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsSubscriptions: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const ledgerAccountAlt: InternalAccount = {
+            ...MOCK_LEDGER_ACCOUNT,
+            id: 'ledger-account-2',
+            address: MOCK_ACCOUNT_ADDRESS_ALT,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve({
+                ...MOCK_CHALLENGE,
+                address: MOCK_ACCOUNT_ADDRESS_ALT,
+              });
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.reject(new Error('Ledger device disconnected'));
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, ledgerAccountAlt];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, false],
+                sids: [MOCK_SUBSCRIPTION_ID, null],
+              });
+            }
+            return undefined;
+          });
+
+          const result =
+            await controller.linkAccountToSubscriptionCandidate(
+              ledgerAccountAlt,
+            );
+
+          expect(result).toBe(false);
+        },
+      );
+    });
+
+    it('should handle AccountAlreadyRegisteredError during hardware wallet link', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsSubscriptions: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SUBSCRIPTION,
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const ledgerAccountAlt: InternalAccount = {
+            ...MOCK_LEDGER_ACCOUNT,
+            id: 'ledger-account-2',
+            address: MOCK_ACCOUNT_ADDRESS_ALT,
+          };
+          let siweJoinCallCount = 0;
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:generateChallenge') {
+              return Promise.resolve({
+                ...MOCK_CHALLENGE,
+                address: MOCK_ACCOUNT_ADDRESS_ALT,
+              });
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmockhardwaresignature');
+            }
+            if (actionType === 'RewardsDataService:siweJoin') {
+              siweJoinCallCount += 1;
+              if (siweJoinCallCount === 1) {
+                throw new AccountAlreadyRegisteredError(
+                  'Account already registered',
+                );
+              }
+              return Promise.resolve(MOCK_SUBSCRIPTION);
+            }
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: MOCK_SUBSCRIPTION,
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, ledgerAccountAlt];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, true],
+                sids: [MOCK_SUBSCRIPTION_ID, MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result =
+            await controller.linkAccountToSubscriptionCandidate(
+              ledgerAccountAlt,
+            );
+
+          expect(result).toBe(true);
+        },
+      );
+    });
+  });
+
+  describe('performSilentAuth with hardware wallet sign result', () => {
+    it('should authenticate hardware wallet with pre-signed SIWE result', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const hardwareWalletSignResult = {
+            signature: '0xpresignedhardwaresignature',
+            challenge: MOCK_CHALLENGE,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.performSilentAuth(
+            MOCK_LEDGER_ACCOUNT,
+            true,
+            false,
+            hardwareWalletSignResult,
+          );
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:siweLogin',
+            expect.objectContaining({
+              challengeId: MOCK_CHALLENGE.id,
+              signature: '0xpresignedhardwaresignature',
+            }),
+          );
+        },
+      );
+    });
+
+    it('should skip silent auth for hardware wallet without pre-signed result', async () => {
+      await withController({ isDisabled: false }, async ({ controller }) => {
+        const result = await controller.performSilentAuth(
+          MOCK_LEDGER_ACCOUNT,
+          true,
+          true,
+          null, // No pre-signed result
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    it('should update state correctly after hardware wallet authentication', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const hardwareWalletSignResult = {
+            signature: '0xpresignedhardwaresignature',
+            challenge: MOCK_CHALLENGE,
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:siweLogin') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.performSilentAuth(
+            MOCK_LEDGER_ACCOUNT,
+            true,
+            false,
+            hardwareWalletSignResult,
+          );
+
+          expect(controller.state.rewardsActiveAccount).toMatchObject({
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+          });
+          expect(
+            controller.state.rewardsSubscriptions[MOCK_SUBSCRIPTION_ID],
+          ).toBeDefined();
+        },
+      );
+    });
+  });
+
+  describe('signSiweEvmMessage', () => {
+    it('should sign SIWE message for hardware wallet', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xsiwe_signature');
+            }
+            return undefined;
+          });
+
+          const result = await controller.signSiweEvmMessage(
+            MOCK_LEDGER_ACCOUNT,
+            MOCK_CHALLENGE,
+          );
+
+          expect(result).toBe('0xsiwe_signature');
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'KeyringController:signPersonalMessage',
+            expect.objectContaining({
+              from: MOCK_ACCOUNT_ADDRESS,
+              siwe: expect.any(Object),
+            }),
+          );
+        },
+      );
+    });
+
+    it('should include SIWE detection in signature request', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          let capturedRequest: unknown;
+          mockMessengerCall.mockImplementation((actionType, request) => {
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              capturedRequest = request;
+              return Promise.resolve('0xsiwe_signature');
+            }
+            return undefined;
+          });
+
+          await controller.signSiweEvmMessage(
+            MOCK_LEDGER_ACCOUNT,
+            MOCK_CHALLENGE,
+          );
+
+          expect(capturedRequest).toMatchObject({
+            from: MOCK_ACCOUNT_ADDRESS,
+            data: expect.any(String),
+            siwe: expect.objectContaining({
+              isSIWEMessage: expect.any(Boolean),
+            }),
+          });
+        },
+      );
+    });
+  });
+
+  describe('handleAuthenticationTrigger with hardware wallets', () => {
+    it('should skip silent auth for hardware wallet accounts in account group', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (
+              actionType ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [false],
+                sids: [null],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.handleAuthenticationTrigger('Test trigger');
+
+          // Silent auth should not be attempted for hardware wallets
+          expect(mockMessengerCall).not.toHaveBeenCalledWith(
+            'RewardsDataService:login',
+            expect.any(Object),
+          );
+        },
+      );
+    });
+
+    it('should handle mixed group with hardware and software wallets', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (
+              actionType ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [MOCK_INTERNAL_ACCOUNT, MOCK_LEDGER_ACCOUNT];
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, false],
+                sids: [MOCK_SUBSCRIPTION_ID, null],
+              });
+            }
+            return undefined;
+          });
+
+          await controller.handleAuthenticationTrigger('Test trigger');
+
+          // Should attempt silent auth only for software wallet
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:login',
+            expect.objectContaining({
+              account: MOCK_ACCOUNT_ADDRESS,
+            }),
+          );
+        },
+      );
+    });
+  });
+
+  describe('getCandidateSubscriptionId with hardware wallets', () => {
+    it('should skip hardware wallets during silent auth attempts', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT, MOCK_QR_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, true],
+                sids: [MOCK_SUBSCRIPTION_ID, MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.getCandidateSubscriptionId();
+
+          // Should return null because only hardware wallets are available
+          // and they require interactive signing
+          expect(result).toBeNull();
+        },
+      );
+    });
+
+    it('should return subscription from mixed group if software wallet is opted in', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_INTERNAL_ACCOUNT, MOCK_LEDGER_ACCOUNT];
+            }
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true, true],
+                sids: [MOCK_SUBSCRIPTION_ID, MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.getCandidateSubscriptionId();
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+  });
+
+  describe('getPrimaryWalletSubscriptionId with hardware wallets', () => {
+    it('should throw error if hardware wallet is opted in but not authenticated', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: null, // Not authenticated
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [null],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          await expect(
+            controller.getPrimaryWalletSubscriptionId([MOCK_LEDGER_ACCOUNT]),
+          ).rejects.toThrow(
+            'Primary wallet account group has opted in but is not authenticated yet',
+          );
+        },
+      );
+    });
+
+    it('should return subscription ID if hardware wallet is authenticated', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getOptInStatus') {
+              return Promise.resolve({
+                ois: [true],
+                sids: [MOCK_SUBSCRIPTION_ID],
+              });
+            }
+            if (actionType === 'AccountsController:listMultichainAccounts') {
+              return [MOCK_LEDGER_ACCOUNT];
+            }
+            return undefined;
+          });
+
+          const result = await controller.getPrimaryWalletSubscriptionId([
+            MOCK_LEDGER_ACCOUNT,
+          ]);
+
+          expect(result).toBe(MOCK_SUBSCRIPTION_ID);
+        },
+      );
+    });
+  });
+
+  describe('getSeasonStatus with hardware wallets', () => {
+    it('should fetch season status and balance for authenticated hardware wallet', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsSeasons: {
+          [MOCK_SEASON_ID]: {
+            id: MOCK_SEASON_ID,
+            name: 'Season 1',
+            startDate: new Date('2024-01-01').getTime(),
+            endDate: new Date('2024-12-31').getTime(),
+            tiers: MOCK_SEASON_TIERS,
+          },
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getSeasonStatus') {
+              return Promise.resolve(MOCK_SEASON_STATE);
+            }
+            return undefined;
+          });
+
+          const result = await controller.getSeasonStatus(
+            MOCK_SUBSCRIPTION_ID,
+            MOCK_SEASON_ID,
+          );
+
+          expect(result).toBeDefined();
+          expect(result?.balance.total).toBe(250);
+          expect(result?.balance.updatedAt).toBeDefined();
+          expect(result?.tier.currentTier.id).toBe('tier-2');
+          expect(result?.tier.nextTier?.id).toBe('tier-3');
+          expect(result?.tier.nextTierPointsNeeded).toBe(250);
+        },
+      );
+    });
+
+    it('should handle authorization failure and reauth for hardware wallet', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsSeasons: {
+          [MOCK_SEASON_ID]: {
+            id: MOCK_SEASON_ID,
+            name: 'Season 1',
+            startDate: new Date('2024-01-01').getTime(),
+            endDate: new Date('2024-12-31').getTime(),
+            tiers: MOCK_SEASON_TIERS,
+          },
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+        rewardsActiveAccount: {
+          account: MOCK_CAIP_ACCOUNT,
+          hasOptedIn: true,
+          subscriptionId: MOCK_SUBSCRIPTION_ID,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        },
+        rewardsAccounts: {
+          [MOCK_CAIP_ACCOUNT]: {
+            account: MOCK_CAIP_ACCOUNT,
+            hasOptedIn: true,
+            subscriptionId: MOCK_SUBSCRIPTION_ID,
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          let getSeasonStatusCallCount = 0;
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getSeasonStatus') {
+              getSeasonStatusCallCount += 1;
+              if (getSeasonStatusCallCount === 1) {
+                throw new AuthorizationFailedError('Token expired');
+              }
+              return Promise.resolve(MOCK_SEASON_STATE);
+            }
+            if (
+              actionType === 'AccountsController:getSelectedMultichainAccount'
+            ) {
+              return MOCK_INTERNAL_ACCOUNT; // Return software wallet for reauth
+            }
+            if (actionType === 'KeyringController:signPersonalMessage') {
+              return Promise.resolve('0xmocksignature');
+            }
+            if (actionType === 'RewardsDataService:login') {
+              return Promise.resolve({
+                ...MOCK_LOGIN_RESPONSE,
+                subscription: { ...MOCK_SUBSCRIPTION },
+              });
+            }
+            return undefined;
+          });
+
+          const result = await controller.getSeasonStatus(
+            MOCK_SUBSCRIPTION_ID,
+            MOCK_SEASON_ID,
+          );
+
+          expect(result).toBeDefined();
+          expect(result?.balance.total).toBe(250);
+          expect(getSeasonStatusCallCount).toBe(2);
+        },
+      );
+    });
+
+    it('should return cached balance for hardware wallet when cache is fresh', async () => {
+      const compositeKey = `${MOCK_SEASON_ID}:${MOCK_SUBSCRIPTION_ID}`;
+      const cachedBalance = 500;
+      const state: Partial<RewardsControllerState> = {
+        rewardsSeasons: {
+          [MOCK_SEASON_ID]: {
+            id: MOCK_SEASON_ID,
+            name: 'Season 1',
+            startDate: new Date('2024-01-01').getTime(),
+            endDate: new Date('2024-12-31').getTime(),
+            tiers: MOCK_SEASON_TIERS,
+          },
+        },
+        rewardsSeasonStatuses: {
+          [compositeKey]: {
+            season: {
+              id: MOCK_SEASON_ID,
+              name: 'Season 1',
+              startDate: new Date('2024-01-01').getTime(),
+              endDate: new Date('2024-12-31').getTime(),
+              tiers: MOCK_SEASON_TIERS,
+            },
+            balance: { total: cachedBalance, updatedAt: Date.now() },
+            tier: {
+              currentTier: MOCK_SEASON_TIERS[2],
+              nextTier: null,
+              nextTierPointsNeeded: null,
+            },
+            lastFetched: Date.now(), // Fresh cache
+          },
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getSeasonStatus(
+            MOCK_SUBSCRIPTION_ID,
+            MOCK_SEASON_ID,
+          );
+
+          expect(result).toBeDefined();
+          expect(result?.balance.total).toBe(cachedBalance);
+          // Should not call the API when cache is fresh
+          expect(mockMessengerCall).not.toHaveBeenCalledWith(
+            'RewardsDataService:getSeasonStatus',
+            expect.any(String),
+            expect.any(String),
+          );
+        },
+      );
+    });
+
+    it('should calculate tier status correctly for hardware wallet balance', async () => {
+      const state: Partial<RewardsControllerState> = {
+        rewardsSeasons: {
+          [MOCK_SEASON_ID]: {
+            id: MOCK_SEASON_ID,
+            name: 'Season 1',
+            startDate: new Date('2024-01-01').getTime(),
+            endDate: new Date('2024-12-31').getTime(),
+            tiers: MOCK_SEASON_TIERS,
+          },
+        },
+        rewardsSubscriptionTokens: {
+          [MOCK_SUBSCRIPTION_ID]: MOCK_SESSION_TOKEN,
+        },
+      };
+
+      await withController(
+        { state, isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          // Test with balance of 50 (tier 0, needs 50 for tier 1)
+          const seasonStateWithLowBalance: SeasonStateDto = {
+            balance: 50,
+            currentTierId: 'tier-1',
+            updatedAt: new Date('2024-06-01T00:00:00.000Z'),
+          };
+
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:getSeasonStatus') {
+              return Promise.resolve(seasonStateWithLowBalance);
+            }
+            return undefined;
+          });
+
+          const result = await controller.getSeasonStatus(
+            MOCK_SUBSCRIPTION_ID,
+            MOCK_SEASON_ID,
+          );
+
+          expect(result).toBeDefined();
+          expect(result?.balance.total).toBe(50);
+          expect(result?.tier.currentTier.id).toBe('tier-1');
+          expect(result?.tier.nextTier?.id).toBe('tier-2');
+          expect(result?.tier.nextTierPointsNeeded).toBe(50); // 100 - 50
+        },
+      );
     });
   });
 });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -553,9 +553,11 @@ export class RewardsController extends BaseController<
         Buffer.from(hotWalletMessage, 'utf8').toString('base64'),
       );
       // Bitcoin signatures are typically hex-encoded, return as-is or convert if needed
-      return { signature: result.signature.startsWith('0x')
-        ? result.signature
-        : `0x${result.signature}` };
+      return {
+        signature: result.signature.startsWith('0x')
+          ? result.signature
+          : `0x${result.signature}`,
+      };
     } else if (isTronAddress(account.address)) {
       if (this.#isTronDisabled()) {
         throw new Error('Unsupported account type for signing rewards message');
@@ -569,9 +571,11 @@ export class RewardsController extends BaseController<
         Buffer.from(hotWalletMessage, 'utf8').toString('base64'),
       );
       // Tron signatures are typically hex-encoded, return as-is or convert if needed
-      return { signature: result.signature.startsWith('0x')
-        ? result.signature
-        : `0x${result.signature}` };
+      return {
+        signature: result.signature.startsWith('0x')
+          ? result.signature
+          : `0x${result.signature}`,
+      };
     } else if (isEvm) {
       const result = await this.#signEvmMessage(account, hotWalletMessage);
       return { signature: result };
@@ -609,7 +613,7 @@ export class RewardsController extends BaseController<
     account: InternalAccount,
     challenge: ChallengeDto,
   ): Promise<string> {
-    const messageHex = Buffer.from(challenge.message, 'utf8').toString('hex');
+    const messageHex = `0x${Buffer.from(challenge.message, 'utf8').toString('hex')}`;
     const siwe = detectSIWE({ data: messageHex });
     const signature = await this.messenger.call(
       'KeyringController:signPersonalMessage',
@@ -1099,9 +1103,10 @@ export class RewardsController extends BaseController<
             const shouldRecheckFresh =
               !accountState.lastFreshOptInStatusCheck ||
               Date.now() - accountState.lastFreshOptInStatusCheck >
-              NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
+                NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
             if (
-              (accountState.hasOptedIn === false || (accountState.hasOptedIn && !accountState.subscriptionId)) &&
+              (accountState.hasOptedIn === false ||
+                (accountState.hasOptedIn && !accountState.subscriptionId)) &&
               shouldRecheckFresh
             ) {
               // Force a fresh check for this not-opted-in account
@@ -1181,14 +1186,17 @@ export class RewardsController extends BaseController<
           const hasOptedIn = freshOptInResults[i];
           const subscriptionId =
             Array.isArray(freshSubscriptionIds) &&
-              i < freshSubscriptionIds.length
+            i < freshSubscriptionIds.length
               ? freshSubscriptionIds[i]
               : null;
           const internalAccount = addressToAccountMap.get(
             address.toLowerCase(),
           );
 
-          const canUseSubscriptionId = subscriptionId && (this.#getSubscriptionToken(subscriptionId) || (internalAccount && !isHardwareAccount(internalAccount)));
+          const canUseSubscriptionId =
+            subscriptionId &&
+            (this.#getSubscriptionToken(subscriptionId) ||
+              (internalAccount && !isHardwareAccount(internalAccount)));
 
           if (internalAccount) {
             const caipAccount =
@@ -1199,14 +1207,17 @@ export class RewardsController extends BaseController<
                 // Update or create account state with fresh opt-in status
                 if (state.rewardsAccounts[caipAccount]) {
                   state.rewardsAccounts[caipAccount].hasOptedIn = hasOptedIn;
-                  state.rewardsAccounts[caipAccount].subscriptionId = canUseSubscriptionId ? subscriptionId : null;
+                  state.rewardsAccounts[caipAccount].subscriptionId =
+                    canUseSubscriptionId ? subscriptionId : null;
                   state.rewardsAccounts[caipAccount].lastFreshOptInStatusCheck =
                     lastFreshOptInStatusCheck;
                 } else {
                   state.rewardsAccounts[caipAccount] = {
                     account: caipAccount,
                     hasOptedIn,
-                    subscriptionId: canUseSubscriptionId ? subscriptionId : null,
+                    subscriptionId: canUseSubscriptionId
+                      ? subscriptionId
+                      : null,
                     perpsFeeDiscount: null,
                     lastPerpsDiscountRateFetched: null,
                     lastFreshOptInStatusCheck,
@@ -1215,7 +1226,8 @@ export class RewardsController extends BaseController<
 
                 if (state.rewardsActiveAccount?.account === caipAccount) {
                   state.rewardsActiveAccount.hasOptedIn = hasOptedIn;
-                  state.rewardsActiveAccount.subscriptionId = canUseSubscriptionId ? subscriptionId : null;
+                  state.rewardsActiveAccount.subscriptionId =
+                    canUseSubscriptionId ? subscriptionId : null;
                   state.rewardsActiveAccount.lastFreshOptInStatusCheck =
                     lastFreshOptInStatusCheck;
                 }
@@ -1378,7 +1390,7 @@ export class RewardsController extends BaseController<
    * @returns Promise<SeasonDtoState> - The season metadata
    */
   async getSeasonMetadata(
-    type: 'current' | 'next' = 'current',
+    type: 'current' | 'next' | 'previous' = 'current',
   ): Promise<SeasonDtoState> {
     const result = await wrapWithCache<SeasonDtoState>({
       key: type,
@@ -1406,6 +1418,8 @@ export class RewardsController extends BaseController<
           seasonInfo = discoverSeasons.current;
         } else if (type === 'next') {
           seasonInfo = discoverSeasons.next;
+        } else if (type === 'previous') {
+          seasonInfo = discoverSeasons.previous;
         }
 
         // If found with valid start date, fetch metadata and populate cache
@@ -1514,7 +1528,7 @@ export class RewardsController extends BaseController<
 
               if (
                 this.state.rewardsActiveAccount?.subscriptionId ===
-                subscriptionId &&
+                  subscriptionId &&
                 !isHardwareAccount(account as InternalAccount)
               ) {
                 await this.performSilentAuth(account, false, false); // try and auth.
@@ -2031,7 +2045,7 @@ export class RewardsController extends BaseController<
         // Defensive: Ensure sids is an array and i is within bounds
         let subscriptionId =
           Array.isArray(optInStatusResponse?.sids) &&
-            i < optInStatusResponse.sids.length
+          i < optInStatusResponse.sids.length
             ? optInStatusResponse.sids[i]
             : null;
         const sessionToken = subscriptionId

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -10,8 +10,8 @@ import {
 } from '@metamask/utils';
 import { base58, isAddress as isEvmAddress } from 'ethers/lib/utils';
 import { HandleSnapRequest } from '@metamask/snaps-controllers';
+import { detectSIWE } from '@metamask/controller-utils';
 import { RewardsControllerMessenger } from '../../controller-init/messengers/rewards-controller-messenger';
-import { isHardwareAccount } from '../../../../shared/lib/accounts';
 import {
   isBtcMainnetAddress,
   isBtcTestnetAddress,
@@ -39,6 +39,7 @@ import {
   SeasonStateDto,
   SeasonMetadataDto,
   DiscoverSeasonsDto,
+  ChallengeDto,
 } from './rewards-controller.types';
 import {
   AccountAlreadyRegisteredError,
@@ -50,6 +51,7 @@ import { signSolanaRewardsMessage } from './utils/solana-snap';
 import { signBitcoinRewardsMessage } from './utils/bitcoin-snap';
 import { signTronRewardsMessage } from './utils/tron-snap';
 import { sortAccounts } from './utils/sortAccounts';
+import { isHardwareAccount } from './utils/isHardwareAccount';
 
 export const DEFAULT_BLOCKED_REGIONS = ['UK'];
 
@@ -59,7 +61,7 @@ const controllerName = 'RewardsController';
 const SEASON_STATUS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
 // Season metadata cache threshold
-const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
+const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
 // Opt-in status stale threshold for not opted-in accounts to force a fresh check (less strict than in mobile for now)
 const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
@@ -503,8 +505,23 @@ export class RewardsController extends BaseController<
   async #signRewardsMessage(
     account: InternalAccount,
     timestamp: number,
-  ): Promise<string> {
-    const message = `rewards,${account.address},${timestamp}`;
+  ): Promise<{ signature: string; challenge?: ChallengeDto }> {
+    const isEvm = isEvmAddress(account.address);
+
+    if (isHardwareAccount(account) && isEvm) {
+      const challenge = await this.messenger.call(
+        'RewardsDataService:generateChallenge',
+        {
+          address: account.address,
+        },
+      );
+      const result = await this.signSiweEvmMessage(account, challenge);
+      return { signature: result, challenge };
+    } else if (isHardwareAccount(account) && !isEvm) {
+      throw new Error('Unsupported account type for signing rewards message');
+    }
+
+    const hotWalletMessage = `rewards,${account.address},${timestamp}`;
 
     if (isSolanaAddress(account.address)) {
       const result = await signSolanaRewardsMessage(
@@ -513,11 +530,13 @@ export class RewardsController extends BaseController<
           'SnapController:handleRequest',
         ) as unknown as HandleSnapRequest['handler'],
         account.id,
-        Buffer.from(message, 'utf8').toString('base64'),
+        Buffer.from(hotWalletMessage, 'utf8').toString('base64'),
       );
-      return `0x${Buffer.from(base58.decode(result.signature)).toString(
-        'hex',
-      )}`;
+      return {
+        signature: `0x${Buffer.from(base58.decode(result.signature)).toString(
+          'hex',
+        )}`,
+      };
     } else if (
       isBtcMainnetAddress(account.address) ||
       isBtcTestnetAddress(account.address)
@@ -531,12 +550,12 @@ export class RewardsController extends BaseController<
           'SnapController:handleRequest',
         ) as unknown as HandleSnapRequest['handler'],
         account.id,
-        Buffer.from(message, 'utf8').toString('base64'),
+        Buffer.from(hotWalletMessage, 'utf8').toString('base64'),
       );
       // Bitcoin signatures are typically hex-encoded, return as-is or convert if needed
-      return result.signature.startsWith('0x')
+      return { signature: result.signature.startsWith('0x')
         ? result.signature
-        : `0x${result.signature}`;
+        : `0x${result.signature}` };
     } else if (isTronAddress(account.address)) {
       if (this.#isTronDisabled()) {
         throw new Error('Unsupported account type for signing rewards message');
@@ -547,15 +566,15 @@ export class RewardsController extends BaseController<
           'SnapController:handleRequest',
         ) as unknown as HandleSnapRequest['handler'],
         account.id,
-        Buffer.from(message, 'utf8').toString('base64'),
+        Buffer.from(hotWalletMessage, 'utf8').toString('base64'),
       );
       // Tron signatures are typically hex-encoded, return as-is or convert if needed
-      return result.signature.startsWith('0x')
+      return { signature: result.signature.startsWith('0x')
         ? result.signature
-        : `0x${result.signature}`;
-    } else if (isEvmAddress(account.address)) {
-      const result = await this.#signEvmMessage(account, message);
-      return result;
+        : `0x${result.signature}` };
+    } else if (isEvm) {
+      const result = await this.#signEvmMessage(account, hotWalletMessage);
+      return { signature: result };
     }
 
     throw new Error('Unsupported account type for signing rewards message');
@@ -574,6 +593,30 @@ export class RewardsController extends BaseController<
       {
         data: hexMessage,
         from: account.address,
+      },
+    );
+    return signature;
+  }
+
+  /**
+   * Sign a SIWE (Sign-In with Ethereum) message for rewards authentication
+   *
+   * @param account - The account to sign with
+   * @param challenge - The challenge DTO containing the message string to sign
+   * @returns The signature of the SIWE message
+   */
+  async signSiweEvmMessage(
+    account: InternalAccount,
+    challenge: ChallengeDto,
+  ): Promise<string> {
+    const messageHex = Buffer.from(challenge.message, 'utf8').toString('hex');
+    const siwe = detectSIWE({ data: messageHex });
+    const signature = await this.messenger.call(
+      'KeyringController:signPersonalMessage',
+      {
+        data: messageHex,
+        from: account.address,
+        siwe,
       },
     );
     return signature;
@@ -613,6 +656,9 @@ export class RewardsController extends BaseController<
         let successAccount: InternalAccount | null = null;
         for (const account of sortedAccounts) {
           try {
+            if (isHardwareAccount(account)) {
+              continue;
+            }
             const subscriptionId = await this.performSilentAuth(
               account,
               false,
@@ -685,20 +731,13 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Check if an internal account supports opt-in for rewards
+   * Check if an internal account supports opt-in for rewards.
    *
    * @param account - The internal account to check
-   * @returns boolean - True if the account supports opt-in, false otherwise
+   * @returns boolean - True if the account supports silent opt-in, false otherwise
    */
   isOptInSupported(account: InternalAccount): boolean {
     try {
-      // Try to check if it's a hardware wallet
-      const isHardware = isHardwareAccount(account);
-      // If it's a hardware wallet, opt-in is not supported
-      if (isHardware) {
-        return false;
-      }
-
       // Check if it's an EVM address (not non-EVM)
       if (isEvmAddress(account.address)) {
         return true;
@@ -768,6 +807,10 @@ export class RewardsController extends BaseController<
     internalAccount?: InternalAccount | null,
     shouldBecomeActiveAccount = true,
     respectSkipSilentAuth = true,
+    hardwareWalletSignResult?: {
+      signature: string;
+      challenge?: ChallengeDto;
+    } | null,
   ): Promise<string | null> {
     if (!internalAccount) {
       if (shouldBecomeActiveAccount) {
@@ -781,9 +824,23 @@ export class RewardsController extends BaseController<
     const account: CaipAccountId | null =
       this.convertInternalAccountToCaipAccountId(internalAccount);
 
-    const shouldSkip = account
-      ? this.shouldSkipSilentAuth(account, internalAccount)
-      : false;
+    let shouldSkip: boolean;
+
+    const hardwareAcc = isHardwareAccount(internalAccount);
+
+    // Assume we can't silent auth for hardware accounts
+    if (
+      hardwareAcc &&
+      (!hardwareWalletSignResult?.challenge ||
+        !hardwareWalletSignResult?.signature)
+    ) {
+      respectSkipSilentAuth = true;
+      shouldSkip = true;
+    } else {
+      shouldSkip = account
+        ? this.shouldSkipSilentAuth(account, internalAccount)
+        : false;
+    }
 
     if (shouldSkip && respectSkipSilentAuth) {
       // This means that we'll have a record for this account
@@ -858,66 +915,88 @@ export class RewardsController extends BaseController<
     try {
       // Generate timestamp and sign the message
       let timestamp = Math.floor(Date.now() / 1000);
-      let signature;
+      let signature: string = hardwareAcc
+        ? hardwareWalletSignResult?.signature || ''
+        : '';
+      const challenge = hardwareAcc
+        ? hardwareWalletSignResult?.challenge
+        : undefined;
       let retryAttempt = 0;
       const MAX_RETRY_ATTEMPTS = 1;
 
-      try {
-        signature = await this.#signRewardsMessage(internalAccount, timestamp);
-      } catch (signError) {
-        log.error(
-          'RewardsController: Failed to generate signature:',
-          signError,
-        );
+      if (!hardwareAcc) {
+        try {
+          const signResult = await this.#signRewardsMessage(
+            internalAccount,
+            timestamp,
+          );
+          signature = signResult.signature;
+        } catch (signError) {
+          log.error(
+            'RewardsController: Failed to generate signature:',
+            signError,
+          );
 
-        // Check if the error is due to locked keyring
-        if (
-          signError &&
-          typeof signError === 'object' &&
-          'message' in signError
-        ) {
-          const errorMessage = (signError as Error).message;
-          if (errorMessage.includes('controller is locked')) {
-            return null; // Exit silently when keyring is locked
+          // Check if the error is due to locked keyring
+          if (
+            signError &&
+            typeof signError === 'object' &&
+            'message' in signError
+          ) {
+            const errorMessage = (signError as Error).message;
+            if (errorMessage.includes('controller is locked')) {
+              return null; // Exit silently when keyring is locked
+            }
           }
-        }
 
-        throw signError;
+          throw signError;
+        }
       }
 
       // Function to execute the login call with retry logic
       const executeLogin = async (
-        ts: number,
         sig: string,
+        challengeDto?: ChallengeDto,
       ): Promise<LoginResponseDto> => {
         try {
+          // Use SIWE login if we have a challenge (hardware wallet)
+          if (challengeDto) {
+            return await this.messenger.call('RewardsDataService:siweLogin', {
+              challengeId: challengeDto.id,
+              signature: sig as `0x${string}`,
+            });
+          }
+          // Use regular login for non-hardware wallets
           return await this.messenger.call('RewardsDataService:login', {
             account: internalAccount.address,
-            timestamp: ts,
+            timestamp,
             signature: sig,
           });
         } catch (error) {
           // Check if it's an InvalidTimestampError and we haven't exceeded retry attempts
+          // Only retry for regular login (not SIWE login)
           if (
             error instanceof InvalidTimestampError &&
-            retryAttempt < MAX_RETRY_ATTEMPTS
+            retryAttempt < MAX_RETRY_ATTEMPTS &&
+            !hardwareAcc
           ) {
             retryAttempt += 1;
             // Use the timestamp from the error for retry
             timestamp = error.timestamp;
-            signature = await this.#signRewardsMessage(
+            const signResult = await this.#signRewardsMessage(
               internalAccount,
               timestamp,
             );
-            return await executeLogin(timestamp, signature);
+            signature = signResult.signature;
+            return await executeLogin(signature, challenge);
           }
           throw error;
         }
       };
 
       const loginResponse: LoginResponseDto = await executeLogin(
-        timestamp,
         signature,
+        challenge,
       );
 
       // Update state with successful authentication
@@ -981,7 +1060,11 @@ export class RewardsController extends BaseController<
     if (!rewardsEnabled) {
       return false;
     }
-    return this.#getAccountState(account)?.hasOptedIn ?? false;
+    return (
+      (this.#getAccountState(account)?.hasOptedIn &&
+        this.#getAccountState(account)?.subscriptionId !== null) ??
+      false
+    );
   }
 
   checkOptInStatusAgainstCache(
@@ -1013,13 +1096,13 @@ export class RewardsController extends BaseController<
           const accountState = this.#getAccountState(caipAccount);
           if (accountState?.hasOptedIn !== undefined) {
             // Check if account is not opted in and needs a recheck
-            const shouldRecheckFreshIfNotOptedIn =
+            const shouldRecheckFresh =
               !accountState.lastFreshOptInStatusCheck ||
               Date.now() - accountState.lastFreshOptInStatusCheck >
-                NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
+              NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
             if (
-              accountState.hasOptedIn === false &&
-              shouldRecheckFreshIfNotOptedIn
+              (accountState.hasOptedIn === false || (accountState.hasOptedIn && !accountState.subscriptionId)) &&
+              shouldRecheckFresh
             ) {
               // Force a fresh check for this not-opted-in account
               addressesNeedingFresh.push(address);
@@ -1098,12 +1181,14 @@ export class RewardsController extends BaseController<
           const hasOptedIn = freshOptInResults[i];
           const subscriptionId =
             Array.isArray(freshSubscriptionIds) &&
-            i < freshSubscriptionIds.length
+              i < freshSubscriptionIds.length
               ? freshSubscriptionIds[i]
               : null;
           const internalAccount = addressToAccountMap.get(
             address.toLowerCase(),
           );
+
+          const canUseSubscriptionId = subscriptionId && (this.#getSubscriptionToken(subscriptionId) || (internalAccount && !isHardwareAccount(internalAccount)));
 
           if (internalAccount) {
             const caipAccount =
@@ -1111,18 +1196,17 @@ export class RewardsController extends BaseController<
             if (caipAccount) {
               const lastFreshOptInStatusCheck = Date.now();
               this.update((state: RewardsControllerState) => {
-                // Update or create account state with fresh opt-in status and subscription ID
+                // Update or create account state with fresh opt-in status
                 if (state.rewardsAccounts[caipAccount]) {
                   state.rewardsAccounts[caipAccount].hasOptedIn = hasOptedIn;
-                  state.rewardsAccounts[caipAccount].subscriptionId =
-                    subscriptionId;
+                  state.rewardsAccounts[caipAccount].subscriptionId = canUseSubscriptionId ? subscriptionId : null;
                   state.rewardsAccounts[caipAccount].lastFreshOptInStatusCheck =
                     lastFreshOptInStatusCheck;
                 } else {
                   state.rewardsAccounts[caipAccount] = {
                     account: caipAccount,
                     hasOptedIn,
-                    subscriptionId,
+                    subscriptionId: canUseSubscriptionId ? subscriptionId : null,
                     perpsFeeDiscount: null,
                     lastPerpsDiscountRateFetched: null,
                     lastFreshOptInStatusCheck,
@@ -1131,7 +1215,7 @@ export class RewardsController extends BaseController<
 
                 if (state.rewardsActiveAccount?.account === caipAccount) {
                   state.rewardsActiveAccount.hasOptedIn = hasOptedIn;
-                  state.rewardsActiveAccount.subscriptionId = subscriptionId;
+                  state.rewardsActiveAccount.subscriptionId = canUseSubscriptionId ? subscriptionId : null;
                   state.rewardsActiveAccount.lastFreshOptInStatusCheck =
                     lastFreshOptInStatusCheck;
                 }
@@ -1424,13 +1508,15 @@ export class RewardsController extends BaseController<
           if (error instanceof AuthorizationFailedError) {
             // Attempt to reauth with a valid account.
             try {
+              const account = await this.messenger.call(
+                'AccountsController:getSelectedMultichainAccount',
+              );
+
               if (
                 this.state.rewardsActiveAccount?.subscriptionId ===
-                subscriptionId
+                subscriptionId &&
+                !isHardwareAccount(account as InternalAccount)
               ) {
-                const account = await this.messenger.call(
-                  'AccountsController:getSelectedMultichainAccount',
-                );
                 await this.performSilentAuth(account, false, false); // try and auth.
               } else if (
                 this.state.rewardsAccounts &&
@@ -1448,7 +1534,10 @@ export class RewardsController extends BaseController<
                     (acc: InternalAccount) => {
                       const accCaipId =
                         convertInternalAccountToCaipAccountId(acc);
-                      return accCaipId === accountForSub.account;
+                      return (
+                        accCaipId === accountForSub.account &&
+                        !isHardwareAccount(acc)
+                      );
                     },
                   );
                   if (intAccountForSub) {
@@ -1606,14 +1695,25 @@ export class RewardsController extends BaseController<
     }
     // Generate timestamp and sign the message for mobile optin
     let timestamp = Math.floor(Date.now() / 1000);
-    let signature = await this.#signRewardsMessage(account, timestamp);
+    let { signature, challenge } = await this.#signRewardsMessage(
+      account,
+      timestamp,
+    );
     let retryAttempt = 0;
     const MAX_RETRY_ATTEMPTS = 1;
     const executeMobileOptin = async (
       ts: number,
       sig: string,
+      chal?: ChallengeDto,
     ): Promise<LoginResponseDto> => {
       try {
+        if (chal) {
+          return await this.messenger.call('RewardsDataService:siweLogin', {
+            challengeId: chal.id,
+            signature: sig as `0x${string}`,
+            referralCode,
+          });
+        }
         return await this.messenger.call('RewardsDataService:mobileOptin', {
           account: account.address,
           timestamp: ts,
@@ -1629,8 +1729,11 @@ export class RewardsController extends BaseController<
           retryAttempt += 1;
           // Use the timestamp from the error for retry
           timestamp = error.timestamp;
-          signature = await this.#signRewardsMessage(account, timestamp);
-          return await executeMobileOptin(timestamp, signature);
+          const { signature: newSignature, challenge: newChallenge } =
+            await this.#signRewardsMessage(account, timestamp);
+          signature = newSignature;
+          challenge = newChallenge;
+          return await executeMobileOptin(timestamp, signature, newChallenge);
         }
         // Check if it's an AccountAlreadyRegisteredError
         if (error instanceof AccountAlreadyRegisteredError) {
@@ -1639,6 +1742,7 @@ export class RewardsController extends BaseController<
             account,
             false,
             false,
+            challenge ? { signature, challenge } : null,
           );
 
           // If silent auth returned a subscription ID, recover with login response
@@ -1662,7 +1766,11 @@ export class RewardsController extends BaseController<
       }
     };
 
-    const optinResponse = await executeMobileOptin(timestamp, signature);
+    const optinResponse = await executeMobileOptin(
+      timestamp,
+      signature,
+      challenge,
+    );
     // Store the subscription token for authenticated requests
     if (optinResponse.subscription?.id && optinResponse.sessionId) {
       this.#storeSubscriptionToken(
@@ -1784,11 +1892,58 @@ export class RewardsController extends BaseController<
   }
 
   /**
+   * Get subscription ID from primary wallet account group accounts
+   * Validates that hardware wallet accounts are authenticated if opted in
+   *
+   * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
+   * @returns Promise<string | null> - The subscription ID or null if none found
+   * @throws Error if a hardware wallet account is opted in but not authenticated
+   */
+  async getPrimaryWalletSubscriptionId(
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ): Promise<string | null> {
+    if (
+      !primaryWalletGroupAccounts ||
+      primaryWalletGroupAccounts.length === 0
+    ) {
+      return null;
+    }
+
+    await this.getOptInStatus({
+      addresses: primaryWalletGroupAccounts.map((account) => account.address),
+    });
+
+    for (const account of primaryWalletGroupAccounts) {
+      const caipAccount = this.convertInternalAccountToCaipAccountId(account);
+      if (caipAccount) {
+        const accountState = this.#getAccountState(caipAccount);
+        if (
+          accountState?.hasOptedIn &&
+          accountState.subscriptionId === null &&
+          isHardwareAccount(account)
+        ) {
+          throw new Error(
+            'Primary wallet account group has opted in but is not authenticated yet',
+          );
+        } else if (accountState?.subscriptionId) {
+          // Prefer the subscription ID of the primary/first account group of the active wallet if it exists
+          return accountState.subscriptionId;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Get candidate subscription ID with fallback logic
    *
+   * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
    * @returns Promise<string | null> - The subscription ID or null if none found
    */
-  async getCandidateSubscriptionId(): Promise<string | null> {
+  async getCandidateSubscriptionId(
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ): Promise<string | null> {
     if (!this.isRewardsFeatureEnabled()) {
       return null;
     }
@@ -1796,6 +1951,14 @@ export class RewardsController extends BaseController<
     // First, check if there's an active account with a subscription
     if (this.state.rewardsActiveAccount?.subscriptionId) {
       return this.state.rewardsActiveAccount.subscriptionId;
+    }
+
+    // Check if any of the provided accounts are opted in but have no subscription ID
+    const primaryWalletSubscriptionId =
+      await this.getPrimaryWalletSubscriptionId(primaryWalletGroupAccounts);
+
+    if (primaryWalletSubscriptionId) {
+      return primaryWalletSubscriptionId;
     }
 
     // Fallback to the first subscription ID from the subscriptions map
@@ -1824,13 +1987,15 @@ export class RewardsController extends BaseController<
     }
 
     // If no subscriptions found, call optinstatus for all internal accounts
+    let optInStatusResponse: OptInStatusDto | undefined;
+    let supportedAccounts: InternalAccount[] = [];
     try {
       const allAccounts = this.messenger.call(
         'AccountsController:listMultichainAccounts',
       );
 
       // Extract addresses from internal accounts using isOptInSupported
-      const supportedAccounts: InternalAccount[] =
+      supportedAccounts =
         allAccounts?.filter((account: InternalAccount) =>
           this.isOptInSupported(account),
         ) || [];
@@ -1843,7 +2008,7 @@ export class RewardsController extends BaseController<
       );
 
       // Call opt-in status check
-      const optInStatusResponse = await this.getOptInStatus({ addresses });
+      optInStatusResponse = await this.getOptInStatus({ addresses });
       if (!optInStatusResponse?.ois?.filter((ois: boolean) => ois).length) {
         return null;
       }
@@ -1866,7 +2031,7 @@ export class RewardsController extends BaseController<
         // Defensive: Ensure sids is an array and i is within bounds
         let subscriptionId =
           Array.isArray(optInStatusResponse?.sids) &&
-          i < optInStatusResponse.sids.length
+            i < optInStatusResponse.sids.length
             ? optInStatusResponse.sids[i]
             : null;
         const sessionToken = subscriptionId
@@ -1880,6 +2045,9 @@ export class RewardsController extends BaseController<
           return subscriptionId;
         }
         try {
+          if (isHardwareAccount(account)) {
+            continue;
+          }
           silentAuthAttempts += 1;
           subscriptionId = await this.performSilentAuth(
             account,
@@ -1905,20 +2073,37 @@ export class RewardsController extends BaseController<
       );
     }
 
-    throw new Error(
-      'No candidate subscription ID found after all silent auth attempts. There is an opted in account but we cannot use it to fetch the season status.',
-    );
+    // Only throw if there are opted-in accounts but none are hot wallets
+    if (optInStatusResponse?.ois) {
+      const hasOptedInHotWallet = supportedAccounts.some(
+        (account, i) =>
+          optInStatusResponse.ois[i] && account && !isHardwareAccount(account),
+      );
+
+      if (hasOptedInHotWallet) {
+        throw new Error(
+          'No candidate subscription ID found after all silent auth attempts. There is an opted in account but we cannot use it to fetch the season status.',
+        );
+      }
+    }
+
+    // Subscription id was found but only hardware wallets were opted in,
+    //  we can't silently auth so users will have to opt in again.
+    return null;
   }
 
   /**
    * Link an account to a subscription via mobile join
    *
    * @param account - The account to link to the subscription
+   * @param invalidateRelatedData - Whether to invalidate related cache data
+   * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
    * @returns Promise<boolean> - The updated subscription information
    */
   async linkAccountToSubscriptionCandidate(
     account: InternalAccount,
     invalidateRelatedData: boolean = true,
+    primaryWalletGroupAccounts?: InternalAccount[],
   ): Promise<boolean> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
@@ -1942,7 +2127,9 @@ export class RewardsController extends BaseController<
     }
 
     // Get candidate subscription ID using the new method
-    const candidateSubscriptionId = await this.getCandidateSubscriptionId();
+    const candidateSubscriptionId = await this.getCandidateSubscriptionId(
+      primaryWalletGroupAccounts,
+    );
     if (!candidateSubscriptionId) {
       throw new Error('No valid subscription found to link account to');
     }
@@ -1954,7 +2141,10 @@ export class RewardsController extends BaseController<
     try {
       // Generate timestamp and sign the message for mobile join
       let timestamp = Math.floor(Date.now() / 1000);
-      let signature = await this.#signRewardsMessage(account, timestamp);
+      let { signature, challenge } = await this.#signRewardsMessage(
+        account,
+        timestamp,
+      );
       let retryAttempt = 0;
       const MAX_RETRY_ATTEMPTS = 1;
 
@@ -1962,6 +2152,7 @@ export class RewardsController extends BaseController<
       const executeMobileJoin = async (
         ts: number,
         sig: string,
+        chal?: ChallengeDto,
       ): Promise<SubscriptionDto> => {
         try {
           const subscriptionToken = this.#getSubscriptionToken(
@@ -1972,7 +2163,17 @@ export class RewardsController extends BaseController<
               `No subscription token found for subscription ID: ${candidateSubscriptionId}`,
             );
           }
-          return await this.messenger.call(
+          if (chal) {
+            return (await this.messenger.call(
+              'RewardsDataService:siweJoin',
+              {
+                challengeId: chal.id,
+                signature: sig as `0x${string}`,
+              },
+              subscriptionToken,
+            )) as SubscriptionDto;
+          }
+          return (await this.messenger.call(
             'RewardsDataService:mobileJoin',
             {
               account: account.address,
@@ -1980,7 +2181,7 @@ export class RewardsController extends BaseController<
               signature: sig as `0x${string}`,
             },
             subscriptionToken,
-          );
+          )) as SubscriptionDto;
         } catch (error) {
           // Check if it's an InvalidTimestampError and we haven't exceeded retry attempts
           if (
@@ -1990,8 +2191,11 @@ export class RewardsController extends BaseController<
             retryAttempt += 1;
             // Use the timestamp from the error for retry
             timestamp = error.timestamp;
-            signature = await this.#signRewardsMessage(account, timestamp);
-            return await executeMobileJoin(timestamp, signature);
+            const { signature: newSignature, challenge: newChallenge } =
+              await this.#signRewardsMessage(account, timestamp);
+            signature = newSignature;
+            challenge = newChallenge;
+            return await executeMobileJoin(timestamp, signature, challenge);
           }
           if (error instanceof AccountAlreadyRegisteredError) {
             // Try to perform silent auth for this account
@@ -1999,6 +2203,7 @@ export class RewardsController extends BaseController<
               account,
               false,
               false,
+              challenge ? { signature, challenge } : null,
             );
 
             // If silent auth returned a subscription ID, return the subscription from cache
@@ -2017,6 +2222,7 @@ export class RewardsController extends BaseController<
       const updatedSubscription: SubscriptionDto = await executeMobileJoin(
         timestamp,
         signature,
+        challenge,
       );
 
       // Update store with accounts and subscriptions (but not activeAccount)
@@ -2062,9 +2268,11 @@ export class RewardsController extends BaseController<
    * Link multiple accounts to a subscription candidate
    *
    * @param accounts - Array of accounts to link to the subscription
+   * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
    */
   async linkAccountsToSubscriptionCandidate(
     accounts: InternalAccount[],
+    primaryWalletGroupAccounts?: InternalAccount[],
   ): Promise<{ account: InternalAccount; success: boolean }[]> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
@@ -2092,6 +2300,7 @@ export class RewardsController extends BaseController<
         const success = await this.linkAccountToSubscriptionCandidate(
           accountToLink,
           false, // we will invalidate at the end of the loop
+          primaryWalletGroupAccounts,
         );
 
         if (success) {

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -829,6 +829,7 @@ export class RewardsController extends BaseController<
       this.convertInternalAccountToCaipAccountId(internalAccount);
 
     let shouldSkip: boolean;
+    let effectiveRespectSkipSilentAuth = respectSkipSilentAuth;
 
     const hardwareAcc = isHardwareAccount(internalAccount);
 
@@ -838,7 +839,7 @@ export class RewardsController extends BaseController<
       (!hardwareWalletSignResult?.challenge ||
         !hardwareWalletSignResult?.signature)
     ) {
-      respectSkipSilentAuth = true;
+      effectiveRespectSkipSilentAuth = true;
       shouldSkip = true;
     } else {
       shouldSkip = account
@@ -846,7 +847,7 @@ export class RewardsController extends BaseController<
         : false;
     }
 
-    if (shouldSkip && respectSkipSilentAuth) {
+    if (shouldSkip && effectiveRespectSkipSilentAuth) {
       // This means that we'll have a record for this account
       let accountState = this.#getAccountState(account as CaipAccountId);
       if (accountState) {

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -409,6 +409,110 @@ export type DiscoverSeasonsDto = {
    * Next season information
    */
   next: SeasonInfoDto | null;
+
+  /**
+   * Previous season information
+   */
+  previous: SeasonInfoDto | null;
+};
+
+/**
+ * Challenge DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type ChallengeDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  id: string;
+
+  /**
+   * The address of the challenge, either ethereum or solana
+   *
+   * @example '0xbd7d160C18b51527fEBd3D6B667143B5C519C32E'
+   */
+  address: string;
+
+  /**
+   * The domain of the challenge
+   *
+   * @example 'example.com'
+   */
+  domain: string;
+
+  /**
+   * The nonce of the challenge
+   *
+   * @example '1234567890'
+   */
+  nonce: bigint;
+
+  /**
+   * The issued at date of the challenge
+   *
+   * @example '2025-01-01T00:00:00.000Z'
+   */
+  issuedAt: string;
+
+  /**
+   * The expiration date of the challenge
+   *
+   * @example '2025-01-01T00:00:00.000Z'
+   */
+  expirationTime: string;
+
+  /**
+   * The SIWE (Sign-In with Ethereum) message to be signed
+   *
+   * @example 'example.com wants you to sign in with your Ethereum account: 0x...'
+   */
+  message: string;
+};
+
+/**
+ * Login DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type SiweLoginDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  challengeId: string;
+
+  /**
+   * The signature of the SIWE message
+   *
+   * @example '0x...'
+   */
+  signature: `0x${string}`;
+
+  /**
+   * Code provided by referrer
+   *
+   * @example '12345'
+   */
+  referralCode?: string;
+};
+
+/**
+ * Join DTO for SIWE (Sign-In with Ethereum) authentication
+ */
+export type SiweJoinDto = {
+  /**
+   * The unique identifier of the challenge
+   *
+   * @example '019717cb-7d10-771e-8052-10c9be058a86'
+   */
+  challengeId: string;
+
+  /**
+   * The signature of the SIWE message
+   *
+   * @example '0x...'
+   */
+  signature: `0x${string}`;
 };
 
 export type SubscriptionReferralDetailsDto = {
@@ -740,7 +844,11 @@ export type RewardsControllerIsOptInSupportedAction = {
  */
 export type RewardsControllerLinkAccountToSubscriptionAction = {
   type: 'RewardsController:linkAccountToSubscriptionCandidate';
-  handler: (account: InternalAccount) => Promise<boolean>;
+  handler: (
+    account: InternalAccount,
+    invalidateRelatedData?: boolean,
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ) => Promise<boolean>;
 };
 
 /**
@@ -750,6 +858,7 @@ export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
   type: 'RewardsController:linkAccountsToSubscriptionCandidate';
   handler: (
     accounts: InternalAccount[],
+    primaryWalletGroupAccounts?: InternalAccount[],
   ) => Promise<{ account: InternalAccount; success: boolean }[]>;
 };
 
@@ -766,7 +875,9 @@ export type RewardsControllerGetGeoRewardsMetadataAction = {
  */
 export type RewardsControllerGetCandidateSubscriptionIdAction = {
   type: 'RewardsController:getCandidateSubscriptionId';
-  handler: () => Promise<string | null>;
+  handler: (
+    primaryWalletGroupAccounts?: InternalAccount[],
+  ) => Promise<string | null>;
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-data-service-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-types.ts
@@ -10,6 +10,11 @@ export interface RewardsDataServiceLoginAction {
   handler: RewardsDataService['login'];
 }
 
+export interface RewardsDataServiceSiweLoginAction {
+  type: `${typeof SERVICE_NAME}:siweLogin`;
+  handler: RewardsDataService['siweLogin'];
+}
+
 export interface RewardsDataServiceEstimatePointsAction {
   type: `${typeof SERVICE_NAME}:estimatePoints`;
   handler: RewardsDataService['estimatePoints'];
@@ -40,6 +45,11 @@ export interface RewardsDataServiceMobileJoinAction {
   handler: RewardsDataService['mobileJoin'];
 }
 
+export interface RewardsDataServiceSiweJoinAction {
+  type: `${typeof SERVICE_NAME}:siweJoin`;
+  handler: RewardsDataService['siweJoin'];
+}
+
 export interface RewardsDataServiceGetOptInStatusAction {
   type: `${typeof SERVICE_NAME}:getOptInStatus`;
   handler: RewardsDataService['getOptInStatus'];
@@ -55,14 +65,22 @@ export interface RewardsDataServiceGetDiscoverSeasonsAction {
   handler: RewardsDataService['getDiscoverSeasons'];
 }
 
+export interface RewardsDataServiceGenerateChallengeAction {
+  type: `${typeof SERVICE_NAME}:generateChallenge`;
+  handler: RewardsDataService['generateChallenge'];
+}
+
 export type RewardsDataServiceActions =
   | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
   | RewardsDataServiceEstimatePointsAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceFetchGeoLocationAction
   | RewardsDataServiceMobileOptinAction
   | RewardsDataServiceValidateReferralCodeAction
   | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceGetSeasonMetadataAction
-  | RewardsDataServiceGetDiscoverSeasonsAction;
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGenerateChallengeAction;

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -24,6 +24,9 @@ import type {
   SeasonStateDto,
   SeasonMetadataDto,
   DiscoverSeasonsDto,
+  ChallengeDto,
+  SiweLoginDto,
+  SiweJoinDto,
 } from './rewards-controller.types';
 
 /**
@@ -124,6 +127,10 @@ export class RewardsDataService {
       this.login.bind(this),
     );
     this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:siweLogin`,
+      this.siweLogin.bind(this),
+    );
+    this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:estimatePoints`,
       this.estimatePoints.bind(this),
     );
@@ -148,6 +155,10 @@ export class RewardsDataService {
       this.mobileJoin.bind(this),
     );
     this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:siweJoin`,
+      this.siweJoin.bind(this),
+    );
+    this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:getOptInStatus`,
       this.getOptInStatus.bind(this),
     );
@@ -158,6 +169,10 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:getDiscoverSeasons`,
       this.getDiscoverSeasons.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:generateChallenge`,
+      this.generateChallenge.bind(this),
     );
   }
 
@@ -331,6 +346,32 @@ export class RewardsDataService {
       this.checkForAccountAlreadyRegisteredError(response, errorData);
 
       throw new Error(`Login failed: ${response.status}`);
+    }
+
+    return (await response.json()) as LoginResponseDto;
+  }
+
+  /**
+   * Perform login via SIWE (Sign-In with Ethereum) signature.
+   *
+   * @param body - The SIWE login request body containing challengeId, signature, and optional referralCode.
+   * @param body.challengeId - The unique identifier of the challenge
+   * @param body.signature - The signature of the SIWE message
+   * @param body.referralCode - Optional referral code provided by referrer
+   * @returns The login response DTO.
+   */
+  async siweLogin(body: SiweLoginDto): Promise<LoginResponseDto> {
+    const response = await this.makeRequest('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+
+      this.checkForAccountAlreadyRegisteredError(response, errorData);
+
+      throw new Error(`SIWE login failed: ${response.status}`);
     }
 
     return (await response.json()) as LoginResponseDto;
@@ -518,6 +559,40 @@ export class RewardsDataService {
   }
 
   /**
+   * Join an account to a subscription via SIWE (Sign-In with Ethereum) signature.
+   *
+   * @param body - The SIWE join request body containing challengeId and signature.
+   * @param subscriptionToken - The subscription token to join the account to.
+   * @returns Promise<SubscriptionDto> - The updated subscription information.
+   */
+  async siweJoin(
+    body: SiweJoinDto,
+    subscriptionToken: string,
+  ): Promise<SubscriptionDto> {
+    const response = await this.makeRequest(
+      '/wr/subscriptions/join',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+      subscriptionToken,
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      log.error('RewardsDataService: siweJoin errorData', errorData);
+
+      this.checkForAccountAlreadyRegisteredError(response, errorData);
+
+      throw new Error(
+        `SIWE join failed: ${response.status} ${errorData?.message || ''}`,
+      );
+    }
+
+    return (await response.json()) as SubscriptionDto;
+  }
+
+  /**
    * Get opt-in status for multiple addresses.
    *
    * @param body - The request body containing addresses to check.
@@ -612,5 +687,32 @@ export class RewardsDataService {
     }
 
     return data as SeasonMetadataDto;
+  }
+
+  /**
+   * Generate a challenge for SIWE (Sign-In with Ethereum) authentication.
+   *
+   * @param body - The challenge generation request body containing address.
+   * @param body.address
+   * @returns The challenge DTO.
+   */
+  async generateChallenge(body: { address: string }): Promise<ChallengeDto> {
+    const response = await this.makeRequest('/auth/challenge/generate', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Generate challenge failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Convert nonce string to bigint if needed
+    if (typeof data.nonce === 'string') {
+      data.nonce = BigInt(data.nonce);
+    }
+
+    return data as ChallengeDto;
   }
 }

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { EthAccountType } from '@metamask/keyring-api';
+import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
+import { isHardwareAccount } from './isHardwareAccount';
+
+// Test constants
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+const MOCK_INTERNAL_ACCOUNT: InternalAccount = {
+  id: 'account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Test Account',
+    keyring: {
+      type: 'HD Key Tree',
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_LEDGER_ACCOUNT: InternalAccount = {
+  id: 'ledger-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Ledger Account',
+    keyring: {
+      type: HardwareKeyringType.ledger,
+    },
+    importTime: Date.now(),
+  },
+};
+
+const MOCK_QR_ACCOUNT: InternalAccount = {
+  id: 'qr-account-1',
+  address: MOCK_ACCOUNT_ADDRESS,
+  type: EthAccountType.Eoa,
+  scopes: ['eip155:1'],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'QR Wallet Account',
+    keyring: {
+      type: HardwareKeyringType.qr,
+    },
+    importTime: Date.now(),
+  },
+};
+
+describe('isHardwareAccount', () => {
+  it('should return true for Ledger hardware wallet', () => {
+    const result = isHardwareAccount(MOCK_LEDGER_ACCOUNT);
+    expect(result).toBe(true);
+  });
+
+  it('should return true for QR hardware wallet', () => {
+    const result = isHardwareAccount(MOCK_QR_ACCOUNT);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for software wallet', () => {
+    const result = isHardwareAccount(MOCK_INTERNAL_ACCOUNT);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for account with missing keyring metadata', () => {
+    const accountWithoutKeyring: InternalAccount = {
+      ...MOCK_INTERNAL_ACCOUNT,
+      metadata: {
+        name: 'Test Account',
+        importTime: Date.now(),
+      } as InternalAccount['metadata'],
+    };
+    const result = isHardwareAccount(accountWithoutKeyring);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for account with null metadata', () => {
+    const accountWithNullMetadata = {
+      ...MOCK_INTERNAL_ACCOUNT,
+      metadata: null,
+    } as unknown as InternalAccount;
+    const result = isHardwareAccount(accountWithNullMetadata);
+    expect(result).toBe(false);
+  });
+});

--- a/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
+++ b/app/scripts/controllers/rewards/utils/isHardwareAccount.ts
@@ -1,0 +1,20 @@
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { DEVICE_KEYRING_MAP } from '../../../../../shared/constants/hardware-wallets';
+
+/**
+ * Check if an account is a hardware wallet account
+ *
+ * @param account - The internal account to check
+ * @returns True if the account is a hardware wallet, false otherwise
+ */
+export function isHardwareAccount(account: InternalAccount): boolean {
+  try {
+    const keyringType = account?.metadata?.keyring?.type;
+    return Object.values(DEVICE_KEYRING_MAP).includes(
+      keyringType as KeyringTypes,
+    );
+  } catch {
+    return false;
+  }
+}

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -10,6 +10,9 @@
       "MetaMask: MetaMetrics invalid trait types": 4,
       "warn: MetaMetricsController#_identify: No userTraits found": 1
     },
+    "app/scripts/controllers/rewards/rewards-data-service.test.ts": {
+      "error: RewardsDataService: Failed to fetch geolocation": 2
+    },
     "app/scripts/controllers/swaps/swaps.test.ts": {
       "Third-party: Bindings failed, using pure JS": 1,
       "µWebSockets: Compatibility warnings": 1,

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -42,6 +42,7 @@
 @import 'permissions-connect-permission-list/index';
 @import 'permission-cell/index';
 @import 'recovery-phrase-reminder/index';
+@import 'rewards/onboarding/onboarding-modal';
 @import 'step-progress-bar/index.scss';
 @import 'selected-account/index';
 @import 'multichain-bridge-transaction-details-modal/index';

--- a/ui/components/app/rewards/RewardsPointsBalance.test.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.test.tsx
@@ -30,6 +30,12 @@ jest.mock('../../../hooks/rewards/useSeasonStatus', () => ({
   useSeasonStatus: jest.fn(),
 }));
 
+jest.mock('../../../hooks/rewards/useOptIn', () => ({
+  useOptIn: jest.fn(() => ({
+    optin: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 jest.mock('../../../hooks/useI18nContext', () => ({
   useI18nContext: jest.fn(() => (key: string, values?: string[]) => {
     if (key === 'rewardsPointsBalance' && values) {
@@ -40,6 +46,12 @@ jest.mock('../../../hooks/useI18nContext', () => ({
     }
     if (key === 'rewardsPointsBalance_couldntLoad') {
       return "Couldn't load";
+    }
+    if (key === 'rewardsSignInToViewPoints') {
+      return 'Sign in to view points';
+    }
+    if (key === 'rewardsSigningIn') {
+      return 'Signing in';
     }
     return key;
   }),
@@ -79,6 +91,9 @@ const mockGetStorageItem = getStorageItem as jest.MockedFunction<
 const mockSetStorageItem = setStorageItem as jest.MockedFunction<
   typeof setStorageItem
 >;
+
+const { useOptIn } = jest.requireMock('../../../hooks/rewards/useOptIn');
+const mockUseOptIn = useOptIn as jest.MockedFunction<typeof useOptIn>;
 
 describe('RewardsPointsBalance', () => {
   // Mock season status with complete structure
@@ -186,6 +201,9 @@ describe('RewardsPointsBalance', () => {
     setSelectorValues({});
     mockUseDispatch.mockReturnValue(jest.fn());
     mockSetStorageItem.mockResolvedValue(undefined);
+    mockUseOptIn.mockReturnValue({
+      optin: jest.fn().mockResolvedValue(undefined),
+    } as ReturnType<typeof useOptIn>);
     // Set IN_TEST to prevent onboarding modal from opening
     process.env.IN_TEST = 'true';
   });
@@ -500,6 +518,113 @@ describe('RewardsPointsBalance', () => {
     expect(container).toHaveClass('gap-1', 'bg-background-transparent');
     expect(textElement).toHaveClass('text-alternative');
     expect(textElement).toHaveTextContent("Couldn't load");
+  });
+
+  it('should render sign-in button when candidateSubscriptionId is error-existing-subscription-hardware-wallet-explicit-sign', () => {
+    const mockOptin = jest.fn().mockResolvedValue(undefined);
+    mockUseOptIn.mockReturnValue({
+      optin: mockOptin,
+    } as ReturnType<typeof useOptIn>);
+
+    setSelectorValues({
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const container = screen.getByTestId('rewards-points-balance');
+    const textElement = screen.getByTestId('rewards-points-balance-value');
+
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass(
+      'flex',
+      'items-center',
+      'gap-1',
+      'px-1.5',
+      'bg-background-muted',
+      'rounded',
+    );
+    expect(textElement).toHaveTextContent('Sign in to view points');
+  });
+
+  it('should call optin when sign-in button is clicked', async () => {
+    const mockOptin = jest.fn().mockResolvedValue(undefined);
+    mockUseOptIn.mockReturnValue({
+      optin: mockOptin,
+    } as ReturnType<typeof useOptIn>);
+
+    setSelectorValues({
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const textElement = screen.getByTestId('rewards-points-balance-value');
+    expect(textElement).toBeInTheDocument();
+    expect(textElement).toHaveTextContent('Sign in to view points');
+
+    await act(async () => {
+      textElement.click();
+    });
+
+    expect(mockOptin).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle optin errors gracefully when sign-in button is clicked', async () => {
+    const mockOptin = jest.fn().mockRejectedValue(new Error('Opt-in failed'));
+    mockUseOptIn.mockReturnValue({
+      optin: mockOptin,
+    } as ReturnType<typeof useOptIn>);
+
+    setSelectorValues({
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const textElement = screen.getByTestId('rewards-points-balance-value');
+
+    await act(async () => {
+      textElement.click();
+    });
+
+    expect(mockOptin).toHaveBeenCalledTimes(1);
+    // Component should still render despite optin error
+    expect(textElement).toBeInTheDocument();
+    expect(textElement).toHaveTextContent('Sign in to view points');
+  });
+
+  it('should render "Signing in" state when optinLoading is true for hardware wallet sign-in', () => {
+    const mockOptin = jest.fn().mockResolvedValue(undefined);
+    mockUseOptIn.mockReturnValue({
+      optin: mockOptin,
+      optinLoading: true,
+    } as ReturnType<typeof useOptIn>);
+
+    setSelectorValues({
+      candidateSubscriptionId:
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+      seasonStatusError: null,
+    });
+
+    render(<RewardsPointsBalance />);
+
+    const container = screen.getByTestId('rewards-points-balance');
+    const textElement = screen.getByTestId('rewards-points-balance-value');
+
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass(
+      'flex',
+      'items-center',
+      'gap-1',
+      'px-1.5',
+      'bg-background-muted',
+      'rounded',
+    );
+    expect(textElement).toHaveTextContent('Signing in');
   });
 
   it('should not open onboarding modal when hasSeenOnboarding is true', () => {

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import log from 'loglevel';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { Skeleton } from '../../component-library/skeleton';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -19,11 +20,13 @@ import {
 } from '../../../ducks/rewards/selectors';
 import { useCandidateSubscriptionId } from '../../../hooks/rewards/useCandidateSubscriptionId';
 import { useSeasonStatus } from '../../../hooks/rewards/useSeasonStatus';
+import { useOptIn } from '../../../hooks/rewards/useOptIn';
 import {
   getStorageItem,
   setStorageItem,
 } from '../../../../shared/lib/storage-helpers';
 import { useAppSelector } from '../../../store/store';
+import { CandidateSubscriptionId } from '../../../ducks/rewards/types';
 import { RewardsBadge } from './RewardsBadge';
 import {
   REWARDS_BADGE_HIDDEN,
@@ -44,7 +47,9 @@ export const RewardsPointsBalance = () => {
   const rewardsBadgeHidden = useSelector(selectRewardsBadgeHidden);
   const seasonStatus = useSelector(selectSeasonStatus);
   const seasonStatusError = useSelector(selectSeasonStatusError);
-  const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
+  const candidateSubscriptionId = useSelector(
+    selectCandidateSubscriptionId,
+  ) as CandidateSubscriptionId;
   const onboardingModalRendered = useSelector(selectOnboardingModalRendered);
   const rewardsActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
@@ -54,13 +59,29 @@ export const RewardsPointsBalance = () => {
     !rewardsActiveAccountSubscriptionId &&
     (candidateSubscriptionId === 'pending' ||
       candidateSubscriptionId === 'retry');
-  const candidateSubscriptionIdError = candidateSubscriptionId === 'error';
+  const candidateSubscriptionIdError =
+    candidateSubscriptionId === 'error' ||
+    candidateSubscriptionId ===
+      'error-existing-subscription-hardware-wallet-explicit-sign';
+  const candidateSubscriptionIdErrorNeedsSignIn =
+    candidateSubscriptionId ===
+    'error-existing-subscription-hardware-wallet-explicit-sign';
+
+  const { optin, optinLoading } = useOptIn();
 
   const isTestEnv = Boolean(process.env.IN_TEST);
 
   const openRewardsOnboardingModal = useCallback(() => {
     dispatch(setOnboardingModalOpen(true));
   }, [dispatch]);
+
+  const handleSignIn = useCallback(async () => {
+    try {
+      await optin();
+    } catch (error) {
+      log.error('[RewardsPointsBalance] Error during opt-in:', error);
+    }
+  }, [optin]);
 
   // entry point hooks
   const { fetchCandidateSubscriptionId } = useCandidateSubscriptionId();
@@ -114,7 +135,6 @@ export const RewardsPointsBalance = () => {
     rewardsEnabled,
     isTestEnv,
     candidateSubscriptionId,
-    rewardsActiveAccountSubscriptionId,
     onboardingModalRendered,
     rewardsOnboardingEnabled,
   ]);
@@ -154,6 +174,24 @@ export const RewardsPointsBalance = () => {
         withPointsSuffix={false}
         onClick={openRewardsOnboardingModal}
         allowHideBadge
+      />
+    );
+  }
+
+  // Show sign-in button if hardware wallet needs authentication
+  if (!seasonStatusError && candidateSubscriptionIdErrorNeedsSignIn) {
+    return optinLoading ? (
+      <RewardsBadge
+        formattedPoints={t('rewardsSigningIn')}
+        withPointsSuffix={false}
+        boxClassName="gap-1 px-1.5 bg-background-muted rounded"
+      />
+    ) : (
+      <RewardsBadge
+        formattedPoints={t('rewardsSignInToViewPoints')}
+        withPointsSuffix={false}
+        boxClassName="gap-1 px-1.5 bg-background-muted rounded"
+        onClick={handleSignIn}
       />
     );
   }

--- a/ui/components/app/rewards/RewardsPointsBalance.tsx
+++ b/ui/components/app/rewards/RewardsPointsBalance.tsx
@@ -137,6 +137,7 @@ export const RewardsPointsBalance = () => {
     candidateSubscriptionId,
     onboardingModalRendered,
     rewardsOnboardingEnabled,
+    rewardsActiveAccountSubscriptionId,
   ]);
 
   const setHasSeenOnboardingInStorage = useCallback(async () => {

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.test.tsx
@@ -266,32 +266,6 @@ describe('OnboardingIntroStep', () => {
     );
   });
 
-  it('on confirm: shows error toast for hardware wallet usage', () => {
-    // Trigger the hardware wallet branch
-    (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
-    (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);
-    (selectOptinAllowedForGeoError as jest.Mock).mockReturnValue(false);
-    (selectCandidateSubscriptionId as jest.Mock).mockReturnValue(undefined);
-    (isHardwareWallet as jest.Mock).mockReturnValue(true);
-
-    render(<OnboardingIntroStep />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'rewardsOnboardingIntroStepConfirm' }),
-    );
-
-    expect(setErrorToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isOpen: true,
-        title: 'rewardsOnboardingIntroHardwareWalletTitle',
-        description: 'rewardsOnboardingIntroHardwareWalletDescription',
-      }),
-    );
-    expect(dispatchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_ERROR_TOAST' }),
-    );
-  });
-
   it('on confirm: proceeds to STEP1 when allowed and not hardware wallet', () => {
     (selectOptinAllowedForGeo as jest.Mock).mockReturnValue(true);
     (selectOptinAllowedForGeoLoading as jest.Mock).mockReturnValue(false);

--- a/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingIntroStep.tsx
@@ -31,7 +31,6 @@ import {
 import { useGeoRewardsMetadata } from '../../../../hooks/rewards/useGeoRewardsMetadata';
 import { useCandidateSubscriptionId } from '../../../../hooks/rewards/useCandidateSubscriptionId';
 import { useAppSelector } from '../../../../store/store';
-import { isHardwareWallet } from '../../../../../shared/modules/selectors';
 
 /**
  * OnboardingIntroStep Component
@@ -58,12 +57,13 @@ const OnboardingIntroStep: React.FC = () => {
   );
   const optinAllowedForGeoError = useSelector(selectOptinAllowedForGeoError);
   const candidateSubscriptionId = useSelector(selectCandidateSubscriptionId);
-  const candidateSubscriptionIdError = candidateSubscriptionId === 'error';
+  const candidateSubscriptionIdError =
+    candidateSubscriptionId === 'error' ||
+    candidateSubscriptionId ===
+      'error-existing-subscription-hardware-wallet-explicit-sign';
   const rewardsActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
   );
-
-  const hardwareWalletUsed = useSelector(isHardwareWallet);
 
   // If we don't know of a subscription id, we need to fetch the geo metadata
   const { fetchGeoRewardsMetadata } = useGeoRewardsMetadata({
@@ -123,18 +123,6 @@ const OnboardingIntroStep: React.FC = () => {
       return;
     }
 
-    // Show error modal if hardware wallet
-    if (hardwareWalletUsed) {
-      dispatch(
-        setErrorToast({
-          isOpen: true,
-          title: t('rewardsOnboardingIntroHardwareWalletTitle'),
-          description: t('rewardsOnboardingIntroHardwareWalletDescription'),
-        }),
-      );
-      return;
-    }
-
     // Proceed to next onboarding step
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP1));
   }, [
@@ -142,7 +130,6 @@ const OnboardingIntroStep: React.FC = () => {
     dispatch,
     fetchCandidateSubscriptionId,
     fetchGeoRewardsMetadata,
-    hardwareWalletUsed,
     optinAllowedForGeo,
     optinAllowedForGeoError,
     optinAllowedForGeoLoading,

--- a/ui/components/app/rewards/onboarding/OnboardingModal.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingModal.tsx
@@ -17,6 +17,7 @@ import {
   selectOnboardingActiveStep,
   selectCandidateSubscriptionId,
 } from '../../../../ducks/rewards/selectors';
+import { getHardwareWalletType } from '../../../../selectors';
 import {
   setOnboardingActiveStep,
   setOnboardingModalOpen,
@@ -28,6 +29,7 @@ import { useTheme } from '../../../../hooks/useTheme';
 import RewardsErrorToast from '../RewardsErrorToast';
 import RewardsQRCode from '../RewardsQRCode';
 import { useAppSelector } from '../../../../store/store';
+import { HardwareKeyringType } from '../../../../../shared/constants/hardware-wallets';
 import OnboardingIntroStep from './OnboardingIntroStep';
 import OnboardingStep1 from './OnboardingStep1';
 import OnboardingStep2 from './OnboardingStep2';
@@ -60,6 +62,7 @@ export default function OnboardingModal({
   const rewardActiveAccountSubscriptionId = useAppSelector(
     (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
   );
+  const hardwareWalletType = useSelector(getHardwareWalletType);
   const dispatch = useDispatch();
 
   const theme = useTheme();
@@ -68,6 +71,8 @@ export default function OnboardingModal({
     () =>
       candidateSubscriptionId &&
       candidateSubscriptionId !== 'error' &&
+      candidateSubscriptionId !==
+        'error-existing-subscription-hardware-wallet-explicit-sign' &&
       candidateSubscriptionId !== 'pending' &&
       candidateSubscriptionId !== 'retry',
     [candidateSubscriptionId],
@@ -121,9 +126,12 @@ export default function OnboardingModal({
       data-testid="rewards-onboarding-modal"
       isOpen={isOpen}
       onClose={handleClose}
+      // qr code hadware wallet uses a popover signing modal, so we don't want to close the onboarding modal when clicking to sign a message
+      isClosedOnOutsideClick={hardwareWalletType !== HardwareKeyringType.qr}
     >
-      <ModalOverlay />
+      <ModalOverlay className="rewards-onboarding-modal__overlay" />
       <ModalContent
+        className="rewards-onboarding-modal__content"
         alignItems={AlignItems.center}
         justifyContent={JustifyContent.center}
         size={ModalContentSize.Md}

--- a/ui/components/app/rewards/onboarding/onboarding-modal.scss
+++ b/ui/components/app/rewards/onboarding/onboarding-modal.scss
@@ -1,0 +1,10 @@
+@use "design-system";
+
+// Lower z-index to ensure this modal appears behind other modals (e.g., QR code signing modal)
+.rewards-onboarding-modal {
+  &__overlay,
+  &__content {
+    z-index: design-system.$modal-z-index - 50;
+  }
+}
+

--- a/ui/ducks/rewards/index.ts
+++ b/ui/ducks/rewards/index.ts
@@ -134,6 +134,7 @@ const rewardsSlice = createSlice({
         previousCandidateId &&
         previousCandidateId !== 'pending' &&
         previousCandidateId !== 'error' &&
+        previousCandidateId !== 'error-existing-subscription-hardware-wallet-explicit-sign' &&
         previousCandidateId !== 'retry';
 
       const candidateIdChanged =

--- a/ui/ducks/rewards/index.ts
+++ b/ui/ducks/rewards/index.ts
@@ -134,7 +134,8 @@ const rewardsSlice = createSlice({
         previousCandidateId &&
         previousCandidateId !== 'pending' &&
         previousCandidateId !== 'error' &&
-        previousCandidateId !== 'error-existing-subscription-hardware-wallet-explicit-sign' &&
+        previousCandidateId !==
+          'error-existing-subscription-hardware-wallet-explicit-sign' &&
         previousCandidateId !== 'retry';
 
       const candidateIdChanged =

--- a/ui/ducks/rewards/types.ts
+++ b/ui/ducks/rewards/types.ts
@@ -10,5 +10,6 @@ export type CandidateSubscriptionId =
   | 'pending'
   | 'retry'
   | 'error'
+  | 'error-existing-subscription-hardware-wallet-explicit-sign'
   | string
   | null;

--- a/ui/helpers/utils/rewards-utils.test.ts
+++ b/ui/helpers/utils/rewards-utils.test.ts
@@ -1,0 +1,421 @@
+import * as bridgeControllerUtils from '@metamask/bridge-controller';
+import log from 'loglevel';
+import { formatAccountToCaipAccountId } from './rewards-utils';
+
+jest.mock('loglevel', () => ({
+  error: jest.fn(),
+}));
+
+describe('rewards-utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('formatAccountToCaipAccountId', () => {
+    describe('valid inputs', () => {
+      it('should format a valid lowercase hex address to CAIP-10 account ID', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1'; // Ethereum mainnet
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format a valid checksummed address to CAIP-10 account ID', () => {
+        const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Polygon mainnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x89'; // Polygon mainnet (137)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:137:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Arbitrum One', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xa4b1'; // Arbitrum One (42161)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:42161:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Optimism', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xa'; // Optimism (10)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:10:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Base', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x2105'; // Base (8453)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:8453:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Linea mainnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xe708'; // Linea (59144)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:59144:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for BNB Smart Chain', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x38'; // BSC (56)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:56:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Goerli testnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x5'; // Goerli (5)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:5:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should format address for Sepolia testnet', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0xaa36a7'; // Sepolia (11155111)
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        expect(result).toBe(
+          'eip155:11155111:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+    });
+
+    describe('hardware wallet account addresses', () => {
+      // Hardware wallet accounts use the same address format as software wallets,
+      // but we test them explicitly to ensure they work correctly.
+
+      it('should format Ledger hardware wallet address', () => {
+        // Ledger addresses are standard Ethereum addresses
+        const ledgerAddress = '0x71c7656ec7ab88b098defb751b7401b5f6d8976f';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(ledgerAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+        );
+      });
+
+      it('should format Trezor hardware wallet address', () => {
+        // Trezor addresses are also standard Ethereum addresses
+        const trezorAddress = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(trezorAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+        );
+      });
+
+      it('should format QR hardware wallet (Keystone) address', () => {
+        // QR-based hardware wallet addresses are also standard Ethereum addresses
+        const keystoneAddress = '0x4e83362442b8d1bec281594cea3050c8eb01311c';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(keystoneAddress, chainId);
+
+        // The checksum is determined by the keccak256 hash of the lowercase address
+        expect(result).toBe(
+          'eip155:1:0x4E83362442B8d1beC281594cEa3050c8EB01311C',
+        );
+      });
+
+      it('should format hardware wallet address on Polygon', () => {
+        const hardwareAddress = '0x71c7656ec7ab88b098defb751b7401b5f6d8976f';
+        const chainId = '0x89'; // Polygon
+
+        const result = formatAccountToCaipAccountId(hardwareAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:137:0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+        );
+      });
+
+      it('should format hardware wallet address on Arbitrum', () => {
+        const hardwareAddress = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
+        const chainId = '0xa4b1'; // Arbitrum
+
+        const result = formatAccountToCaipAccountId(hardwareAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:42161:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+        );
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle address with mixed case (converts to checksum)', () => {
+        // Input is mixed case but not correct checksum - gets converted to proper checksum
+        const mixedCaseAddress = '0xD8Da6BF26964AF9D7eed9e03e53415D37Aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(mixedCaseAddress, chainId);
+
+        // The checksum conversion normalizes the case
+        expect(result).toBe(
+          'eip155:1:0xD8Da6BF26964AF9D7eed9e03e53415D37Aa96045',
+        );
+      });
+
+      it('should handle all lowercase address', () => {
+        const lowercaseAddress = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(lowercaseAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+
+      it('should handle all uppercase address (except prefix)', () => {
+        // When input is all uppercase (except prefix), it gets converted to checksum
+        // The toChecksumHexAddress preserves the input case for non-checksum addresses
+        const uppercaseAddress = '0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(uppercaseAddress, chainId);
+
+        // All uppercase input gets preserved as toChecksumHexAddress sees it as checksum
+        expect(result).toBe(
+          'eip155:1:0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045',
+        );
+      });
+
+      it('should handle zero address', () => {
+        const zeroAddress = '0x0000000000000000000000000000000000000000';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(zeroAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x0000000000000000000000000000000000000000',
+        );
+      });
+
+      it('should handle dead address', () => {
+        const deadAddress = '0x000000000000000000000000000000000000dead';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(deadAddress, chainId);
+
+        expect(result).toBe(
+          'eip155:1:0x000000000000000000000000000000000000dEaD',
+        );
+      });
+
+      it('should handle empty chain ID (converts to 0)', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const emptyChainId = '';
+
+        const result = formatAccountToCaipAccountId(address, emptyChainId);
+
+        // Empty string converts to 0x0 which is chain ID 0
+        expect(result).toBe(
+          'eip155:0:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should pass through non-hex address without checksum conversion', () => {
+        const invalidAddress = 'not-a-valid-address';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(invalidAddress, chainId);
+
+        // For non-hex addresses, isValidHexAddress returns false so the address
+        // is used as-is without checksum conversion
+        expect(result).toBe('eip155:1:not-a-valid-address');
+      });
+
+      it('should return null and log error for invalid chain ID', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const invalidChainId = 'invalid-chain-id';
+
+        const result = formatAccountToCaipAccountId(address, invalidChainId);
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+
+      it('should return null when formatChainIdToCaip throws', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+        jest
+          .spyOn(bridgeControllerUtils, 'formatChainIdToCaip')
+          .mockImplementationOnce(() => {
+            throw new Error('Invalid chain ID format');
+          });
+
+        const result = formatAccountToCaipAccountId(address, '0x1');
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+
+      it('should return null when internal processing throws an error', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+        // Mock formatChainIdToCaip to return invalid data that will cause parseCaipChainId to fail
+        jest
+          .spyOn(bridgeControllerUtils, 'formatChainIdToCaip')
+          .mockImplementationOnce(() => 'invalid:caip:format:with:extra:parts');
+
+        const result = formatAccountToCaipAccountId(address, '0x1');
+
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+    });
+
+    describe('non-hex address handling', () => {
+      // When isValidHexAddress returns false, the address is used as-is
+      // without checksum conversion
+
+      it('should pass through non-hex address unchanged', () => {
+        const nonHexAddress = 'some-identifier-123';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(nonHexAddress, chainId);
+
+        // The function doesn't validate the address format, it just passes it through
+        expect(result).toBe('eip155:1:some-identifier-123');
+      });
+
+      it('should pass through address without 0x prefix', () => {
+        const addressWithoutPrefix = 'd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(
+          addressWithoutPrefix,
+          chainId,
+        );
+
+        // isValidHexAddress from @metamask/utils checks for 0x prefix
+        expect(result).toBe(
+          'eip155:1:d8da6bf26964af9d7eed9e03e53415d37aa96045',
+        );
+      });
+
+      it('should return null for empty address', () => {
+        const emptyAddress = '';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(emptyAddress, chainId);
+
+        // Empty address causes toCaipAccountId to throw, returns null
+        expect(result).toBeNull();
+        expect(log.error).toHaveBeenCalledWith(
+          '[rewards-utils] Error formatting account to CAIP-10:',
+          expect.any(Error),
+        );
+      });
+    });
+
+    describe('checksum address conversion', () => {
+      it('should convert lowercase hex address to checksum format', () => {
+        // These test vectors are from EIP-55
+        const testCases = [
+          {
+            input: '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed',
+            expected: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+          },
+          {
+            input: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
+            expected: '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+          },
+          {
+            input: '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
+            expected: '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
+          },
+          {
+            input: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb',
+            expected: '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+          },
+        ];
+
+        for (const { input, expected } of testCases) {
+          const result = formatAccountToCaipAccountId(input, '0x1');
+          expect(result).toBe(`eip155:1:${expected}`);
+        }
+      });
+    });
+
+    describe('return type', () => {
+      it('should return CaipAccountId type for valid inputs', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const chainId = '0x1';
+
+        const result = formatAccountToCaipAccountId(address, chainId);
+
+        // CaipAccountId is a branded string type
+        expect(typeof result).toBe('string');
+        expect(result).toMatch(/^eip155:\d+:0x[a-fA-F0-9]{40}$/u);
+      });
+
+      it('should return null for errors', () => {
+        const address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+        const invalidChainId = 'not-a-valid-chain-id';
+
+        const result = formatAccountToCaipAccountId(address, invalidChainId);
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/ui/helpers/utils/rewards-utils.ts
+++ b/ui/helpers/utils/rewards-utils.ts
@@ -1,0 +1,34 @@
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import {
+  toCaipAccountId,
+  parseCaipChainId,
+  type CaipAccountId,
+  isValidHexAddress,
+  Hex,
+} from '@metamask/utils';
+import log from 'loglevel';
+import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+
+/**
+ * Formats an address to CAIP-10 account ID
+ *
+ * @param address - The address to format
+ * @param chainId - The chain ID to use for the CAIP-10 account ID
+ * @returns The CAIP-10 account ID or null if formatting fails
+ */
+export const formatAccountToCaipAccountId = (
+  address: string,
+  chainId: string,
+): CaipAccountId | null => {
+  try {
+    const caipChainId = formatChainIdToCaip(chainId);
+    const { namespace, reference } = parseCaipChainId(caipChainId);
+    const coercedAddress = isValidHexAddress(address as Hex)
+      ? toChecksumHexAddress(address)
+      : address;
+    return toCaipAccountId(namespace, reference, coercedAddress);
+  } catch (error) {
+    log.error('[rewards-utils] Error formatting account to CAIP-10:', error);
+    return null;
+  }
+};

--- a/ui/hooks/bridge/useRewards.ts
+++ b/ui/hooks/bridge/useRewards.ts
@@ -7,13 +7,7 @@ import {
   formatChainIdToCaip,
   selectBridgeQuotes,
 } from '@metamask/bridge-controller';
-import {
-  toCaipAccountId,
-  parseCaipChainId,
-  type CaipAccountId,
-  isValidHexAddress,
-  Hex,
-} from '@metamask/utils';
+import { type CaipAccountId } from '@metamask/utils';
 import log from 'loglevel';
 import { debounce } from 'lodash';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -36,12 +30,13 @@ import {
   EstimatePointsDto,
   EstimatedPointsDto,
 } from '../../../shared/types/rewards';
-import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+import { formatAccountToCaipAccountId } from '../../helpers/utils/rewards-utils';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
 import {
   selectRewardsAccountLinkedTimestamp,
   selectRewardsEnabled,
 } from '../../ducks/rewards/selectors';
+import { usePrimaryWalletGroupAccounts } from '../rewards/usePrimaryWalletGroupAccounts';
 
 /**
  *
@@ -84,29 +79,6 @@ type UseRewardsResult = {
   hasError: boolean;
   accountOptedIn: boolean | null;
   rewardsAccountScope: InternalAccount | null;
-};
-
-/**
- * Formats an address to CAIP-10 account ID
- *
- * @param address
- * @param chainId
- */
-const formatAccountToCaipAccountId = (
-  address: string,
-  chainId: string,
-): CaipAccountId | null => {
-  try {
-    const caipChainId = formatChainIdToCaip(chainId);
-    const { namespace, reference } = parseCaipChainId(caipChainId);
-    const coercedAddress = isValidHexAddress(address as Hex)
-      ? toChecksumHexAddress(address)
-      : address;
-    return toCaipAccountId(namespace, reference, coercedAddress);
-  } catch (error) {
-    log.error('[useRewards] Error formatting account to CAIP-10:', error);
-    return null;
-  }
 };
 
 type UseRewardsParams = {
@@ -152,6 +124,8 @@ export const useRewardsWithQuote = ({
   const rewardsAccountLinkedTimestamp = useSelector(
     selectRewardsAccountLinkedTimestamp,
   );
+  const { accounts: primaryWalletGroupAccounts } =
+    usePrimaryWalletGroupAccounts();
   // Track linked timestamp per account address to prevent triggering for accounts that weren't linked
   const localRewardsAccountLinkedTimestamp = useRef<Map<string, number | null>>(
     new Map(),
@@ -273,7 +247,7 @@ export const useRewardsWithQuote = ({
       try {
         // Check if there's a subscription first
         const candidateSubscriptionId = (await dispatch(
-          getRewardsCandidateSubscriptionId(),
+          getRewardsCandidateSubscriptionId(primaryWalletGroupAccounts),
         )) as unknown as string | null;
 
         if (!candidateSubscriptionId) {

--- a/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
@@ -1,7 +1,10 @@
 import { act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import log from 'loglevel';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createMockInternalAccount } from '../../../test/jest/mocks';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
 import { useCandidateSubscriptionId } from './useCandidateSubscriptionId';
 
 // Mock store actions used by the hook
@@ -14,14 +17,60 @@ jest.mock('loglevel', () => ({
   setLevel: jest.fn(),
 }));
 
+// Mock usePrimaryWalletGroupAccounts hook - use mutable ref pattern for test-level changes
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accountGroupId: 'account-group-1',
+    accounts: [] as InternalAccount[],
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
+
 const { getRewardsCandidateSubscriptionId } = jest.requireMock(
   '../../store/actions',
 ) as { getRewardsCandidateSubscriptionId: jest.Mock };
 const mockLogError = log.error as jest.MockedFunction<typeof log.error>;
 
+// Helper to create software wallet account
+const createSoftwareAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Software Account',
+  });
+
+// Helper to create hardware wallet accounts
+const createLedgerAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Ledger Account',
+    keyringType: HardwareKeyringType.ledger,
+  });
+
+const createTrezorAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'Trezor Account',
+    keyringType: HardwareKeyringType.trezor,
+  });
+
+const createQrAccount = (address: string): InternalAccount =>
+  createMockInternalAccount({
+    address,
+    name: 'QR Hardware Account',
+    keyringType: HardwareKeyringType.qr,
+  });
+
 describe('useCandidateSubscriptionId', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mock to default empty state
+    mockPrimaryWalletGroupAccounts.current = {
+      accountGroupId: 'account-group-1',
+      accounts: [],
+    };
   });
 
   describe('Initial State', () => {
@@ -202,6 +251,7 @@ describe('useCandidateSubscriptionId', () => {
       const rewardsState = store?.getState().rewards;
       expect(rewardsState?.candidateSubscriptionId).toBe('abc-id');
     });
+
     it('uses rewardsActiveAccountSubscriptionId when available and does not fetch', async () => {
       const { result, store } = renderHookWithProvider(
         () => useCandidateSubscriptionId(),
@@ -313,6 +363,693 @@ describe('useCandidateSubscriptionId', () => {
         '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
         mockError,
       );
+    });
+  });
+
+  describe('Hardware wallet subscription ID resolution', () => {
+    it('passes primary wallet group accounts including Ledger hardware wallet to action', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'hardware-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        ledgerAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('hardware-sub-id');
+    });
+
+    it('passes primary wallet group accounts including Trezor hardware wallet to action', async () => {
+      const trezorAccount = createTrezorAccount('0xTrezorAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [trezorAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'trezor-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        trezorAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('trezor-sub-id');
+    });
+
+    it('passes primary wallet group accounts including QR hardware wallet to action', async () => {
+      const qrAccount = createQrAccount('0xQrAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [qrAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'qr-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        qrAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('qr-sub-id');
+    });
+
+    it('passes mixed software and hardware wallet accounts to action', async () => {
+      const softwareAccount = createSoftwareAccount('0xSoftwareAddress');
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      const trezorAccount = createTrezorAccount('0xTrezorAddress');
+
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [softwareAccount, ledgerAccount, trezorAccount],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'mixed-sub-id',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        softwareAccount,
+        ledgerAccount,
+        trezorAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('mixed-sub-id');
+    });
+
+    it('sets special error sentinel when Ledger hardware wallet needs explicit authentication', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const hardwareWalletError = new Error(
+        'Primary wallet account group has opted in but is not authenticated yet',
+      );
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw hardwareWalletError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        ledgerAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe(
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+      );
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        hardwareWalletError,
+      );
+    });
+
+    it('sets special error sentinel when Trezor hardware wallet needs explicit authentication', async () => {
+      const trezorAccount = createTrezorAccount('0xTrezorAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [trezorAccount],
+      };
+
+      const hardwareWalletError = new Error(
+        'Primary wallet account group has opted in but is not authenticated yet',
+      );
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw hardwareWalletError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        trezorAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe(
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+      );
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        hardwareWalletError,
+      );
+    });
+
+    it('sets special error sentinel when QR hardware wallet needs explicit authentication', async () => {
+      const qrAccount = createQrAccount('0xQrAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [qrAccount],
+      };
+
+      const hardwareWalletError = new Error(
+        'Primary wallet account group has opted in but is not authenticated yet',
+      );
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw hardwareWalletError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([
+        qrAccount,
+      ]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe(
+        'error-existing-subscription-hardware-wallet-explicit-sign',
+      );
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        hardwareWalletError,
+      );
+    });
+
+    it('does not trigger retry when candidateSubscriptionId is hardware wallet error value', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'new-sub-id',
+      );
+
+      const { store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false, // ensure unlock effect doesn't trigger
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+          rewards: {
+            candidateSubscriptionId:
+              'error-existing-subscription-hardware-wallet-explicit-sign',
+          },
+        },
+      );
+
+      // Wait a bit to ensure useEffect doesn't trigger
+      await waitFor(
+        () => {
+          expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+          const rewardsState = store?.getState().rewards;
+          expect(rewardsState?.candidateSubscriptionId).toBe(
+            'error-existing-subscription-hardware-wallet-explicit-sign',
+          );
+        },
+        { timeout: 100 },
+      );
+    });
+
+    it('sets generic error sentinel for non-hardware-wallet-specific errors', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const genericError = new Error('Network error');
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw genericError;
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        genericError,
+      );
+    });
+  });
+
+  describe('Edge cases with no valid subscription', () => {
+    it('handles null subscription ID response', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => null,
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+
+    it('handles empty string subscription ID response', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => '',
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('');
+    });
+
+    it('handles empty primary wallet group accounts', async () => {
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [],
+      };
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => null,
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledWith([]);
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+
+    it('handles non-Error thrown object', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'string error';
+        },
+      );
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Non-Error objects should fall through to generic error handling
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
+        'string error',
+      );
+    });
+
+    it('handles rewards disabled with rewardsEnabled flag false', async () => {
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: false },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBeNull();
+    });
+  });
+
+  describe('Concurrent fetch prevention (isLoading ref)', () => {
+    it('prevents multiple concurrent fetches', async () => {
+      let resolvePromise: (value: string) => void;
+      const slowPromise = new Promise<string>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => () => slowPromise,
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // Start first fetch (won't complete immediately)
+      act(() => {
+        result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Try to start second fetch while first is pending
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Should only be called once because isLoading prevents second call
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Resolve the promise
+      await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        resolvePromise?.('delayed-sub-id');
+      });
+    });
+
+    it('resets isLoading after successful fetch allowing subsequent fetches', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'first-sub-id',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // First fetch
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Second fetch should be allowed after first completes
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'second-sub-id',
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets isLoading after failed fetch allowing subsequent fetches', async () => {
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('First fetch failed');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: null,
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      // First fetch (will fail)
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(1);
+
+      // Second fetch should be allowed after first completes (even with failure)
+      (getRewardsCandidateSubscriptionId as jest.Mock).mockImplementation(
+        () => async () => 'second-sub-id',
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('rewardsActiveAccountSubscriptionId takes precedence', () => {
+    it('uses active account subscription ID even with hardware wallet in group', async () => {
+      const ledgerAccount = createLedgerAccount('0xLedgerAddress');
+      mockPrimaryWalletGroupAccounts.current = {
+        accountGroupId: 'account-group-1',
+        accounts: [ledgerAccount],
+      };
+
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: {
+              account: 'eip155:1:0xLedgerAddress',
+              subscriptionId: 'active-hw-sub-id',
+            },
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      // Should not fetch because active account subscription ID is available
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('active-hw-sub-id');
+    });
+
+    it('skips fetch and resets isLoading when active account subscription ID becomes available', async () => {
+      // This tests the early return path at line 43-48
+      const { result, store } = renderHookWithProvider(
+        () => useCandidateSubscriptionId(),
+        {
+          metamask: {
+            isUnlocked: false,
+            useExternalServices: true,
+            remoteFeatureFlags: { rewardsEnabled: true },
+            rewardsActiveAccount: {
+              account: 'eip155:1:0xabc',
+              subscriptionId: 'existing-sub-id',
+            },
+            rewardsSubscriptions: {},
+          },
+        },
+      );
+
+      await act(async () => {
+        await result.current.fetchCandidateSubscriptionId();
+      });
+
+      expect(getRewardsCandidateSubscriptionId).not.toHaveBeenCalled();
+      const rewardsState = store?.getState().rewards;
+      expect(rewardsState?.candidateSubscriptionId).toBe('existing-sub-id');
     });
   });
 });

--- a/ui/hooks/rewards/useCandidateSubscriptionId.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.ts
@@ -9,6 +9,7 @@ import {
 } from '../../ducks/rewards/selectors';
 import { setCandidateSubscriptionId } from '../../ducks/rewards';
 import { useAppSelector } from '../../store/store';
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
 
 type UseCandidateSubscriptionIdReturn = {
   fetchCandidateSubscriptionId: () => Promise<void>;
@@ -27,6 +28,10 @@ export const useCandidateSubscriptionId =
     const rewardsActiveAccountSubscriptionId = useAppSelector(
       (state) => state.metamask.rewardsActiveAccount?.subscriptionId,
     );
+
+    // Get accounts for the primary account group
+    const { accounts: primaryWalletGroupAccounts } =
+      usePrimaryWalletGroupAccounts();
 
     const isLoading = useRef(false);
 
@@ -49,7 +54,7 @@ export const useCandidateSubscriptionId =
         isLoading.current = true;
 
         const candidateId = (await dispatch(
-          getRewardsCandidateSubscriptionId(),
+          getRewardsCandidateSubscriptionId(primaryWalletGroupAccounts),
         )) as unknown as string | null;
         dispatch(setCandidateSubscriptionId(candidateId));
       } catch (error) {
@@ -57,11 +62,29 @@ export const useCandidateSubscriptionId =
           '[useCandidateSubscriptionId] Error fetching candidate subscription ID:',
           error,
         );
-        dispatch(setCandidateSubscriptionId('error'));
+        // Check if it's the specific error for hardware wallet needing authentication
+        if (
+          error instanceof Error &&
+          error.message ===
+            'Primary wallet account group has opted in but is not authenticated yet'
+        ) {
+          dispatch(
+            setCandidateSubscriptionId(
+              'error-existing-subscription-hardware-wallet-explicit-sign',
+            ),
+          );
+        } else {
+          dispatch(setCandidateSubscriptionId('error'));
+        }
       } finally {
         isLoading.current = false;
       }
-    }, [isRewardsEnabled, dispatch, rewardsActiveAccountSubscriptionId]);
+    }, [
+      isRewardsEnabled,
+      dispatch,
+      rewardsActiveAccountSubscriptionId,
+      primaryWalletGroupAccounts,
+    ]);
 
     useEffect(() => {
       if (candidateSubscriptionId === 'retry') {

--- a/ui/hooks/rewards/useLinkAccountGroup.test.tsx
+++ b/ui/hooks/rewards/useLinkAccountGroup.test.tsx
@@ -14,6 +14,7 @@ import { createMockInternalAccount } from '../../../test/jest/mocks';
 import { createMockMultichainAccountsState } from '../../selectors/multichain-accounts/test-utils';
 import { AccountTreeWallets } from '../../selectors/multichain-accounts/account-tree.types';
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
 import { useLinkAccountGroup } from './useLinkAccountGroup';
 
 // Mock store actions used by the hook
@@ -36,6 +37,18 @@ jest.mock('../../ducks/rewards', () => {
     })),
   };
 });
+
+// Mock usePrimaryWalletGroupAccounts to avoid selector chain issues
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accounts: [] as InternalAccount[],
+    accountGroupId: undefined as string | undefined,
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
 
 const {
   rewardsIsOptInSupported,
@@ -113,9 +126,79 @@ const buildStateWithAccounts = (accounts: InternalAccount[]) => {
   );
 };
 
+// Helper to create hardware wallet accounts
+const createMockLedgerAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Ledger Account ${id}`,
+    keyring: { type: HardwareKeyringType.ledger },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockTrezorAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Trezor Account ${id}`,
+    keyring: { type: HardwareKeyringType.trezor },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockQRAccount = (id: string, address: string): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `QR Account ${id}`,
+    keyring: { type: HardwareKeyringType.qr },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockSoftwareAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Software Account ${id}`,
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
 describe('useLinkAccountGroup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPrimaryWalletGroupAccounts.current = {
+      accounts: [],
+      accountGroupId: undefined,
+    };
   });
 
   describe('Initial State', () => {
@@ -133,6 +216,23 @@ describe('useLinkAccountGroup', () => {
       expect(typeof result.current.linkAccountGroup).toBe('function');
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isError).toBe(false);
+    });
+
+    it('returns failure when no accountGroupId is provided', async () => {
+      const state = buildStateWithAccounts([]);
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(undefined),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(report).toEqual({ success: false, byAddress: {} });
     });
   });
 
@@ -305,13 +405,13 @@ describe('useLinkAccountGroup', () => {
         (c: { event: MetaMetricsEventName }) => c.event,
       );
       const startedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_STARTED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingStarted,
       ).length;
       const completedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_COMPLETED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingCompleted,
       ).length;
       const failedCount = eventNames.filter(
-        (e) => e === 'REWARDS_ACCOUNT_LINKING_FAILED',
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
       ).length;
 
       expect(startedCount).toBe(2);
@@ -432,6 +532,796 @@ describe('useLinkAccountGroup', () => {
         success: false,
         byAddress: {},
       });
+    });
+  });
+
+  describe('Hardware wallet account group linking', () => {
+    it('links a group containing only Ledger hardware wallet accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const ledger2 = createMockLedgerAccount('ledger-2', '0xLedger222');
+      const state = buildStateWithAccounts([ledger1, ledger2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+        { account: ledger2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1, ledger2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xLedger111': true, '0xLedger222': true },
+      });
+    });
+
+    it('links a group containing only Trezor hardware wallet accounts', async () => {
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const trezor2 = createMockTrezorAccount('trezor-2', '0xTrezor222');
+      const state = buildStateWithAccounts([trezor1, trezor2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: trezor1, success: true },
+        { account: trezor2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [trezor1, trezor2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xTrezor111': true, '0xTrezor222': true },
+      });
+    });
+
+    it('links a group containing only QR hardware wallet accounts', async () => {
+      const qr1 = createMockQRAccount('qr-1', '0xQR111');
+      const qr2 = createMockQRAccount('qr-2', '0xQR222');
+      const state = buildStateWithAccounts([qr1, qr2]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: qr1, success: true },
+        { account: qr2, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [qr1, qr2],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xQR111': true, '0xQR222': true },
+      });
+    });
+
+    it('tracks account_type in events for hardware wallet accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      // Verify events were tracked with account_type property
+      const startedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      );
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent[0].properties).toHaveProperty('account_type');
+
+      const completedEvent = mockTrackEvent.mock.calls.find(
+        (call) =>
+          call[0].event === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent[0].properties).toHaveProperty('account_type');
+    });
+  });
+
+  describe('Mixed groups (software + hardware wallets)', () => {
+    it('links a mixed group with software and Ledger hardware wallet accounts', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1, ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true, '0xLedger111': true },
+      });
+    });
+
+    it('links a mixed group with software, Ledger, and Trezor accounts', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const state = buildStateWithAccounts([software1, ledger1, trezor1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: true },
+        { account: trezor1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1, ledger1, trezor1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: {
+          '0xSoftware111': true,
+          '0xLedger111': true,
+          '0xTrezor111': true,
+        },
+      });
+    });
+
+    it('handles mixed group where only hardware wallet accounts are supported', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      // Software account not supported, hardware account supported
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        ({ account }) =>
+          () => {
+            return account.metadata.keyring.type === HardwareKeyringType.ledger;
+          },
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only ledger1 should be linked
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xLedger111': true },
+      });
+    });
+
+    it('handles mixed group where only software wallet accounts are supported', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      // Software account supported, hardware account not supported
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        ({ account }) =>
+          () => {
+            return account.metadata.keyring.type === 'HD Key Tree';
+          },
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only software1 should be linked
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [software1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true },
+      });
+    });
+
+    it('handles mixed group where some accounts are already opted-in', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      // Software already opted in, hardware not
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [true, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Only ledger1 should be linked (software1 already opted in)
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+      expect(result.current.isError).toBe(false);
+      expect(report).toEqual({
+        success: true,
+        byAddress: { '0xSoftware111': true, '0xLedger111': true },
+      });
+    });
+  });
+
+  describe('Error handling for partial group linking failures', () => {
+    it('handles partial failure where software account succeeds and hardware account fails', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: true },
+        { account: ledger1, success: false },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Verify partial success/failure
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': true, '0xLedger111': false },
+      });
+
+      // Verify timestamp is set when at least one account succeeds
+      expect(mockSetRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+
+      // Verify metrics
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(eventNames).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      );
+      expect(eventNames).toContain(
+        MetaMetricsEventName.RewardsAccountLinkingFailed,
+      );
+    });
+
+    it('handles partial failure where hardware account succeeds and software account fails', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: false },
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      // Verify partial success/failure
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': true },
+      });
+
+      // Verify timestamp is set when at least one account succeeds
+      expect(mockSetRewardsAccountLinkedTimestamp).toHaveBeenCalled();
+    });
+
+    it('handles multiple hardware wallets with partial failures', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const trezor1 = createMockTrezorAccount('trezor-1', '0xTrezor111');
+      const qr1 = createMockQRAccount('qr-1', '0xQR111');
+      const state = buildStateWithAccounts([ledger1, trezor1, qr1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+        { account: trezor1, success: false },
+        { account: qr1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: {
+          '0xLedger111': true,
+          '0xTrezor111': false,
+          '0xQR111': true,
+        },
+      });
+
+      // Verify correct count of started/completed/failed events
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      const startedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingStarted,
+      ).length;
+      const completedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingCompleted,
+      ).length;
+      const failedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      ).length;
+
+      expect(startedCount).toBe(3);
+      expect(completedCount).toBe(2);
+      expect(failedCount).toBe(1);
+    });
+
+    it('handles complete failure of all accounts in a mixed group', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: software1, success: false },
+        { account: ledger1, success: false },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': false },
+      });
+
+      // Verify timestamp is NOT set when all accounts fail
+      expect(mockSetRewardsAccountLinkedTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('handles exception during linking and marks all accounts as failed', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false, false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => {
+        throw new Error('Hardware wallet connection failed');
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: { '0xSoftware111': false, '0xLedger111': false },
+      });
+
+      // Verify all failure events are tracked
+      const eventNames = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      const failedCount = eventNames.filter(
+        (e) => e === MetaMetricsEventName.RewardsAccountLinkingFailed,
+      ).length;
+      expect(failedCount).toBe(2);
+
+      // Verify timestamp is NOT set
+      expect(mockSetRewardsAccountLinkedTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('handles exception during opt-in status check', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([software1, ledger1]);
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('Network error');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let report;
+      await act(async () => {
+        report = await result.current.linkAccountGroup();
+      });
+
+      expect(result.current.isError).toBe(true);
+      expect(report).toEqual({
+        success: false,
+        byAddress: {},
+      });
+
+      // Linking should not be called
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Primary wallet group accounts', () => {
+    it('passes primary wallet group accounts to the linking function', async () => {
+      const software1 = createMockSoftwareAccount('sw-1', '0xSoftware111');
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      const primaryAccounts = [software1];
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: primaryAccounts,
+        accountGroupId: 'entropy:primary/0',
+      };
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        primaryAccounts,
+      );
+    });
+
+    it('handles empty primary wallet group accounts', async () => {
+      const ledger1 = createMockLedgerAccount('ledger-1', '0xLedger111');
+      const state = buildStateWithAccounts([ledger1]);
+
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: [],
+        accountGroupId: undefined,
+      };
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => async () => [
+        { account: ledger1, success: true },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.linkAccountGroup();
+      });
+
+      expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
+        [ledger1],
+        [],
+      );
+    });
+  });
+
+  describe('Loading state', () => {
+    it('sets loading to true during linking and false after completion', async () => {
+      const a1 = createMockInternalAccount({ id: 'acc-1', address: '0x111' });
+      const state = buildStateWithAccounts([a1]);
+
+      let resolveLinking: (
+        value: { account: InternalAccount; success: boolean }[],
+      ) => void;
+      const linkingPromise = new Promise<
+        { account: InternalAccount; success: boolean }[]
+      >((resolve) => {
+        resolveLinking = resolve;
+      });
+
+      (rewardsIsOptInSupported as jest.Mock).mockImplementation(
+        () => () => true,
+      );
+      (rewardsGetOptInStatus as jest.Mock).mockImplementation(
+        () => async () => ({ ois: [false] }),
+      );
+      (
+        rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
+      ).mockImplementation(() => () => linkingPromise);
+
+      const { result } = renderHookWithProvider(
+        () => useLinkAccountGroup(GROUP_ID),
+        state,
+        undefined,
+        Container,
+      );
+
+      let linkPromise: Promise<unknown>;
+      await act(async () => {
+        linkPromise = result.current.linkAccountGroup();
+      });
+
+      // Resolve the linking promise
+      await act(async () => {
+        resolveLinking([{ account: a1, success: true }]);
+        await linkPromise;
+      });
+
+      expect(result.current.isLoading).toBe(false);
     });
   });
 });

--- a/ui/hooks/rewards/useLinkAccountGroup.ts
+++ b/ui/hooks/rewards/useLinkAccountGroup.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../shared/constants/metametrics';
 import { getAccountTypeCategory } from '../../pages/multichain-accounts/account-details/account-type-utils';
 import { setRewardsAccountLinkedTimestamp } from '../../ducks/rewards';
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
 
 type LinkStatusReport = {
   success: boolean;
@@ -41,6 +42,10 @@ export const useLinkAccountGroup = (
   );
 
   const { trackEvent } = useContext(MetaMetricsContext);
+
+  // Get accounts for the primary account group
+  const { accounts: primaryWalletGroupAccounts } =
+    usePrimaryWalletGroupAccounts();
 
   const triggerAccountLinkingEvent = useCallback(
     (event: MetaMetricsEventName, account: InternalAccount) => {
@@ -128,7 +133,10 @@ export const useLinkAccountGroup = (
 
       try {
         const results = (await dispatch(
-          rewardsLinkAccountsToSubscriptionCandidate(accountsToLink),
+          rewardsLinkAccountsToSubscriptionCandidate(
+            accountsToLink,
+            primaryWalletGroupAccounts,
+          ),
         )) as unknown as { account: InternalAccount; success: boolean }[];
 
         // Process results and emit completion/failure events
@@ -174,7 +182,12 @@ export const useLinkAccountGroup = (
     } finally {
       setIsLoading(false);
     }
-  }, [dispatch, internalAccountsForGroup, triggerAccountLinkingEvent]);
+  }, [
+    dispatch,
+    internalAccountsForGroup,
+    triggerAccountLinkingEvent,
+    primaryWalletGroupAccounts,
+  ]);
 
   return {
     linkAccountGroup,

--- a/ui/hooks/rewards/useOptIn.test.tsx
+++ b/ui/hooks/rewards/useOptIn.test.tsx
@@ -9,6 +9,18 @@ import {
 } from '../../../shared/constants/metametrics';
 import { useOptIn } from './useOptIn';
 
+// Mock usePrimaryWalletGroupAccounts hook
+const mockPrimaryWalletGroupAccounts = {
+  current: {
+    accounts: [] as InternalAccount[],
+    accountGroupId: undefined as string | undefined,
+  },
+};
+
+jest.mock('./usePrimaryWalletGroupAccounts', () => ({
+  usePrimaryWalletGroupAccounts: () => mockPrimaryWalletGroupAccounts.current,
+}));
+
 // Mocks
 jest.mock('../../store/actions', () => ({
   rewardsOptIn: jest.fn(() => async () => 'sub-123'),
@@ -16,6 +28,9 @@ jest.mock('../../store/actions', () => ({
     { account: {} as InternalAccount, success: true },
   ]),
   updateMetaMetricsTraits: jest.fn(() => async () => {
+    // noop
+  }),
+  linkRewardToShieldSubscription: jest.fn(() => async () => {
     // noop
   }),
 }));
@@ -121,6 +136,13 @@ jest.mock(
   }),
 );
 
+const mockIsHardwareAccount = jest.fn((_account: InternalAccount) => false);
+jest.mock('../../../shared/lib/accounts', () => ({
+  ...jest.requireActual('../../../shared/lib/accounts'),
+  isHardwareAccount: (account: InternalAccount) =>
+    mockIsHardwareAccount(account),
+}));
+
 const { rewardsOptIn } = jest.requireMock('../../store/actions') as {
   rewardsOptIn: jest.Mock;
 };
@@ -130,6 +152,9 @@ const { rewardsLinkAccountsToSubscriptionCandidate } = jest.requireMock(
 const { updateMetaMetricsTraits } = jest.requireMock('../../store/actions') as {
   updateMetaMetricsTraits: jest.Mock;
 };
+const { linkRewardToShieldSubscription } = jest.requireMock(
+  '../../store/actions',
+) as { linkRewardToShieldSubscription: jest.Mock };
 const { setCandidateSubscriptionId } = jest.requireMock(
   '../../ducks/rewards',
 ) as { setCandidateSubscriptionId: jest.Mock };
@@ -157,6 +182,13 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 describe('useOptIn', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mutable mock values
+    mockPrimaryWalletGroupAccounts.current = {
+      accounts: mockSideEffectAccounts,
+      accountGroupId: 'entropy:test/1',
+    };
+
+    mockIsHardwareAccount.mockReturnValue(false);
     (rewardsOptIn as jest.Mock).mockImplementation(() => async () => 'sub-123');
     (
       rewardsLinkAccountsToSubscriptionCandidate as jest.Mock
@@ -164,6 +196,11 @@ describe('useOptIn', () => {
       { account: {} as InternalAccount, success: true },
     ]);
     (updateMetaMetricsTraits as jest.Mock).mockImplementation(
+      () => async () => {
+        // noop
+      },
+    );
+    (linkRewardToShieldSubscription as jest.Mock).mockImplementation(
       () => async () => {
         // noop
       },
@@ -259,7 +296,7 @@ describe('useOptIn', () => {
       });
     });
 
-    it('uses side effect accounts for opt-in when available and links active group accounts', async () => {
+    it('uses primary wallet group accounts for opt-in when available and links active group accounts', async () => {
       (rewardsOptIn as jest.Mock).mockImplementation(
         () => async () => 'sub-side-effect',
       );
@@ -275,7 +312,7 @@ describe('useOptIn', () => {
         await result.current.optin();
       });
 
-      // Should opt-in with side effect accounts (entropy:test/1)
+      // Should opt-in with primary wallet group accounts
       expect(rewardsOptIn).toHaveBeenCalledWith({
         accounts: mockSideEffectAccounts,
         referralCode: undefined,
@@ -284,22 +321,16 @@ describe('useOptIn', () => {
       // Should link active group accounts after opt-in
       expect(rewardsLinkAccountsToSubscriptionCandidate).toHaveBeenCalledWith(
         mockActiveGroupAccounts,
+        mockSideEffectAccounts,
       );
     });
 
-    it('uses active group accounts for opt-in when no side effect accounts available', async () => {
-      // Mock to return empty array for side effect accounts
-      (getInternalAccountsFromGroupById as jest.Mock).mockImplementation(
-        (_state, groupId: string) => {
-          if (groupId === 'entropy:test/1') {
-            return [];
-          }
-          if (groupId === 'entropy:test/0') {
-            return mockActiveGroupAccounts;
-          }
-          return [];
-        },
-      );
+    it('uses active group accounts for opt-in when no primary wallet group accounts available', async () => {
+      // Mock to return empty array for primary wallet group accounts
+      mockPrimaryWalletGroupAccounts.current = {
+        accounts: [],
+        accountGroupId: undefined,
+      };
 
       (rewardsOptIn as jest.Mock).mockImplementation(
         () => async () => 'sub-active',
@@ -322,7 +353,7 @@ describe('useOptIn', () => {
         referralCode: undefined,
       });
 
-      // Should not link accounts when there are no accounts to link
+      // Should link primary wallet group accounts (empty in this case)
       expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
     });
 
@@ -357,6 +388,41 @@ describe('useOptIn', () => {
 
       // Should not link accounts when there are no accounts to link
       expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+    });
+
+    it('does not link accounts when first account to link is a hardware account', async () => {
+      // Mock isHardwareAccount to return true for the first account to link
+      mockIsHardwareAccount.mockReturnValue(true);
+
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-hw-skip-link',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Should check if first account to link is hardware
+      expect(mockIsHardwareAccount).toHaveBeenCalledWith(
+        mockActiveGroupAccounts[0],
+      );
+
+      // Should not link accounts when first account is a hardware account
+      expect(rewardsLinkAccountsToSubscriptionCandidate).not.toHaveBeenCalled();
+
+      // Opt-in should still succeed
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
+        'sub-hw-skip-link',
+      );
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
     });
 
     it('swallows link errors without affecting final state', async () => {
@@ -463,4 +529,145 @@ describe('useOptIn', () => {
       expect(events).not.toContain(MetaMetricsEventName.RewardsOptInCompleted);
     });
   });
+
+  describe('Shield subscription linking', () => {
+    it('links reward to shield subscription when options are provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-123',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).toHaveBeenCalledWith(
+        'shield-sub-123',
+        100,
+      );
+    });
+
+    it('does not link to shield subscription when options are not provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-no-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn(),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('does not link when only rewardPoints is provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-partial-shield',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn({ rewardPoints: 100 }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('does not link when only shieldSubscriptionId is provided', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-partial-shield-2',
+      );
+
+      const { result } = renderHookWithProvider(
+        () => useOptIn({ shieldSubscriptionId: 'shield-sub-456' }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+
+    it('swallows shield subscription linking errors without affecting opt-in success', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(
+        () => async () => 'sub-shield-error',
+      );
+      (linkRewardToShieldSubscription as jest.Mock).mockImplementation(
+        () => async () => {
+          throw new Error('Shield linking failed');
+        },
+      );
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-error',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      // Opt-in should still succeed despite shield linking failure
+      expect(result.current.optinError).toBeNull();
+      expect(setCandidateSubscriptionId).toHaveBeenCalledWith(
+        'sub-shield-error',
+      );
+      const events = mockTrackEvent.mock.calls.map((args) => args[0].event);
+      expect(events).toContain(MetaMetricsEventName.RewardsOptInCompleted);
+    });
+
+    it('does not link to shield subscription when subscriptionId is null', async () => {
+      (rewardsOptIn as jest.Mock).mockImplementation(() => async () => null);
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useOptIn({
+            rewardPoints: 100,
+            shieldSubscriptionId: 'shield-sub-null',
+          }),
+        {},
+        undefined,
+        Container,
+      );
+
+      await act(async () => {
+        await result.current.optin();
+      });
+
+      expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/ui/hooks/rewards/useOptIn.test.tsx
+++ b/ui/hooks/rewards/useOptIn.test.tsx
@@ -669,5 +669,4 @@ describe('useOptIn', () => {
       expect(linkRewardToShieldSubscription).not.toHaveBeenCalled();
     });
   });
-
 });

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -1,15 +1,12 @@
 import { useCallback, useState, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { AccountGroupId } from '@metamask/account-api';
 import log from 'loglevel';
 import {
-  getMultichainAccountsByWalletId,
-  getWalletIdAndNameByAccountAddress,
   getSelectedAccountGroup,
   getInternalAccountsFromGroupById,
 } from '../../selectors/multichain-accounts/account-tree';
 import { setCandidateSubscriptionId } from '../../ducks/rewards';
-import { getSelectedAccount } from '../../selectors';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -24,7 +21,8 @@ import {
 } from '../../store/actions';
 import { handleRewardsErrorMessage } from '../../components/app/rewards/utils/handleRewardsErrorMessage';
 import { useI18nContext } from '../useI18nContext';
-import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
+import { isHardwareAccount } from '../../../shared/lib/accounts';
 
 export type UseOptinResult = {
   /**
@@ -58,33 +56,7 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
   const { trackEvent } = useContext(MetaMetricsContext);
   const t = useI18nContext();
   const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
-  const selectedAccount = useSelector(getSelectedAccount);
-  const { id: walletId } = useSelector((state) =>
-    getWalletIdAndNameByAccountAddress(state, selectedAccount.address),
-  ) || { walletId: undefined };
 
-  const accountGroupsByWallet = useSelector((state: MultichainAccountsState) =>
-    walletId
-      ? getMultichainAccountsByWalletId(state, walletId as AccountWalletId)
-      : {},
-  );
-
-  // Link the first account group in the wallet if it's not the selected account group.
-  const sideEffectAccountGroupIdToLink = useMemo(
-    () =>
-      accountGroupsByWallet ? Object.keys(accountGroupsByWallet)[0] : undefined,
-    [accountGroupsByWallet],
-  );
-
-  // Get accounts for side effect account group
-  const sideEffectAccounts = useSelector((state) =>
-    sideEffectAccountGroupIdToLink
-      ? getInternalAccountsFromGroupById(
-          state,
-          sideEffectAccountGroupIdToLink as AccountGroupId,
-        )
-      : [],
-  );
 
   // Get accounts for active (selected) account group
   const activeGroupAccounts = useSelector((state) =>
@@ -95,6 +67,12 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
         )
       : [],
   );
+
+  // Get accounts for the primary account group
+  const {
+    accounts: primaryWalletGroupAccounts,
+    accountGroupId: primaryWalletAccountGroupId,
+  } = usePrimaryWalletGroupAccounts();
 
   const handleOptIn = useCallback(
     async (referralCode?: string) => {
@@ -116,27 +94,31 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
         setOptinLoading(true);
         setOptinError(null);
 
+
         // First, opt in with side effect accounts
         const accountsToOptIn =
-          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
-            ? sideEffectAccounts
+          primaryWalletAccountGroupId && primaryWalletGroupAccounts.length > 0
+            ? primaryWalletGroupAccounts
             : activeGroupAccounts;
 
         const accountsToLinkAfterOptIn =
-          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
+          primaryWalletAccountGroupId && primaryWalletGroupAccounts.length > 0
             ? activeGroupAccounts
-            : sideEffectAccounts;
+            : primaryWalletGroupAccounts;
 
         subscriptionId = (await dispatch(
           rewardsOptIn({ accounts: accountsToOptIn, referralCode }),
         )) as unknown as string | null;
 
         if (subscriptionId) {
-          if (accountsToLinkAfterOptIn.length > 0) {
+          // Prevent more than 1 explicit sign request for opting in, in case of hardware wallet
+          // Linking of other accounts for the hardware wallet can be handled later.
+          if (accountsToLinkAfterOptIn.length > 0 && !isHardwareAccount(accountsToLinkAfterOptIn[0])) {
             try {
               await dispatch(
                 rewardsLinkAccountsToSubscriptionCandidate(
                   accountsToLinkAfterOptIn,
+                  primaryWalletGroupAccounts,
                 ),
               );
             } catch {
@@ -199,8 +181,8 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
     },
     [
       trackEvent,
-      sideEffectAccountGroupIdToLink,
-      sideEffectAccounts,
+      primaryWalletAccountGroupId,
+      primaryWalletGroupAccounts,
       activeGroupAccounts,
       dispatch,
       t,

--- a/ui/hooks/rewards/useOptIn.ts
+++ b/ui/hooks/rewards/useOptIn.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useContext, useMemo } from 'react';
+import { useCallback, useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import log from 'loglevel';
@@ -20,9 +20,9 @@ import {
   linkRewardToShieldSubscription,
 } from '../../store/actions';
 import { handleRewardsErrorMessage } from '../../components/app/rewards/utils/handleRewardsErrorMessage';
+import { isHardwareAccount } from '../../../shared/lib/accounts';
 import { useI18nContext } from '../useI18nContext';
 import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
-import { isHardwareAccount } from '../../../shared/lib/accounts';
 
 export type UseOptinResult = {
   /**
@@ -56,7 +56,6 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
   const { trackEvent } = useContext(MetaMetricsContext);
   const t = useI18nContext();
   const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
-
 
   // Get accounts for active (selected) account group
   const activeGroupAccounts = useSelector((state) =>
@@ -94,7 +93,6 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
         setOptinLoading(true);
         setOptinError(null);
 
-
         // First, opt in with side effect accounts
         const accountsToOptIn =
           primaryWalletAccountGroupId && primaryWalletGroupAccounts.length > 0
@@ -113,7 +111,10 @@ export const useOptIn = (options?: UseOptInOptions): UseOptinResult => {
         if (subscriptionId) {
           // Prevent more than 1 explicit sign request for opting in, in case of hardware wallet
           // Linking of other accounts for the hardware wallet can be handled later.
-          if (accountsToLinkAfterOptIn.length > 0 && !isHardwareAccount(accountsToLinkAfterOptIn[0])) {
+          if (
+            accountsToLinkAfterOptIn.length > 0 &&
+            !isHardwareAccount(accountsToLinkAfterOptIn[0])
+          ) {
             try {
               await dispatch(
                 rewardsLinkAccountsToSubscriptionCandidate(

--- a/ui/hooks/rewards/usePrimaryWalletGroupAccounts.test.ts
+++ b/ui/hooks/rewards/usePrimaryWalletGroupAccounts.test.ts
@@ -1,0 +1,696 @@
+import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { renderHook } from '@testing-library/react-hooks';
+import { HardwareKeyringType } from '../../../shared/constants/hardware-wallets';
+
+// Import after mocks
+import { usePrimaryWalletGroupAccounts } from './usePrimaryWalletGroupAccounts';
+
+// Mock the selectors module
+const mockGetSelectedAccount = jest.fn();
+const mockGetWalletIdAndNameByAccountAddress = jest.fn();
+const mockGetMultichainAccountsByWalletId = jest.fn();
+const mockGetInternalAccountsFromGroupById = jest.fn();
+
+jest.mock('../../selectors', () => ({
+  getSelectedAccount: (...args: unknown[]) => mockGetSelectedAccount(...args),
+}));
+
+jest.mock('../../selectors/multichain-accounts/account-tree', () => ({
+  getWalletIdAndNameByAccountAddress: (...args: unknown[]) =>
+    mockGetWalletIdAndNameByAccountAddress(...args),
+  getMultichainAccountsByWalletId: (...args: unknown[]) =>
+    mockGetMultichainAccountsByWalletId(...args),
+  getInternalAccountsFromGroupById: (...args: unknown[]) =>
+    mockGetInternalAccountsFromGroupById(...args),
+}));
+
+// Mock react-redux useSelector to call our mocked selectors
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector) => {
+    // Call the selector with a minimal state object
+    return selector({});
+  }),
+}));
+
+// Constants
+const PRIMARY_GROUP_ID = 'entropy:test-wallet/0' as AccountGroupId;
+const SECONDARY_GROUP_ID = 'entropy:test-wallet/1' as AccountGroupId;
+const WALLET_ID = 'entropy:test-wallet' as AccountWalletId;
+
+// Helper functions to create mock accounts
+const createMockLedgerAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Ledger Account ${id}`,
+    keyring: { type: HardwareKeyringType.ledger },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockTrezorAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Trezor Account ${id}`,
+    keyring: { type: HardwareKeyringType.trezor },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockQRAccount = (id: string, address: string): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `QR Account ${id}`,
+    keyring: { type: HardwareKeyringType.qr },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+const createMockSoftwareAccount = (
+  id: string,
+  address: string,
+): InternalAccount => ({
+  id,
+  address,
+  metadata: {
+    name: `Software Account ${id}`,
+    keyring: { type: 'HD Key Tree' },
+    importTime: Date.now(),
+  },
+  options: {},
+  methods: [],
+  type: 'eip155:eoa',
+  scopes: ['eip155:1'],
+});
+
+/**
+ * Helper to set up all mocks for a typical test scenario
+ *
+ * @param options0
+ * @param options0.selectedAddress
+ * @param options0.walletId
+ * @param options0.accountGroupsByWallet
+ * @param options0.primaryGroupAccounts
+ */
+const setupMocks = ({
+  selectedAddress = '0xAccount111',
+  walletId = WALLET_ID,
+  accountGroupsByWallet = {} as Record<AccountGroupId, unknown>,
+  primaryGroupAccounts = [] as InternalAccount[],
+}: {
+  selectedAddress?: string;
+  walletId?: AccountWalletId | undefined;
+  accountGroupsByWallet?: Record<AccountGroupId, unknown>;
+  primaryGroupAccounts?: InternalAccount[];
+} = {}) => {
+  mockGetSelectedAccount.mockReturnValue({ address: selectedAddress });
+  mockGetWalletIdAndNameByAccountAddress.mockReturnValue(
+    walletId ? { id: walletId, name: 'Test Wallet' } : null,
+  );
+  mockGetMultichainAccountsByWalletId.mockReturnValue(accountGroupsByWallet);
+  mockGetInternalAccountsFromGroupById.mockReturnValue(primaryGroupAccounts);
+};
+
+describe('usePrimaryWalletGroupAccounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Filtering accounts by primary wallet group', () => {
+    it('returns accounts from the primary (first) group when wallet has multiple groups', () => {
+      const primaryAccounts = [
+        createMockSoftwareAccount('sw-1', '0xPrimary111'),
+        createMockSoftwareAccount('sw-2', '0xPrimary222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xPrimary111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+          [SECONDARY_GROUP_ID]: { id: SECONDARY_GROUP_ID },
+        },
+        primaryGroupAccounts: primaryAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(2);
+      expect(result.current.accounts.map((a) => a.address)).toEqual([
+        '0xPrimary111',
+        '0xPrimary222',
+      ]);
+    });
+
+    it('returns accounts from the single group when wallet has only one group', () => {
+      const accounts = [
+        createMockSoftwareAccount('sw-1', '0xAccount111'),
+        createMockSoftwareAccount('sw-2', '0xAccount222'),
+        createMockSoftwareAccount('sw-3', '0xAccount333'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(3);
+    });
+
+    it('returns the correct primary group for the selected account wallet', () => {
+      const wallet1Accounts = [
+        createMockSoftwareAccount('w1-acc-1', '0xWallet1Account111'),
+      ];
+
+      const wallet1GroupId = 'entropy:wallet-1/0' as AccountGroupId;
+
+      setupMocks({
+        selectedAddress: '0xWallet1Account111',
+        walletId: 'entropy:wallet-1' as AccountWalletId,
+        accountGroupsByWallet: {
+          [wallet1GroupId]: { id: wallet1GroupId },
+        },
+        primaryGroupAccounts: wallet1Accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(wallet1GroupId);
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0].address).toBe('0xWallet1Account111');
+    });
+  });
+
+  describe('Mixed account types (software, Ledger, QR, Trezor)', () => {
+    it('returns all accounts in primary group including mixed hardware types', () => {
+      const mixedAccounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+        createMockTrezorAccount('trezor-1', '0xTrezor111'),
+        createMockQRAccount('qr-1', '0xQR111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: mixedAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(4);
+      expect(result.current.accounts.map((a) => a.address)).toEqual([
+        '0xSoftware111',
+        '0xLedger111',
+        '0xTrezor111',
+        '0xQR111',
+      ]);
+    });
+
+    it('returns only Ledger accounts when primary group has only Ledger accounts', () => {
+      const ledgerAccounts = [
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+        createMockLedgerAccount('ledger-2', '0xLedger222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xLedger111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: ledgerAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.ledger);
+      });
+    });
+
+    it('returns only QR accounts when primary group has only QR accounts', () => {
+      const qrAccounts = [
+        createMockQRAccount('qr-1', '0xQR111'),
+        createMockQRAccount('qr-2', '0xQR222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xQR111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: qrAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.qr);
+      });
+    });
+
+    it('returns only Trezor accounts when primary group has only Trezor accounts', () => {
+      const trezorAccounts = [
+        createMockTrezorAccount('trezor-1', '0xTrezor111'),
+        createMockTrezorAccount('trezor-2', '0xTrezor222'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xTrezor111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: trezorAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(2);
+      result.current.accounts.forEach((account) => {
+        expect(account.metadata.keyring.type).toBe(HardwareKeyringType.trezor);
+      });
+    });
+
+    it('correctly identifies account types in a mixed primary group', () => {
+      const mixedAccounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: mixedAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      const softwareAccount = result.current.accounts.find(
+        (a) => a.address === '0xSoftware111',
+      );
+      const ledgerAccount = result.current.accounts.find(
+        (a) => a.address === '0xLedger111',
+      );
+
+      expect(softwareAccount?.metadata.keyring.type).toBe('HD Key Tree');
+      expect(ledgerAccount?.metadata.keyring.type).toBe(
+        HardwareKeyringType.ledger,
+      );
+    });
+  });
+
+  describe('Empty/null wallet group scenarios', () => {
+    it('returns empty accounts array when primary group has no accounts', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns empty accounts when wallet has no groups', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('handles undefined walletId gracefully (null return from getWalletIdAndNameByAccountAddress)', () => {
+      // When getWalletIdAndNameByAccountAddress returns null, the fallback { walletId: undefined } is used
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue(null);
+      mockGetMultichainAccountsByWalletId.mockReturnValue({});
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('uses fallback when getWalletIdAndNameByAccountAddress returns undefined', () => {
+      // Test the || { walletId: undefined } fallback explicitly
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue(undefined);
+      mockGetMultichainAccountsByWalletId.mockReturnValue({});
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns undefined accountGroupId when wallet groups are empty object', () => {
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+
+    it('returns empty array when accountGroupsByWallet is undefined', () => {
+      mockGetSelectedAccount.mockReturnValue({ address: '0xAccount111' });
+      mockGetWalletIdAndNameByAccountAddress.mockReturnValue({
+        id: WALLET_ID,
+        name: 'Test Wallet',
+      });
+      mockGetMultichainAccountsByWalletId.mockReturnValue(undefined);
+      mockGetInternalAccountsFromGroupById.mockReturnValue([]);
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+      expect(result.current.accounts).toEqual([]);
+    });
+  });
+
+  describe('Memoization behavior', () => {
+    it('returns the same reference when state does not change', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePrimaryWalletGroupAccounts(),
+      );
+
+      const firstResult = result.current;
+      rerender();
+      const secondResult = result.current;
+
+      // The hook uses useMemo for primaryAccountGroupId, so the reference should be stable
+      expect(firstResult.accountGroupId).toBe(secondResult.accountGroupId);
+    });
+
+    it('returns stable accounts array reference when accounts do not change', () => {
+      const accounts = [
+        createMockSoftwareAccount('sw-1', '0xSoftware111'),
+        createMockLedgerAccount('ledger-1', '0xLedger111'),
+      ];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePrimaryWalletGroupAccounts(),
+      );
+
+      const firstAccounts = result.current.accounts;
+      rerender();
+      const secondAccounts = result.current.accounts;
+
+      // Both renders should return the same account data
+      expect(firstAccounts).toEqual(secondAccounts);
+      expect(firstAccounts.length).toBe(secondAccounts.length);
+    });
+
+    it('useMemo recalculates primaryAccountGroupId only when accountGroupsByWallet changes', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      // First render should have calculated the primary group ID
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('returns first group as primary when groups are added in non-sequential order', () => {
+      const accounts1 = [createMockSoftwareAccount('sw-1', '0xFirst111')];
+      const groupId5 = 'entropy:test-wallet/5' as AccountGroupId;
+
+      // Create groups with IDs that might not be in expected order
+      // Object.keys order is based on insertion order in modern JS
+      setupMocks({
+        selectedAddress: '0xFirst111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+          [groupId5]: { id: groupId5 },
+        },
+        primaryGroupAccounts: accounts1,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      // Should return the first group in the object
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts[0].address).toBe('0xFirst111');
+    });
+
+    it('handles wallet with single account correctly', () => {
+      const singleAccount = createMockLedgerAccount(
+        'ledger-1',
+        '0xSingleLedger',
+      );
+
+      setupMocks({
+        selectedAddress: '0xSingleLedger',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [singleAccount],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBe(PRIMARY_GROUP_ID);
+      expect(result.current.accounts).toHaveLength(1);
+      expect(result.current.accounts[0].address).toBe('0xSingleLedger');
+      expect(result.current.accounts[0].metadata.keyring.type).toBe(
+        HardwareKeyringType.ledger,
+      );
+    });
+
+    it('handles large number of accounts in a group', () => {
+      const manyAccounts: InternalAccount[] = [];
+      for (let i = 0; i < 100; i++) {
+        manyAccounts.push(
+          createMockSoftwareAccount(
+            `sw-${i}`,
+            `0xAccount${i.toString().padStart(4, '0')}`,
+          ),
+        );
+      }
+
+      setupMocks({
+        selectedAddress: '0xAccount0000',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: manyAccounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accounts).toHaveLength(100);
+    });
+  });
+
+  describe('Return type structure', () => {
+    it('returns correct shape with accountGroupId and accounts', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current).toHaveProperty('accountGroupId');
+      expect(result.current).toHaveProperty('accounts');
+      expect(typeof result.current.accountGroupId).toBe('string');
+      expect(Array.isArray(result.current.accounts)).toBe(true);
+    });
+
+    it('accounts array contains InternalAccount objects with expected properties', () => {
+      const accounts = [createMockSoftwareAccount('sw-1', '0xSoftware111')];
+
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: accounts,
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      const account = result.current.accounts[0];
+      expect(account).toHaveProperty('id');
+      expect(account).toHaveProperty('address');
+      expect(account).toHaveProperty('metadata');
+      expect(account.metadata).toHaveProperty('name');
+      expect(account.metadata).toHaveProperty('keyring');
+      expect(account.metadata.keyring).toHaveProperty('type');
+    });
+
+    it('accountGroupId is undefined when no groups exist', () => {
+      setupMocks({
+        selectedAddress: '0xSoftware111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {},
+        primaryGroupAccounts: [],
+      });
+
+      const { result } = renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(result.current.accountGroupId).toBeUndefined();
+    });
+  });
+
+  describe('Selector integration', () => {
+    it('calls getSelectedAccount selector', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetSelectedAccount).toHaveBeenCalled();
+    });
+
+    it('calls getWalletIdAndNameByAccountAddress with selected account address', () => {
+      setupMocks({
+        selectedAddress: '0xSelectedAddress',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetWalletIdAndNameByAccountAddress).toHaveBeenCalled();
+    });
+
+    it('calls getMultichainAccountsByWalletId when walletId is available', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetMultichainAccountsByWalletId).toHaveBeenCalled();
+    });
+
+    it('calls getInternalAccountsFromGroupById when primary group ID is determined', () => {
+      setupMocks({
+        selectedAddress: '0xAccount111',
+        walletId: WALLET_ID,
+        accountGroupsByWallet: {
+          [PRIMARY_GROUP_ID]: { id: PRIMARY_GROUP_ID },
+        },
+        primaryGroupAccounts: [],
+      });
+
+      renderHook(() => usePrimaryWalletGroupAccounts());
+
+      expect(mockGetInternalAccountsFromGroupById).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
+++ b/ui/hooks/rewards/usePrimaryWalletGroupAccounts.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { getSelectedAccount } from '../../selectors';
+import {
+  getMultichainAccountsByWalletId,
+  getWalletIdAndNameByAccountAddress,
+  getInternalAccountsFromGroupById,
+} from '../../selectors/multichain-accounts/account-tree';
+import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
+
+/**
+ * Hook to get accounts for the primary (first) account group in the wallet
+ * of the currently selected account.
+ *
+ * @returns Object containing the accountGroupId and accounts array for the primary wallet group
+ */
+export const usePrimaryWalletGroupAccounts = (): {
+  accountGroupId: AccountGroupId | undefined;
+  accounts: InternalAccount[];
+} => {
+  const selectedAccount = useSelector(getSelectedAccount);
+  const { id: walletId } = useSelector((state) =>
+    getWalletIdAndNameByAccountAddress(state, selectedAccount.address),
+  ) || { walletId: undefined };
+
+  const accountGroupsByWallet = useSelector((state: MultichainAccountsState) =>
+    walletId
+      ? getMultichainAccountsByWalletId(state, walletId as AccountWalletId)
+      : {},
+  );
+
+  // Get the first account group ID from the wallet (primary account group)
+  const primaryAccountGroupId = useMemo(
+    () =>
+      accountGroupsByWallet ? Object.keys(accountGroupsByWallet)[0] : undefined,
+    [accountGroupsByWallet],
+  );
+
+  // Get accounts for the primary account group
+  const primaryWalletGroupAccounts = useSelector((state) =>
+    primaryAccountGroupId
+      ? getInternalAccountsFromGroupById(
+          state,
+          primaryAccountGroupId as AccountGroupId,
+        )
+      : [],
+  );
+
+  return {
+    accountGroupId: primaryAccountGroupId as AccountGroupId | undefined,
+    accounts: primaryWalletGroupAccounts,
+  };
+};

--- a/ui/hooks/rewards/useSeasonStatus.test.ts
+++ b/ui/hooks/rewards/useSeasonStatus.test.ts
@@ -180,7 +180,12 @@ describe('useSeasonStatus', () => {
       });
     });
 
-    const INVALID_SUB_IDS = ['pending', 'retry', 'error'] as const;
+    const INVALID_SUB_IDS = [
+      'pending',
+      'retry',
+      'error',
+      'error-existing-subscription-hardware-wallet-explicit-sign',
+    ] as const;
     type InvalidSubId = (typeof INVALID_SUB_IDS)[number];
 
     INVALID_SUB_IDS.forEach((subId: InvalidSubId) => {
@@ -353,7 +358,12 @@ describe('useSeasonStatus', () => {
       expect(mockOnAuthorizationError).not.toHaveBeenCalled();
     });
 
-    const SUB_IDS = ['pending', 'retry', 'error'] as const;
+    const SUB_IDS = [
+      'pending',
+      'retry',
+      'error',
+      'error-existing-subscription-hardware-wallet-explicit-sign',
+    ] as const;
     type PendingState = (typeof SUB_IDS)[number];
 
     SUB_IDS.forEach((subId: PendingState) => {

--- a/ui/hooks/rewards/useSeasonStatus.ts
+++ b/ui/hooks/rewards/useSeasonStatus.ts
@@ -51,6 +51,7 @@ export const useSeasonStatus = ({
       subscriptionId === 'pending' ||
       subscriptionId === 'retry' ||
       subscriptionId === 'error' ||
+      subscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign' ||
       !isRewardsEnabled
     ) {
       dispatch(setSeasonStatus(null));

--- a/ui/hooks/rewards/useSeasonStatus.ts
+++ b/ui/hooks/rewards/useSeasonStatus.ts
@@ -51,7 +51,8 @@ export const useSeasonStatus = ({
       subscriptionId === 'pending' ||
       subscriptionId === 'retry' ||
       subscriptionId === 'error' ||
-      subscriptionId === 'error-existing-subscription-hardware-wallet-explicit-sign' ||
+      subscriptionId ===
+        'error-existing-subscription-hardware-wallet-explicit-sign' ||
       !isRewardsEnabled
     ) {
       dispatch(setSeasonStatus(null));

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -67,7 +67,6 @@ import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-s
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SerializedUR } from '@metamask/eth-qr-keyring';
 import {
   BillingPortalResponse,
@@ -7057,7 +7056,7 @@ export function getRewardsCandidateSubscriptionId(
 }
 
 export function getRewardsSeasonMetadata(
-  type?: 'current' | 'next',
+  type?: 'current' | 'next' | 'previous',
 ): ThunkAction<
   Promise<SeasonDtoState>,
   MetaMaskReduxState,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -67,6 +67,7 @@ import { BACKUPANDSYNC_FEATURES } from '@metamask/profile-sync-controller/user-s
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 import { SerializedUR } from '@metamask/eth-qr-keyring';
 import {
   BillingPortalResponse,
@@ -7044,15 +7045,13 @@ export function getRewardsHasAccountOptedIn(
   };
 }
 
-export function getRewardsCandidateSubscriptionId(): ThunkAction<
-  Promise<string | null>,
-  MetaMaskReduxState,
-  unknown,
-  AnyAction
-> {
+export function getRewardsCandidateSubscriptionId(
+  primaryWalletGroupAccounts?: InternalAccount[],
+): ThunkAction<Promise<string | null>, MetaMaskReduxState, unknown, AnyAction> {
   return async () => {
     return await submitRequestToBackground<string | null>(
       'getRewardsCandidateSubscriptionId',
+      primaryWalletGroupAccounts ? [primaryWalletGroupAccounts] : undefined,
     );
   };
 }
@@ -7180,6 +7179,7 @@ export function rewardsGetOptInStatus(
 
 export function rewardsLinkAccountsToSubscriptionCandidate(
   accounts: InternalAccount[],
+  primaryWalletGroupAccounts?: InternalAccount[],
 ): ThunkAction<
   Promise<{ account: InternalAccount; success: boolean }[]>,
   MetaMaskReduxState,
@@ -7189,7 +7189,12 @@ export function rewardsLinkAccountsToSubscriptionCandidate(
   return async () => {
     return await submitRequestToBackground<
       { account: InternalAccount; success: boolean }[]
-    >('rewardsLinkAccountsToSubscriptionCandidate', [accounts]);
+    >(
+      'rewardsLinkAccountsToSubscriptionCandidate',
+      primaryWalletGroupAccounts
+        ? [accounts, primaryWalletGroupAccounts]
+        : [accounts],
+    );
   };
 }
 


### PR DESCRIPTION
## **Description**

Support for hardware wallets in rewards feature for extension.

## **Changelog**

CHANGELOG entry: support for hardware wallets in rewards feature for extension.

## **Screenshots**

- Message shown to users when we know their hardware wallet is associated with a subscription but can't authenticate with it unless they explicitly sign a message:

<img width="1931" height="630" alt="sign-message-to-authenticate-existing-sub" src="https://github.com/user-attachments/assets/94140fb3-6373-492e-963e-39ff33e38b67" />

- Multi subscription balance (hardware wallet = subscription B). Hot wallet was already opted in

![multi-subscription](https://github.com/user-attachments/assets/aad6eed0-4bbd-486e-9f80-7451fec811c8)

- Fresh wallet & hardware wallet without existing subscriptions & opt in + link account(s) via swap flow

![new-subscription-hardware-wallet-and-link-via-swap](https://github.com/user-attachments/assets/87a6f7d4-20eb-4505-8f08-6d99cc87697b)

- Opting in while ledger is not connected/paired (message from existing thrown error)

<img width="1931" height="1654" alt="image" src="https://github.com/user-attachments/assets/f7f4f0a1-d5cb-46b4-a312-e23338fa95e9" />

<img width="1931" height="1654" alt="image" src="https://github.com/user-attachments/assets/5ab24b36-9fc1-4693-93f1-f28d650b2e9a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High: introduces new SIWE auth + challenge endpoints and changes rewards authentication/subscription selection logic, which can affect opt-in/linking and access to balances (especially across mixed hardware/software account groups).
> 
> **Overview**
> Adds hardware-wallet support to Rewards by introducing a SIWE-based authentication path: the controller can now `generateChallenge`, request SIWE-aware `signPersonalMessage`, and call new data-service endpoints `siweLogin`/`siweJoin` for opt-in and account linking.
> 
> Refines subscription-id handling and caching so hardware accounts don’t persist/use a `subscriptionId` unless a usable session token exists, skips hardware accounts during *silent* auth attempts, and extends season discovery/metadata to include `previous` seasons (with a shorter metadata cache TTL).
> 
> Updates the UI to handle the new “hardware wallet needs explicit sign-in” state (`error-existing-subscription-hardware-wallet-explicit-sign`) by showing a sign-in / signing-in badge, adjusts onboarding to no longer block hardware wallets, and ensures the onboarding modal stays behind QR signing modals via z-index/outside-click tweaks. Locale strings for the removed hardware-wallet onboarding error are deleted and new sign-in strings are added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a3cdc3682949dd2770b59d1a7d850bb7195a6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->