### PR TITLE
chore: update delete button from red to white

### DIFF
--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -11,7 +11,6 @@ import {
   Text,
 } from '../../component-library';
 import { MenuItem } from '../../ui/menu';
-import { IconColor, TextColor } from '../../../helpers/constants/design-system';
 
 export const NetworkListItemMenu = ({
   anchorElement,

--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -94,14 +94,13 @@ export const NetworkListItemMenu = ({
           <MenuItem
             ref={deleteRef}
             iconNameLegacy={IconName.Trash}
-            iconColorLegacy={IconColor.errorDefault}
             onClick={(e) => {
               e.stopPropagation();
               onDeleteClick();
             }}
             data-testid="network-list-item-options-delete"
           >
-            <Text color={TextColor.errorDefault}>{t('delete')}</Text>
+            <Text>{t('delete')}</Text>
           </MenuItem>
         ) : null}
       </Box>


### PR DESCRIPTION
## **Description**

Update delete button from red to white

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40261?quickstart=1)

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-660

## **Manual testing steps**

1. Go to this page network picker from the home page
2. Click on the more icon
3. Observe change

## **Screenshots/Recordings**

`~`

### **Before**

<img width="450"  alt="image" src="https://github.com/user-attachments/assets/9ad16ac5-6b70-407c-8c43-571027859147" />


### **After**

<img width="450"  alt="Screenshot 2026-02-19 at 4 37 59 PM" src="https://github.com/user-attachments/assets/ac4e4f8e-8010-4225-bb6e-24d867a57fd8" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a UI styling change to the network list item menu with no logic, data flow, or security impact.
> 
> **Overview**
> Updates `NetworkListItemMenu` so the Delete menu item no longer uses error (red) styling: removes the legacy `IconColor.errorDefault` icon color and `TextColor.errorDefault` text color, leaving the default menu styling (white) for the delete action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d14f22afbec035fa165757db54432d311460648. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->