### PR TITLE
fix: fixed document not focus error with offscreen API

### DIFF
--- a/app/offscreen/clipboard.test.ts
+++ b/app/offscreen/clipboard.test.ts
@@ -1,0 +1,346 @@
+import {
+  ClipboardAction,
+  OffscreenCommunicationTarget,
+} from '../../shared/constants/offscreen-communication';
+import initClipboard from './clipboard';
+
+// ── Chrome runtime mock ──────────────────────────────────────────────────
+
+type MessageListener = (
+  msg: { target: string; action: ClipboardAction },
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void,
+) => boolean | void;
+
+const listeners: MessageListener[] = [];
+
+const EXTENSION_ID = 'test-extension-id';
+
+// jsdom doesn't provide document.execCommand, so we define a mock.
+let execCommandMock: jest.Mock;
+
+beforeEach(() => {
+  listeners.length = 0;
+
+  globalThis.chrome = {
+    runtime: {
+      id: EXTENSION_ID,
+      onMessage: {
+        addListener: (fn: MessageListener) => {
+          listeners.push(fn);
+        },
+      },
+    },
+  } as unknown as typeof chrome;
+
+  // Install a mock for document.execCommand (not present in jsdom).
+  execCommandMock = jest.fn().mockReturnValue(true);
+  document.execCommand = execCommandMock;
+});
+
+afterEach(() => {
+  // Clean up any leftover textareas
+  document.querySelectorAll('textarea').forEach((el) => el.remove());
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Simulate dispatching a chrome.runtime.onMessage message. */
+function dispatchMessage(
+  msg: { target: string; action: ClipboardAction },
+  sender: chrome.runtime.MessageSender,
+): Promise<unknown> {
+  return new Promise((resolve) => {
+    for (const listener of listeners) {
+      const result = listener(msg, sender, resolve);
+      if (result === true) {
+        // Listener indicated async response — wait for sendResponse.
+        return;
+      }
+    }
+    // No listener claimed the message; resolve with undefined.
+    resolve(undefined);
+  });
+}
+
+const EXTENSION_ORIGIN = `chrome-extension://${EXTENSION_ID}`;
+
+/** Build a `MessageSender` for a trusted extension page (e.g. side panel). */
+function trustedExtensionSender(
+  page = '/sidepanel.html',
+): chrome.runtime.MessageSender {
+  return {
+    id: EXTENSION_ID,
+    origin: EXTENSION_ORIGIN,
+    url: `${EXTENSION_ORIGIN}${page}`,
+  } as chrome.runtime.MessageSender;
+}
+
+/** Build a `MessageSender` for a content script in a web page tab. */
+function contentScriptSender(): chrome.runtime.MessageSender {
+  return {
+    id: EXTENSION_ID,
+    origin: EXTENSION_ORIGIN,
+    url: `${EXTENSION_ORIGIN}/sidepanel.html`,
+    tab: { id: 42 } as chrome.tabs.Tab,
+  } as chrome.runtime.MessageSender;
+}
+
+/** Build a `MessageSender` for a different (external) extension. */
+function externalExtensionSender(): chrome.runtime.MessageSender {
+  return {
+    id: 'other-extension-id',
+    origin: 'chrome-extension://other-extension-id',
+    url: 'chrome-extension://other-extension-id/popup.html',
+  } as chrome.runtime.MessageSender;
+}
+
+/**
+ * Make the `execCommand('paste')` mock write `pasteText` into any
+ * textarea present in the DOM (mimicking a real paste).
+ */
+function stubClipboardPaste(pasteText: string): void {
+  execCommandMock.mockImplementation((cmd: string) => {
+    if (cmd === 'paste') {
+      const textarea = document.querySelector('textarea');
+      if (textarea) {
+        textarea.value = pasteText;
+      }
+      return true;
+    }
+    return false;
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('clipboard offscreen handler', () => {
+  describe('sender validation', () => {
+    it('responds to a trusted extension page', async () => {
+      stubClipboardPaste('hello world');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        trustedExtensionSender(),
+      );
+
+      expect(response).toStrictEqual({
+        success: true,
+        text: 'hello world',
+      });
+    });
+
+    it('rejects messages from content scripts (sender.tab is set)', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        contentScriptSender(),
+      );
+
+      // No listener claimed async handling → resolved as undefined
+      expect(response).toBeUndefined();
+    });
+
+    it('rejects messages from external extensions', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        externalExtensionSender(),
+      );
+
+      expect(response).toBeUndefined();
+    });
+
+    it('rejects messages with a mismatched origin', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        {
+          id: EXTENSION_ID,
+          origin: 'https://evil.com',
+          url: `${EXTENSION_ORIGIN}/popup.html`,
+        } as chrome.runtime.MessageSender,
+      );
+
+      expect(response).toBeUndefined();
+    });
+
+    it('rejects messages with no origin', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        { id: EXTENSION_ID } as chrome.runtime.MessageSender,
+      );
+
+      expect(response).toBeUndefined();
+    });
+
+    it('rejects messages from the offscreen document itself', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        {
+          id: EXTENSION_ID,
+          origin: EXTENSION_ORIGIN,
+          url: `${EXTENSION_ORIGIN}/offscreen.html`,
+        } as chrome.runtime.MessageSender,
+      );
+
+      expect(response).toBeUndefined();
+    });
+
+    it('rejects messages from a Snap iframe URL', async () => {
+      stubClipboardPaste('secret SRP words');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        {
+          id: EXTENSION_ID,
+          origin: EXTENSION_ORIGIN,
+          url: `${EXTENSION_ORIGIN}/snaps/index.html`,
+        } as chrome.runtime.MessageSender,
+      );
+
+      expect(response).toBeUndefined();
+    });
+
+    const allowedPages = [
+      '/popup.html',
+      '/popup-init.html',
+      '/sidepanel.html',
+      '/home.html',
+    ];
+
+    for (const page of allowedPages) {
+      it(`accepts messages from allowed page ${page}`, async () => {
+        stubClipboardPaste('hello world');
+        initClipboard();
+
+        const response = await dispatchMessage(
+          {
+            target: OffscreenCommunicationTarget.clipboardOffscreen,
+            action: ClipboardAction.readClipboard,
+          },
+          trustedExtensionSender(page),
+        );
+
+        expect(response).toStrictEqual({
+          success: true,
+          text: 'hello world',
+        });
+      });
+    }
+  });
+
+  describe('target filtering', () => {
+    it('ignores messages with a different target', () => {
+      initClipboard();
+
+      const sendResponse = jest.fn();
+      const result = listeners[0](
+        {
+          target: 'some-other-target',
+          action: ClipboardAction.readClipboard,
+        },
+        trustedExtensionSender(),
+        sendResponse,
+      );
+
+      expect(result).toBe(false);
+      expect(sendResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('readClipboard action', () => {
+    it('returns clipboard text on success', async () => {
+      stubClipboardPaste('seed phrase words here');
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        trustedExtensionSender(),
+      );
+
+      expect(response).toStrictEqual({
+        success: true,
+        text: 'seed phrase words here',
+      });
+    });
+
+    it('returns an error when execCommand throws', async () => {
+      execCommandMock.mockImplementation(() => {
+        throw new Error('paste failed');
+      });
+      initClipboard();
+
+      const response = await dispatchMessage(
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        trustedExtensionSender(),
+      );
+
+      expect(response).toStrictEqual({
+        success: false,
+        error: 'paste failed',
+      });
+    });
+
+    it('cleans up the temporary textarea even on error', () => {
+      execCommandMock.mockImplementation(() => {
+        throw new Error('paste failed');
+      });
+      initClipboard();
+
+      const sendResponse = jest.fn();
+      listeners[0](
+        {
+          target: OffscreenCommunicationTarget.clipboardOffscreen,
+          action: ClipboardAction.readClipboard,
+        },
+        trustedExtensionSender(),
+        sendResponse,
+      );
+
+      // No leftover textareas in the DOM
+      expect(document.querySelectorAll('textarea')).toHaveLength(0);
+    });
+  });
+});

--- a/app/offscreen/clipboard.ts
+++ b/app/offscreen/clipboard.ts
@@ -1,0 +1,65 @@
+import {
+  ClipboardAction,
+  OffscreenCommunicationTarget,
+} from '../../shared/constants/offscreen-communication';
+
+/**
+ * Reads clipboard text inside the offscreen document.
+ *
+ * execCommand('paste') requires a focused, editable element to paste into,
+ * so we create a temporary textarea, paste into it, read the value, and
+ * remove it. navigator.clipboard.readText() silently fails in offscreen
+ * documents (https://issuetracker.google.com/issues/41497480), making
+ * execCommand the only working option.
+ *
+ * Requires the 'clipboardRead' extension permission.
+ *
+ * @returns The clipboard text content.
+ */
+function readClipboardText(): string {
+  const textarea = document.createElement('textarea');
+  document.body.appendChild(textarea);
+  textarea.focus();
+  // eslint-disable-next-line deprecation/deprecation -- see JSDoc above
+  document.execCommand('paste');
+  const text = textarea.value;
+  document.body.removeChild(textarea);
+  return text;
+}
+
+/**
+ * Initializes the clipboard offscreen handler.
+ * Listens for clipboard read requests from extension pages (e.g. side panel)
+ * and responds with the clipboard text.
+ */
+export default function initClipboard(): void {
+  chrome.runtime.onMessage.addListener(
+    (
+      msg: {
+        target: string;
+        action: ClipboardAction;
+      },
+      _sender,
+      sendResponse,
+    ) => {
+      if (msg.target !== OffscreenCommunicationTarget.clipboardOffscreen) {
+        return false;
+      }
+
+      if (msg.action === ClipboardAction.readClipboard) {
+        try {
+          const text = readClipboardText();
+          sendResponse({ success: true, text });
+        } catch (error) {
+          sendResponse({
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        return true;
+      }
+
+      return false;
+    },
+  );
+}

--- a/app/offscreen/clipboard.ts
+++ b/app/offscreen/clipboard.ts
@@ -19,18 +19,98 @@ import {
 function readClipboardText(): string {
   const textarea = document.createElement('textarea');
   document.body.appendChild(textarea);
-  textarea.focus();
-  // eslint-disable-next-line deprecation/deprecation -- see JSDoc above
-  document.execCommand('paste');
-  const text = textarea.value;
-  document.body.removeChild(textarea);
-  return text;
+  try {
+    textarea.focus();
+    // eslint-disable-next-line deprecation/deprecation -- see JSDoc above
+    document.execCommand('paste');
+    const text = textarea.value;
+    return text;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
+ * Extension page paths that are allowed to read the clipboard through the
+ * offscreen handler. Only first-party UI pages are included — the offscreen
+ * document itself and Snap iframes are deliberately excluded.
+ */
+const ALLOWED_EXTENSION_PAGE_PATHS = new Set([
+  '/popup.html',
+  '/popup-init.html',
+  '/sidepanel.html',
+  '/home.html',
+]);
+
+/**
+ * Returns `true` when the sender is a first-party extension page such as the
+ * popup or side panel — i.e. it belongs to **this** extension and is **not**
+ * a content script, another extension, or an internal page like the offscreen
+ * document.
+ *
+ * Checks performed (all must pass):
+ * 1. `sender.id === chrome.runtime.id` — rejects other extensions.
+ * 2. `!sender.tab` — rejects content scripts, which always carry a `tab`
+ *    property referencing the web-page tab they live in.
+ * 3. `sender.origin` matches the extension origin — rejects opaque or
+ *    cross-origin senders (e.g. sandboxed iframes).
+ * 4. `sender.url` pathname is in {@link ALLOWED_EXTENSION_PAGE_PATHS} —
+ *    rejects unexpected contexts such as the offscreen document itself or
+ *    Snap iframes.
+ *
+ * @param sender - The `MessageSender` provided by `chrome.runtime.onMessage`.
+ * @returns Whether the sender is a trusted extension page.
+ */
+function isTrustedExtensionSender(
+  sender: chrome.runtime.MessageSender,
+): boolean {
+  if (sender.id !== chrome.runtime.id || sender.tab) {
+    return false;
+  }
+
+  const expectedOrigin = `chrome-extension://${chrome.runtime.id}`;
+  if (sender.origin !== expectedOrigin) {
+    return false;
+  }
+
+  if (!sender.url) {
+    return false;
+  }
+
+  try {
+    const { pathname } = new URL(sender.url);
+    return ALLOWED_EXTENSION_PAGE_PATHS.has(pathname);
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Initializes the clipboard offscreen handler.
  * Listens for clipboard read requests from extension pages (e.g. side panel)
  * and responds with the clipboard text.
+ *
+ * ── Security notes ──────────────────────────────────────────────────────
+ *
+ * **Sensitive data**: The clipboard may contain a Secret Recovery Phrase
+ * (SRP). The response is delivered *only* to the original caller via the
+ * `sendResponse` callback — it is **not** broadcast to other
+ * `chrome.runtime.onMessage` listeners. `sendResponse` is a one-shot
+ * reply channel scoped to the sender of the message.
+ *
+ * **Sender validation**: Before reading the clipboard we verify that the
+ * request originates from a first-party extension page (popup / side panel)
+ * and not from a content script or another extension. This prevents
+ * compromised web-page contexts or rogue Snaps from exfiltrating
+ * clipboard contents.
+ *
+ * **Constraints that MUST be maintained**:
+ * 1. Never log, persist, or emit clipboard text to Sentry / telemetry /
+ *    breadcrumbs.
+ * 2. Never relay the clipboard text through a second `sendMessage` call.
+ * 3. Keep sender validation in this handler — removing it would let any
+ *    content script read the user's clipboard.
+ * ─────────────────────────────────────────────────────────────────────────
  */
 export default function initClipboard(): void {
   chrome.runtime.onMessage.addListener(
@@ -39,10 +119,18 @@ export default function initClipboard(): void {
         target: string;
         action: ClipboardAction;
       },
-      _sender,
+      sender,
       sendResponse,
     ) => {
       if (msg.target !== OffscreenCommunicationTarget.clipboardOffscreen) {
+        return false;
+      }
+
+      // Reject requests that do not come from a trusted extension page.
+      // Content scripts (sender.tab is set) and other extensions
+      // (sender.id !== ours) are not allowed to read the clipboard through
+      // this handler. See JSDoc on initClipboard for full rationale.
+      if (!isTrustedExtensionSender(sender)) {
         return false;
       }
 

--- a/app/offscreen/offscreen.ts
+++ b/app/offscreen/offscreen.ts
@@ -14,6 +14,7 @@ import initLedger from './ledger';
 import initTrezor from './trezor';
 import initLattice from './lattice';
 import initConnectivityDetection from './connectivity';
+import initClipboard from './clipboard';
 
 /**
  * Initialize a post message stream with the parent window that is initialized
@@ -38,6 +39,7 @@ async function init(): Promise<void> {
   initializePostMessageStream();
   initTrezor();
   initLattice();
+  initClipboard();
   ///: BEGIN:ONLY_INCLUDE_IF(ocap-kernel)
   runKernel().catch((error) => {
     console.error('Ocap Kernel fatal error:', error);

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -76,9 +76,9 @@ export async function createOffscreen() {
 
     await chrome.offscreen.createDocument({
       url: './offscreen.html',
-      reasons: ['IFRAME_SCRIPTING'],
+      reasons: ['IFRAME_SCRIPTING', 'CLIPBOARD'],
       justification:
-        'Used for Hardware Wallet and Snaps scripts to communicate with the extension.',
+        'Used for Hardware Wallet and Snaps scripts to communicate with the extension, and for clipboard access in the side panel.',
     });
   } catch (error) {
     if (offscreenDocumentLoadedListener) {

--- a/shared/constants/offscreen-communication.ts
+++ b/shared/constants/offscreen-communication.ts
@@ -21,6 +21,9 @@ export enum OffscreenCommunicationTarget {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   extensionMain = 'extension',
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  clipboardOffscreen = 'clipboard-offscreen',
 }
 
 /**
@@ -94,6 +97,15 @@ export enum LedgerAction {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   getAppConfiguration = 'ledger-get-app-configuration',
+}
+
+/**
+ * Defines actions intended to be sent to the Clipboard Offscreen handler.
+ */
+export enum ClipboardAction {
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  readClipboard = 'clipboard-read',
 }
 
 /**

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -35,6 +35,7 @@ describe('SrpInputImport', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetEnvironmentType.mockReturnValue('popup');
+    jest.spyOn(window, 'focus').mockImplementation(() => undefined);
   });
 
   it('should render', () => {
@@ -63,12 +64,15 @@ describe('SrpInputImport', () => {
     });
   });
 
-  it('should ask for explicit permission to read the clipboard in Chrome side panel', async () => {
+  it('should ask for explicit permission and focus textarea before reading clipboard in Chrome side panel', async () => {
     mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
 
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,
     );
+    const textarea = getByTestId('srp-input-import__srp-note');
+    const focusSpy = jest.spyOn(textarea, 'focus');
+
     const pasteButton = getByTestId('srp-input-import__paste-button');
     fireEvent.click(pasteButton);
 
@@ -76,6 +80,7 @@ describe('SrpInputImport', () => {
       expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
+      expect(focusSpy).toHaveBeenCalled();
       expect(mockClipboardReadText).toHaveBeenCalled();
     });
   });

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -8,6 +8,14 @@ import {
 } from '../../../../shared/constants/app';
 import SrpInputImport from './srp-input-import';
 
+const mockPermissionsRequest = jest.fn().mockResolvedValue(true);
+
+jest.mock('webextension-polyfill', () => ({
+  permissions: {
+    request: (...args: unknown[]) => mockPermissionsRequest(...args),
+  },
+}));
+
 const mockGetEnvironmentType = jest.fn().mockReturnValue('popup');
 
 jest.mock('../../../../app/scripts/lib/util', () => ({
@@ -48,7 +56,7 @@ describe('SrpInputImport', () => {
     fireEvent.click(pasteButton);
 
     await waitFor(() => {
-      expect(browser.permissions.request).toHaveBeenCalledWith({
+      expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
       expect(mockClipboardReadText).toHaveBeenCalled();
@@ -65,7 +73,7 @@ describe('SrpInputImport', () => {
     fireEvent.click(pasteButton);
 
     await waitFor(() => {
-      expect(browser.permissions.request).toHaveBeenCalledWith({
+      expect(mockPermissionsRequest).toHaveBeenCalledWith({
         permissions: ['clipboardRead'],
       });
       expect(mockClipboardReadText).toHaveBeenCalled();

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -6,13 +6,19 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   PLATFORM_FIREFOX,
 } from '../../../../shared/constants/app';
+import {
+  ClipboardAction,
+  OffscreenCommunicationTarget,
+} from '../../../../shared/constants/offscreen-communication';
 import SrpInputImport from './srp-input-import';
 
 const mockPermissionsRequest = jest.fn().mockResolvedValue(true);
+const mockPermissionsContains = jest.fn().mockResolvedValue(false);
 
 jest.mock('webextension-polyfill', () => ({
   permissions: {
     request: (...args: unknown[]) => mockPermissionsRequest(...args),
+    contains: (...args: unknown[]) => mockPermissionsContains(...args),
   },
 }));
 
@@ -31,11 +37,22 @@ Object.defineProperty(navigator, 'clipboard', {
   },
 });
 
+const mockSendMessage = jest.fn();
+
 describe('SrpInputImport', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetEnvironmentType.mockReturnValue('popup');
     jest.spyOn(window, 'focus').mockImplementation(() => undefined);
+
+    // Mock chrome.runtime.sendMessage for offscreen clipboard fallback
+    globalThis.chrome = {
+      ...globalThis.chrome,
+      runtime: {
+        ...globalThis.chrome?.runtime,
+        sendMessage: mockSendMessage,
+      },
+    } as unknown as typeof chrome;
   });
 
   it('should render', () => {
@@ -82,6 +99,60 @@ describe('SrpInputImport', () => {
       });
       expect(focusSpy).toHaveBeenCalled();
       expect(mockClipboardReadText).toHaveBeenCalled();
+    });
+  });
+
+  it('should skip permissions.request when clipboardRead is already granted in Chrome side panel', async () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+    // Simulate permission already granted on mount
+    mockPermissionsContains.mockResolvedValue(true);
+
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+
+    // Wait for the useEffect to resolve permissions.contains
+    await waitFor(() => {
+      expect(mockPermissionsContains).toHaveBeenCalledWith({
+        permissions: ['clipboardRead'],
+      });
+    });
+
+    const pasteButton = getByTestId('srp-input-import__paste-button');
+    fireEvent.click(pasteButton);
+
+    await waitFor(() => {
+      // permissions.request should NOT be called — cached permission skips it
+      expect(mockPermissionsRequest).not.toHaveBeenCalled();
+      expect(mockClipboardReadText).toHaveBeenCalled();
+    });
+  });
+
+  it('should fall back to offscreen clipboard read when document is not focused in Chrome side panel', async () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+    // First readText call fails (permission dialog stole focus)
+    mockClipboardReadText.mockRejectedValueOnce(
+      new Error('Document is not focused'),
+    );
+    // Offscreen document returns clipboard text
+    mockSendMessage.mockResolvedValueOnce({
+      success: true,
+      text: 'test word1 word2 word3',
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+
+    const pasteButton = getByTestId('srp-input-import__paste-button');
+    fireEvent.click(pasteButton);
+
+    await waitFor(() => {
+      expect(mockClipboardReadText).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        target: OffscreenCommunicationTarget.clipboardOffscreen,
+        action: ClipboardAction.readClipboard,
+      });
     });
   });
 });

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -2,8 +2,18 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as browserRuntime from '../../../../shared/modules/browser-runtime.utils';
-import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_SIDEPANEL,
+  PLATFORM_FIREFOX,
+} from '../../../../shared/constants/app';
 import SrpInputImport from './srp-input-import';
+
+const mockGetEnvironmentType = jest.fn().mockReturnValue('popup');
+
+jest.mock('../../../../app/scripts/lib/util', () => ({
+  ...jest.requireActual('../../../../app/scripts/lib/util'),
+  getEnvironmentType: () => mockGetEnvironmentType(),
+}));
 
 const mockClipboardReadText = jest.fn().mockResolvedValue('some mock text');
 
@@ -14,6 +24,11 @@ Object.defineProperty(navigator, 'clipboard', {
 });
 
 describe('SrpInputImport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnvironmentType.mockReturnValue('popup');
+  });
+
   it('should render', () => {
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,
@@ -25,6 +40,23 @@ describe('SrpInputImport', () => {
     jest
       .spyOn(browserRuntime, 'getBrowserName')
       .mockReturnValue(PLATFORM_FIREFOX);
+
+    const { getByTestId } = renderWithProvider(
+      <SrpInputImport onChange={jest.fn()} />,
+    );
+    const pasteButton = getByTestId('srp-input-import__paste-button');
+    fireEvent.click(pasteButton);
+
+    await waitFor(() => {
+      expect(browser.permissions.request).toHaveBeenCalledWith({
+        permissions: ['clipboardRead'],
+      });
+      expect(mockClipboardReadText).toHaveBeenCalled();
+    });
+  });
+
+  it('should ask for explicit permission to read the clipboard in Chrome side panel', async () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
 
     const { getByTestId } = renderWithProvider(
       <SrpInputImport onChange={jest.fn()} />,

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { isValidMnemonic } from '@ethersproject/hdnode';
+import browser from 'webextension-polyfill';
 
 import { Textarea, TextareaResize } from '../../component-library/textarea';
 import {
@@ -25,8 +26,14 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_SIDEPANEL,
+  PLATFORM_FIREFOX,
+} from '../../../../shared/constants/app';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import/no-restricted-paths
+import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { parseSecretRecoveryPhrase } from './parse-secret-recovery-phrase';
 
 const SRP_LENGTHS = [12, 15, 18, 21, 24];
@@ -253,8 +260,11 @@ export default function SrpInputImport({
     [draftSrp],
   );
 
-  // in firefox, we do need to request permission explicitly, to read the clipboard
-  const requestPermissionAndTriggerPasteFireFox = async () => {
+  // Request clipboardRead extension permission explicitly and then read clipboard.
+  // This is needed for Firefox (always) and Chrome side panel (where the web
+  // Clipboard API permission prompt is not displayed to the user, causing
+  // navigator.clipboard.readText() to throw "permission denied").
+  const requestPermissionAndReadClipboard = async () => {
     try {
       const permissionGranted = await browser.permissions.request({
         permissions: ['clipboardRead'],
@@ -272,23 +282,35 @@ export default function SrpInputImport({
 
   const onTriggerPaste = async () => {
     setMisSpelledWords([]);
-    if (getBrowserName() === PLATFORM_FIREFOX) {
-      await requestPermissionAndTriggerPasteFireFox();
+
+    // Firefox and Chrome side panel both need to request the clipboardRead
+    // extension permission explicitly before reading the clipboard.
+    // In the side panel, the web Clipboard API permission prompt is never
+    // shown to the user, so navigator.clipboard.readText() fails without
+    // the extension-level permission being granted first.
+    const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+
+    if (getBrowserName() === PLATFORM_FIREFOX || isSidePanel) {
+      await requestPermissionAndReadClipboard();
       return;
     }
 
-    const permissionResult = await navigator.permissions.query({
-      name: 'clipboard-read' as PermissionName,
-    });
+    try {
+      const permissionResult = await navigator.permissions.query({
+        name: 'clipboard-read' as PermissionName,
+      });
 
-    if (
-      permissionResult.state === 'granted' ||
-      permissionResult.state === 'prompt'
-    ) {
-      const newSrp = await navigator.clipboard.readText();
-      if (newSrp.trim().match(/\s/u)) {
-        onSrpPaste(newSrp);
+      if (
+        permissionResult.state === 'granted' ||
+        permissionResult.state === 'prompt'
+      ) {
+        const newSrp = await navigator.clipboard.readText();
+        if (newSrp.trim().match(/\s/u)) {
+          onSrpPaste(newSrp);
+        }
       }
+    } catch (error) {
+      console.error('Error reading clipboard', error);
     }
   };
 

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -4,6 +4,7 @@ import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { isValidMnemonic } from '@ethersproject/hdnode';
 import browser from 'webextension-polyfill';
 
+import log from 'loglevel';
 import { Textarea, TextareaResize } from '../../component-library/textarea';
 import {
   Box,
@@ -74,6 +75,7 @@ export default function SrpInputImport({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const onChangeRef = useRef(onChange);
   const hasClipboardPermissionRef = useRef(false);
+  const isPastingRef = useRef(false);
 
   // Keep the ref updated with the latest onChange callback
   useEffect(() => {
@@ -254,7 +256,6 @@ export default function SrpInputImport({
     clipBoardEvent.preventDefault();
     const newSrp = clipBoardEvent.clipboardData.getData('text');
     if (newSrp.trim().match(/\s/u)) {
-      clipBoardEvent.preventDefault();
       onSrpPaste(newSrp);
     }
   };
@@ -280,6 +281,24 @@ export default function SrpInputImport({
     },
     [draftSrp],
   );
+
+  // Falls back to the offscreen document to read the clipboard.
+  // The offscreen document is exempt from focus/activation requirements,
+  // so it works even when the permission dialog has stolen focus.
+  // Only available in Chrome (MV3); Firefox has no offscreen API.
+  const readClipboardViaOffscreen = async () => {
+    try {
+      const response = await chrome.runtime.sendMessage({
+        target: OffscreenCommunicationTarget.clipboardOffscreen,
+        action: ClipboardAction.readClipboard,
+      });
+      if (response?.success && response.text?.trim().match(/\s/u)) {
+        onSrpPaste(response.text);
+      }
+    } catch (offscreenError) {
+      log.error('Offscreen clipboard read failed', offscreenError);
+    }
+  };
 
   // Read clipboard via the extension's clipboardRead permission.
   // Used for Firefox (always) and Chrome side panel (web permission prompt
@@ -312,58 +331,57 @@ export default function SrpInputImport({
         error.message.includes('Document is not focused')
       ) {
         // Permission dialog stole focus — fall back to offscreen document.
-        // Only available in Chrome side panel; Firefox has no offscreen API.
         const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
         if (isSidePanel) {
-          try {
-            const response = await chrome.runtime.sendMessage({
-              target: OffscreenCommunicationTarget.clipboardOffscreen,
-              action: ClipboardAction.readClipboard,
-            });
-            if (response?.success && response.text?.trim().match(/\s/u)) {
-              onSrpPaste(response.text);
-            }
-          } catch (offscreenError) {
-            console.error('Offscreen clipboard read failed', offscreenError);
-          }
+          await readClipboardViaOffscreen();
+          return;
         }
-        return;
       }
-      console.error('Error requesting clipboard permission', error);
+      log.error('Error requesting clipboard permission', error);
     }
   };
 
   const onTriggerPaste = async () => {
-    setMisSpelledWords([]);
-
-    // Firefox and Chrome side panel both need to request the clipboardRead
-    // extension permission explicitly before reading the clipboard.
-    // In the side panel, the web Clipboard API permission prompt is never
-    // shown to the user, so navigator.clipboard.readText() fails without
-    // the extension-level permission being granted first.
-    const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
-
-    if (getBrowserName() === PLATFORM_FIREFOX || isSidePanel) {
-      await requestPermissionAndReadClipboard();
+    if (isPastingRef.current) {
       return;
     }
 
-    try {
-      const permissionResult = await navigator.permissions.query({
-        name: 'clipboard-read' as PermissionName,
-      });
+    isPastingRef.current = true;
 
-      if (
-        permissionResult.state === 'granted' ||
-        permissionResult.state === 'prompt'
-      ) {
-        const newSrp = await navigator.clipboard.readText();
-        if (newSrp.trim().match(/\s/u)) {
-          onSrpPaste(newSrp);
-        }
+    try {
+      setMisSpelledWords([]);
+
+      // Firefox and Chrome side panel both need to request the clipboardRead
+      // extension permission explicitly before reading the clipboard.
+      // In the side panel, the web Clipboard API permission prompt is never
+      // shown to the user, so navigator.clipboard.readText() fails without
+      // the extension-level permission being granted first.
+      const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+
+      if (getBrowserName() === PLATFORM_FIREFOX || isSidePanel) {
+        await requestPermissionAndReadClipboard();
+        return;
       }
-    } catch (error) {
-      console.error('Error reading clipboard', error);
+
+      try {
+        const permissionResult = await navigator.permissions.query({
+          name: 'clipboard-read' as PermissionName,
+        });
+
+        if (
+          permissionResult.state === 'granted' ||
+          permissionResult.state === 'prompt'
+        ) {
+          const newSrp = await navigator.clipboard.readText();
+          if (newSrp.trim().match(/\s/u)) {
+            onSrpPaste(newSrp);
+          }
+        }
+      } catch (error) {
+        log.error('Error reading clipboard', error);
+      }
+    } finally {
+      isPastingRef.current = false;
     }
   };
 

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -30,6 +30,10 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   PLATFORM_FIREFOX,
 } from '../../../../shared/constants/app';
+import {
+  ClipboardAction,
+  OffscreenCommunicationTarget,
+} from '../../../../shared/constants/offscreen-communication';
 import { getBrowserName } from '../../../../shared/modules/browser-runtime.utils';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -69,11 +73,27 @@ export default function SrpInputImport({
   const srpRefs = useRef<ListOfTextFieldRefs>({});
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const onChangeRef = useRef(onChange);
+  const hasClipboardPermissionRef = useRef(false);
 
   // Keep the ref updated with the latest onChange callback
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  // Pre-check clipboardRead permission on mount so the paste handler can skip
+  // the async browser.permissions.request() call when permission is already
+  // granted. This preserves the transient user activation from the click event,
+  // which navigator.clipboard.readText() requires in Chrome's side panel.
+  useEffect(() => {
+    const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+    if (getBrowserName() === PLATFORM_FIREFOX || isSidePanel) {
+      browser.permissions
+        .contains({ permissions: ['clipboardRead'] })
+        .then((result) => {
+          hasClipboardPermissionRef.current = result;
+        });
+    }
+  }, []);
 
   const checkForInvalidWords = useCallback(
     (srp?: DraftSrp[]) => {
@@ -261,22 +281,23 @@ export default function SrpInputImport({
     [draftSrp],
   );
 
-  // Request clipboardRead extension permission explicitly and then read clipboard.
-  // This is needed for Firefox (always) and Chrome side panel (where the web
-  // Clipboard API permission prompt is not displayed to the user, causing
-  // navigator.clipboard.readText() to throw "permission denied").
-  //
-  // In Chrome's side panel, document.hasFocus() may return false when the main
-  // browser view was last focused, causing navigator.clipboard.readText() to
-  // throw "Document is not focused". Focusing the textarea (via textareaRef)
-  // before reading ensures the side panel document has focus.
+  // Read clipboard via the extension's clipboardRead permission.
+  // Used for Firefox (always) and Chrome side panel (web permission prompt
+  // is never shown). Skips permissions.request() when already granted to
+  // preserve transient activation (https://issues.chromium.org/issues/381823726).
+  // If readText() still fails ("Document is not focused" — happens on the
+  // first-ever paste when the permission dialog steals focus), falls back to
+  // the offscreen document which is exempt from focus/activation requirements.
   const requestPermissionAndReadClipboard = async () => {
     try {
-      const permissionGranted = await browser.permissions.request({
-        permissions: ['clipboardRead'],
-      });
-      if (!permissionGranted) {
-        throw new Error('`ClipboardRead` permission not granted');
+      if (!hasClipboardPermissionRef.current) {
+        const permissionGranted = await browser.permissions.request({
+          permissions: ['clipboardRead'],
+        });
+        if (!permissionGranted) {
+          throw new Error('`ClipboardRead` permission not granted');
+        }
+        hasClipboardPermissionRef.current = true;
       }
 
       window.focus();
@@ -286,6 +307,28 @@ export default function SrpInputImport({
         onSrpPaste(newSrp);
       }
     } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Document is not focused')
+      ) {
+        // Permission dialog stole focus — fall back to offscreen document.
+        // Only available in Chrome side panel; Firefox has no offscreen API.
+        const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+        if (isSidePanel) {
+          try {
+            const response = await chrome.runtime.sendMessage({
+              target: OffscreenCommunicationTarget.clipboardOffscreen,
+              action: ClipboardAction.readClipboard,
+            });
+            if (response?.success && response.text?.trim().match(/\s/u)) {
+              onSrpPaste(response.text);
+            }
+          } catch (offscreenError) {
+            console.error('Offscreen clipboard read failed', offscreenError);
+          }
+        }
+        return;
+      }
       console.error('Error requesting clipboard permission', error);
     }
   };

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -67,6 +67,7 @@ export default function SrpInputImport({
   const [hasInvalidChecksum, setHasInvalidChecksum] = useState(false);
 
   const srpRefs = useRef<ListOfTextFieldRefs>({});
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const onChangeRef = useRef(onChange);
 
   // Keep the ref updated with the latest onChange callback
@@ -264,16 +265,25 @@ export default function SrpInputImport({
   // This is needed for Firefox (always) and Chrome side panel (where the web
   // Clipboard API permission prompt is not displayed to the user, causing
   // navigator.clipboard.readText() to throw "permission denied").
+  //
+  // In Chrome's side panel, document.hasFocus() may return false when the main
+  // browser view was last focused, causing navigator.clipboard.readText() to
+  // throw "Document is not focused". Focusing the textarea (via textareaRef)
+  // before reading ensures the side panel document has focus.
   const requestPermissionAndReadClipboard = async () => {
     try {
       const permissionGranted = await browser.permissions.request({
         permissions: ['clipboardRead'],
       });
-      if (permissionGranted) {
-        const newSrp = await navigator.clipboard.readText();
-        if (newSrp.trim().match(/\s/u)) {
-          onSrpPaste(newSrp);
-        }
+      if (!permissionGranted) {
+        throw new Error('`ClipboardRead` permission not granted');
+      }
+
+      window.focus();
+      textareaRef.current?.focus();
+      const newSrp = await navigator.clipboard.readText();
+      if (newSrp.trim().match(/\s/u)) {
+        onSrpPaste(newSrp);
       }
     } catch (error) {
       console.error('Error requesting clipboard permission', error);
@@ -439,6 +449,7 @@ export default function SrpInputImport({
               borderRadius={BorderRadius.LG}
             >
               <Textarea
+                ref={textareaRef}
                 data-testid="srp-input-import__srp-note"
                 borderColor={BorderColor.transparent}
                 backgroundColor={BackgroundColor.transparent}


### PR DESCRIPTION
## **Description**

In Chrome's side panel, `navigator.clipboard.readText()` fails with **"Document is not focused"** on the first paste attempt because the `browser.permissions.request()` dialog steals focus from the side panel. This breaks the SRP paste flow for users onboarding via the side panel.

This PR fixes the issue with two improvements:

1. **Permission caching** — On mount, we pre-check whether `clipboardRead` is already granted via `browser.permissions.contains()`. If so, the paste handler skips the async `permissions.request()` call entirely, preserving Chrome's transient user activation so `navigator.clipboard.readText()` succeeds.

2. **Offscreen clipboard fallback** — When `readText()` still fails with "Document is not focused" (e.g. the very first paste where the permission dialog consumed focus), we fall back to reading the clipboard via the offscreen document using `document.execCommand('paste')`, which is exempt from the focus/activation requirement.

A new clipboard handler is added to the offscreen document (`app/offscreen/clipboard.ts`) that listens for `chrome.runtime.sendMessage` requests and responds with the clipboard text.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/XXXXX?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a bug where pasting the Secret Recovery Phrase failed in Chrome's side panel due to the document losing focus after the permission prompt.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the extension with `yarn start` and load it in Chrome.
2. Open the MetaMask side panel (right-click the extension icon → "Open side panel").
3. Begin the onboarding/import flow and reach the SRP input step.
4. Copy a valid 12-word secret recovery phrase to your clipboard.
5. Click the **Paste** button on the SRP input.
6. If the clipboardRead permission prompt appears, grant it.
7. Verify the SRP is pasted successfully into the input fields (even on the first attempt).
8. Close and reopen the side panel, repeat the paste — verify it works without a permission prompt the second time.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR. Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.