### PR TITLE
feat: add mUSD education splash page with geo-blocking and deep linking

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2088,6 +2088,9 @@
   "deepLink_theHomePage": {
     "message": "the home page"
   },
+  "deepLink_theMusdEducationPage": {
+    "message": "the MUSD conversion education page"
+  },
   "deepLink_theNFTsPage": {
     "message": "the NFTs page"
   },
@@ -4036,6 +4039,21 @@
     "message": "$1 wants to use $2 Snaps",
     "description": "$1 is the dapp and $2 is the number of snaps it wants to connect to."
   },
+  "musdBonusExplanation": {
+    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and receive up to a $1% bonus. Terms apply.",
+    "description": "$1 is the bonus APY percentage"
+  },
+  "musdBoostDescription": {
+    "message": "Convert your stablecoins to mUSD and receive up to a $1% bonus.",
+    "description": "$1 is the bonus percentage (e.g., 3)"
+  },
+  "musdBoostTitle": {
+    "message": "Get $1% on your stablecoins",
+    "description": "$1 is the bonus percentage (e.g., 3)"
+  },
+  "musdBuyMusd": {
+    "message": "Buy mUSD"
+  },
   "musdClaimClaimingTo": {
     "message": "Claiming to",
     "description": "Label for the account row in the mUSD claim confirmation screen"
@@ -4053,6 +4071,40 @@
   },
   "musdConversionTitle": {
     "message": "mUSD Conversion"
+  },
+  "musdConversionToastFailed": {
+    "message": "mUSD conversion failed"
+  },
+  "musdConversionToastInProgress": {
+    "message": "Converting $1 → mUSD",
+    "description": "$1 is the source token symbol (e.g., USDC)"
+  },
+  "musdConversionToastSuccess": {
+    "message": "Your mUSD is here!"
+  },
+  "musdConvert": {
+    "message": "Convert"
+  },
+  "musdEarnBonusPercentage": {
+    "message": "Earn a $1% bonus",
+    "description": "$1 is the bonus percentage (e.g., 3)"
+  },
+  "musdEducationGetStarted": {
+    "message": "Get started"
+  },
+  "musdEducationHeadline": {
+    "message": "GET $1% ON STABLECOINS",
+    "description": "$1 is the bonus APY percentage"
+  },
+  "musdEducationNotNow": {
+    "message": "Not now"
+  },
+  "musdGetBonusPercentage": {
+    "message": "Get $1% bonus",
+    "description": "$1 is the bonus percentage (e.g., 3)"
+  },
+  "musdGetMusd": {
+    "message": "Get mUSD"
   },
   "mustSelectOne": {
     "message": "Must select at least 1 token."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2088,6 +2088,9 @@
   "deepLink_theHomePage": {
     "message": "the home page"
   },
+  "deepLink_theMusdEducationPage": {
+    "message": "the MUSD conversion education page"
+  },
   "deepLink_theNFTsPage": {
     "message": "the NFTs page"
   },
@@ -4036,6 +4039,10 @@
     "message": "$1 wants to use $2 Snaps",
     "description": "$1 is the dapp and $2 is the number of snaps it wants to connect to."
   },
+  "musdBonusExplanation": {
+    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and receive up to a $1% bonus. Terms apply.",
+    "description": "$1 is the bonus APY percentage"
+  },
   "musdClaimClaimingTo": {
     "message": "Claiming to",
     "description": "Label for the account row in the mUSD claim confirmation screen"
@@ -4053,6 +4060,26 @@
   },
   "musdConversionTitle": {
     "message": "mUSD Conversion"
+  },
+  "musdConversionToastFailed": {
+    "message": "mUSD conversion failed"
+  },
+  "musdConversionToastInProgress": {
+    "message": "Converting $1 → mUSD",
+    "description": "$1 is the source token symbol (e.g., USDC)"
+  },
+  "musdConversionToastSuccess": {
+    "message": "Your mUSD is here!"
+  },
+  "musdEducationGetStarted": {
+    "message": "Get started"
+  },
+  "musdEducationHeadline": {
+    "message": "GET $1% ON STABLECOINS",
+    "description": "$1 is the bonus APY percentage"
+  },
+  "musdEducationNotNow": {
+    "message": "Not now"
   },
   "mustSelectOne": {
     "message": "Must select at least 1 token."

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -7,6 +7,7 @@ import { notifications } from './notifications';
 import { onboarding } from './onboarding';
 import { swap } from './swap';
 import { nonevm } from './nonevm';
+import { musd } from './musd';
 import { perps } from './perps';
 import { predict } from './predict';
 import { rewards } from './rewards';
@@ -38,7 +39,7 @@ export function addRoute(route: Route) {
 }
 
 if (process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS || process.env.IN_TEST) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   addRoute(require('./test-route').test);
 }
 
@@ -50,6 +51,7 @@ addRoute(notifications);
 addRoute(onboarding);
 addRoute(swap);
 addRoute(nonevm);
+addRoute(musd);
 addRoute(perps);
 addRoute(predict);
 addRoute(rewards);

--- a/shared/lib/deep-links/routes/musd.test.ts
+++ b/shared/lib/deep-links/routes/musd.test.ts
@@ -1,0 +1,34 @@
+import { musd, MUSD_DEEPLINK_PARAM } from './musd';
+
+describe('musd deep link route', () => {
+  it('has the correct pathname', () => {
+    expect(musd.pathname).toBe('/earn-musd');
+  });
+
+  it('returns the correct title key', () => {
+    expect(musd.getTitle(new URLSearchParams())).toBe(
+      'deepLink_theMusdEducationPage',
+    );
+  });
+
+  it('returns an in-extension path with isDeeplink=true', () => {
+    const result = musd.handler(new URLSearchParams());
+
+    expect('path' in result).toBe(true);
+    expect('query' in result).toBe(true);
+
+    const { path, query } = result as { path: string; query: URLSearchParams };
+    expect(path).toBe('/musd/education');
+    expect(query.get(MUSD_DEEPLINK_PARAM)).toBe('true');
+  });
+
+  it('forwards incoming query params alongside isDeeplink', () => {
+    const params = new URLSearchParams({ token: '0xabc', chain: '0x1' });
+    const result = musd.handler(params);
+
+    const { query } = result as { path: string; query: URLSearchParams };
+    expect(query.get(MUSD_DEEPLINK_PARAM)).toBe('true');
+    expect(query.get('token')).toBe('0xabc');
+    expect(query.get('chain')).toBe('0x1');
+  });
+});

