### PR TITLE
feat: update mUSD claim modal to match new design

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4092,10 +4092,6 @@
     "message": "Claiming to",
     "description": "Label for the account row in the mUSD claim confirmation screen"
   },
-  "musdClaimDescription": {
-    "message": "Bonus payout will be on Linea network.",
-    "description": "Subtitle shown on the mUSD claim confirmation screen explaining rewards are on Linea"
-  },
   "musdClaimTitle": {
     "message": "Claim bonus",
     "description": "Title for the mUSD bonus claim confirmation screen"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4092,10 +4092,6 @@
     "message": "Claiming to",
     "description": "Label for the account row in the mUSD claim confirmation screen"
   },
-  "musdClaimDescription": {
-    "message": "Bonus payout will be on Linea network.",
-    "description": "Subtitle shown on the mUSD claim confirmation screen explaining rewards are on Linea"
-  },
   "musdClaimTitle": {
     "message": "Claim bonus",
     "description": "Title for the mUSD bonus claim confirmation screen"

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2334,7 +2334,6 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx": {
-      "MetaMask: Background connection not initialized": 16,
       "Reselect: Identity function warnings": 5,
       "warn: ⚠️ React Router Future Flag": 2
     },

--- a/ui/pages/confirmations/components/confirm/header/header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header.tsx
@@ -28,6 +28,7 @@ import HeaderInfo from './header-info';
 import { WalletInitiatedHeader } from './wallet-initiated-header';
 
 const CONFIRMATIONS_WITH_ALT_HEADER = [
+  TransactionType.musdClaim,
   TransactionType.simpleSend,
   TransactionType.shieldSubscriptionApprove,
   TransactionType.tokenMethodSafeTransferFrom,

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { DefaultRootState } from 'react-redux';
 import { fireEvent } from '@testing-library/react';
 
-import { getMockTokenTransferConfirmState } from '../../../../../../test/data/confirmations/helper';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import {
+  getMockConfirmStateForTransaction,
+  getMockTokenTransferConfirmState,
+} from '../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import configureStore from '../../../../../store/store';
 import * as ConfirmActions from '../../../hooks/useConfirmActions';
@@ -38,5 +45,37 @@ describe('<WalletInitiatedHeader />', () => {
     );
     fireEvent.click(getByTestId('wallet-initiated-header-back-button'));
     expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('calls onCancel without navigateBackForSend for musdClaim back button', () => {
+    const mockOnCancel = jest.fn();
+    jest.spyOn(ConfirmActions, 'useConfirmActions').mockImplementation(() => ({
+      onCancel: mockOnCancel,
+      resetTransactionState: jest.fn(),
+    }));
+
+    const musdClaimState = getMockConfirmStateForTransaction({
+      id: 'musd-claim-id',
+      chainId: '0xe708',
+      type: TransactionType.musdClaim,
+      status: TransactionStatus.unapproved,
+      time: Date.now(),
+      origin: 'metamask',
+      txParams: {
+        from: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+        to: '0x1234567890abcdef1234567890abcdef12345678',
+        value: '0x0',
+      },
+    } as Parameters<typeof getMockConfirmStateForTransaction>[0]);
+
+    const { getByTestId } = render(musdClaimState);
+    fireEvent.click(getByTestId('wallet-initiated-header-back-button'));
+
+    expect(mockOnCancel).toHaveBeenCalledWith(
+      expect.objectContaining({ location: 'confirmation' }),
+    );
+    expect(mockOnCancel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ navigateBackForSend: true }),
+    );
   });
 });

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 import { DefaultRootState } from 'react-redux';
 import { fireEvent } from '@testing-library/react';
 
