### PR TITLE
chore: Add local Claude settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ package
 .idea
 .sublime-project
 
+# LLMs
+.claude/*.local.*
+
 *.bak
 
 # VIM


### PR DESCRIPTION
## **Description**

Claude stores local settings as `.claude/settings.local.json`. These local settings are populated whenever you e.g. allowlist a shell command. These local settings are per-user and should be ignored. If we ever want repo-wide settings, they'd go in `.claude/settings.json`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts `.gitignore`; no runtime, build, or security-sensitive code changes.
> 
> **Overview**
> Updates `.gitignore` to ignore Claude per-user local settings files under `.claude/` (e.g., `settings.local.json`) via the pattern `.claude/*.local.*`, preventing these machine-specific configs from being committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a43a33138fccd2397c8a9c481bbc7d87207d2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->