### PR TITLE
style(locales): convert all-caps UI strings to sentence case

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1268,7 +1268,7 @@
     "description": "$1 is string 'cancel' or 'speed up'"
   },
   "cancelled": {
-    "message": "Cancelled"
+    "message": "Canceled"
   },
   "carouselAllCaughtUp": {
     "message": "You're all caught up!",
@@ -3469,7 +3469,7 @@
     "message": "Invalid Secret Recovery Phrase"
   },
   "invalidSeedPhraseCaseSensitive": {
-    "message": "Invalid input! Secret Recovery Phrase is case sensitive."
+    "message": "Invalid input. Secret Recovery Phrase is case sensitive."
   },
   "invalidSeedPhraseNotFound": {
     "message": "Secret Recovery Phrase not found."
@@ -4568,7 +4568,7 @@
     "message": "Unstaking requested"
   },
   "notificationTransactionFailedMessage": {
-    "message": "Transaction $1 failed! $2",
+    "message": "Transaction $1 failed. $2",
     "description": "Content of the browser notification that appears when a transaction fails"
   },
   "notificationTransactionFailedTitle": {
@@ -6454,7 +6454,7 @@
     "description": "Link to learn more about security alerts"
   },
   "securityAndPrivacy": {
-    "message": "Security & privacy"
+    "message": "Security and privacy"
   },
   "securityChangePassword": {
     "message": "Change password"
@@ -6472,7 +6472,7 @@
     "message": "New password saved"
   },
   "securityDefaultSettingsSocialLogin": {
-    "message": "Security & privacy"
+    "message": "Security and privacy"
   },
   "securityDescription": {
     "message": "Reduce your chances of joining unsafe networks and protect your accounts"
@@ -6512,7 +6512,7 @@
     "message": "Back up your Secret Recovery Phrase so you never lose access to your wallet. Be sure to store it in a safe place that only you can access and won’t forget."
   },
   "securitySrpLabel": {
-    "message": "SECRET RECOVERY PHRASES"
+    "message": "Secret Recovery Phrases"
   },
   "securitySrpWalletRecovery": {
     "message": "Manage recovery methods"
@@ -7094,10 +7094,10 @@
     "message": "If you cancel, your wallet and transactions will not be covered."
   },
   "shieldTxCancelNotAllowed": {
-    "message": "Your subscription cannot be cancelled at the moment."
+    "message": "Your subscription cannot be canceled at the moment."
   },
   "shieldTxCancelNotAllowedPendingVerification": {
-    "message": "Your subscription cannot be cancelled due to pending verification."
+    "message": "Your subscription cannot be canceled due to pending verification."
   },
   "shieldTxCancelWhenPausedDetails": {
     "message": "Your plan isn't active while paused. If you cancel, your plan will immediately end."
@@ -7182,11 +7182,11 @@
     "message": "Cancel plan"
   },
   "shieldTxMembershipCancelNotification": {
-    "message": "Your plan will be cancelled on $1.",
+    "message": "Your plan will be canceled on $1.",
     "description": "The $1 is the date"
   },
   "shieldTxMembershipCancelledDate": {
-    "message": "You cancelled your plan on $1",
+    "message": "You canceled your plan on $1",
     "description": "The $1 is the date"
   },
   "shieldTxMembershipErrorInsufficientFunds": {
@@ -8040,7 +8040,7 @@
     "message": "Swap would have failed"
   },
   "stxCancelledDescription": {
-    "message": "Your transaction would have failed and was cancelled to protect you from paying unnecessary gas fees."
+    "message": "Your transaction would have failed and was canceled to protect you from paying unnecessary gas fees."
   },
   "stxCancelledSubDescription": {
     "message": "Try your swap again. We’ll be here to protect you against similar risks next time."
@@ -8082,10 +8082,10 @@
     "message": "A transaction has been successful but we’re unsure what it is. This may be due to submitting another transaction while this swap was processing."
   },
   "stxUserCancelled": {
-    "message": "Swap cancelled"
+    "message": "Swap canceled"
   },
   "stxUserCancelledDescription": {
-    "message": "Your transaction has been cancelled and you did not pay any unnecessary gas fees."
+    "message": "Your transaction has been canceled and you did not pay any unnecessary gas fees."
   },
   "submit": {
     "message": "Submit"
@@ -8144,7 +8144,7 @@
     "message": "This is the minimum amount you will receive. You may receive more depending on slippage."
   },
   "swapAndSend": {
-    "message": "Swap & Send"
+    "message": "Swap and send"
   },
   "swapApproval": {
     "message": "Approve $1 for swaps",
@@ -8608,7 +8608,7 @@
     "message": "Transaction cancel attempted with estimated gas fee of $1 at $2"
   },
   "transactionCancelSuccess": {
-    "message": "Transaction successfully cancelled at $2"
+    "message": "Transaction successfully canceled at $2"
   },
   "transactionConfirmed": {
     "message": "Transaction confirmed at $2."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Audits and updates `app/_locales/en/messages.json` against the MetaMask Content Design Style Guide, fixing the same categories of violations addressed in [metamask-mobile#26285](https://github.com/MetaMask/metamask-mobile/pull/26285).

Changes made:

- **All-caps → sentence case:** `"SECRET RECOVERY PHRASES"` → `"Secret Recovery Phrases"` (special term title case per style guide)
- **UK → US English spelling:** `"cancelled"` → `"canceled"` (9 instances)
- **Ampersand → "and":** `"Security & privacy"` → `"Security and privacy"` (2 instances); `"Swap & Send"` → `"Swap and send"`
- **Exclamation marks removed from error messages:** `"Invalid input!"` → `"Invalid input."` and `"Transaction $1 failed!"` → `"Transaction $1 failed."`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40253?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: None

## **Manual testing steps**

1. Search for the updated keys (`securitySrpLabel`, `securityAndPrivacy`, `securityDefaultSettingsSocialLogin`, `swapAndSend`, `invalidSeedPhraseCaseSensitive`, `notificationTransactionFailedMessage`, `cancelled`) in the UI
2. Confirm updated strings display correctly with no truncation or layout issues
3. Confirm "Security and privacy" settings label renders correctly in Settings
4. Confirm "Swap and send" renders correctly in the swap flow

## **Screenshots/Recordings**

N/A — copy-only change with no visual layout impact expected

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.