-import {
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
-import {
-  getMockConfirmStateForTransaction,
-  getMockTokenTransferConfirmState,
-} from '../../../../../../test/data/confirmations/helper';
+import { getMockTokenTransferConfirmState } from '../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import configureStore from '../../../../../store/store';
 import * as ConfirmActions from '../../../hooks/useConfirmActions';
@@ -45,37 +38,5 @@ describe('<WalletInitiatedHeader />', () => {
     );
     fireEvent.click(getByTestId('wallet-initiated-header-back-button'));
     expect(mockOnCancel).toHaveBeenCalled();
-  });
-
-  it('calls onCancel without navigateBackForSend for musdClaim back button', () => {
-    const mockOnCancel = jest.fn();
-    jest.spyOn(ConfirmActions, 'useConfirmActions').mockImplementation(() => ({
-      onCancel: mockOnCancel,
-      resetTransactionState: jest.fn(),
-    }));
-
-    const musdClaimState = getMockConfirmStateForTransaction({
-      id: 'musd-claim-id',
-      chainId: '0xe708',
-      type: TransactionType.musdClaim,
-      status: TransactionStatus.unapproved,
-      time: Date.now(),
-      origin: 'metamask',
-      txParams: {
-        from: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-        to: '0x1234567890abcdef1234567890abcdef12345678',
-        value: '0x0',
-      },
-    } as Parameters<typeof getMockConfirmStateForTransaction>[0]);
-
-    const { getByTestId } = render(musdClaimState);
-    fireEvent.click(getByTestId('wallet-initiated-header-back-button'));
-
-    expect(mockOnCancel).toHaveBeenCalledWith(
-      expect.objectContaining({ location: 'confirmation' }),
-    );
-    expect(mockOnCancel).not.toHaveBeenCalledWith(
-      expect.objectContaining({ navigateBackForSend: true }),
-    );
   });
 });

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -43,6 +43,11 @@ export const WalletInitiatedHeader = () => {
       return;
     }
 
