### PR TITLE
fix: migrate hype slip44 correct value NE ctrl

### DIFF
--- a/app/scripts/migrations/196.test.ts
+++ b/app/scripts/migrations/196.test.ts
@@ -1,0 +1,229 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './196';
+
+const VERSION = version;
+const OLD_VERSION = VERSION - 1;
+
+describe(`migration #${VERSION}`, () => {
+  let mockedCaptureException: jest.Mock;
+
+  beforeEach(() => {
+    mockedCaptureException = jest.fn();
+    global.sentry = { captureException: mockedCaptureException };
+  });
+
+  afterEach(() => {
+    global.sentry = undefined;
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        OtherRandomController: {},
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      OtherRandomController: {},
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(`Migration ${VERSION}: NetworkEnablementController not found.`),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController has changed type', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: [
+          {
+            foo: 'bar',
+          },
+        ],
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: [
+        {
+          foo: 'bar',
+        },
+      ],
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: NetworkEnablementController is not an object: object`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: {
+          anotherFieldThatIsNotNativeAssetIdentifiers: {},
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: {
+        anotherFieldThatIsNotNativeAssetIdentifiers: {},
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers has changed type', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: {
+          // Not the correct type, should be an object.
+          nativeAssetIdentifiers: [
+            'eip155:1/slip44:60',
+            'eip155:999/slip44:2457',
+          ],
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: [
+          'eip155:1/slip44:60',
+          'eip155:999/slip44:2457',
+        ],
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error(
+        `Migration ${VERSION}: NetworkEnablementController.nativeAssetIdentifiers is not an object: object.`,
+      ),
+    );
+  });
+
+  it('DOES NOT modify the controller if a HYPE entry with correct value already exists', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: {
+          nativeAssetIdentifiers: {
+            'eip155:1': 'eip155:1/slip44:60',
+            'eip155:999': 'eip155:999/slip44:2457',
+          },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+          'eip155:999': 'eip155:999/slip44:2457',
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+
+  it('DOES NOT modify the controller if no HYPE entry already exist', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: {
+          nativeAssetIdentifiers: {
+            'eip155:1': 'eip155:1/slip44:60',
+          },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+
+  it('SUCCESSFULY transforms incorrect HYPE slip44 value to correct value', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        NetworkEnablementController: {
+          nativeAssetIdentifiers: {
+            'eip155:1': 'eip155:1/slip44:60',
+            'eip155:999': 'eip155:999/slip44:1',
+          },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual({
+      NetworkEnablementController: {
+        nativeAssetIdentifiers: {
+          'eip155:1': 'eip155:1/slip44:60',
+          'eip155:999': 'eip155:999/slip44:2457',
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(
+      new Set(['NetworkEnablementController']),
+    );
+  });
+});

--- a/app/scripts/migrations/196.ts
+++ b/app/scripts/migrations/196.ts
@@ -1,0 +1,65 @@
+import { getErrorMessage, hasProperty } from '@metamask/utils';
+
+import { captureException } from '../../../shared/lib/sentry';
+import { checkNetworkEnablementState } from './196_utils';
+import type { Migrate } from './types';
+
+export type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 196;
+
+export const TARGET_KEY = 'eip155:999';
+export const VALUE_TO_SET = 'eip155:999/slip44:2457';
+
+// Context: HYPE token (eip155:999/slip44:2457) was incorrectly set to eip155:999/slip44:1 (1 instead of 2457)
+// for some users in NetworkEnablementController.nativeAssetIdentifiers state.
+// This is because https://chainid.network/chains.json is fetched to populate this state,
+// and that chainId "999" references a "WanChain testnet" instead of HyperEVM.
+// PR https://github.com/MetaMask/core/pull/7975 addresses future population by forcing an
+// override at fetch-time.
+// However such fetching is not always triggered if an user had already added the network,
+// hence the need for this migration that - ontop of the PR above - will migrate the incorrect
+// entry ('eip155:999/slip44:1') to the correct one ('eip155:999/slip44:2457').
+//
+// This migration will operate only if an entry already exists AND is not 'eip155:999/slip44:2457'.
+export const migrate = (async (
+  versionedData: VersionedData,
+  changedControllers: Set<string>,
+): Promise<void> => {
+  versionedData.meta.version = version;
+  try {
+    // Transforming directly the state here without doing a copy.
+    // Because only one change action is possible, so it happens or doesn't.
+    transformState(versionedData.data, changedControllers);
+  } catch (error) {
+    console.error(error);
+    const newError = new Error(
+      `Migration #${version}: ${getErrorMessage(error)}`,
+    );
+    captureException(newError);
+  }
+}) satisfies Migrate;
+
+function transformState(
+  state: Record<string, unknown>,
+  changedControllers: Set<string>,
+) {
+  if (!checkNetworkEnablementState(state, version)) {
+    return;
+  }
+  const { nativeAssetIdentifiers } = state.NetworkEnablementController;
+  // Only setting the value if the key already exists
+  if (!hasProperty(nativeAssetIdentifiers, TARGET_KEY)) {
+    return;
+  }
+  // Only setting the value if the key isn't already correctly set
+  if (nativeAssetIdentifiers[TARGET_KEY] === VALUE_TO_SET) {
+    return;
+  }
+  // Setting the correct value, overridding the wrong one
+  nativeAssetIdentifiers[TARGET_KEY] = VALUE_TO_SET;
+  changedControllers.add('NetworkEnablementController');
+}

