### PR TITLE
ci: Ensure publish step runs when some transitive required jobs are skipped

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -726,7 +726,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    if: ${{ github.event_name == 'push' && github.ref_name == 'stable' && needs.get-requirements.outputs.needs-releases == 'true' }}
+    if: ${{ !cancelled() && needs.all-jobs-pass.result == 'success' && github.event_name == 'push' && github.ref_name == 'stable' && needs.get-requirements.outputs.needs-releases == 'true' }}
     needs:
       - get-requirements
       - all-jobs-pass


### PR DESCRIPTION
## **Description**

Our GitHub actions workflows were recently refactored (#39197) to make it easier to conditionally skip unnecessary validation steps. This refactor had an unintended consequence for the `publish-release` step: it no longer ran if _any_ preceding step was skipped.

This is because the `success()` condition is implicitly added to the `if:` condition of each step, unless some status check function is explicitly included in the condition, and `success()` only returns `true` if _all preceding jobs_ were successful (not failed, cancelled or skipped).

See https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions

The condition has been updated to only require the success of `all-jobs-pass`, which is what we wanted.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40287?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

Unfortunately we can't test this easily without triggering a release. We will do that immediately after this is merged. There is no consequence for failure (other than having to fix it)

## **Screenshots/Recordings**

The skipped publish step recently happened with v13.19.0, as can be seen here: https://github.com/MetaMask/metamask-extension/actions/runs/22200399214/job/64217105069

The full logs for that step say this:

```
2026-02-19T22:05:20.4340000Z Evaluating publish-release.if
2026-02-19T22:05:20.4340000Z Evaluating: (success() && (((github.event_name == 'push') && (github.ref_name == 'stable') && (needs.get-requirements.outputs.needs-releases == 'true'))))
2026-02-19T22:05:20.4340000Z Expanded: (false && ((github.event_name == 'push') && (github.ref_name == 'stable') && (needs.get-requirements.outputs.needs-releases == 'true')))
2026-02-19T22:05:20.4340000Z Result: false
```
This clearly shows that `success()` was evaluated as `false`. The "Locales changed only checks" step was skipped during this workflow and it _is_ a dependency of `all-jobs-pass` (which is itself a dependency of `publish-release`), which is enough to make this "not successful".

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI condition change limited to release-job gating; risk is mainly unintended publish behavior if the new condition is too permissive.
> 
> **Overview**
> Updates the `publish-release` job condition in `.github/workflows/main.yml` to explicitly require `!cancelled()` and `needs.all-jobs-pass.result == 'success'`, instead of relying on the implicit `success()` check.
> 
> This ensures stable-branch release publishing runs when some transitive prerequisite jobs are intentionally `skipped`, while still blocking on actual failures via `all-jobs-pass`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e510808335a0baea736c7038b3b95387d68650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->