### PR TITLE
feat: update gas sponsorship UI

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -1,11 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Text, TextVariant } from '@metamask/design-system-react';
+import { Text, TextColor, TextVariant } from '@metamask/design-system-react';
 import {
   BackgroundColor,
   BorderRadius,
-  TextColor,
 } from '../../../helpers/constants/design-system';
 import { Box } from '../../component-library';
 import CurrencyDisplay from '../../ui/currency-display';
@@ -15,6 +14,9 @@ import { EtherDenomination } from '../../../../shared/constants/common';
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { RecipientWithAddress } from '../../ui/sender-to-recipient/sender-to-recipient.component';
 import TransactionBreakdownRow from './transaction-breakdown-row';
+
+// TODO remove - testing Paid by MetaMask on all networks
+const __FORCE_SHOW_SPONSORED = true;
 
 export default class TransactionBreakdown extends PureComponent {
   static contextTypes = {
@@ -119,7 +121,7 @@ export default class TransactionBreakdown extends PureComponent {
           </TransactionBreakdownRow>
         )}
 
-        {isGasFeeSponsored && (
+        {(isGasFeeSponsored || __FORCE_SHOW_SPONSORED) && (
           <TransactionBreakdownRow title={t('networkFee')}>
             <Box
               backgroundColor={BackgroundColor.successMuted}
@@ -129,7 +131,7 @@ export default class TransactionBreakdown extends PureComponent {
             >
               <Text
                 variant={TextVariant.BodyXs}
-                color={TextColor.successDefault}
+                color={TextColor.SuccessDefault}
                 className="transaction-breakdown__value"
               >
                 {t('paidByMetaMask')}
@@ -137,7 +139,7 @@ export default class TransactionBreakdown extends PureComponent {
             </Box>
           </TransactionBreakdownRow>
         )}
-        {!isGasFeeSponsored && (
+        {!(isGasFeeSponsored || __FORCE_SHOW_SPONSORED) && (
           <>
             {gasPaidByAddress && (
               // TODO: Use i18n

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -1,12 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Text, TextColor, TextVariant } from '@metamask/design-system-react';
-import {
-  BackgroundColor,
-  BorderRadius,
-} from '../../../helpers/constants/design-system';
-import { Box } from '../../component-library';
+import { SuccessPill } from '../../component-library';
 import CurrencyDisplay from '../../ui/currency-display';
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import HexToDecimal from '../../ui/hex-to-decimal';
@@ -120,20 +115,10 @@ export default class TransactionBreakdown extends PureComponent {
 
         {isGasFeeSponsored && (
           <TransactionBreakdownRow title={t('networkFee')}>
-            <Box
-              backgroundColor={BackgroundColor.successMuted}
-              paddingLeft={2}
-              paddingRight={2}
-              borderRadius={BorderRadius.SM}
-            >
-              <Text
-                variant={TextVariant.BodyXs}
-                color={TextColor.SuccessDefault}
-                className="transaction-breakdown__value"
-              >
-                {t('paidByMetaMask')}
-              </Text>
-            </Box>
+            <SuccessPill
+              label={t('paidByMetaMask')}
+              className="transaction-breakdown__value"
+            />
           </TransactionBreakdownRow>
         )}
         {!isGasFeeSponsored && (

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -15,9 +15,6 @@ import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { RecipientWithAddress } from '../../ui/sender-to-recipient/sender-to-recipient.component';
 import TransactionBreakdownRow from './transaction-breakdown-row';
 
-// TODO remove - testing Paid by MetaMask on all networks
-const __FORCE_SHOW_SPONSORED = true;
-
 export default class TransactionBreakdown extends PureComponent {
   static contextTypes = {
     t: PropTypes.func,
@@ -121,7 +118,7 @@ export default class TransactionBreakdown extends PureComponent {
           </TransactionBreakdownRow>
         )}
 
-        {(isGasFeeSponsored || __FORCE_SHOW_SPONSORED) && (
+        {isGasFeeSponsored && (
           <TransactionBreakdownRow title={t('networkFee')}>
             <Box
               backgroundColor={BackgroundColor.successMuted}
@@ -139,7 +136,7 @@ export default class TransactionBreakdown extends PureComponent {
             </Box>
           </TransactionBreakdownRow>
         )}
-        {!(isGasFeeSponsored || __FORCE_SHOW_SPONSORED) && (
+        {!isGasFeeSponsored && (
           <>
             {gasPaidByAddress && (
               // TODO: Use i18n

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -2,6 +2,12 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Text, TextVariant } from '@metamask/design-system-react';
+import {
+  BackgroundColor,
+  BorderRadius,
+  TextColor,
+} from '../../../helpers/constants/design-system';
+import { Box } from '../../component-library';
 import CurrencyDisplay from '../../ui/currency-display';
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import HexToDecimal from '../../ui/hex-to-decimal';
@@ -115,15 +121,22 @@ export default class TransactionBreakdown extends PureComponent {
 
         {isGasFeeSponsored && (
           <TransactionBreakdownRow title={t('networkFee')}>
-            <Text
-              variant={TextVariant.BodyXs}
-              className="transaction-breakdown__value"
+            <Box
+              backgroundColor={BackgroundColor.successMuted}
+              paddingLeft={2}
+              paddingRight={2}
+              borderRadius={BorderRadius.SM}
             >
-              {t('paidByMetaMask')}
-            </Text>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.successDefault}
+                className="transaction-breakdown__value"
+              >
+                {t('paidByMetaMask')}
+              </Text>
+            </Box>
           </TransactionBreakdownRow>
         )}
-        {}
         {!isGasFeeSponsored && (
           <>
             {gasPaidByAddress && (

--- a/ui/components/component-library/index.ts
+++ b/ui/components/component-library/index.ts
@@ -58,6 +58,8 @@ export { PickerNetwork } from './picker-network';
 export type { PickerNetworkProps } from './picker-network';
 export { Tag } from './tag';
 export type { TagProps } from './tag';
+export { SuccessPill } from './success-pill';
+export type { SuccessPillProps } from './success-pill';
 export { TagUrl } from './tag-url';
 export type { TagUrlProps } from './tag-url';
 export { Text, ValidTag, TextDirection, InvisibleCharacter } from './text';

--- a/ui/components/component-library/success-pill/__snapshots__/success-pill.test.tsx.snap
+++ b/ui/components/component-library/success-pill/__snapshots__/success-pill.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SuccessPill should render the label inside the pill and match snapshot 1`] = `
+<div>
+  <div
+    class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-success-muted mm-box--rounded-sm"
+    data-testid="success-pill"
+  >
+    <p
+      class="text-success-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+    >
+      Paid by MetaMask
+    </p>
+  </div>
+</div>
+`;
+
+exports[`SuccessPill should render with custom label 1`] = `
+<div>
+  <div
+    class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-success-muted mm-box--rounded-sm"
+    data-testid="success-pill"
+  >
+    <p
+      class="text-success-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+    >
+      No network fee
+    </p>
+  </div>
+</div>
+`;

--- a/ui/components/component-library/success-pill/index.ts
+++ b/ui/components/component-library/success-pill/index.ts
@@ -1,0 +1,5 @@
+export { SuccessPill } from './success-pill';
+export type {
+  SuccessPillProps,
+  SuccessPillComponent,
+} from './success-pill.types';

--- a/ui/components/component-library/success-pill/success-pill.test.tsx
+++ b/ui/components/component-library/success-pill/success-pill.test.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable jest/require-top-level-describe */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { SuccessPill } from './success-pill';
+
+describe('SuccessPill', () => {
+  it('should render the label inside the pill and match snapshot', () => {
+    const { getByTestId, container } = render(
+      <SuccessPill data-testid="success-pill" label="Paid by MetaMask" />,
+    );
+    expect(getByTestId('success-pill')).toBeDefined();
+    expect(getByTestId('success-pill')).toHaveTextContent('Paid by MetaMask');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with custom label', () => {
+    const { getByTestId, container } = render(
+      <SuccessPill data-testid="success-pill" label="No network fee" />,
+    );
+    expect(getByTestId('success-pill')).toHaveTextContent('No network fee');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should apply success styling (mm-tag with label)', () => {
+    const { getByTestId } = render(
+      <SuccessPill data-testid="success-pill" label="Paid by MetaMask" />,
+    );
+    const pill = getByTestId('success-pill');
+    expect(pill).toHaveClass('mm-tag');
+    expect(pill).toHaveTextContent('Paid by MetaMask');
+  });
+
+  it('should forward a ref to the root html element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<SuccessPill label="Test" ref={ref} />);
+    expect(ref.current).not.toBeNull();
+    if (ref.current) {
+      expect(ref.current.nodeName).toBe('DIV');
+    }
+  });
+});

--- a/ui/components/component-library/success-pill/success-pill.tsx
+++ b/ui/components/component-library/success-pill/success-pill.tsx
@@ -12,20 +12,18 @@ import type {
  * Used for "Paid by MetaMask", "No network fee", and similar labels.
  */
 export const SuccessPill: SuccessPillComponent = React.forwardRef(
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  function SuccessPill<C extends React.ElementType = 'div'>(
-    { label, ...props }: SuccessPillProps<C>,
-    ref: React.Ref<Element>,
+  function SuccessPill(
+    { label, ...props }: SuccessPillProps,
+    ref: React.Ref<HTMLDivElement>,
   ) {
     return (
       <Tag
-        ref={ref as React.Ref<HTMLDivElement>}
+        ref={ref}
         label={label}
         backgroundColor={BackgroundColor.successMuted}
         labelProps={{ color: TextColor.SuccessDefault as never }}
         textVariant={TextVariant.BodySm}
-        {...(props as React.ComponentProps<typeof Tag>)}
+        {...props}
       />
     );
   },

--- a/ui/components/component-library/success-pill/success-pill.tsx
+++ b/ui/components/component-library/success-pill/success-pill.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { TextColor, TextVariant } from '@metamask/design-system-react';
+import { BackgroundColor } from '../../../helpers/constants/design-system';
+import { Tag } from '../tag';
+import type {
+  SuccessPillComponent,
+  SuccessPillProps,
+} from './success-pill.types';
+
+/**
+ * A pill-shaped label with success (green) styling.
+ * Used for "Paid by MetaMask", "No network fee", and similar labels.
+ */
+export const SuccessPill: SuccessPillComponent = React.forwardRef(
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  function SuccessPill<C extends React.ElementType = 'div'>(
+    { label, ...props }: SuccessPillProps<C>,
+    ref: React.Ref<Element>,
+  ) {
+    return (
+      <Tag
+        ref={ref as React.Ref<HTMLDivElement>}
+        label={label}
+        backgroundColor={BackgroundColor.successMuted}
+        labelProps={{ color: TextColor.SuccessDefault as never }}
+        textVariant={TextVariant.BodySm}
+        {...(props as React.ComponentProps<typeof Tag>)}
+      />
+    );
+  },
+);

--- a/ui/components/component-library/success-pill/success-pill.tsx
+++ b/ui/components/component-library/success-pill/success-pill.tsx
@@ -20,11 +20,11 @@ export const SuccessPill: SuccessPillComponent = React.forwardRef(
     return (
       <Tag
         ref={ref}
+        {...props}
         label={label}
         backgroundColor={BackgroundColor.successMuted}
         labelProps={{ color: TextColor.SuccessDefault as never }}
         textVariant={TextVariant.BodySm}
-        {...props}
       />
     );
   },

--- a/ui/components/component-library/success-pill/success-pill.tsx
+++ b/ui/components/component-library/success-pill/success-pill.tsx
@@ -12,6 +12,7 @@ import type {
  * Used for "Paid by MetaMask", "No network fee", and similar labels.
  */
 export const SuccessPill: SuccessPillComponent = React.forwardRef(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   function SuccessPill(
     { label, ...props }: SuccessPillProps,
     ref: React.Ref<HTMLDivElement>,

--- a/ui/components/component-library/success-pill/success-pill.types.ts
+++ b/ui/components/component-library/success-pill/success-pill.types.ts
@@ -1,0 +1,22 @@
+import type {
+  PolymorphicComponentPropWithRef,
+  StyleUtilityProps,
+} from '../box';
+
+export type SuccessPillStyleUtilityProps = {
+  /**
+   * The text content of the pill (e.g. "Paid by MetaMask", "No network fee")
+   */
+  label: string | React.ReactNode;
+} & StyleUtilityProps;
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type SuccessPillProps<C extends React.ElementType> =
+  PolymorphicComponentPropWithRef<C, SuccessPillStyleUtilityProps>;
+
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type SuccessPillComponent = <C extends React.ElementType = 'div'>(
+  props: SuccessPillProps<C>,
+) => React.ReactElement | null;

--- a/ui/components/component-library/success-pill/success-pill.types.ts
+++ b/ui/components/component-library/success-pill/success-pill.types.ts
@@ -10,8 +10,10 @@ export type SuccessPillStyleUtilityProps = {
   label: string | React.ReactNode;
 } & StyleUtilityProps;
 
-export type SuccessPillProps =
-  PolymorphicComponentPropWithRef<'div', SuccessPillStyleUtilityProps>;
+export type SuccessPillProps = PolymorphicComponentPropWithRef<
+  'div',
+  SuccessPillStyleUtilityProps
+>;
 
 export type SuccessPillComponent = (
   props: SuccessPillProps,

--- a/ui/components/component-library/success-pill/success-pill.types.ts
+++ b/ui/components/component-library/success-pill/success-pill.types.ts
@@ -10,13 +10,9 @@ export type SuccessPillStyleUtilityProps = {
   label: string | React.ReactNode;
 } & StyleUtilityProps;
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type SuccessPillProps<C extends React.ElementType> =
-  PolymorphicComponentPropWithRef<C, SuccessPillStyleUtilityProps>;
+export type SuccessPillProps =
+  PolymorphicComponentPropWithRef<'div', SuccessPillStyleUtilityProps>;
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type SuccessPillComponent = <C extends React.ElementType = 'div'>(
-  props: SuccessPillProps<C>,
+export type SuccessPillComponent = (
+  props: SuccessPillProps,
 ) => React.ReactElement | null;

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
                   style="overflow: hidden;"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                     data-testid="Ethereum"
                   >
                     <div
@@ -196,7 +196,7 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
                   style="overflow: hidden;"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                     data-testid="OP"
                   >
                     <div
@@ -327,7 +327,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                   style="overflow: hidden;"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                     data-testid="Ethereum"
                   >
                     <div
@@ -368,7 +368,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                   style="overflow: hidden;"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                     data-testid="OP"
                   >
                     <div

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -20,7 +20,7 @@ exports[`NetworkListItem renders properly 1`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Polygon"
       >
         <div

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -13,11 +13,12 @@ import {
   AlignItems,
   BackgroundColor,
   BlockSize,
+  BorderRadius,
   Display,
+  FlexDirection,
   JustifyContent,
   TextColor,
   IconColor,
-  FlexDirection,
   TextVariant,
   BorderColor,
 } from '../../../helpers/constants/design-system';
@@ -260,7 +261,9 @@ export const NetworkListItem = ({
         <Box
           width={BlockSize.Full}
           display={Display.Flex}
+          flexDirection={FlexDirection.Row}
           alignItems={AlignItems.center}
+          gap={2}
           data-testid={name}
         >
           <Tooltip
@@ -281,12 +284,23 @@ export const NetworkListItem = ({
               {name}
             </Text>
           </Tooltip>
+          {isNetworkGasSponsored(chainId) && (
+            <Box
+              backgroundColor={BackgroundColor.successMuted}
+              paddingLeft={2}
+              paddingRight={2}
+              borderRadius={BorderRadius.SM}
+              display={Display.InlineFlex}
+            >
+              <Text
+                variant={TextVariant.bodySm}
+                color={TextColor.successDefault}
+              >
+                {t('noNetworkFee')}
+              </Text>
+            </Box>
+          )}
         </Box>
-        {isNetworkGasSponsored(chainId) && (
-          <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
-            {t('noNetworkFee')}
-          </Text>
-        )}
         {rpcEndpoint && (
           <Box
             className="multichain-network-list-item__rpc-endpoint"

--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -13,7 +13,6 @@ import {
   AlignItems,
   BackgroundColor,
   BlockSize,
-  BorderRadius,
   Display,
   FlexDirection,
   JustifyContent,
@@ -31,6 +30,7 @@ import {
   Icon,
   IconName,
   IconSize,
+  SuccessPill,
   Text,
 } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -285,20 +285,10 @@ export const NetworkListItem = ({
             </Text>
           </Tooltip>
           {isNetworkGasSponsored(chainId) && (
-            <Box
-              backgroundColor={BackgroundColor.successMuted}
-              paddingLeft={2}
-              paddingRight={2}
-              borderRadius={BorderRadius.SM}
+            <SuccessPill
+              label={t('noNetworkFee')}
               display={Display.InlineFlex}
-            >
-              <Text
-                variant={TextVariant.bodySm}
-                color={TextColor.successDefault}
-              >
-                {t('noNetworkFee')}
-              </Text>
-            </Box>
+            />
           )}
         </Box>
         {rpcEndpoint && (

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Ethereum"
                       >
                         <div
@@ -190,7 +190,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Linea"
                       >
                         <div
@@ -253,7 +253,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="BNB Chain"
                       >
                         <div
@@ -312,7 +312,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Chain 5"
                       >
                         <div
@@ -375,7 +375,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Monad"
                       >
                         <div
@@ -1364,7 +1364,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Ethereum"
                       >
                         <div
@@ -1427,7 +1427,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Linea"
                       >
                         <div
@@ -1490,7 +1490,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="BNB Chain"
                       >
                         <div
@@ -1549,7 +1549,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Chain 5"
                       >
                         <div
@@ -1612,7 +1612,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       style="overflow: hidden;"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
                         data-testid="Monad"
                       >
                         <div

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../../../shared/modules/network.utils';
 import {
   AlignItems,
+  BackgroundColor,
   BlockSize,
   BorderRadius,
   Display,
@@ -371,7 +372,12 @@ const DefaultNetworks = memo(() => {
             src={networkImageUrl}
             borderRadius={BorderRadius.LG}
           />
-          <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
+            alignItems={AlignItems.center}
+            gap={2}
+          >
             <Text
               variant={TextVariant.bodyMdMedium}
               color={TextColor.textDefault}
@@ -379,12 +385,20 @@ const DefaultNetworks = memo(() => {
               {network.name}
             </Text>
             {isNetworkGasSponsored(network.chainId) && (
-              <Text
-                variant={TextVariant.bodySm}
-                color={TextColor.textAlternative}
+              <Box
+                backgroundColor={BackgroundColor.successMuted}
+                paddingLeft={2}
+                paddingRight={2}
+                borderRadius={BorderRadius.SM}
+                display={Display.InlineFlex}
               >
-                {t('noNetworkFee')}
-              </Text>
+                <Text
+                  variant={TextVariant.bodySm}
+                  color={TextColor.successDefault}
+                >
+                  {t('noNetworkFee')}
+                </Text>
+              </Box>
             )}
           </Box>
           <ButtonIcon

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../../../../shared/modules/network.utils';
 import {
   AlignItems,
-  BackgroundColor,
   BlockSize,
   BorderRadius,
   Display,
@@ -38,6 +37,7 @@ import {
   ButtonIconSize,
   IconName,
   IconSize,
+  SuccessPill,
   Text,
 } from '../../../../component-library';
 import { NetworkListItem } from '../../../network-list-item';
@@ -385,20 +385,10 @@ const DefaultNetworks = memo(() => {
               {network.name}
             </Text>
             {isNetworkGasSponsored(network.chainId) && (
-              <Box
-                backgroundColor={BackgroundColor.successMuted}
-                paddingLeft={2}
-                paddingRight={2}
-                borderRadius={BorderRadius.SM}
+              <SuccessPill
+                label={t('noNetworkFee')}
                 display={Display.InlineFlex}
-              >
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.successDefault}
-                >
-                  {t('noNetworkFee')}
-                </Text>
-              </Box>
+              />
             )}
           </Box>
           <ButtonIcon

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="All networks"
       >
         <div
@@ -84,7 +84,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Solana"
       >
         <div
@@ -125,7 +125,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Bitcoin"
       >
         <div
@@ -166,7 +166,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Ethereum"
       >
         <div
@@ -207,7 +207,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="OP"
       >
         <div
@@ -248,7 +248,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Polygon"
       >
         <div
@@ -289,7 +289,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="BNB Chain"
       >
         <div
@@ -330,7 +330,7 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Tron"
       >
         <div
@@ -358,17 +358,17 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
 
 exports[`BridgeInputGroup should render destination networks 3`] = `
 [
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:e92eb8d31dccb497e712b982d787222dae4d9f3503cca3569c7a96bbd5bb2f35",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:c6ab4b1f41996afda9220fbe8503fa6985c2f54e14bec5b7ed8a9530938f06db",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:e92eb8d31dccb497e712b982d787222dae4d9f3503cca3569c7a96bbd5bb2f35",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:c6ab4b1f41996afda9220fbe8503fa6985c2f54e14bec5b7ed8a9530938f06db",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
 
 exports[`BridgeInputGroup should render destination networks 4`] = `
 [
   [
-    "https://bridge.api.cx.metamask.io/getTokens/popular",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
       "headers": {
@@ -380,7 +380,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/search",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -392,7 +392,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/popular",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}]}",
       "headers": {
@@ -404,7 +404,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/search",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -461,7 +461,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="All networks"
       >
         <div
@@ -502,7 +502,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Solana"
       >
         <div
@@ -543,7 +543,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Bitcoin"
       >
         <div
@@ -584,7 +584,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="Ethereum"
       >
         <div
@@ -625,7 +625,7 @@ exports[`BridgeInputGroup should render source networks 2`] = `
       style="overflow: hidden;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--align-items-center mm-box--width-full"
+        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
         data-testid="OP"
       >
         <div
@@ -653,17 +653,17 @@ exports[`BridgeInputGroup should render source networks 2`] = `
 
 exports[`BridgeInputGroup should render source networks 3`] = `
 [
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:503dca807bc28c124ddd2340e17a335eb411cc81363589c7a73716053f469fd3",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:d4ebccd5f98957b00ea939fb0c1fccbdb21ab61290f7557e3f96855866f19789",
-  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:503dca807bc28c124ddd2340e17a335eb411cc81363589c7a73716053f469fd3",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:d4ebccd5f98957b00ea939fb0c1fccbdb21ab61290f7557e3f96855866f19789",
+  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
 
 exports[`BridgeInputGroup should render source networks 4`] = `
 [
   [
-    "https://bridge.api.cx.metamask.io/getTokens/popular",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
       "headers": {
@@ -675,7 +675,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/search",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -687,7 +687,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/popular",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}]}",
       "headers": {
@@ -699,7 +699,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.api.cx.metamask.io/getTokens/search",
+    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -358,17 +358,17 @@ exports[`BridgeInputGroup should render destination networks 2`] = `
 
 exports[`BridgeInputGroup should render destination networks 3`] = `
 [
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:e92eb8d31dccb497e712b982d787222dae4d9f3503cca3569c7a96bbd5bb2f35",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:c6ab4b1f41996afda9220fbe8503fa6985c2f54e14bec5b7ed8a9530938f06db",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:e92eb8d31dccb497e712b982d787222dae4d9f3503cca3569c7a96bbd5bb2f35",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:c6ab4b1f41996afda9220fbe8503fa6985c2f54e14bec5b7ed8a9530938f06db",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
 
 exports[`BridgeInputGroup should render destination networks 4`] = `
 [
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
+    "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
       "headers": {
@@ -380,7 +380,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
+    "https://bridge.api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10","eip155:137","eip155:56","tron:728126428"],"includeAssets":[{"assetId":"eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA","symbol":"mUSD","name":"MetaMask USD","decimals":6},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -392,7 +392,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
+    "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}]}",
       "headers": {
@@ -404,7 +404,7 @@ exports[`BridgeInputGroup should render destination networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
+    "https://bridge.api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -653,17 +653,17 @@ exports[`BridgeInputGroup should render source networks 2`] = `
 
 exports[`BridgeInputGroup should render source networks 3`] = `
 [
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:503dca807bc28c124ddd2340e17a335eb411cc81363589c7a73716053f469fd3",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:d4ebccd5f98957b00ea939fb0c1fccbdb21ab61290f7557e3f96855866f19789",
-  "bridgeCache:https://bridge.dev-api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:503dca807bc28c124ddd2340e17a335eb411cc81363589c7a73716053f469fd3",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/popular:52d1392eaabba42428cc7ee8801c662237b8afbc5861e76be9fcfe81f7c0366f",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:d4ebccd5f98957b00ea939fb0c1fccbdb21ab61290f7557e3f96855866f19789",
+  "bridgeCache:https://bridge.api.cx.metamask.io/getTokens/search:f2b6768c8767172e7655a5129095d585b1cb3107c3a77a72b3f7285b8b51ccf5",
 ]
 `;
 
 exports[`BridgeInputGroup should render source networks 4`] = `
 [
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
+    "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"eip155:1/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"eip155:10/erc20:0xc00e94Cb662C3520282E6f5717214004A7f26888","symbol":"COMP","name":"Compound","decimals":6},{"assetId":"eip155:10/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9},{"assetId":"eip155:10/slip44:60","symbol":"ETH","name":"Ether","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"bip122:000000000019d6689c085ae165831e93/slip44:0","symbol":"BTC","name":"Bitcoin","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6},{"assetId":"eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984","symbol":"UNI","name":"Uniswap","decimals":10},{"assetId":"eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA","symbol":"LINK","name":"Link","decimals":9}]}",
       "headers": {
@@ -675,7 +675,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
+    "https://bridge.api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp","bip122:000000000019d6689c085ae165831e93","eip155:1","eip155:10"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {
@@ -687,7 +687,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/popular",
+    "https://bridge.api.cx.metamask.io/getTokens/popular",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","symbol":"SOL","name":"Solana","decimals":18},{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}]}",
       "headers": {
@@ -699,7 +699,7 @@ exports[`BridgeInputGroup should render source networks 4`] = `
     },
   ],
   [
-    "https://bridge.dev-api.cx.metamask.io/getTokens/search",
+    "https://bridge.api.cx.metamask.io/getTokens/search",
     {
       "body": "{"chainIds":["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],"includeAssets":[{"assetId":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC","name":"USDC","decimals":6}],"query":"SD"}",
       "headers": {

--- a/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
@@ -273,10 +273,10 @@ exports[`MultichainBridgeQuoteCard should render gas sponsored text when gasSpon
         data-testid="network-fees-sponsored"
       >
         <div
-          class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--background-color-success-muted mm-box--rounded-sm"
+          class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-success-muted mm-box--rounded-sm"
         >
           <p
-            class="mm-box mm-text mm-text--body-sm mm-box--color-success-default"
+            class="text-success-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
           >
             Paid by MetaMask
           </p>

--- a/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
@@ -272,11 +272,15 @@ exports[`MultichainBridgeQuoteCard should render gas sponsored text when gasSpon
         class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--flex-wrap-nowrap mm-box--justify-content-space-between mm-box--align-items-center"
         data-testid="network-fees-sponsored"
       >
-        <p
-          class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+        <div
+          class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--background-color-success-muted mm-box--rounded-sm"
         >
-          Paid by MetaMask
-        </p>
+          <p
+            class="mm-box mm-text mm-text--body-sm mm-box--color-success-default"
+          >
+            Paid by MetaMask
+          </p>
+        </div>
       </div>
     </div>
     <div

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -8,7 +8,7 @@ import {
 } from '@metamask/bridge-controller';
 import { bpsToPercentage } from '../../../ducks/bridge/utils';
 import {
-  Box,
+  SuccessPill,
   Text,
   PopoverPosition,
   IconName,
@@ -32,8 +32,6 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { formatNetworkFee, formatTokenAmount } from '../utils/quote';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
-  BackgroundColor,
-  BorderRadius,
   IconColor,
   JustifyContent,
   TextColor,
@@ -316,19 +314,7 @@ export const MultichainBridgeQuoteCard = ({
             </Row>
             {shouldShowGasSponsored && (
               <Row gap={1} data-testid="network-fees-sponsored">
-                <Box
-                  backgroundColor={BackgroundColor.successMuted}
-                  paddingLeft={2}
-                  paddingRight={2}
-                  borderRadius={BorderRadius.SM}
-                >
-                  <Text
-                    variant={TextVariant.bodySm}
-                    color={TextColor.successDefault}
-                  >
-                    {t('swapGasFeesSponsored')}
-                  </Text>
-                </Box>
+                <SuccessPill label={t('swapGasFeesSponsored')} />
               </Row>
             )}
             {!shouldShowGasSponsored && activeQuote.quote.gasIncluded && (

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -8,6 +8,7 @@ import {
 } from '@metamask/bridge-controller';
 import { bpsToPercentage } from '../../../ducks/bridge/utils';
 import {
+  Box,
   Text,
   PopoverPosition,
   IconName,
@@ -31,6 +32,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { formatNetworkFee, formatTokenAmount } from '../utils/quote';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
+  BackgroundColor,
+  BorderRadius,
   IconColor,
   JustifyContent,
   TextColor,
@@ -313,12 +316,19 @@ export const MultichainBridgeQuoteCard = ({
             </Row>
             {shouldShowGasSponsored && (
               <Row gap={1} data-testid="network-fees-sponsored">
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.textDefault}
+                <Box
+                  backgroundColor={BackgroundColor.successMuted}
+                  paddingLeft={2}
+                  paddingRight={2}
+                  borderRadius={BorderRadius.SM}
                 >
-                  {t('swapGasFeesSponsored')}
-                </Text>
+                  <Text
+                    variant={TextVariant.bodySm}
+                    color={TextColor.successDefault}
+                  >
+                    {t('swapGasFeesSponsored')}
+                  </Text>
+                </Box>
               </Row>
             )}
             {!shouldShowGasSponsored && activeQuote.quote.gasIncluded && (

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -10,6 +10,8 @@ import { Skeleton } from '../../../../../../../components/component-library/skel
 import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   AlignItems,
+  BackgroundColor,
+  BorderRadius,
   Display,
   FlexDirection,
   JustifyContent,
@@ -105,12 +107,20 @@ export const EditGasFeesRow = ({
             gap={1}
           >
             {isGasFeeSponsored && (
-              <Text
-                color={TextColor.textDefault}
-                data-testid="paid-by-meta-mask"
+              <Box
+                backgroundColor={BackgroundColor.successMuted}
+                paddingLeft={2}
+                paddingRight={2}
+                borderRadius={BorderRadius.SM}
               >
-                {t('paidByMetaMask')}
-              </Text>
+                <Text
+                  variant={TextVariant.bodySm}
+                  color={TextColor.successDefault}
+                  data-testid="paid-by-meta-mask"
+                >
+                  {t('paidByMetaMask')}
+                </Text>
+              </Box>
             )}
             {isGasFeeEditable && <EditGasIconButton />}
             {estimationFailed && !isGasFeeSponsored && (

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -5,13 +5,15 @@ import { useSelector } from 'react-redux';
 import { TEST_CHAINS } from '../../../../../../../../shared/constants/network';
 import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
-import { Box, Text } from '../../../../../../../components/component-library';
+import {
+  Box,
+  SuccessPill,
+  Text,
+} from '../../../../../../../components/component-library';
 import { Skeleton } from '../../../../../../../components/component-library/skeleton';
 import Tooltip from '../../../../../../../components/ui/tooltip';
 import {
   AlignItems,
-  BackgroundColor,
-  BorderRadius,
   Display,
   FlexDirection,
   JustifyContent,
@@ -107,20 +109,10 @@ export const EditGasFeesRow = ({
             gap={1}
           >
             {isGasFeeSponsored && (
-              <Box
-                backgroundColor={BackgroundColor.successMuted}
-                paddingLeft={2}
-                paddingRight={2}
-                borderRadius={BorderRadius.SM}
-              >
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.successDefault}
-                  data-testid="paid-by-meta-mask"
-                >
-                  {t('paidByMetaMask')}
-                </Text>
-              </Box>
+              <SuccessPill
+                label={t('paidByMetaMask')}
+                data-testid="paid-by-meta-mask"
+              />
             )}
             {isGasFeeEditable && <EditGasIconButton />}
             {estimationFailed && !isGasFeeSponsored && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.

-->

## **Description**

Updates the gas sponsorship UI so "Paid by MetaMask" and "No network fee" use a green pill style across Send, Dapp, Swap, and network lists.

N.B: Feature flags to show gas sponsorship are enabled on dev-only for now.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40210?quickstart=1)

## **Changelog**



<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Gas sponsorship UI
- Show green “Paid by MetaMask” pill on Send/Dapp confirmation and transaction details when gas is sponsored. 
- Show green “No network fee” pill next to network name in network lists (Your networks, Select token, default networks).
- Show “Paid by MetaMask” pill on Bridge/Swap quote card when network fee is sponsored. 
- Feature flags are dev-only; no change in production until enabled.

## **Related issues**

Fixes:

## **Manual testing steps**

**1. Send – confirmation:** 
- Switch to a sponsored network (Monad or SEI)
- Start a Send (native or token).
- On the Review screen, confirm the Network fee row shows a green “Paid by MetaMask” pill.

**2. Send – transaction details**
- Complete the send (or use an existing sponsored tx).
- Open the transaction in activity/details.
- Confirm the breakdown shows Network fee with a green “Paid by MetaMask” pill.

**3. Network lists – “No network fee”**
- Open a network list (e.g. Your networks, or Select token / network picker).
- For a sponsored network (e.g. Sei, Monad), confirm “No network fee” appears in a green pill on the same line as the network name (not below it).

**4. Bridge/Swap – quote card**
- On a sponsored network, open Bridge/Swap and get a quote.
- On the quote card, confirm the Network fee row shows a green “Paid by MetaMask” pill when the quote is gas sponsored.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<img  height="600" alt="Screenshot 2026-02-18 at 17 31 04" src="https://github.com/user-attachments/assets/737b2d5b-aa78-49f1-80a7-a04049211d17" />
<img height="600" alt="Screenshot 2026-02-19 at 14 18 34" src="https://github.com/user-attachments/assets/1484092a-af63-4153-b17a-6b3437e225a3" />
<img  height="600" alt="Screenshot 2026-02-18 at 17 31 28" src="https://github.com/user-attachments/assets/325c66cc-2587-49c7-b6dc-1117f804683c" />
<img  height="600" alt="Screenshot 2026-02-19 at 14 16 06" src="https://github.com/user-attachments/assets/ff80eafc-1226-480b-bfa5-0a25ee680b59" />
<img  height="600" alt="Screenshot 2026-02-19 at 14 12 58" src="https://github.com/user-attachments/assets/3d41e57b-36c6-40a4-b7c4-1d2d51f75d19" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component addition and label rendering changes; primary risk is minor visual/layout regressions in network list rows and fee displays.
> 
> **Overview**
> Adds a new component-library primitive, `SuccessPill`, to render success-styled (green) pill labels and includes unit/snapshot coverage.
> 
> Replaces plain `Text` labels with `SuccessPill` for gas sponsorship messaging: **“Paid by MetaMask”** in transaction breakdown, confirm gas fee row, and bridge quote card, and **“No network fee”** next to sponsored networks in network list surfaces. Network list layouts were adjusted (row flex + `gap`) to keep the pill inline with the network name, updating related snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8bd7e7ff56b1f82ab263653babde1dd8343c8bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->