### PR TITLE
fix: clipboard read request issue in sidepanel

### DIFF
--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -35,6 +35,7 @@ describe('SrpInputImport', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetEnvironmentType.mockReturnValue('popup');
+    jest.spyOn(window, 'focus').mockImplementation(() => undefined);
   });
 
   it('should render', () => {
@@ -63,12 +64,15 @@ describe('SrpInputImport', () => {
     });
   });
 
-  it('should ask for explicit permission to read the clipboard in Chrome side panel', async () => {
+  it('should ask for explicit permission and focus textarea before reading clipboard in Chrome side panel', async () => {
     mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
 
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,
     );
+    const textarea = getByTestId('srp-input-import__srp-note');
+    const focusSpy = jest.spyOn(textarea, 'focus');
+
     const pasteButton = getByTestId('srp-input-import__paste-button');
     fireEvent.click(pasteButton);
 
@@ -76,6 +80,7 @@ describe('SrpInputImport', () => {
       expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
+      expect(focusSpy).toHaveBeenCalled();
       expect(mockClipboardReadText).toHaveBeenCalled();
     });
   });

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -8,6 +8,14 @@ import {
 } from '../../../../shared/constants/app';
 import SrpInputImport from './srp-input-import';
 
+const mockPermissionsRequest = jest.fn().mockResolvedValue(true);
+
+jest.mock('webextension-polyfill', () => ({
+  permissions: {
+    request: (...args: unknown[]) => mockPermissionsRequest(...args),
+  },
+}));
+
 const mockGetEnvironmentType = jest.fn().mockReturnValue('popup');
 
 jest.mock('../../../../app/scripts/lib/util', () => ({
@@ -48,7 +56,7 @@ describe('SrpInputImport', () => {
     fireEvent.click(pasteButton);
 
     await waitFor(() => {
-      expect(browser.permissions.request).toHaveBeenCalledWith({
+      expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
       expect(mockClipboardReadText).toHaveBeenCalled();
@@ -65,7 +73,7 @@ describe('SrpInputImport', () => {
     fireEvent.click(pasteButton);
 
     await waitFor(() => {
-      expect(browser.permissions.request).toHaveBeenCalledWith({
+      expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
       expect(mockClipboardReadText).toHaveBeenCalled();

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -2,8 +2,18 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as browserRuntime from '../../../../shared/modules/browser-runtime.utils';
-import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_SIDEPANEL,
+  PLATFORM_FIREFOX,
+} from '../../../../shared/constants/app';
 import SrpInputImport from './srp-input-import';
+
+const mockGetEnvironmentType = jest.fn().mockReturnValue('popup');
+
+jest.mock('../../../../app/scripts/lib/util', () => ({
+  ...jest.requireActual('../../../../app/scripts/lib/util'),
+  getEnvironmentType: () => mockGetEnvironmentType(),
+}));
 
 const mockClipboardReadText = jest.fn().mockResolvedValue('some mock text');
 
@@ -14,6 +24,11 @@ Object.defineProperty(navigator, 'clipboard', {
 });
 
 describe('SrpInputImport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnvironmentType.mockReturnValue('popup');
+  });
+
   it('should render', () => {
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,
@@ -25,6 +40,23 @@ describe('SrpInputImport', () => {
     jest
       .spyOn(browserRuntime, 'getBrowserName')
       .mockReturnValue(PLATFORM_FIREFOX);
+
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+    const pasteButton = getByTestId('srp-input-import__paste-button');
+    fireEvent.click(pasteButton);
+
+    await waitFor(() => {
+      expect(browser.permissions.request).toHaveBeenCalledWith({
+        permissions: ['clipboardRead'],
+      });
+      expect(mockClipboardReadText).toHaveBeenCalled();
+    });
+  });
+
+  it('should ask for explicit permission to read the clipboard in Chrome side panel', async () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
 
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { isValidMnemonic } from '@ethersproject/hdnode';
+import browser from 'webextension-polyfill';
 
 import { Textarea, TextareaResize } from '../../component-library/textarea';
 import {
@@ -25,8 +26,14 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_SIDEPANEL,
+  PLATFORM_FIREFOX,
+} from '../../../../shared/constants/app';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { parseSecretRecoveryPhrase } from './parse-secret-recovery-phrase';
 
 const SRP_LENGTHS = [12, 15, 18, 21, 24];
@@ -253,8 +260,11 @@ export default function SrpInputImport({
     [draftSrp],
   );
 
-  // in firefox, we do need to request permission explicitly, to read the clipboard
-  const requestPermissionAndTriggerPasteFireFox = async () => {
+  // Request clipboardRead extension permission explicitly and then read clipboard.
+  // This is needed for Firefox (always) and Chrome side panel (where the web
+  // Clipboard API permission prompt is not displayed to the user, causing
+  // navigator.clipboard.readText() to throw "permission denied").
+  const requestPermissionAndReadClipboard = async () => {
     try {
       const permissionGranted = await browser.permissions.request({
         permissions: ['clipboardRead'],
@@ -272,23 +282,35 @@ export default function SrpInputImport({
 
   const onTriggerPaste = async () => {
     setMisSpelledWords([]);
-    if (getBrowserName() === PLATFORM_FIREFOX) {
-      await requestPermissionAndTriggerPasteFireFox();
+
+    // Firefox and Chrome side panel both need to request the clipboardRead
+    // extension permission explicitly before reading the clipboard.
+    // In the side panel, the web Clipboard API permission prompt is never
+    // shown to the user, so navigator.clipboard.readText() fails without
+    // the extension-level permission being granted first.
+    const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+
+    if (getBrowserName() === PLATFORM_FIREFOX || isSidePanel) {
+      await requestPermissionAndReadClipboard();
       return;
     }
 
-    const permissionResult = await navigator.permissions.query({
-      name: 'clipboard-read' as PermissionName,
-    });
+    try {
+      const permissionResult = await navigator.permissions.query({
+        name: 'clipboard-read' as PermissionName,
+      });
 
-    if (
-      permissionResult.state === 'granted' ||
-      permissionResult.state === 'prompt'
-    ) {
-      const newSrp = await navigator.clipboard.readText();
-      if (newSrp.trim().match(/\s/u)) {
-        onSrpPaste(newSrp);
+      if (
+        permissionResult.state === 'granted' ||
+        permissionResult.state === 'prompt'
+      ) {
+        const newSrp = await navigator.clipboard.readText();
+        if (newSrp.trim().match(/\s/u)) {
+          onSrpPaste(newSrp);
+        }
       }
+    } catch (error) {
+      console.error('Error reading clipboard', error);
     }
   };
 

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -67,6 +67,7 @@ export default function SrpInputImport({
   const [hasInvalidChecksum, setHasInvalidChecksum] = useState(false);
 
   const srpRefs = useRef<ListOfTextFieldRefs>({});
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const onChangeRef = useRef(onChange);
 
   // Keep the ref updated with the latest onChange callback
@@ -264,16 +265,25 @@ export default function SrpInputImport({
   // This is needed for Firefox (always) and Chrome side panel (where the web
   // Clipboard API permission prompt is not displayed to the user, causing
   // navigator.clipboard.readText() to throw "permission denied").
+  //
+  // In Chrome's side panel, document.hasFocus() may return false when the main
+  // browser view was last focused, causing navigator.clipboard.readText() to
+  // throw "Document is not focused". Focusing the textarea (via textareaRef)
+  // before reading ensures the side panel document has focus.
   const requestPermissionAndReadClipboard = async () => {
     try {
       const permissionGranted = await browser.permissions.request({
         permissions: ['clipboardRead'],
       });
-      if (permissionGranted) {
-        const newSrp = await navigator.clipboard.readText();
-        if (newSrp.trim().match(/\s/u)) {
-          onSrpPaste(newSrp);
-        }
+      if (!permissionGranted) {
+        throw new Error('`ClipboardRead` permission not granted');
+      }
+
+      window.focus();
+      textareaRef.current?.focus();
+      const newSrp = await navigator.clipboard.readText();
+      if (newSrp.trim().match(/\s/u)) {
+        onSrpPaste(newSrp);
       }
     } catch (error) {
       console.error('Error requesting clipboard permission', error);
@@ -439,6 +449,7 @@ export default function SrpInputImport({
               borderRadius={BorderRadius.LG}
             >
               <Textarea
+                ref={textareaRef}
                 data-testid="srp-input-import__srp-note"
                 borderColor={BorderColor.transparent}
                 backgroundColor={BackgroundColor.transparent}


### PR DESCRIPTION
## **Description**

Fixes the "Paste" button being non-functional in Chrome's side panel mode during the "Add New Wallet" → "Import a Wallet" flow.

**Root cause:** Two Chrome limitations with the Clipboard API in the side panel context:

1. **Permission prompt suppressed:** Chrome does not display the web `clipboard-read` permission prompt inside extension side panels. `navigator.permissions.query()` returns `state: 'prompt'`, but calling `navigator.clipboard.readText()` throws "permission denied" without ever showing the prompt. This is a [known Chrome behavior](https://stackoverflow.com/questions/56306153/domexception-on-calling-navigator-clipboard-readtext) with the Async Clipboard API in non-standard document contexts.

2. **Document focus requirement:** Chrome's `navigator.clipboard.readText()` requires `document.hasFocus() === true`. In the side panel, when the user was last interacting with the main browser view, `document.hasFocus()` returns `false` — causing a `"NotAllowedError: Document is not focused"` error even after clicking the Paste button. Related: [crbug.com/1224037](https://crbug.com/1224037), [MDN Clipboard.readText() security notes](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#security).

**Changes:**
- Detect the side panel environment via `getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL`.
- Request the `clipboardRead` extension permission explicitly via `browser.permissions.request()` (from `webextension-polyfill`) for both Firefox and Chrome side panel — bypassing the broken web Permissions API prompt.
- Add a `textareaRef` to programmatically focus the SRP textarea before calling `navigator.clipboard.readText()`. Focusing the textarea transfers document focus to the side panel, satisfying Chrome's `document.hasFocus()` requirement.
- Add unit tests covering Firefox and Chrome side panel clipboard permission flows.

`Ctrl+V` / `Cmd+V` was unaffected because native keyboard paste goes through the browser's input handling, which doesn't require `document.hasFocus()` or the web permission prompt.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/XXXXX?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed the "Paste" button not working in Chrome side panel mode during wallet import

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40213

## **Manual testing steps**

1. Open the MetaMask extension in Chrome **Side Panel** mode
2. Navigate to account list → "Add Wallet" → "Import a Wallet"
3. Copy a valid SRP to your system clipboard
4. While viewing another site in the main browser view (so the side panel does not have focus), click the "Paste" button
5. Verify the SRP is pasted into the textarea
6. Repeat step 4 after clicking inside the side panel first — verify it also works
7. Open MetaMask as a **popup** and repeat steps 2–5 — verify existing clipboard behavior is unchanged
8. Open MetaMask in **Firefox** and repeat steps 2–5 — verify Firefox clipboard behavior is unchanged

## **Screenshots/Recordings**

### **Before**

### **After**

Clicking the Paste button in the side panel correctly pastes the SRP from the clipboard.

https://github.com/user-attachments/assets/3e8cecb7-0350-4f5f-b7f9-bd5513a105e2



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR. Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches clipboard-permission and focus behavior during wallet import; mistakes could break paste UX across environments, though the change is localized and covered by new tests.
> 
> **Overview**
> Fixes the SRP import “Paste” button in Chrome side panel by treating side panel like Firefox: explicitly requesting `clipboardRead` via `browser.permissions.request()` and focusing the SRP textarea (plus `window.focus()`) before calling `navigator.clipboard.readText()`.
> 
> Refactors the paste path into `requestPermissionAndReadClipboard()`, adds error handling around clipboard reads, and extends unit tests to mock `webextension-polyfill`/`getEnvironmentType()` and cover both Firefox and side panel behaviors (including textarea focusing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17bb4b18e2fa2c9988535fc5426be2b967fe6371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->