### PR TITLE
fix: add `watchAsset` tokens to wallet selected network, not dApp network

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.test.js
@@ -36,7 +36,6 @@ describe('watchAssetHandler', () => {
       asset: req.params.options,
       type: req.params.type,
       origin: req.origin,
-      networkClientId: req.networkClientId,
     });
     expect(res.result).toStrictEqual(true);
     expect(mockEnd).toHaveBeenCalledWith();
@@ -68,7 +67,6 @@ describe('watchAssetHandler', () => {
       asset: req.params.options,
       type: req.params.type,
       origin: req.origin,
-      networkClientId: req.networkClientId,
     });
     expect(res.result).toStrictEqual(true);
     expect(mockEnd).toHaveBeenCalledWith();

--- a/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.ts
@@ -13,9 +13,11 @@ import { ERC1155, ERC721 } from '@metamask/controller-utils';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import { HandlerWrapper } from './types';
 
-type HandleWatchAssetRequest = (
-  options: Record<string, string | Record<string, string>>,
-) => Promise<void>;
+type HandleWatchAssetRequest = (options: {
+  asset: Record<string, string | Record<string, string>>;
+  type: string;
+  origin: string;
+}) => Promise<void>;
 
 type WatchAssetRequest<Params extends JsonRpcParams> = JsonRpcRequest<Params> &
   Partial<{ origin: string; networkClientId: string }> & {
@@ -64,7 +66,6 @@ async function watchAssetHandler<Params extends JsonRpcParams = JsonRpcParams>(
     const {
       params: { options: asset, type },
       origin,
-      networkClientId,
     } = req;
 
     const { tokenId } = asset;
@@ -85,7 +86,6 @@ async function watchAssetHandler<Params extends JsonRpcParams = JsonRpcParams>(
       asset,
       type,
       origin: origin ?? '',
-      networkClientId: networkClientId ?? '',
     });
     res.result = true;
     return end();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6604,7 +6604,8 @@ export default class MetamaskController extends EventEmitter {
   handleWatchAssetRequest = ({ asset, type, origin }) => {
     // watchAsset should always use the wallet's selected network, not the dApp's network
     // This ensures tokens are added to the correct network the user is viewing
-    const networkClientId = this.networkController.state.selectedNetworkClientId;
+    const networkClientId =
+      this.networkController.state.selectedNetworkClientId;
 
     switch (type) {
       case ERC20:

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6601,7 +6601,11 @@ export default class MetamaskController extends EventEmitter {
     });
   }
 
-  handleWatchAssetRequest = ({ asset, type, origin, networkClientId }) => {
+  handleWatchAssetRequest = ({ asset, type, origin }) => {
+    // watchAsset should always use the wallet's selected network, not the dApp's network
+    // This ensures tokens are added to the correct network the user is viewing
+    const networkClientId = this.networkController.state.selectedNetworkClientId;
+
     switch (type) {
       case ERC20:
         return this.tokensController.watchAsset({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`wallet_watchAsset` was adding tokens (and NFTs) using the `networkClientId` from the RPC request (dApp’s origin), which could be different from the wallet’s selected network. This change makes watchAsset always use the wallet’s selected network, so tokens are added on the chain the user is viewing.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40265?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed `wallet_watchAsset` so tokens and NFTs are added to the wallet’s selected network instead of the dApp’s network.

## **Related issues**

Fixes: #40264 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/8e841f6a-529a-4ee7-a3a2-86d05ab789f6



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how assets are assigned to networks during `watchAsset`, which could affect where tokens/NFTs appear for users on multi-network setups; scope is small and covered by unit tests.
> 
> **Overview**
> Fixes `wallet_watchAsset` so added tokens/NFTs always target the wallet’s *selected* network.
> 
> This removes passing `networkClientId` through the `watch-asset` RPC middleware and updates `metamask-controller` `handleWatchAssetRequest` to derive `networkClientId` from `networkController.state.selectedNetworkClientId`, with tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb55130e72e03ed006b6d7d9a87c02ac5c9af61c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->