+    if (currentConfirmation.type === TransactionType.musdClaim) {
+      onCancel({ location: MetaMetricsEventLocation.Confirmation });
+      return;
+    }
+
     const isNativeSend =
       currentConfirmation.type === TransactionType.simpleSend;
     const isERC20TokenSend =

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -38,10 +38,12 @@ export const EditGasFeesRow = ({
   fiatFee,
   fiatFeeWith18SignificantDigits,
   nativeFee,
+  hideEditIcon,
 }: {
   fiatFee: string;
   fiatFeeWith18SignificantDigits: string | null;
   nativeFee: string;
+  hideEditIcon?: boolean;
 }) => {
   const t = useI18nContext();
 
@@ -83,7 +85,10 @@ export const EditGasFeesRow = ({
   }
 
   const isGasFeeEditable =
-    !isQuotedSwapDisplayedInInfo && !gasFeeToken && !isGasFeeSponsored;
+    !hideEditIcon &&
+    !isQuotedSwapDisplayedInInfo &&
+    !gasFeeToken &&
+    !isGasFeeSponsored;
   const shouldShowPrimaryFiatValue =
     showFiat && hasFiatValue && !showAdvancedDetails && !isGasFeeSponsored;
 

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -38,12 +38,12 @@ export const EditGasFeesRow = ({
   fiatFee,
   fiatFeeWith18SignificantDigits,
   nativeFee,
-  hideEditIcon,
+  disableUpdate,
 }: {
   fiatFee: string;
   fiatFeeWith18SignificantDigits: string | null;
   nativeFee: string;
-  hideEditIcon?: boolean;
+  disableUpdate?: boolean;
 }) => {
   const t = useI18nContext();
 
@@ -85,7 +85,7 @@ export const EditGasFeesRow = ({
   }
 
   const isGasFeeEditable =
-    !hideEditIcon &&
+    !disableUpdate &&
     !isQuotedSwapDisplayedInInfo &&
     !gasFeeToken &&
     !isGasFeeSponsored;

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {
   SimulationError,
+  TransactionType,
   UserFeeLevel,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
@@ -169,5 +170,33 @@ describe('<GasFeesDetails />', () => {
 
       expect(getByTestId('gas-fee-details-speed')).toBeInTheDocument();
     });
+  });
+
+  it('does not render speed row for musdClaim transactions', async () => {
+    const confirmation = {
+      ...genUnapprovedContractInteractionConfirmation({}),
+      type: TransactionType.musdClaim,
+    };
+    const store = configureStore(
+      getMockConfirmStateForTransaction(confirmation, {
+        metamask: {
+          preferences: {
+            showFiatInTestnets: true,
+            showConfirmationAdvancedDetails: false,
+          },
+        },
+      }),
+    );
+
+    const { queryByTestId } = renderWithConfirmContextProvider(
+      <GasFeesDetails />,
+      store,
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(queryByTestId('gas-fee-details-speed')).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Box } from '../../../../../../../components/component-library';
@@ -58,12 +61,15 @@ export const GasFeesDetails = (): JSX.Element | null => {
     return null;
   }
 
+  const isSimpleGasFee = transactionMeta.type === TransactionType.musdClaim;
+
   return (
     <>
       <EditGasFeesRow
         fiatFee={estimatedFeeFiat}
         fiatFeeWith18SignificantDigits={estimatedFeeFiatWith18SignificantDigits}
         nativeFee={estimatedFeeNative}
+        hideEditIcon={isSimpleGasFee}
       />
       {showAdvancedDetails &&
         hasLayer1GasFee &&
@@ -88,7 +94,8 @@ export const GasFeesDetails = (): JSX.Element | null => {
             />
           </>
         )}
-      {supportsEIP1559 &&
+      {!isSimpleGasFee &&
+        supportsEIP1559 &&
         !transactionMeta.selectedGasFeeToken &&
         !transactionMeta.isGasFeeSponsored && (
           <ConfirmInfoAlertRow

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -69,7 +69,7 @@ export const GasFeesDetails = (): JSX.Element | null => {
         fiatFee={estimatedFeeFiat}
         fiatFeeWith18SignificantDigits={estimatedFeeFiatWith18SignificantDigits}
         nativeFee={estimatedFeeNative}
-        hideEditIcon={isSimpleGasFee}
+        disableUpdate={isSimpleGasFee}
       />
       {showAdvancedDetails &&
         hasLayer1GasFee &&

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -115,9 +115,6 @@ const getTitle = (
     case TransactionType.contractInteraction:
       title = t('confirmTitleTransaction');
       break;
-    case TransactionType.musdClaim:
-      title = t('musdClaimTitle');
-      break;
     case TransactionType.batch:
       title = isUpgradeOnly
         ? t('confirmTitleAccountTypeSwitch')
@@ -194,8 +191,6 @@ const getDescription = (
   switch (confirmation?.type) {
     case TransactionType.contractInteraction:
       return '';
-    case TransactionType.musdClaim:
-      return t('musdClaimDescription');
     case TransactionType.batch:
       if (isUpgradeOnly) {
         return t('confirmTitleDescDelegationUpgrade');

--- a/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-heading.tsx
+++ b/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-heading.tsx
@@ -11,8 +11,14 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+} from '../../../../../components/component-library';
+import { getAvatarNetworkColor } from '../../../../../helpers/utils/accounts';
 import { Skeleton } from '../../../../../components/component-library/skeleton';
 import { useConfirmContext } from '../../../context/confirm';
+import useConfirmationNetworkInfo from '../../../hooks/useConfirmationNetworkInfo';
 import { useMerklClaimAmount } from '../../../hooks/musd/useMerklClaimAmount';
 
 const MUSD_ICON_SRC = './images/musd-icon-no-background-2x.png';
@@ -25,12 +31,27 @@ const MusdClaimHeading = () => {
   const { displayClaimAmount, fiatDisplayValue, pending } =
     useMerklClaimAmount(transactionMeta);
 
+  const { networkImageUrl, networkDisplayName } = useConfirmationNetworkInfo();
+
   const TokenImage = (
-    <AvatarToken
-      src={MUSD_ICON_SRC}
-      name={MUSD_SYMBOL}
-      size={AvatarTokenSize.Xl}
-    />
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
+      <AvatarToken
+        src={MUSD_ICON_SRC}
+        name={MUSD_SYMBOL}
+        size={AvatarTokenSize.Xl}
+      />
+      <AvatarNetwork
+        src={networkImageUrl}
+        name={networkDisplayName}
+        size={AvatarNetworkSize.Xs}
+        backgroundColor={getAvatarNetworkColor(networkDisplayName)}
+        style={{
+          position: 'absolute',
+          right: -2,
+          bottom: -2,
+        }}
+      />
+    </div>
   );
 
   const TokenValueSkeleton = (

--- a/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
@@ -55,6 +55,11 @@ jest.mock('../../../../../store/actions', () => ({
   }),
 }));
 
+jest.mock('../../../../../store/background-connection', () => ({
+  ...jest.requireActual('../../../../../store/background-connection'),
+  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('../../../../../components/app/musd/merkl-client', () => ({
   getClaimedAmountFromContract: jest.fn().mockResolvedValue(null),
 }));

--- a/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
@@ -129,34 +129,4 @@ describe('MusdClaimInfo', () => {
       expect(result.getByTestId('gas-fee-section')).toBeDefined();
     });
   });
-
-  it('renders claiming-to and network in separate sections', async () => {
-    const transaction = buildMusdClaimTransaction();
-    const state = getMockConfirmState({
-      metamask: {
-        pendingApprovals: {
-          [transaction.id]: {
-            id: transaction.id,
-            type: ApprovalType.Transaction,
-          },
-        },
-        transactions: [transaction],
-      },
-    });
-    const mockStore = configureMockStore()(state);
-
-    let result: ReturnType<typeof renderWithConfirmContextProvider>;
-    await act(async () => {
-      result = renderWithConfirmContextProvider(<MusdClaimInfo />, mockStore);
-
-      const claimingToSection = result.getByTestId(
-        'musd-claim-details-section',
-      );
-      const networkSection = result.getByTestId('musd-claim-network-section');
-
-      // Sections are separate DOM elements
-      expect(claimingToSection).not.toBe(networkSection);
-      expect(claimingToSection.contains(networkSection)).toBe(false);
-    });
-  });
 });

--- a/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.test.tsx
@@ -124,4 +124,34 @@ describe('MusdClaimInfo', () => {
       expect(result.getByTestId('gas-fee-section')).toBeDefined();
     });
   });
+
+  it('renders claiming-to and network in separate sections', async () => {
+    const transaction = buildMusdClaimTransaction();
+    const state = getMockConfirmState({
+      metamask: {
+        pendingApprovals: {
+          [transaction.id]: {
+            id: transaction.id,
+            type: ApprovalType.Transaction,
+          },
+        },
+        transactions: [transaction],
+      },
+    });
+    const mockStore = configureMockStore()(state);
+
+    let result: ReturnType<typeof renderWithConfirmContextProvider>;
+    await act(async () => {
+      result = renderWithConfirmContextProvider(<MusdClaimInfo />, mockStore);
+
+      const claimingToSection = result.getByTestId(
+        'musd-claim-details-section',
+      );
+      const networkSection = result.getByTestId('musd-claim-network-section');
+
+      // Sections are separate DOM elements
+      expect(claimingToSection).not.toBe(networkSection);
+      expect(claimingToSection.contains(networkSection)).toBe(false);
+    });
+  });
 });

--- a/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
+++ b/ui/pages/confirmations/components/info/musd-claim-info/musd-claim-info.tsx
@@ -25,7 +25,9 @@ export const MusdClaimInfo = () => {
     <>
       <MusdClaimHeading />
       <ConfirmInfoSection data-testid="musd-claim-details-section">
-        <AccountRow label={t('musdClaimClaimingTo')} />
+        <AccountRow label={t('musdClaimClaimingTo')} showChevron />
+      </ConfirmInfoSection>
+      <ConfirmInfoSection data-testid="musd-claim-network-section">
         <NetworkRow />
       </ConfirmInfoSection>
       <GasFeesSection />

--- a/ui/pages/confirmations/components/rows/account-row/account-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/account-row/account-row.test.tsx
@@ -122,4 +122,58 @@ describe('AccountRow', () => {
       expect(result.getByText('Sending from')).toBeDefined();
     });
   });
+
+  it('renders chevron icon when showChevron is true', async () => {
+    const transaction = buildTransaction();
+    const state = getMockConfirmState({
+      metamask: {
+        pendingApprovals: {
+          [transaction.id]: {
+            id: transaction.id,
+            type: ApprovalType.Transaction,
+          },
+        },
+        transactions: [transaction],
+      },
+    });
+    const mockStore = configureMockStore()(state);
+
+    let result: ReturnType<typeof renderWithConfirmContextProvider>;
+    await act(async () => {
+      result = renderWithConfirmContextProvider(
+        <AccountRow label="Claiming to" showChevron />,
+        mockStore,
+      );
+      expect(
+        result.container.querySelector('.mm-icon--name-arrow-right'),
+      ).toBeDefined();
+    });
+  });
+
+  it('does not render chevron icon by default', async () => {
+    const transaction = buildTransaction();
+    const state = getMockConfirmState({
+      metamask: {
+        pendingApprovals: {
+          [transaction.id]: {
+            id: transaction.id,
+            type: ApprovalType.Transaction,
+          },
+        },
+        transactions: [transaction],
+      },
+    });
+    const mockStore = configureMockStore()(state);
+
+    let result: ReturnType<typeof renderWithConfirmContextProvider>;
+    await act(async () => {
+      result = renderWithConfirmContextProvider(
+        <AccountRow label="Claiming to" />,
+        mockStore,
+      );
+      expect(
+        result.container.querySelector('.mm-icon--name-arrow-right'),
+      ).toBeNull();
+    });
+  });
 });

--- a/ui/pages/confirmations/components/rows/account-row/account-row.tsx
+++ b/ui/pages/confirmations/components/rows/account-row/account-row.tsx
@@ -1,5 +1,16 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import React from 'react';
+import {
+  Icon,
+  IconName,
+  IconSize,
+  Box,
+} from '../../../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  IconColor,
+} from '../../../../../helpers/constants/design-system';
 import { useConfirmContext } from '../../../context/confirm';
 import {
   ConfirmInfoRow,
@@ -8,18 +19,28 @@ import {
 
 type AccountRowProps = {
   label: string;
+  showChevron?: boolean;
 };
 
-export const AccountRow = ({ label }: AccountRowProps) => {
+export const AccountRow = ({ label, showChevron }: AccountRowProps) => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
   return (
     <ConfirmInfoRow label={label}>
-      <ConfirmInfoRowAddress
-        address={transactionMeta.txParams.from}
-        chainId={transactionMeta.chainId}
-      />
+      <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+        <ConfirmInfoRowAddress
+          address={transactionMeta.txParams.from}
+          chainId={transactionMeta.chainId}
+        />
+        {showChevron && (
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            color={IconColor.iconDefault}
+          />
+        )}
+      </Box>
     </ConfirmInfoRow>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the design of musd rewards claiming modal to properly match the designs in figma

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40291?quickstart=1)

## **Changelog**
CHANGELOG entry: Changed styling of the MUSD rewards claiming modal

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
[MUSD-302](https://consensyssoftware.atlassian.net/browse/MUSD-302)

## **Manual testing steps**

1. Enable the earnMerklCampaignClaiming remote feature flag (e.g. via .manifest-overrides.json)
2. Ensure you have an account holding mUSD on Mainnet or Linea with unclaimed Merkl rewards
3. On the tokens list, click `Claim Bonus` - verify that the modal which appears is styled correctly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="525" height="1005" alt="image" src="https://github.com/user-attachments/assets/af2e1b76-99a9-4202-bfa9-2c5ce737a43d" />


### **After**
<img width="536" height="1030" alt="image" src="https://github.com/user-attachments/assets/4c1683c2-e2d7-4bf3-8f32-e0bf2767f3c7" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation UX and navigation behavior for `TransactionType.musdClaim`, including disabling gas fee edits and altering back/cancel handling, which could affect how users review and submit these transactions. Scope is limited to the mUSD claim flow and associated shared rows/components.
> 
> **Overview**
> Updates the `mUSD` claim confirmation to match the new design by switching it to the alternate confirmation header, adding a network badge overlay to the token hero, and restructuring the info sections (separate network section and a chevron affordance on the account row).
> 
> Simplifies gas presentation for `musdClaim` by disabling gas fee editing and hiding the EIP-1559 *Speed* row, and adjusts wallet-initiated back behavior to cancel the confirmation instead of navigating.
> 
> Cleans up copy by removing the `musdClaimDescription` locale string and corresponding title/description handling, and updates/extends unit tests and the console baseline to reflect the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d9a1323c0267221ec5f804006c2b1ca646ae362. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUSD-302]: https://consensyssoftware.atlassian.net/browse/MUSD-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