### PR TITLE
chore: use tron-wallet-snap preview build for NEB-555 testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "@metamask/bridge-status-controller": "64.3.0",
     "@ledgerhq/hw-transport-webhid@npm:^6.31.0": "patch:@ledgerhq/hw-transport-webhid@npm%3A6.31.0#~/.yarn/patches/@ledgerhq-hw-transport-webhid-npm-6.31.0-efbecf27ab.patch",
     "fast-xml-parser": "^5.3.6",
-    "@metamask/snaps-controllers": "^18.0.0"
+    "@metamask/snaps-controllers": "^18.0.0",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.22.0-preview-730f5a2"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8921,10 +8921,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.21.1":
-  version: 1.21.1
-  resolution: "@metamask/tron-wallet-snap@npm:1.21.1"
-  checksum: 10/02b479ad79758dc7ddafd694f4d54ed1e928d98740fc89e489b951f0029a02aeab1f8b5a565139a2ce17c52fd1c109007ebbe27938ff7b92c539e62b35ec838d
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.22.0-preview-730f5a2":
+  version: 1.22.0-preview-730f5a2
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.22.0-preview-730f5a2"
+  checksum: 10/2c6f7dfd55f31d0d571c457105e01e7cc5d58caec0012e53b61724da2f87f69c2f25fcaeca2573345cc5f0087fad0847b768d5d17f03f2299a743ab59edb27ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

This PR installs the preview build of `@metamask-previews/tron-wallet-snap@1.22.0-preview-730f5a2` from [snap-tron-wallet#206](https://github.com/MetaMask/snap-tron-wallet/pull/206) to allow QA testing of the fix for empty IDs on derived accounts leading to state saving failures.

## References

- Snap PR: https://github.com/MetaMask/snap-tron-wallet/pull/206
- Ticket: NEB-555

## Checklist

- [ ] QA testing of account discovery flow
- [ ] Verify derived accounts persist correctly
- [ ] Confirm no state saving failures


Made with [Cursor](https://cursor.com)