### PR TITLE
chore: ignore prebuild-install deprecation advisory

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -77,6 +77,9 @@ npmAuditIgnoreAdvisories:
   # A deprecated v10.x version is used in a few different places, most notably Storybook.
   - 'glob (deprecation)'
 
+  # Deprecated transitive dependency of better-sqlite3. No maintained alternative available yet.
+  - 'prebuild-install (deprecation)'
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'


### PR DESCRIPTION
## **Description**

Adds `prebuild-install (deprecation)` to `npmAuditIgnoreAdvisories` in `.yarnrc.yml`.

**Reason:** `prebuild-install` is deprecated and has no maintained alternative yet. It is a transitive dependency of `better-sqlite3` and does not pose a security risk.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn npm audit` and verify the `prebuild-install` deprecation warning no longer appears.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.