--- a/app/scripts/migrations/196_utils.ts
+++ b/app/scripts/migrations/196_utils.ts
@@ -1,0 +1,64 @@
+import { hasProperty, isObject } from '@metamask/utils';
+
+import { captureException } from '../../../shared/lib/sentry';
+
+type StateNECWithNativeAssetIdentifiers = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  NetworkEnablementController: {
+    nativeAssetIdentifiers: { [key: string]: string };
+  };
+};
+
+// DO NOT MODIFY (copy for your own migration if needed).
+// The goal of this file is to centralize some logic that may already exist
+// in some other migration but for which we accept the fact that they are
+// repeated instead of being refactored.
+// Introducing "common functions" in migration may be a bad practice
+// because changes in them would affect multiple migrations.
+// Also, some migrations are only interested in some specific checks.
+// The idea is to have such logic in a separate <migrationNumber>_utils file
+// to make reviewing PRs less intimidating.
+// Functions of this file are tested as part of <migrationNumber>.test.ts
+// and for that reason they don't have their own tests.
+export const checkNetworkEnablementState = (
+  state: Record<string, unknown>,
+  version: number,
+): state is StateNECWithNativeAssetIdentifiers => {
+  const networkEnablementState = state.NetworkEnablementController;
+
+  if (!hasProperty(state, 'NetworkEnablementController')) {
+    captureException(
+      new Error(`Migration ${version}: NetworkEnablementController not found.`),
+    );
+    return false;
+  }
+
+  if (!isObject(networkEnablementState)) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController is not an object: ${typeof networkEnablementState}`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(networkEnablementState, 'nativeAssetIdentifiers')) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
+      ),
+    );
+    return false;
+  }
+
+  if (!isObject(networkEnablementState.nativeAssetIdentifiers)) {
+    captureException(
+      new Error(
+        `Migration ${version}: NetworkEnablementController.nativeAssetIdentifiers is not an object: ${typeof networkEnablementState.nativeAssetIdentifiers}.`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+};

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -231,6 +231,7 @@ const migrations = [
   require('./193'),
   require('./194'),
   require('./195'),
+  require('./196'),
 ];
 
 export default migrations;

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-controller>@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-enablement-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1807,7 +1807,7 @@
         "uuid": true
       }
     },
-    "@metamask/bridge-controller>@metamask/network-controller": {
+    "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -1837,64 +1837,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/network-enablement-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2683,7 +2625,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-controller>@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-enablement-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1807,7 +1807,7 @@
         "uuid": true
       }
     },
-    "@metamask/bridge-controller>@metamask/network-controller": {
+    "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -1837,64 +1837,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/network-enablement-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2683,7 +2625,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-controller>@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-enablement-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1807,7 +1807,7 @@
         "uuid": true
       }
     },
-    "@metamask/bridge-controller>@metamask/network-controller": {
+    "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -1837,64 +1837,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/network-enablement-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2683,7 +2625,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1724,7 +1724,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/bridge-controller>@metamask/network-controller": true,
+        "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1750,7 +1750,7 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
-        "@metamask/network-enablement-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
         "lodash": true
@@ -1807,7 +1807,7 @@
         "uuid": true
       }
     },
-    "@metamask/bridge-controller>@metamask/network-controller": {
+    "@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -1837,64 +1837,6 @@
       }
     },
     "@metamask/bridge-status-controller>@metamask/bridge-controller>@metamask/multichain-network-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/network-enablement-controller>@metamask/network-controller": {
-      "globals": {
-        "Intl.NumberFormat": true,
-        "URL": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/connectivity-controller": true,
-        "@metamask/controller-utils": true,
-        "@metamask/network-controller>@metamask/eth-block-tracker": true,
-        "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
-        "@metamask/eth-json-rpc-middleware": true,
-        "@metamask/eth-json-rpc-provider": true,
-        "@metamask/controller-utils>@metamask/eth-query": true,
-        "@metamask/json-rpc-engine": true,
-        "@metamask/rpc-errors": true,
-        "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
-        "@metamask/utils": true,
-        "cockatiel": true,
-        "addons-linter>deepmerge": true,
-        "eslint>fast-deep-equal": true,
-        "immer": true,
-        "lodash": true,
-        "reselect": true,
-        "uri-js": true,
-        "uuid": true
-      }
-    },
-    "@metamask/transaction-controller>@metamask/network-controller": {
       "globals": {
         "Intl.NumberFormat": true,
         "URL": true,
@@ -2683,7 +2625,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -2321,7 +2321,7 @@
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/transaction-controller>@metamask/gas-fee-controller": true,
         "@metamask/metamask-eth-abis": true,
-        "@metamask/transaction-controller>@metamask/network-controller": true,
+        "@metamask/network-controller": true,
         "@metamask/transaction-controller>@metamask/nonce-tracker": true,
         "@metamask/rpc-errors": true,
         "@metamask/utils": true,

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "@metamask/multichain-transactions-controller": "^6.0.0",
     "@metamask/name-controller": "^9.0.0",
     "@metamask/network-controller": "^30.0.0",
-    "@metamask/network-enablement-controller": "^4.1.0",
+    "@metamask/network-enablement-controller": "^4.1.1",
     "@metamask/notification-services-controller": "^22.0.0",
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/obs-store": "^9.0.0",

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -181,7 +181,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 195,
+      "currentMigrationVersion": 196,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1138,6 +1138,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 195
+    "version": 196
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -36,7 +36,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 195,
+      "currentMigrationVersion": 196,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2150,6 +2150,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 195
+    "version": 196
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -316,5 +316,5 @@
     },
     "config": "object"
   },
-  "meta": { "version": 195 }
+  "meta": { "version": 196 }
 }

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -39,6 +39,7 @@
       "error: Error: Migration 186: Invalid NetworkController": 1,
       "error: Error: Migration 189: Invalid NetworkController": 1,
       "error: Error: Migration 193: SnapController not": 1,
+      "error: Error: Migration 196: NetworkEnablementController not": 1,
       "error: Error: No INFURA_PROJECT_ID set!": 1,
       "warn: Migration 139: typeof state.SelectedNetworkController is": 1,
       "warn: Migration 183.1: currencyRates not found": 1,
@@ -173,6 +174,12 @@
       "error: Error: Migration 193: SnapController missing": 1,
       "error: Error: Migration 193: SnapController not": 1,
       "error: Error: Migration 193: SnapController.snaps is": 1
+    },
+    "app/scripts/migrations/196.test.ts": {
+      "error: Error: Migration 196: NetworkEnablementController is": 1,
+      "error: Error: Migration 196: NetworkEnablementController missing": 1,
+      "error: Error: Migration 196: NetworkEnablementController not": 1,
+      "error: Error: Migration 196: NetworkEnablementController.nativeAsse...": 1
     },
     "app/scripts/services/subscription/subscription-service.test.ts": {
       "Reselect: Identity function warnings": 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,9 +5745,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@npm:^36.0.0":
-  version: 36.0.0
-  resolution: "@metamask/accounts-controller@npm:36.0.0"
+"@metamask/accounts-controller@npm:^36.0.0, @metamask/accounts-controller@npm:^36.0.1":
+  version: 36.0.1
+  resolution: "@metamask/accounts-controller@npm:36.0.1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
@@ -5757,7 +5757,7 @@ __metadata:
     "@metamask/keyring-internal-api": "npm:^10.0.0"
     "@metamask/keyring-utils": "npm:^3.1.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/snaps-controllers": "npm:^17.2.0"
     "@metamask/snaps-sdk": "npm:^10.3.0"
     "@metamask/snaps-utils": "npm:^11.7.0"
@@ -5771,7 +5771,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/fe8199bda61fda63ce9d787115a536645a485bb797f154566396144c4da00fe01b782c75aa063b7e5089a75cc3d0570c6e9fdea4212bc1604d9474c255604a46
+  checksum: 10/b60d45d06d85d481c2f6b397a1a2845866f8cfa18dd6d02ca0ab81809a1e543667c5d2bba82abc06ef53600bcd4e6c233268a530a81dce2779c3721d81946465
   languageName: node
   linkType: hard
 
@@ -6274,6 +6274,22 @@ __metadata:
     "@tanstack/query-core": "npm:^5.62.16"
     uuid: "npm:^8.3.2"
   checksum: 10/ee6c956511cf530342cac9dc27f21705109bea9c57b3babe51390ca0601a913507cf40db9fbf27459cff8d1de551dd291afeb0d5ea8119fd5d00130df222aafe
+  languageName: node
+  linkType: hard
+
+"@metamask/core-backend@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/core-backend@npm:6.0.0"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^36.0.0"
+    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@tanstack/query-core": "npm:^5.62.16"
+    uuid: "npm:^8.3.2"
+  checksum: 10/b663aa0ce78ffd493f556070906d7f008c0bd97ce613445366340fe61c0db4b85ca5ce7153a21fb4358a1b5fac31973b708ecb1795fa13fb1d827f62718eaca8
   languageName: node
   linkType: hard
 
@@ -6969,16 +6985,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^26.0.0, @metamask/gas-fee-controller@npm:^26.0.2":
-  version: 26.0.2
-  resolution: "@metamask/gas-fee-controller@npm:26.0.2"
+"@metamask/gas-fee-controller@npm:^26.0.0, @metamask/gas-fee-controller@npm:^26.0.2, @metamask/gas-fee-controller@npm:^26.0.3":
+  version: 26.0.3
+  resolution: "@metamask/gas-fee-controller@npm:26.0.3"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
-    "@metamask/network-controller": "npm:^29.0.0"
-    "@metamask/polling-controller": "npm:^16.0.2"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/polling-controller": "npm:^16.0.3"
     "@metamask/utils": "npm:^11.9.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/uuid": "npm:^8.3.0"
@@ -6986,7 +7002,7 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 10/055f93e947039edd640971ae6f9b126cc1a10d0a55a4f92f67fa1c33e7b7375c50b3db9f323d3d0b8b8bbc5d5ed5aa9dd015c7aef42e165d657760dd15b617a5
+  checksum: 10/c554094e845f93d19a81b5d0273648f0a066039e3296549eb57cd53e2a48ccb503bc261feb55d8a932d2eef7b68913d25319e91bebd53fb2ba7cbfca6ddfc8cb
   languageName: node
   linkType: hard
 
@@ -7621,22 +7637,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-network-controller@npm:^3.0.0, @metamask/multichain-network-controller@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@metamask/multichain-network-controller@npm:3.0.2"
+"@metamask/multichain-network-controller@npm:^3.0.0, @metamask/multichain-network-controller@npm:^3.0.2, @metamask/multichain-network-controller@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@metamask/multichain-network-controller@npm:3.0.4"
   dependencies:
-    "@metamask/accounts-controller": "npm:^35.0.2"
+    "@metamask/accounts-controller": "npm:^36.0.1"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
-    "@metamask/keyring-internal-api": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/keyring-api": "npm:^21.5.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.9.0"
     "@solana/addresses": "npm:^2.0.0"
     lodash: "npm:^4.17.21"
-  checksum: 10/75ae1529389fd77c2cad9cd003d07315d6dfd61c25e48a27cdc30f5b86f85908be789912bdc640575b49e6296b860561479aa2e0c7091f8e073915c1b5cd736c
+  checksum: 10/bbdda3f49160b9a23bab2f9695b1eba7e2ccd29b4ba72347cd9efdd22f898c1b910965a220d969ded28f2624d0d8783f885f5f727e2e8f2f027481c21d5c8fb5
   languageName: node
   linkType: hard
 
@@ -7759,21 +7775,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/network-enablement-controller@npm:4.1.0"
+"@metamask/network-enablement-controller@npm:^4.1.0, @metamask/network-enablement-controller@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "@metamask/network-enablement-controller@npm:4.1.2"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/keyring-api": "npm:^21.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/keyring-api": "npm:^21.5.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/multichain-network-controller": "npm:^3.0.2"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/multichain-network-controller": "npm:^3.0.4"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/slip44": "npm:^4.3.0"
-    "@metamask/transaction-controller": "npm:^62.9.2"
+    "@metamask/transaction-controller": "npm:^62.17.1"
     "@metamask/utils": "npm:^11.9.0"
     reselect: "npm:^5.1.1"
-  checksum: 10/3cc79865a49b95e7c7577eda6c1d00e1fdeb60c4357adde865fcacd4e334d421865f319d78c2659bd6745196beefed4651075bbb81e4b8caeeede20d5f8622ae
+  checksum: 10/2860220c63c941173a66be21011c58014421868d1e0e67d05d7ae30c156ac8352d752317e31ac773fa1420a5fdc7126b7c78e317d53d404cd76fd0781cf2c0cb
   languageName: node
   linkType: hard
 
@@ -8002,18 +8018,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/polling-controller@npm:^16.0.0, @metamask/polling-controller@npm:^16.0.2":
-  version: 16.0.2
-  resolution: "@metamask/polling-controller@npm:16.0.2"
+"@metamask/polling-controller@npm:^16.0.0, @metamask/polling-controller@npm:^16.0.2, @metamask/polling-controller@npm:^16.0.3":
+  version: 16.0.3
+  resolution: "@metamask/polling-controller@npm:16.0.3"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/utils": "npm:^11.9.0"
     "@types/uuid": "npm:^8.3.0"
     fast-json-stable-stringify: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/a956c11f7b29321267ae33a4f29a0663637a83fbf1a21602bfcbb3a2d1fc5a28d1fc7cff32be09bf460ebda000bd339a65e3391dfe0fa19d67a6ca591af386b6
+  checksum: 10/31182b6d62fa949bf8bee834a65aba819e52ce77c208faebb33f6e3982834e87877e29d2d93952264988ea309d110b003adf69f358dc5820eeab7ab3c09f924f
   languageName: node
   linkType: hard
 
@@ -8856,9 +8872,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.9.2":
-  version: 62.17.0
-  resolution: "@metamask/transaction-controller@npm:62.17.0"
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0, @metamask/transaction-controller@npm:^62.9.2":
+  version: 62.17.1
+  resolution: "@metamask/transaction-controller@npm:62.17.1"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -8867,16 +8883,16 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^36.0.0"
+    "@metamask/accounts-controller": "npm:^36.0.1"
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/core-backend": "npm:5.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/core-backend": "npm:^6.0.0"
     "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.2"
+    "@metamask/gas-fee-controller": "npm:^26.0.3"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^29.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/nonce-tracker": "npm:^6.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
@@ -8891,7 +8907,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/5d97bd9711dda578af1d563da9e24db78087ad46636cd924b8d53d68d30ec00fb23aee3cf5ebf95d5cba95eddf794c3d7dd8dcec78c5c6e9a36dd70be6deeac0
+  checksum: 10/b82970496e11c919f2be425ebd0aafcf10f355a8521b2c2d6aa62ab1bd634e8f71187f48e57d40a7c87620a61263fde38e5529d304ec5f144f8000f20b0acd27
   languageName: node
   linkType: hard
 
@@ -33810,7 +33826,7 @@ __metadata:
     "@metamask/multichain-transactions-controller": "npm:^6.0.0"
     "@metamask/name-controller": "npm:^9.0.0"
     "@metamask/network-controller": "npm:^30.0.0"
-    "@metamask/network-enablement-controller": "npm:^4.1.0"
+    "@metamask/network-enablement-controller": "npm:^4.1.1"
     "@metamask/notification-services-controller": "npm:^22.0.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/obs-store": "npm:^9.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40206?quickstart=1)

Context: HYPE token (`eip155:999/slip44:2457`) was incorrectly set to `eip155:999/slip44:1` (`1` instead of `2457`)
for some users in _NetworkEnablementController.nativeAssetIdentifiers_ state.
This is because https://chainid.network/chains.json is fetched to populate this state,
and that chainId "999" references a "WanChain testnet" instead of HyperEVM.
PR https://github.com/MetaMask/core/pull/7975 addresses future population by forcing an
override at fetch-time.
However such fetching is not always triggered if an user had already added the network,
hence the need for this migration that - ontop of the PR above - will migrate the incorrect
entry ('eip155:999/slip44:1') to the correct one ('eip155:999/slip44:2457').

This migration will operate only if an entry already exists AND is not 'eip155:999/slip44:2457'.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migrates `NetworkEnablementController.nativeAssetIdentifiers['eip155:999']` to value `eip155:999/slip44:2457` if applicable.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-574

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="200" alt="image" src="https://github.com/user-attachments/assets/1237ba32-2c36-4b76-a47f-c9bea0fb0799" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Migration is narrowly scoped to a single stored key and is guarded by shape checks and “only-if-present” logic; main risk is incorrect assumptions about persisted state shapes, mitigated by early exits and Sentry logging.
> 
> **Overview**
> Adds state migration `196` to fix an incorrect `NetworkEnablementController.nativeAssetIdentifiers['eip155:999']` value by overwriting it with `eip155:999/slip44:2457` **only when the key already exists and is not already correct**, and records `NetworkEnablementController` as changed.
> 
> Introduces a small `196_utils` validator that Sentry-logs unexpected/missing controller state shapes, adds comprehensive unit coverage for these edge cases, wires the migration into the main migrations list, and bumps e2e fixture migration versions accordingly. Also updates `@metamask/network-enablement-controller` (and related lockfile/policy entries) to the newer patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb4c11dab8bb73cfae47433cba26f5be40865c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->