--- a/shared/lib/deep-links/routes/musd.ts
+++ b/shared/lib/deep-links/routes/musd.ts
@@ -1,0 +1,17 @@
+import { Route } from './route';
+
+export const MUSD_DEEPLINK_PARAM = 'isDeeplink';
+
+export const musd = new Route({
+  pathname: '/earn-musd',
+  getTitle: (_: URLSearchParams) => 'deepLink_theMusdEducationPage',
+  handler: function handler(params: URLSearchParams) {
+    const query = new URLSearchParams();
+    query.set(MUSD_DEEPLINK_PARAM, 'true');
+    params.forEach((value, key) => query.append(key, value));
+    return {
+      path: '/musd/education',
+      query,
+    };
+  },
+});

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../store/store';
+import { BuyGetMusdCtaVariant } from '../../../hooks/musd/useMusdCtaVisibility';
+import { MusdBuyGetCta } from './musd-buy-get-cta';
+
+// Mock useI18nContext
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string, values?: string[]) => {
+    const translations: Record<string, string> = {
+      musdBuyMusd: 'Buy mUSD',
+      musdGetMusd: 'Get mUSD',
+      musdEarnBonusPercentage: `Earn a ${values?.[0] || '3'}% bonus`,
+    };
+    return translations[key] || key;
+  },
+}));
+
+// Mock MetaMetricsContext with a real React context so useContext works,
+// but replace Provider with Fragment so the createContext default value is used
+jest.mock('../../../contexts/metametrics', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  const _trackEvent = jest.fn();
+  const MetaMetricsContext = ReactActual.createContext({
+    trackEvent: _trackEvent,
+    bufferedTrace: jest.fn().mockResolvedValue(undefined),
+    bufferedEndTrace: jest.fn().mockResolvedValue(undefined),
+    onboardingParentContext: { current: null },
+  });
+  MetaMetricsContext.Provider = (({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) =>
+    ReactActual.createElement(
+      ReactActual.Fragment,
+      null,
+      children,
+    )) as unknown as typeof MetaMetricsContext.Provider;
+  return {
+    MetaMetricsContext,
+    LegacyMetaMetricsProvider: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __mockTrackEvent: _trackEvent,
+  };
+});
+const { __mockTrackEvent: mockTrackEvent } = jest.requireMock<{
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __mockTrackEvent: jest.Mock;
+}>('../../../contexts/metametrics');
+
+// Mock useMusdConversion
+const mockStartConversionFlow = jest.fn();
+jest.mock('../../../hooks/musd', () => ({
+  useMusdConversion: () => ({
+    startConversionFlow: mockStartConversionFlow,
+    educationSeen: false,
+  }),
+  useMusdGeoBlocking: () => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+  }),
+}));
+
+const mockOpenTab = jest.fn();
+
+const createMockStore = (overrides = {}) => {
+  return configureStore({
+    metamask: {
+      remoteFeatureFlags: {
+        earnMusdConversionFlowEnabled: true,
+        earnMusdCtaEnabled: true,
+      },
+      selectedNetworkClientId: 'mainnet',
+      networkConfigurationsByChainId: {
+        '0x1': {
+          chainId: '0x1',
+          name: 'Ethereum Mainnet',
+          rpcEndpoints: [
+            {
+              networkClientId: 'mainnet',
+              url: 'https://mainnet.infura.io',
+            },
+          ],
+          defaultRpcEndpointIndex: 0,
+        },
+        '0xe708': {
+          chainId: '0xe708',
+          name: 'Linea Mainnet',
+          rpcEndpoints: [
+            {
+              networkClientId: 'linea-mainnet',
+              url: 'https://linea.infura.io',
+            },
+          ],
+          defaultRpcEndpointIndex: 0,
+        },
+      },
+      internalAccounts: {
+        selectedAccount: 'account-1',
+        accounts: {
+          'account-1': { id: 'account-1', address: '0x123' },
+        },
+      },
+      musdConversionEducationSeen: false,
+      musdConversionDismissedCtaKeys: [],
+    },
+    ...overrides,
+  });
+};
+
+describe('MusdBuyGetCta', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(global, 'platform', {
+      value: { openTab: mockOpenTab },
+      writable: true,
+    });
+  });
+
+  describe('GET variant', () => {
+    it('renders "Get mUSD" text for GET variant', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const elements = screen.getAllByText('Get mUSD');
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('calls startConversionFlow when clicked', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const ctaElement = screen.getByTestId('musd-buy-get-cta');
+      fireEvent.click(ctaElement);
+
+      expect(mockStartConversionFlow).toHaveBeenCalledWith({
+        entryPoint: 'home',
+      });
+    });
+
+    it('tracks analytics event with GET variant', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const ctaElement = screen.getByTestId('musd-buy-get-cta');
+      fireEvent.click(ctaElement);
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            location: 'home_screen',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            cta_type: 'musd_conversion_primary_cta',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            network_chain_id: '0x1',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            redirects_to: 'conversion_education_screen',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('BUY variant', () => {
+    it('renders "Buy mUSD" text for BUY variant', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.BUY}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const elements = screen.getAllByText('Buy mUSD');
+      expect(elements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('opens buy crypto page when clicked for BUY variant', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.BUY}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const ctaElement = screen.getByTestId('musd-buy-get-cta');
+      fireEvent.click(ctaElement);
+
+      expect(mockOpenTab).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining('/buy'),
+        }),
+      );
+    });
+  });
+
+  describe('network icon', () => {
+    it('shows network icon when showNetworkIcon is true', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+          showNetworkIcon
+        />,
+        store,
+      );
+
+      expect(
+        screen.getByTestId('musd-buy-get-cta-network-icon'),
+      ).toBeInTheDocument();
+    });
+
+    it('hides network icon when showNetworkIcon is false', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+          showNetworkIcon={false}
+        />,
+        store,
+      );
+
+      expect(
+        screen.queryByTestId('musd-buy-get-cta-network-icon'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('bonus text', () => {
+    it('displays bonus percentage in subtitle', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      expect(screen.getByText('Earn a 3% bonus')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('is focusable and keyboard accessible', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      const ctaElement = screen.getByTestId('musd-buy-get-cta');
+      expect(ctaElement).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  describe('does not render', () => {
+    it('returns null when variant is null', () => {
+      const store = createMockStore();
+      const { container } = renderWithProvider(
+        <MusdBuyGetCta variant={null} selectedChainId="0x1" />,
+        store,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/ui/components/app/musd/musd-buy-get-cta.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.tsx
@@ -1,0 +1,260 @@
+/**
+ * MusdBuyGetCta Component
+ *
+ * Primary banner CTA that appears above the token list.
+ * Shows "Buy mUSD" for empty wallets or "Get mUSD" for users with convertible tokens.
+ *
+ * Based on mobile's MusdConversionAssetListCta component.
+ */
+
+import React, { useCallback, useContext, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import type { ChainId } from '../../../../shared/constants/network';
+import {
+  AlignItems,
+  BackgroundColor,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  Box,
+  ButtonPrimary,
+  ButtonPrimarySize,
+  Text,
+} from '../../component-library';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useMusdConversion } from '../../../hooks/musd';
+import { BuyGetMusdCtaVariant } from '../../../hooks/musd/useMusdCtaVisibility';
+import {
+  getMultichainNetworkConfigurationsByChainId,
+  getImageForChainId,
+} from '../../../selectors/multichain';
+import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import { MUSD_CONVERSION_APY } from './constants';
+import {
+  createMusdCtaClickedEventProperties,
+  MUSD_EVENTS_CONSTANTS,
+  type MusdCtaClickedEventProperties,
+} from './musd-events';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type MusdBuyGetCtaProps = {
+  /** CTA variant - 'buy' or 'get' */
+  variant: BuyGetMusdCtaVariant | null;
+  /** Selected chain ID (hex) */
+  selectedChainId: Hex | null;
+  /** Whether to show the network icon */
+  showNetworkIcon?: boolean;
+  /** Custom className */
+  className?: string;
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Primary banner CTA for mUSD acquisition
+ *
+ * Shows different content based on variant:
+ * - BUY: For empty wallets, routes to Ramp to buy mUSD
+ * - GET: For users with convertible tokens, routes to conversion flow
+ *
+ * @param options0
+ * @param options0.variant
+ * @param options0.selectedChainId
+ * @param options0.showNetworkIcon
+ * @param options0.className
+ */
+export const MusdBuyGetCta: React.FC<MusdBuyGetCtaProps> = ({
+  variant,
+  selectedChainId,
+  showNetworkIcon = false,
+  className,
+}) => {
+  const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const { startConversionFlow, educationSeen } = useMusdConversion();
+  const { openBuyCryptoInPdapp } = useRamps();
+
+  // Get network configuration for icon
+  const networkConfigurationsByChainId = useSelector(
+    getMultichainNetworkConfigurationsByChainId,
+  );
+
+  const networkConfig = selectedChainId
+    ? networkConfigurationsByChainId[selectedChainId]
+    : null;
+  const networkName = networkConfig?.name ?? 'Unknown Network';
+  const networkIcon = selectedChainId
+    ? getImageForChainId(selectedChainId)
+    : null;
+
+  /**
+   * CTA text based on variant
+   */
+  const ctaText = useMemo(() => {
+    switch (variant) {
+      case BuyGetMusdCtaVariant.BUY:
+        return t('musdBuyMusd');
+      case BuyGetMusdCtaVariant.GET:
+        return t('musdGetMusd');
+      default:
+        return '';
+    }
+  }, [variant, t]);
+
+  /**
+   * Subtitle text with bonus percentage
+   */
+  const subtitleText = t('musdEarnBonusPercentage', [
+    String(MUSD_CONVERSION_APY),
+  ]);
+
+  /**
+   * Handle CTA click
+   */
+  const handleClick = useCallback(() => {
+    const { REDIRECT_DESTINATIONS } = MUSD_EVENTS_CONSTANTS;
+    let redirectsTo: MusdCtaClickedEventProperties['redirects_to'];
+    if (variant === BuyGetMusdCtaVariant.BUY) {
+      redirectsTo = REDIRECT_DESTINATIONS.BUY_SCREEN;
+    } else if (educationSeen) {
+      redirectsTo = REDIRECT_DESTINATIONS.CUSTOM_AMOUNT_SCREEN;
+    } else {
+      redirectsTo = REDIRECT_DESTINATIONS.CONVERSION_EDUCATION_SCREEN;
+    }
+
+    trackEvent({
+      event: MetaMetricsEventName.MusdConversionCtaClicked,
+      category: MetaMetricsEventCategory.Tokens,
+      properties: createMusdCtaClickedEventProperties({
+        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.HOME_SCREEN,
+        redirectsTo,
+        ctaType: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
+        ctaText,
+        chainId: selectedChainId,
+        chainName: networkName,
+        clickTarget: MUSD_EVENTS_CONSTANTS.CTA_CLICK_TARGETS.CTA_BUTTON,
+      }),
+    });
+
+    if (variant === BuyGetMusdCtaVariant.BUY) {
+      openBuyCryptoInPdapp((selectedChainId as ChainId) ?? undefined);
+    } else if (variant === BuyGetMusdCtaVariant.GET) {
+      startConversionFlow({
+        entryPoint: 'home',
+      });
+    }
+  }, [
+    variant,
+    selectedChainId,
+    networkName,
+    ctaText,
+    educationSeen,
+    trackEvent,
+    openBuyCryptoInPdapp,
+    startConversionFlow,
+  ]);
+
+  // Don't render if no variant
+  if (!variant) {
+    return null;
+  }
+
+  return (
+    <Box
+      data-testid="musd-buy-get-cta"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.spaceBetween}
+      alignItems={AlignItems.center}
+      padding={4}
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyPress={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          handleClick();
+        }
+      }}
+      className={className}
+      style={{ cursor: 'pointer', minHeight: '64px' }}
+    >
+      {/* Left side: Icon and text */}
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        gap={3}
+      >
+        {/* Network icon (conditional) */}
+        {showNetworkIcon && selectedChainId && networkIcon && (
+          <Box data-testid="musd-buy-get-cta-network-icon">
+            <AvatarNetwork
+              src={networkIcon}
+              name={networkName}
+              size={AvatarNetworkSize.Md}
+            />
+          </Box>
+        )}
+
+        {/* mUSD icon (when no network icon) */}
+        {!showNetworkIcon && (
+          <Box
+            display={Display.Flex}
+            alignItems={AlignItems.center}
+            justifyContent={JustifyContent.center}
+            backgroundColor={BackgroundColor.primaryMuted}
+            style={{
+              width: '40px',
+              height: '40px',
+              borderRadius: '50%',
+            }}
+          >
+            <Text
+              variant={TextVariant.bodyMdMedium}
+              color={TextColor.primaryDefault}
+            >
+              M
+            </Text>
+          </Box>
+        )}
+
+        {/* Text content */}
+        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+          <Text variant={TextVariant.bodyMdMedium}>{ctaText}</Text>
+          <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
+            {subtitleText}
+          </Text>
+        </Box>
+      </Box>
+
+      {/* Right side: Action button */}
+      <ButtonPrimary
+        size={ButtonPrimarySize.Sm}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          handleClick();
+        }}
+      >
+        {ctaText}
+      </ButtonPrimary>
+    </Box>
+  );
+};
+
+export default MusdBuyGetCta;

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -1,5 +1,7 @@
 import { memoize } from 'lodash';
 
+import { MUSD_ROUTE_DEFINITIONS } from '../../pages/musd/constants/routes';
+
 type AppRoute = {
   path: string;
   label: string;
@@ -585,6 +587,7 @@ export const ROUTES = [
     label: 'Review Gator Permissions',
     trackInAnalytics: false,
   },
+  ...MUSD_ROUTE_DEFINITIONS,
 ] as const satisfies AppRoute[];
 
 export type AppRoutes = (typeof ROUTES)[number];

--- a/ui/pages/musd/index.tsx
+++ b/ui/pages/musd/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * MUSD Conversion Page
+ *
+ * Main entry point for the mUSD stablecoin conversion feature.
+ * Handles routing to the education screen.
+ */
+
+import React from 'react';
+import { Routes, Route, Navigate, useSearchParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectIsMusdConversionFlowEnabled } from '../../selectors/musd';
+import { useMusdGeoBlocking } from '../../hooks/musd';
+import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { MUSD_DEEPLINK_PARAM } from '../../../shared/lib/deep-links/routes/musd';
+import { MUSD_CONVERSION_ROUTES } from './constants/routes';
+import MusdEducationScreen from './screens/education';
+
+/**
+ * MUSD Conversion Page Component
+ *
+ * Routes:
+ * - /musd/education - Education/onboarding screen
+ */
+const MusdConversionPage: React.FC = () => {
+  const isFeatureEnabled = useSelector(selectIsMusdConversionFlowEnabled);
+  const [searchParams] = useSearchParams();
+  const isDeeplink = searchParams.get(MUSD_DEEPLINK_PARAM) === 'true';
+  const { isBlocked, isLoading: isGeoLoading } = useMusdGeoBlocking();
+
+  // Redirect if feature is disabled
+  if (!isFeatureEnabled) {
+    return <Navigate to={DEFAULT_ROUTE} replace />;
+  }
+
+  // Redirect geo-blocked users to home (deeplink users see education with a home CTA instead)
+  if (isBlocked && !isGeoLoading && !isDeeplink) {
+    return <Navigate to={DEFAULT_ROUTE} replace />;
+  }
+
+  return (
+    <div className="musd-conversion-page" style={{ height: '100%', flex: 1 }}>
+      <Routes>
+        {/* Education screen */}
+        <Route
+          path={MUSD_CONVERSION_ROUTES.EDUCATION.RELATIVE}
+          element={<MusdEducationScreen />}
+        />
+
+        {/* Default: redirect to education */}
+        <Route
+          path="/"
+          element={
+            <Navigate to={MUSD_CONVERSION_ROUTES.EDUCATION.RELATIVE} replace />
+          }
+        />
+      </Routes>
+    </div>
+  );
+};
+
+export default MusdConversionPage;

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -1,0 +1,329 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import configureStore from '../../../store/store';
+import MusdEducationScreen from './education';
+
+// Mock useMusdConversion hook
+const mockStartConversionFlow = jest.fn().mockResolvedValue(undefined);
+const mockUseMusdGeoBlocking = jest.fn().mockReturnValue({
+  isBlocked: false,
+  userCountry: 'US',
+  isLoading: false,
+});
+const mockDefaultPaymentToken = { address: '0xAbc', chainId: '0x1' };
+const mockUseMusdConversionTokens = jest.fn().mockReturnValue({
+  tokens: [{ address: '0xabc', chainId: '0x1', symbol: 'USDC' }],
+  defaultPaymentToken: mockDefaultPaymentToken,
+});
+const mockUseCanBuyMusd = jest.fn().mockReturnValue({
+  canBuyMusdInRegion: true,
+  isLoading: false,
+});
+jest.mock('../../../hooks/musd', () => ({
+  useMusdConversion: () => ({
+    startConversionFlow: mockStartConversionFlow,
+    educationSeen: false,
+  }),
+  useMusdGeoBlocking: () => mockUseMusdGeoBlocking(),
+  useMusdConversionTokens: () => mockUseMusdConversionTokens(),
+  useCanBuyMusd: () => mockUseCanBuyMusd(),
+}));
+
+const mockOpenBuyCryptoInPdapp = jest.fn();
+jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp }),
+}));
+
+// Mock Redux dispatch
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+// Mock navigate and search params (isDeeplink)
+const mockNavigate = jest.fn();
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [
+    {
+      get: (key: string) =>
+        key === 'isDeeplink' ? mockSearchParamsGet() : null,
+    },
+  ],
+}));
+
+const createMockStore = () => {
+  return configureStore({
+    metamask: {
+      remoteFeatureFlags: {
+        earnMusdConversionFlowEnabled: true,
+      },
+      selectedNetworkClientId: 'mainnet',
+      networkConfigurationsByChainId: {
+        '0x1': { chainId: '0x1', name: 'Ethereum Mainnet' },
+      },
+      internalAccounts: {
+        selectedAccount: 'account-1',
+        accounts: {
+          'account-1': { id: 'account-1', address: '0x123' },
+        },
+      },
+      musdConversionEducationSeen: false,
+      musdConversionDismissedCtaKeys: [],
+    },
+  });
+};
+
+describe('MusdEducationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParamsGet.mockReturnValue(null);
+    mockUseMusdGeoBlocking.mockReturnValue({
+      isBlocked: false,
+      userCountry: 'US',
+      isLoading: false,
+    });
+    mockUseMusdConversionTokens.mockReturnValue({
+      tokens: [{ address: '0xabc', chainId: '0x1', symbol: 'USDC' }],
+      defaultPaymentToken: mockDefaultPaymentToken,
+    });
+    mockUseCanBuyMusd.mockReturnValue({
+      canBuyMusdInRegion: true,
+      isLoading: false,
+    });
+  });
+
+  it('renders the headline with the bonus percentage', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    expect(screen.getByText('GET 3% ON STABLECOINS')).toBeInTheDocument();
+  });
+
+  it('renders the body copy', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    expect(
+      screen.getByText(/Convert your stablecoins to mUSD/u),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the illustration image', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', './images/musd-education-coin.png');
+  });
+
+  it('renders the "Get started" primary button', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const button = screen.getByTestId('musd-education-continue-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Get started');
+  });
+
+  it('renders the "Not now" secondary button', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const button = screen.getByTestId('musd-education-not-now-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Not now');
+  });
+
+  it('renders the close icon button', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const closeButton = screen.getByTestId('musd-education-skip-button');
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('dispatches setMusdConversionEducationSeen and starts conversion flow on "Get started" click', async () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const button = screen.getByTestId('musd-education-continue-button');
+    fireEvent.click(button);
+
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(mockStartConversionFlow).toHaveBeenCalledWith({
+      preferredToken: mockDefaultPaymentToken,
+      skipEducation: true,
+    });
+  });
+
+  it('dispatches setMusdConversionEducationSeen and navigates home on close click', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const closeButton = screen.getByTestId('musd-education-skip-button');
+    fireEvent.click(closeButton);
+
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+  });
+
+  it('dispatches setMusdConversionEducationSeen and navigates home on "Not now" click', () => {
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const notNowButton = screen.getByTestId('musd-education-not-now-button');
+    fireEvent.click(notNowButton);
+
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+  });
+
+  it('shows "Continue" when geo-blocked (non-deeplink) and navigates home on click', () => {
+    mockUseMusdGeoBlocking.mockReturnValue({
+      isBlocked: true,
+      userCountry: 'GB',
+      isLoading: false,
+    });
+    const store = createMockStore();
+    renderWithProvider(<MusdEducationScreen />, store);
+
+    const button = screen.getByTestId('musd-education-continue-button');
+    expect(button).toHaveTextContent('Continue');
+    fireEvent.click(button);
+
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    expect(mockStartConversionFlow).not.toHaveBeenCalled();
+    expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------
+  // Deeplink with no eligible conversion tokens
+  // -------------------------------------------------------------------
+
+  describe('deeplink with no eligible conversion tokens', () => {
+    beforeEach(() => {
+      mockSearchParamsGet.mockReturnValue('true');
+      mockUseMusdConversionTokens.mockReturnValue({
+        tokens: [],
+        defaultPaymentToken: null,
+      });
+    });
+
+    it('shows "Buy mUSD" and opens buy flow when user can buy', () => {
+      mockUseCanBuyMusd.mockReturnValue({
+        canBuyMusdInRegion: true,
+        isLoading: false,
+      });
+      const store = createMockStore();
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      expect(button).toHaveTextContent('Buy mUSD');
+      fireEvent.click(button);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledWith('0x1');
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+    });
+
+    it('shows "Continue" and navigates home when user cannot buy (geo-blocked)', () => {
+      mockUseMusdGeoBlocking.mockReturnValue({
+        isBlocked: true,
+        userCountry: 'GB',
+        isLoading: false,
+      });
+      mockUseCanBuyMusd.mockReturnValue({
+        canBuyMusdInRegion: false,
+        isLoading: false,
+      });
+      const store = createMockStore();
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      expect(button).toHaveTextContent('Continue');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+    });
+
+    it('shows "Continue" and navigates home when ramp unavailable in region', () => {
+      mockUseCanBuyMusd.mockReturnValue({
+        canBuyMusdInRegion: false,
+        isLoading: false,
+      });
+      const store = createMockStore();
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      expect(button).toHaveTextContent('Continue');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Deeplink with eligible conversion tokens
+  // -------------------------------------------------------------------
+
+  describe('deeplink with eligible conversion tokens', () => {
+    beforeEach(() => {
+      mockSearchParamsGet.mockReturnValue('true');
+      mockUseMusdConversionTokens.mockReturnValue({
+        tokens: [{ address: '0xabc', chainId: '0x1', symbol: 'USDC' }],
+        defaultPaymentToken: mockDefaultPaymentToken,
+      });
+    });
+
+    it('shows "Get started" and starts conversion flow when user can buy', async () => {
+      const store = createMockStore();
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      expect(button).toHaveTextContent('Get started');
+      fireEvent.click(button);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockStartConversionFlow).toHaveBeenCalledWith({
+        preferredToken: mockDefaultPaymentToken,
+        skipEducation: true,
+        entryPoint: 'deeplink',
+      });
+      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+    });
+
+    it('shows "Continue" and navigates home when user cannot buy', () => {
+      mockUseCanBuyMusd.mockReturnValue({
+        canBuyMusdInRegion: false,
+        isLoading: false,
+      });
+      const store = createMockStore();
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      expect(button).toHaveTextContent('Continue');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -292,7 +292,7 @@ describe('MusdEducationScreen', () => {
       });
     });
 
-    it('shows "Get started" and starts conversion flow when user can buy', async () => {
+    it('shows "Get started" and starts conversion flow', async () => {
       const store = createMockStore();
       renderWithProvider(<MusdEducationScreen />, store);
 
@@ -309,7 +309,7 @@ describe('MusdEducationScreen', () => {
       expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
     });
 
-    it('shows "Continue" and navigates home when user cannot buy', () => {
+    it('shows "Get started" and starts conversion flow even when user cannot buy in region', async () => {
       mockUseCanBuyMusd.mockReturnValue({
         canBuyMusdInRegion: false,
         isLoading: false,
@@ -318,11 +318,15 @@ describe('MusdEducationScreen', () => {
       renderWithProvider(<MusdEducationScreen />, store);
 
       const button = screen.getByTestId('musd-education-continue-button');
-      expect(button).toHaveTextContent('Continue');
+      expect(button).toHaveTextContent('Get started');
       fireEvent.click(button);
 
-      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
-      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockStartConversionFlow).toHaveBeenCalledWith({
+        preferredToken: mockDefaultPaymentToken,
+        skipEducation: true,
+        entryPoint: 'deeplink',
+      });
       expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
     });
   });

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -86,10 +86,10 @@ const MusdEducationScreen: React.FC = () => {
 
   /**
    * Handle primary CTA click.
-   * - Deeplink + can buy + no tokens: open buy flow then go home ("Buy mUSD").
-   * - Deeplink + cannot buy: go home ("Continue").
-   * - Geo-blocked: go home ("Continue").
-   * - Otherwise: start conversion flow ("Get started").
+   * - Deeplink + no tokens + can buy: open buy flow then go home ("Buy mUSD").
+   * - Deeplink + no tokens + cannot buy: go home ("Continue").
+   * - Geo-blocked (non-deeplink): go home ("Continue").
+   * - Otherwise (including deeplink + has tokens): start conversion flow ("Get started").
    */
   const handleContinue = useCallback(async () => {
     dispatch(setMusdConversionEducationSeen(true));
@@ -100,7 +100,7 @@ const MusdEducationScreen: React.FC = () => {
       return;
     }
 
-    if (isDeeplink && !canBuyMusdInRegion) {
+    if (isDeeplinkNoTokensContinueHome) {
       navigate(DEFAULT_ROUTE);
       return;
     }
@@ -129,8 +129,8 @@ const MusdEducationScreen: React.FC = () => {
     dispatch,
     navigate,
     isDeeplinkNoTokensGoToBuy,
+    isDeeplinkNoTokensContinueHome,
     isDeeplink,
-    canBuyMusdInRegion,
     isGeoBlocked,
     openBuyCryptoInPdapp,
     startConversionFlow,
@@ -149,11 +149,7 @@ const MusdEducationScreen: React.FC = () => {
   let primaryButtonLabel = t('musdEducationGetStarted');
   if (isDeeplinkNoTokensGoToBuy) {
     primaryButtonLabel = t('musdBuyMusd');
-  } else if (
-    isDeeplinkNoTokensContinueHome ||
-    isGeoBlocked ||
-    (isDeeplink && !canBuyMusdInRegion)
-  ) {
+  } else if (isDeeplinkNoTokensContinueHome || isGeoBlocked) {
     primaryButtonLabel = t('continue');
   }
 

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -1,0 +1,262 @@
+/**
+ * MUSD Education Screen
+ *
+ * Splash screen that introduces the mUSD conversion feature and its bonus.
+ * Shown to users who haven't seen the education content before.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import {
+  Box,
+  Text,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  IconColor,
+  TextVariant,
+  TextColor,
+  TextAlign,
+  FontFamily,
+  TextTransform,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxAlignItems,
+  BoxBackgroundColor,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { setMusdConversionEducationSeen } from '../../../store/actions';
+import {
+  useMusdConversion,
+  useMusdGeoBlocking,
+  useMusdConversionTokens,
+  useCanBuyMusd,
+} from '../../../hooks/musd';
+import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import {
+  MUSD_CONVERSION_APY,
+  MUSD_CONVERSION_DEFAULT_CHAIN_ID,
+} from '../../../components/app/musd/constants';
+import { MUSD_DEEPLINK_PARAM } from '../../../../shared/lib/deep-links/routes/musd';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+
+const MUSD_EDUCATION_COIN_IMAGE = './images/musd-education-coin.png';
+
+/**
+ * MUSD Education Screen Component
+ *
+ * Displays a splash screen with:
+ * - Close (X) icon button in the top-right corner
+ * - Large hero headline using MMPoly font
+ * - Body copy explaining the mUSD conversion bonus
+ * - Central illustration (coin + MetaMask fox + bonus)
+ * - "Get started" primary button and "Not now" link button
+ */
+const MusdEducationScreen: React.FC = () => {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const [searchParams] = useSearchParams();
+
+  const isDeeplink = searchParams.get(MUSD_DEEPLINK_PARAM) === 'true';
+
+  const { startConversionFlow } = useMusdConversion();
+  const { isBlocked: isGeoBlocked } = useMusdGeoBlocking();
+  const { tokens: conversionTokens, defaultPaymentToken } =
+    useMusdConversionTokens();
+  const { canBuyMusdInRegion } = useCanBuyMusd();
+  const { openBuyCryptoInPdapp } = useRamps();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const hasEligibleConversionTokens = conversionTokens.length > 0;
+
+  /**
+   * When deeplink and user has no eligible tokens: if they can buy in region
+   * (not geo-blocked AND buyable on at least one enabled chain) then primary
+   * CTA goes to buy flow; otherwise "Continue" goes home.
+   */
+  const isDeeplinkNoTokensContinueHome =
+    isDeeplink && !hasEligibleConversionTokens && !canBuyMusdInRegion;
+  const isDeeplinkNoTokensGoToBuy =
+    isDeeplink && !hasEligibleConversionTokens && canBuyMusdInRegion;
+
+  /**
+   * Handle primary CTA click.
+   * - Deeplink + can buy + no tokens: open buy flow then go home ("Buy mUSD").
+   * - Deeplink + cannot buy: go home ("Continue").
+   * - Geo-blocked: go home ("Continue").
+   * - Otherwise: start conversion flow ("Get started").
+   */
+  const handleContinue = useCallback(async () => {
+    dispatch(setMusdConversionEducationSeen(true));
+
+    if (isDeeplinkNoTokensGoToBuy) {
+      openBuyCryptoInPdapp(MUSD_CONVERSION_DEFAULT_CHAIN_ID);
+      navigate(DEFAULT_ROUTE);
+      return;
+    }
+
+    if (isDeeplink && !canBuyMusdInRegion) {
+      navigate(DEFAULT_ROUTE);
+      return;
+    }
+
+    if (isGeoBlocked) {
+      navigate(DEFAULT_ROUTE);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await startConversionFlow({
+        preferredToken: defaultPaymentToken
+          ? {
+              address: defaultPaymentToken.address,
+              chainId: defaultPaymentToken.chainId,
+            }
+          : undefined,
+        skipEducation: true,
+        entryPoint: isDeeplink ? 'deeplink' : undefined,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    dispatch,
+    navigate,
+    isDeeplinkNoTokensGoToBuy,
+    isDeeplink,
+    canBuyMusdInRegion,
+    isGeoBlocked,
+    openBuyCryptoInPdapp,
+    startConversionFlow,
+    defaultPaymentToken,
+  ]);
+
+  /**
+   * Handle close / "Not now" button click.
+   * Marks education as seen and navigates home.
+   */
+  const handleSkip = useCallback(() => {
+    dispatch(setMusdConversionEducationSeen(true));
+    navigate(DEFAULT_ROUTE);
+  }, [dispatch, navigate]);
+
+  let primaryButtonLabel = t('musdEducationGetStarted');
+  if (isDeeplinkNoTokensGoToBuy) {
+    primaryButtonLabel = t('musdBuyMusd');
+  } else if (
+    isDeeplinkNoTokensContinueHome ||
+    isGeoBlocked ||
+    (isDeeplink && !canBuyMusdInRegion)
+  ) {
+    primaryButtonLabel = t('continue');
+  }
+
+  return (
+    <Box
+      className="musd-education-screen"
+      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      flexDirection={BoxFlexDirection.Column}
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+    >
+      {/* Close icon – top-right */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.End}
+        paddingTop={3}
+        paddingRight={4}
+      >
+        <ButtonIcon
+          iconName={IconName.Close}
+          ariaLabel={t('close') as string}
+          size={ButtonIconSize.Sm}
+          color={IconColor.IconDefault}
+          onClick={handleSkip}
+          data-testid="musd-education-skip-button"
+        />
+      </Box>
+
+      {/* Main content – vertically centered */}
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        paddingLeft={4}
+        paddingRight={4}
+        style={{ flex: 1 }}
+      >
+        {/* Hero headline */}
+        <Box marginBottom={3}>
+          <Text
+            variant={TextVariant.DisplayMd}
+            fontFamily={FontFamily.Hero}
+            textAlign={TextAlign.Center}
+            color={TextColor.TextDefault}
+            textTransform={TextTransform.Uppercase}
+          >
+            {t('musdEducationHeadline', [String(MUSD_CONVERSION_APY)])}
+          </Text>
+        </Box>
+
+        {/* Body copy */}
+        <Box marginBottom={4}>
+          <Text
+            variant={TextVariant.BodyMd}
+            textAlign={TextAlign.Center}
+            color={TextColor.TextAlternative}
+          >
+            {t('musdBonusExplanation', [String(MUSD_CONVERSION_APY)])}
+          </Text>
+        </Box>
+
+        {/* Central illustration */}
+        <Box
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
+        >
+          <img
+            src={MUSD_EDUCATION_COIN_IMAGE}
+            alt={t('musdGetMusd') as string}
+            width={252}
+            height={252}
+          />
+        </Box>
+      </Box>
+
+      {/* Footer actions – full-width buttons with padding to match Figma */}
+      <Box flexDirection={BoxFlexDirection.Column} gap={2} padding={4}>
+        <Box style={{ width: '100%' }}>
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            onClick={handleContinue}
+            disabled={isLoading}
+            style={{ width: '100%' }}
+            data-testid="musd-education-continue-button"
+          >
+            {primaryButtonLabel}
+          </Button>
+        </Box>
+
+        <Box style={{ width: '100%' }}>
+          <Button
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Lg}
+            onClick={handleSkip}
+            style={{ width: '100%', color: 'var(--color-overlay-inverse)' }}
+            data-testid="musd-education-not-now-button"
+          >
+            {t('musdEducationNotNow')}
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default MusdEducationScreen;

--- a/ui/pages/musd/screens/index.ts
+++ b/ui/pages/musd/screens/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MUSD Conversion Screens
+ *
+ * Exports all screen components for the mUSD conversion feature.
+ */
+
+export { default as MusdEducationScreen } from './education';

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -66,6 +66,7 @@ import {
   PERPS_MARKET_DETAIL_ROUTE,
   PERPS_ACTIVITY_ROUTE,
 } from '../../helpers/constants/routes';
+import { MUSD_CONVERSION_ROUTE } from '../musd/constants/routes';
 import { getProviderConfig } from '../../../shared/modules/selectors/networks';
 import {
   getNetworkIdentifier,
@@ -340,6 +341,10 @@ const PerpsActivityPage = mmLazy(
   (() =>
     import('../perps/perps-activity-page.tsx')) as unknown as DynamicImportType,
 );
+const MusdConversionPage = mmLazy(
+  (() => import('../musd/index.tsx')) as unknown as DynamicImportType,
+);
+// End Lazy Routes
 
 // Perps pages wrapped with PerpsControllerProvider
 const WrappedPerpsHomePage = () => (
@@ -365,8 +370,6 @@ const WrappedPerpsActivityPage = () => (
     <PerpsActivityPage />
   </PerpsControllerProvider>
 );
-
-// End Lazy Routes
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Routes() {
@@ -818,6 +821,12 @@ export default function Routes() {
       createRouteWithLayout({
         path: PERPS_MARKET_LIST_ROUTE,
         component: WrappedMarketListView,
+        layout: RootLayout,
+        authenticated: true,
+      }),
+      createRouteWithLayout({
+        path: `${MUSD_CONVERSION_ROUTE}/*`,
+        component: MusdConversionPage,
         layout: RootLayout,
         authenticated: true,
       }),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Introduce the mUSD conversion education screen as a splash page that presents the stablecoin bonus offer to users. This builds on the phase 1 mUSD conversion infrastructure.

- Add MusdEducationScreen with hero headline, bonus copy, coin illustration, and "Get started" / "Not now" CTAs
- Add MusdConversionPage entry point with nested routing, feature flag gating, and geo-blocking redirects
- Register `/earn-musd` deep link route that navigates to `/musd/education` with an `isDeeplink` query param
- Handle deeplink edge cases: geo-blocked users see a "Continue" CTA to go home; users with no eligible tokens are routed to the buy flow when available in their region
- Wire MUSD routes into the central route registry and lazy-load the page in routes.component.tsx
- Add i18n messages (en, en_GB) for education screen, conversion toasts, and deep link page title
- Add unit tests for education screen and deep link route handler

Tickets: MUSD-290, MUSD-292, MUSD-304, MUSD-350

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40280?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds musd conversion deeplink, splash page and geoblocking

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-290
Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-350
Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-304
Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-292

## **Manual testing steps**

```
Feature: mUSD Education Splash Page, Geoblocking, and Deeplinking

  Background:
    Given the user is logged in
    And the mUSD conversion feature flag is enabled

  # Deep Link
  Scenario: Deep link opens education screen with deeplink flag and forwarded params
    When the user opens deep link "/earn-musd?token=0xabc"
    Then they see "/musd/education?isDeeplink=true&token=0xabc"

  # Feature Gate
  Scenario: Feature flag disabled redirects to home
    Given the mUSD conversion feature flag is disabled
    When the user navigates to "/musd/education"
    Then they are redirected to home

  # Standard Flow
  Scenario: "Get started" begins conversion flow
    Given the user is not geo-blocked and has eligible tokens
    When the user navigates to "/musd/education"
    And taps "Get started"
    Then the conversion flow starts and education is marked seen

  Scenario: "Not now" or close icon returns home
    When the user navigates to "/musd/education"
    And taps "Not now" or the close icon
    Then they are navigated home and education is marked seen

  # Geoblocking – In-App
  Scenario: Geo-blocked in-app user is redirected before seeing education
    Given the user is geo-blocked and did not arrive via deep link
    When the user navigates to "/musd"
    Then they are redirected to home

  # Geoblocking – Deeplink
  Scenario: Geo-blocked deeplink user sees education with "Continue" CTA
    Given the user is geo-blocked
    When the user opens deep link "/earn-musd"
    Then the education screen is shown with a "Continue" button
    And tapping "Continue" navigates home without starting conversion

  # Deeplink – No Eligible Tokens
  Scenario: Deeplink user with no tokens but buy available sees "Buy mUSD"
    Given the user is not geo-blocked, has no eligible tokens, and can buy in region
    When the user opens deep link "/earn-musd"
    Then tapping "Buy mUSD" opens the buy flow and navigates home

  Scenario: Deeplink user with no tokens and no buy available sees "Continue"
    Given the user has no eligible tokens and cannot buy in region
    When the user opens deep link "/earn-musd"
    Then tapping "Continue" navigates home

  # Deeplink – Has Eligible Tokens
  Scenario: Deeplink user with eligible tokens taps "Get started"
    Given the user is not geo-blocked and has eligible tokens
    When the user opens deep link "/earn-musd"
    Then tapping "Get started" starts the conversion flow with entryPoint "deeplink"

  # Fail-Closed Geolocation
  Scenario: Geolocation API failure treats user as geo-blocked
    Given the geolocation API returns an error
    When the user navigates to "/musd"
    Then they are redirected to home
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="496" height="685" alt="Screenshot 2026-02-20 at 7 26 04 AM" src="https://github.com/user-attachments/assets/0bcc63f7-f282-4f50-b7da-e015c45db33c" />

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/250d430f8902472287e33cd4ad6d89ff

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new user-facing routing and conditional navigation (feature-flag gating, geo-blocking, deeplink query handling) that can affect access to the conversion flow, but is largely isolated to new `musd` pages/components with unit tests.
> 
> **Overview**
> Introduces an mUSD education splash experience and wires it into the extension router under `/musd/education`, gated by the `earnMusdConversionFlowEnabled` flag and with geo-blocking redirects (with special handling for deeplink users).
> 
> Adds a new deep link route `/earn-musd` that forwards query params and injects `isDeeplink=true` to land users on the education screen, plus a new home-screen primary CTA component (`MusdBuyGetCta`) that either starts the conversion flow or opens the buy flow and emits MetaMetrics events.
> 
> Updates route registries/analytics-tracked paths to include the new mUSD routes, and adds i18n strings (including toasts/headlines) and unit tests for the deep link handler, education screen, and CTA behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72a4adcf883ab86c94aadab9e696bab5d9046fed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->