### PR TITLE
fix: hide claim bonus badge when no rewards are available

### DIFF
--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -59,7 +59,7 @@ jest.mock('react-router-dom', () => {
 jest.mock('../../musd', () => ({
   ClaimBonusBadge: () => null,
   isEligibleForMerklRewards: jest.fn().mockReturnValue(false),
-  useMerklRewards: jest.fn().mockReturnValue({ claimableReward: null }),
+  useMerklRewards: jest.fn().mockReturnValue({ hasClaimableReward: false }),
 }));
 
 describe('Token Cell', () => {

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -56,6 +56,12 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../musd', () => ({
+  ClaimBonusBadge: () => null,
+  isEligibleForMerklRewards: jest.fn().mockReturnValue(false),
+  useMerklRewards: jest.fn().mockReturnValue({ claimableReward: null }),
+}));
+
 describe('Token Cell', () => {
   const mockState = {
     metamask: {

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -110,7 +110,8 @@ export default function TokenCell({
             privacyMode={privacyMode}
           />
         }
-        footerLeftDisplay={
+        footerLeftDisplay={<TokenCellPercentChange token={displayToken} />}
+        footerRightDisplay={
           hasClaimableReward ? (
             <ClaimBonusBadge
               tokenAddress={token.address as string}
@@ -119,14 +120,11 @@ export default function TokenCell({
               refetchRewards={refetchMerklRewards}
             />
           ) : (
-            <TokenCellPercentChange token={displayToken} />
+            <TokenCellPrimaryDisplay
+              token={displayToken}
+              privacyMode={privacyMode}
+            />
           )
-        }
-        footerRightDisplay={
-          <TokenCellPrimaryDisplay
-            token={displayToken}
-            privacyMode={privacyMode}
-          />
         }
       />
       {isEvm && showScamWarningModal && (

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { Hex } from '@metamask/utils';
 import { useTokenDisplayInfo } from '../hooks';
@@ -23,12 +23,7 @@ import { type TokenWithFiatAmount } from '../types';
 import GenericAssetCellLayout from '../asset-list/cells/generic-asset-cell-layout';
 import { AssetCellBadge } from '../asset-list/cells/asset-cell-badge';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
-import {
-  ClaimBonusBadge,
-  isEligibleForMerklRewards,
-  useMerklRewards,
-} from '../../musd';
-import { getMerklRewardsEnabled } from '../../musd/selectors';
+import { ClaimBonusBadge, useMerklRewards } from '../../musd';
 import {
   TokenCellTitle,
   TokenCellPercentChange,
@@ -66,21 +61,11 @@ export default function TokenCell({
   );
   const [showScamWarningModal, setShowScamWarningModal] = useState(false);
 
-  const merklRewardsEnabled = useSelector(getMerklRewardsEnabled);
-
-  const showClaimBonusBadge = useMemo(
-    () =>
-      showMerklBadge &&
-      merklRewardsEnabled &&
-      isEligibleForMerklRewards(token.chainId, token.address),
-    [showMerklBadge, merklRewardsEnabled, token.chainId, token.address],
-  );
-
   // Check whether there are rewards available for the user
   const { claimableReward, refetch: refetchMerklRewards } = useMerklRewards({
     tokenAddress: token.address,
     chainId: token.chainId as Hex,
-    isEligible: showClaimBonusBadge,
+    showMerklBadge,
   });
 
   const tokenDisplayInfo = useTokenDisplayInfo({

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -23,7 +23,11 @@ import { type TokenWithFiatAmount } from '../types';
 import GenericAssetCellLayout from '../asset-list/cells/generic-asset-cell-layout';
 import { AssetCellBadge } from '../asset-list/cells/asset-cell-badge';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
-import { ClaimBonusBadge, isEligibleForMerklRewards } from '../../musd';
+import {
+  ClaimBonusBadge,
+  isEligibleForMerklRewards,
+  useMerklRewards,
+} from '../../musd';
 import { getMerklRewardsEnabled } from '../../musd/selectors';
 import {
   TokenCellTitle,
@@ -72,6 +76,13 @@ export default function TokenCell({
     [showMerklBadge, merklRewardsEnabled, token.chainId, token.address],
   );
 
+  // Check whether there are rewards available for the user
+  const { claimableReward, refetch: refetchMerklRewards } = useMerklRewards({
+    tokenAddress: token.address,
+    chainId: token.chainId as Hex,
+    isEligible: showClaimBonusBadge,
+  });
+
   const tokenDisplayInfo = useTokenDisplayInfo({
     token,
     fixCurrencyToUSD,
@@ -115,12 +126,12 @@ export default function TokenCell({
           />
         }
         footerLeftDisplay={
-          showClaimBonusBadge ? (
+          claimableReward ? (
             <ClaimBonusBadge
               tokenAddress={token.address as string}
               chainId={token.chainId as Hex}
               label={t('merklRewardsClaimBonus')}
-              fallback={<TokenCellPercentChange token={displayToken} />}
+              refetchRewards={refetchMerklRewards}
             />
           ) : (
             <TokenCellPercentChange token={displayToken} />

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -62,7 +62,7 @@ export default function TokenCell({
   const [showScamWarningModal, setShowScamWarningModal] = useState(false);
 
   // Check whether there are rewards available for the user
-  const { claimableReward, refetch: refetchMerklRewards } = useMerklRewards({
+  const { hasClaimableReward, refetch: refetchMerklRewards } = useMerklRewards({
     tokenAddress: token.address,
     chainId: token.chainId as Hex,
     showMerklBadge,
@@ -111,7 +111,7 @@ export default function TokenCell({
           />
         }
         footerLeftDisplay={
-          claimableReward ? (
+          hasClaimableReward ? (
             <ClaimBonusBadge
               tokenAddress={token.address as string}
               chainId={token.chainId as Hex}

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -120,6 +120,7 @@ export default function TokenCell({
               tokenAddress={token.address as string}
               chainId={token.chainId as Hex}
               label={t('merklRewardsClaimBonus')}
+              fallback={<TokenCellPercentChange token={displayToken} />}
             />
           ) : (
             <TokenCellPercentChange token={displayToken} />

--- a/ui/components/app/musd/claim-bonus-badge.tsx
+++ b/ui/components/app/musd/claim-bonus-badge.tsx
@@ -13,30 +13,22 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMerklClaim } from './hooks/useMerklClaim';
 import { useOnMerklClaimConfirmed } from './hooks/useOnMerklClaimConfirmed';
-import { useMerklRewards } from './hooks/useMerklRewards';
 
 export const ClaimBonusBadge = ({
   label,
   tokenAddress,
   chainId,
-  fallback,
+  refetchRewards,
 }: {
   label: string;
   tokenAddress: string;
   chainId: Hex;
-  /** A react element that will be shown in the case that there are no bonuses to claim */
-  fallback: React.ReactElement;
+  refetchRewards: () => void;
 }) => {
   const t = useI18nContext();
 
-  // Check whether there are rewards available for the user
-  const { claimableReward, refetch } = useMerklRewards({
-    tokenAddress,
-    chainId,
-  });
-
   // Refetch rewards when a pending claim is confirmed
-  useOnMerklClaimConfirmed(refetch);
+  useOnMerklClaimConfirmed(refetchRewards);
 
   const { claimRewards, isClaiming, error } = useMerklClaim({
     tokenAddress,
@@ -50,10 +42,6 @@ export const ClaimBonusBadge = ({
     },
     [claimRewards],
   );
-
-  if (!claimableReward) {
-    return fallback;
-  }
 
   if (isClaiming) {
     return (

--- a/ui/components/app/musd/claim-bonus-badge.tsx
+++ b/ui/components/app/musd/claim-bonus-badge.tsx
@@ -19,10 +19,13 @@ export const ClaimBonusBadge = ({
   label,
   tokenAddress,
   chainId,
+  fallback,
 }: {
   label: string;
   tokenAddress: string;
   chainId: Hex;
+  /** A react element that will be shown in the case that there are no bonuses to claim */
+  fallback: React.ReactElement;
 }) => {
   const t = useI18nContext();
 
@@ -49,7 +52,7 @@ export const ClaimBonusBadge = ({
   );
 
   if (!claimableReward) {
-    return null;
+    return fallback;
   }
 
   if (isClaiming) {

--- a/ui/components/app/musd/claim-bonus-badge.tsx
+++ b/ui/components/app/musd/claim-bonus-badge.tsx
@@ -12,6 +12,8 @@ import {
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMerklClaim } from './hooks/useMerklClaim';
+import { useOnMerklClaimConfirmed } from './hooks/useOnMerklClaimConfirmed';
+import { useMerklRewards } from './hooks/useMerklRewards';
 
 export const ClaimBonusBadge = ({
   label,
@@ -23,6 +25,16 @@ export const ClaimBonusBadge = ({
   chainId: Hex;
 }) => {
   const t = useI18nContext();
+
+  // Check whether there are rewards available for the user
+  const { claimableReward, refetch } = useMerklRewards({
+    tokenAddress,
+    chainId,
+  });
+
+  // Refetch rewards when a pending claim is confirmed
+  useOnMerklClaimConfirmed(refetch);
+
   const { claimRewards, isClaiming, error } = useMerklClaim({
     tokenAddress,
     chainId,
@@ -35,6 +47,10 @@ export const ClaimBonusBadge = ({
     },
     [claimRewards],
   );
+
+  if (!claimableReward) {
+    return null;
+  }
 
   if (isClaiming) {
     return (

--- a/ui/components/app/musd/hooks/useMerklClaim.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.ts
@@ -12,7 +12,6 @@ import {
   DISTRIBUTOR_CLAIM_ABI,
   MERKL_CLAIM_CHAIN_ID,
   MERKL_DISTRIBUTOR_ADDRESS,
-  ELIGIBLE_TOKENS,
 } from '../constants';
 import { fetchMerklRewardsForAsset } from '../merkl-client';
 import type { MetaMaskReduxDispatch } from '../../../../store/store';
@@ -133,30 +132,4 @@ export const useMerklClaim = ({
     isClaiming,
     error,
   };
-};
-
-/**
- * Check if a token is eligible for Merkl rewards.
- * Compares addresses case-insensitively since Ethereum addresses are case-insensitive.
- * Returns false for native tokens (undefined/null address).
- *
- * @param chainId - The chain ID of the token
- * @param address - The token's contract address
- * @returns Whether the token is eligible for Merkl rewards
- */
-export const isEligibleForMerklRewards = (
-  chainId: string,
-  address: string | undefined | null,
-): boolean => {
-  if (!address) {
-    return false;
-  }
-  const eligibleAddresses = ELIGIBLE_TOKENS[chainId];
-  if (!eligibleAddresses) {
-    return false;
-  }
-  const addressLower = address.toLowerCase();
-  return eligibleAddresses.some(
-    (eligibleAddress) => eligibleAddress.toLowerCase() === addressLower,
-  );
 };

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -5,11 +5,7 @@ import {
   AGLAMERKL_ADDRESS_LINEA,
   MUSD_TOKEN_ADDRESS,
 } from '../constants';
-import {
-  isEligibleForMerklRewards,
-  useMerklRewards,
-  formatClaimableAmount,
-} from './useMerklRewards';
+import { isEligibleForMerklRewards, useMerklRewards } from './useMerklRewards';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -28,7 +24,9 @@ const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 
 /**
  * Helper to set up useSelector mock.
- * The hook only calls useSelector once (for the selected account).
+ * The hook calls useSelector twice: once for getMerklRewardsEnabled and once
+ * for the selected account. mockReturnValue covers both (truthy object for the
+ * feature flag, correct shape for the account).
  *
  * @param overrides - Optional overrides
  * @param overrides.account - The mock account object
@@ -85,42 +83,6 @@ describe('isEligibleForMerklRewards', () => {
   });
 });
 
-describe('formatClaimableAmount', () => {
-  it('returns null for zero amount', () => {
-    expect(formatClaimableAmount(0n, 18)).toBeNull();
-  });
-
-  it('returns null for negative amount', () => {
-    expect(formatClaimableAmount(-1n, 18)).toBeNull();
-  });
-
-  it('returns "< 0.01" for very small amounts', () => {
-    // 1 wei of an 18-decimal token
-    expect(formatClaimableAmount(1n, 18)).toBe('< 0.01');
-  });
-
-  it('formats amount with 2 decimal places', () => {
-    // 1.5 tokens with 6 decimals = 1500000
-    expect(formatClaimableAmount(1500000n, 6)).toBe('1.50');
-  });
-
-  it('formats large amounts correctly', () => {
-    // 100.99 tokens with 6 decimals = 100990000
-    expect(formatClaimableAmount(100990000n, 6)).toBe('100.99');
-  });
-
-  it('formats small but displayable amounts', () => {
-    // 0.02 tokens with 6 decimals = 20000
-    expect(formatClaimableAmount(20000n, 6)).toBe('0.02');
-  });
-
-  it('returns null when amount rounds to 0.00', () => {
-    // Amount so small it rounds to 0.00 but > 0
-    // This would be handled by the < 0.01 check
-    expect(formatClaimableAmount(1n, 6)).toBe('< 0.01');
-  });
-});
-
 describe('useMerklRewards', () => {
   const mockFetchMerklRewardsForAsset =
     merklClient.fetchMerklRewardsForAsset as jest.MockedFunction<
@@ -138,20 +100,20 @@ describe('useMerklRewards', () => {
     mockGetClaimedAmountFromContract.mockResolvedValue(null);
   });
 
-  it('returns null claimableReward for ineligible token', () => {
+  it('returns false for ineligible token', () => {
     const { result } = renderHook(() =>
       useMerklRewards({
         tokenAddress: '0xunknown',
         chainId: '0x1' as `0x${string}`,
-        isEligible: false,
+        showMerklBadge: false,
       }),
     );
 
-    expect(result.current.claimableReward).toBeNull();
+    expect(result.current.hasClaimableReward).toBe(false);
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
   });
 
-  it('fetches and formats claimable reward using API claimed value as fallback', async () => {
+  it('returns true when claimable reward exists using API claimed value as fallback', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
       token: {
         address: MUSD_TOKEN_ADDRESS,
@@ -173,7 +135,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -181,7 +143,7 @@ describe('useMerklRewards', () => {
       await waitForNextUpdate();
     });
 
-    expect(result.current.claimableReward).toBe('10.50');
+    expect(result.current.hasClaimableReward).toBe(true);
   });
 
   it('uses on-chain claimed amount when available', async () => {
@@ -206,7 +168,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -215,14 +177,14 @@ describe('useMerklRewards', () => {
     });
 
     // 10.5 - 5.5 = 5.0 MUSD claimable
-    expect(result.current.claimableReward).toBe('5.00');
+    expect(result.current.hasClaimableReward).toBe(true);
     expect(mockGetClaimedAmountFromContract).toHaveBeenCalledWith(
       MOCK_ADDRESS,
       MUSD_TOKEN_ADDRESS,
     );
   });
 
-  it('returns null when on-chain shows all claimed', async () => {
+  it('returns false when on-chain shows all claimed', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
       token: {
         address: MUSD_TOKEN_ADDRESS,
@@ -244,7 +206,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -252,17 +214,17 @@ describe('useMerklRewards', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(result.current.claimableReward).toBeNull();
+    expect(result.current.hasClaimableReward).toBe(false);
   });
 
-  it('returns null when API returns no matching reward', async () => {
+  it('returns false when API returns no matching reward', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
 
     const { result } = renderHook(() =>
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -272,10 +234,10 @@ describe('useMerklRewards', () => {
     });
 
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
-    expect(result.current.claimableReward).toBeNull();
+    expect(result.current.hasClaimableReward).toBe(false);
   });
 
-  it('returns null when all rewards are claimed (API)', async () => {
+  it('returns false when all rewards are claimed (API)', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
       token: {
         address: MUSD_TOKEN_ADDRESS,
@@ -295,7 +257,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -303,7 +265,7 @@ describe('useMerklRewards', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(result.current.claimableReward).toBeNull();
+    expect(result.current.hasClaimableReward).toBe(false);
   });
 
   it('handles API errors gracefully', async () => {
@@ -316,7 +278,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -325,7 +287,7 @@ describe('useMerklRewards', () => {
     });
 
     expect(consoleSpy).toHaveBeenCalled();
-    expect(result.current.claimableReward).toBeNull();
+    expect(result.current.hasClaimableReward).toBe(false);
     consoleSpy.mockRestore();
   });
 
@@ -337,7 +299,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -369,7 +331,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
-        isEligible: true,
+        showMerklBadge: true,
       }),
     );
 
@@ -378,6 +340,6 @@ describe('useMerklRewards', () => {
     });
 
     // Falls back to API value (claimed=0), so full amount is claimable
-    expect(result.current.claimableReward).toBe('10.50');
+    expect(result.current.hasClaimableReward).toBe(true);
   });
 });

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -18,6 +18,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../merkl-client');
 
+jest.mock('..', () => ({
+  useOnMerklClaimConfirmed: jest.fn(),
+}));
+
 const { useSelector } = jest.requireMock('react-redux');
 
 const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
@@ -139,6 +143,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: '0xunknown',
         chainId: '0x1' as `0x${string}`,
+        isEligible: false,
       }),
     );
 
@@ -168,6 +173,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -200,6 +206,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -237,6 +244,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -254,6 +262,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -286,6 +295,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -306,6 +316,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -326,6 +337,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 
@@ -357,6 +369,7 @@ describe('useMerklRewards', () => {
       useMerklRewards({
         tokenAddress: MUSD_TOKEN_ADDRESS,
         chainId: '0x1' as `0x${string}`,
+        isEligible: true,
       }),
     );
 

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -1,0 +1,370 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as merklClient from '../merkl-client';
+import {
+  AGLAMERKL_ADDRESS_MAINNET,
+  AGLAMERKL_ADDRESS_LINEA,
+  MUSD_TOKEN_ADDRESS,
+} from '../constants';
+import {
+  isEligibleForMerklRewards,
+  useMerklRewards,
+  formatClaimableAmount,
+} from './useMerklRewards';
+
+// Mock dependencies
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../merkl-client');
+
+const { useSelector } = jest.requireMock('react-redux');
+
+const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+/**
+ * Helper to set up useSelector mock.
+ * The hook only calls useSelector once (for the selected account).
+ *
+ * @param overrides - Optional overrides
+ * @param overrides.account - The mock account object
+ */
+const setupSelectorMock = (overrides: { account?: unknown } = {}) => {
+  const account = overrides.account ?? { address: MOCK_ADDRESS };
+  useSelector.mockReturnValue(account);
+};
+
+describe('isEligibleForMerklRewards', () => {
+  it('returns true for mUSD on mainnet', () => {
+    expect(isEligibleForMerklRewards('0x1', MUSD_TOKEN_ADDRESS)).toBe(true);
+  });
+
+  it('returns true for mUSD on Linea', () => {
+    expect(isEligibleForMerklRewards('0xe708', MUSD_TOKEN_ADDRESS)).toBe(true);
+  });
+
+  it('returns true for test token on mainnet', () => {
+    expect(isEligibleForMerklRewards('0x1', AGLAMERKL_ADDRESS_MAINNET)).toBe(
+      true,
+    );
+  });
+
+  it('returns true for test token on Linea', () => {
+    expect(isEligibleForMerklRewards('0xe708', AGLAMERKL_ADDRESS_LINEA)).toBe(
+      true,
+    );
+  });
+
+  it('returns false for unsupported chain', () => {
+    expect(isEligibleForMerklRewards('0x89', MUSD_TOKEN_ADDRESS)).toBe(false);
+  });
+
+  it('returns false for unsupported token on supported chain', () => {
+    expect(isEligibleForMerklRewards('0x1', '0xunknowntoken')).toBe(false);
+  });
+
+  it('returns false for null address', () => {
+    expect(isEligibleForMerklRewards('0x1', null)).toBe(false);
+  });
+
+  it('returns false for undefined address', () => {
+    expect(isEligibleForMerklRewards('0x1', undefined)).toBe(false);
+  });
+
+  it('is case-insensitive for address comparison', () => {
+    expect(
+      isEligibleForMerklRewards('0x1', MUSD_TOKEN_ADDRESS.toLowerCase()),
+    ).toBe(true);
+    expect(
+      isEligibleForMerklRewards('0x1', MUSD_TOKEN_ADDRESS.toUpperCase()),
+    ).toBe(true);
+  });
+});
+
+describe('formatClaimableAmount', () => {
+  it('returns null for zero amount', () => {
+    expect(formatClaimableAmount(0n, 18)).toBeNull();
+  });
+
+  it('returns null for negative amount', () => {
+    expect(formatClaimableAmount(-1n, 18)).toBeNull();
+  });
+
+  it('returns "< 0.01" for very small amounts', () => {
+    // 1 wei of an 18-decimal token
+    expect(formatClaimableAmount(1n, 18)).toBe('< 0.01');
+  });
+
+  it('formats amount with 2 decimal places', () => {
+    // 1.5 tokens with 6 decimals = 1500000
+    expect(formatClaimableAmount(1500000n, 6)).toBe('1.50');
+  });
+
+  it('formats large amounts correctly', () => {
+    // 100.99 tokens with 6 decimals = 100990000
+    expect(formatClaimableAmount(100990000n, 6)).toBe('100.99');
+  });
+
+  it('formats small but displayable amounts', () => {
+    // 0.02 tokens with 6 decimals = 20000
+    expect(formatClaimableAmount(20000n, 6)).toBe('0.02');
+  });
+
+  it('returns null when amount rounds to 0.00', () => {
+    // Amount so small it rounds to 0.00 but > 0
+    // This would be handled by the < 0.01 check
+    expect(formatClaimableAmount(1n, 6)).toBe('< 0.01');
+  });
+});
+
+describe('useMerklRewards', () => {
+  const mockFetchMerklRewardsForAsset =
+    merklClient.fetchMerklRewardsForAsset as jest.MockedFunction<
+      typeof merklClient.fetchMerklRewardsForAsset
+    >;
+
+  const mockGetClaimedAmountFromContract =
+    merklClient.getClaimedAmountFromContract as jest.MockedFunction<
+      typeof merklClient.getClaimedAmountFromContract
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupSelectorMock();
+    mockGetClaimedAmountFromContract.mockResolvedValue(null);
+  });
+
+  it('returns null claimableReward for ineligible token', () => {
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: '0xunknown',
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    expect(result.current.claimableReward).toBeNull();
+    expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
+  });
+
+  it('fetches and formats claimable reward using API claimed value as fallback', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '10500000', // 10.5 MUSD
+      claimed: '0',
+      recipient: MOCK_ADDRESS,
+    });
+    // On-chain read returns null → fallback to API claimed value (0)
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    expect(result.current.claimableReward).toBe('10.50');
+  });
+
+  it('uses on-chain claimed amount when available', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '10500000', // 10.5 MUSD total
+      claimed: '0', // API says 0 claimed (stale)
+      recipient: MOCK_ADDRESS,
+    });
+    // On-chain read says 5.5 MUSD already claimed
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce('5500000');
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    // 10.5 - 5.5 = 5.0 MUSD claimable
+    expect(result.current.claimableReward).toBe('5.00');
+    expect(mockGetClaimedAmountFromContract).toHaveBeenCalledWith(
+      MOCK_ADDRESS,
+      MUSD_TOKEN_ADDRESS,
+    );
+  });
+
+  it('returns null when on-chain shows all claimed', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '1000000', // 1 MUSD
+      claimed: '0', // API says unclaimed (stale)
+      recipient: MOCK_ADDRESS,
+    });
+    // On-chain says all claimed
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce('1000000');
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.claimableReward).toBeNull();
+  });
+
+  it('returns null when API returns no matching reward', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    // Allow the effect to execute and resolve
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
+    expect(result.current.claimableReward).toBeNull();
+  });
+
+  it('returns null when all rewards are claimed (API)', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '1000000',
+      claimed: '1000000', // All claimed
+      recipient: MOCK_ADDRESS,
+    });
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.claimableReward).toBeNull();
+  });
+
+  it('handles API errors gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockFetchMerklRewardsForAsset.mockRejectedValueOnce(
+      new Error('Network error'),
+    );
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(result.current.claimableReward).toBeNull();
+    consoleSpy.mockRestore();
+  });
+
+  it('aborts fetch on unmount', () => {
+    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
+
+    const { unmount } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    unmount();
+
+    expect(abortSpy).toHaveBeenCalled();
+    abortSpy.mockRestore();
+  });
+
+  it('falls back to API claimed value when getClaimedAmountFromContract returns null', async () => {
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
+
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '10500000',
+      claimed: '0',
+      recipient: MOCK_ADDRESS,
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    // Falls back to API value (claimed=0), so full amount is claimable
+    expect(result.current.claimableReward).toBe('10.50');
+  });
+});

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -69,6 +69,7 @@ export const formatClaimableAmount = (
 type UseMerklRewardsOptions = {
   tokenAddress: string | undefined;
   chainId: Hex;
+  isEligible: boolean;
 };
 
 type UseMerklRewardsReturn = {
@@ -85,18 +86,18 @@ type UseMerklRewardsReturn = {
  * @param options - Hook options
  * @param options.tokenAddress - The token's contract address
  * @param options.chainId - The chain ID of the token
- * @returns Claimable reward amount and refetch function
+ * @param options.isEligible - whether the token is actually eligible for rewards. Determines whether we make a request
+ * @returns Claimable reward amount
  */
 export const useMerklRewards = ({
   tokenAddress,
   chainId,
+  isEligible,
 }: UseMerklRewardsOptions): UseMerklRewardsReturn => {
   const [claimableReward, setClaimableReward] = useState<string | null>(null);
 
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
-
-  const isEligible = isEligibleForMerklRewards(chainId, tokenAddress);
 
   const fetchClaimableRewards = useCallback(
     async (abortController: AbortController) => {

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
 import { getSelectedInternalAccount } from '../../../../selectors/accounts';
@@ -7,6 +7,7 @@ import {
   fetchMerklRewardsForAsset,
   getClaimedAmountFromContract,
 } from '../merkl-client';
+import { getMerklRewardsEnabled } from '../selectors';
 
 /**
  * Check if a token is eligible for Merkl rewards.
@@ -69,7 +70,7 @@ export const formatClaimableAmount = (
 type UseMerklRewardsOptions = {
   tokenAddress: string | undefined;
   chainId: Hex;
-  isEligible: boolean;
+  showMerklBadge: boolean;
 };
 
 type UseMerklRewardsReturn = {
@@ -86,18 +87,28 @@ type UseMerklRewardsReturn = {
  * @param options - Hook options
  * @param options.tokenAddress - The token's contract address
  * @param options.chainId - The chain ID of the token
- * @param options.isEligible - whether the token is actually eligible for rewards. Determines whether we make a request
+ * @param options.showMerklBadge - whether the token should be shown. If false we don't make a request.
  * @returns Claimable reward amount
  */
 export const useMerklRewards = ({
   tokenAddress,
   chainId,
-  isEligible,
+  showMerklBadge,
 }: UseMerklRewardsOptions): UseMerklRewardsReturn => {
+  const merklRewardsEnabled = useSelector(getMerklRewardsEnabled);
+
   const [claimableReward, setClaimableReward] = useState<string | null>(null);
 
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
+
+  const isEligible = useMemo(
+    () =>
+      showMerklBadge &&
+      merklRewardsEnabled &&
+      isEligibleForMerklRewards(chainId, tokenAddress),
+    [showMerklBadge, merklRewardsEnabled, chainId, tokenAddress],
+  );
 
   const fetchClaimableRewards = useCallback(
     async (abortController: AbortController) => {

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -1,0 +1,190 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { ELIGIBLE_TOKENS } from '../constants';
+import {
+  fetchMerklRewardsForAsset,
+  getClaimedAmountFromContract,
+} from '../merkl-client';
+
+/**
+ * Check if a token is eligible for Merkl rewards.
+ * Compares addresses case-insensitively since Ethereum addresses are case-insensitive.
+ * Returns false for native tokens (undefined/null address).
+ *
+ * @param chainId - The chain ID of the token
+ * @param address - The token's contract address
+ * @returns Whether the token is eligible for Merkl rewards
+ */
+export const isEligibleForMerklRewards = (
+  chainId: string,
+  address: string | undefined | null,
+): boolean => {
+  if (!address) {
+    return false;
+  }
+  const eligibleAddresses = ELIGIBLE_TOKENS[chainId];
+  if (!eligibleAddresses) {
+    return false;
+  }
+  const addressLower = address.toLowerCase();
+  return eligibleAddresses.some(
+    (eligibleAddress) => eligibleAddress.toLowerCase() === addressLower,
+  );
+};
+
+/**
+ * Format unclaimed base units into a human-readable display amount.
+ * Returns a string with exactly 2 decimal places, or "< 0.01" for very small amounts.
+ *
+ * @param unclaimedBaseUnits - The unclaimed amount in base units (wei-like)
+ * @param tokenDecimals - The number of decimals for the token
+ * @returns Formatted display string, or null if amount is zero
+ */
+export const formatClaimableAmount = (
+  unclaimedBaseUnits: bigint,
+  tokenDecimals: number,
+): string | null => {
+  if (unclaimedBaseUnits <= 0n) {
+    return null;
+  }
+
+  const divisor = BigInt(10 ** tokenDecimals);
+  const whole = unclaimedBaseUnits / divisor;
+  const remainder = unclaimedBaseUnits % divisor;
+
+  const decimalPart = Number(remainder) / Number(divisor);
+  const totalAmount = Number(whole) + decimalPart;
+
+  if (totalAmount < 0.01) {
+    return '< 0.01';
+  }
+
+  const displayAmount = totalAmount.toFixed(2);
+
+  return displayAmount;
+};
+
+type UseMerklRewardsOptions = {
+  tokenAddress: string | undefined;
+  chainId: Hex;
+};
+
+type UseMerklRewardsReturn = {
+  claimableReward: string | null;
+  refetch: () => void;
+};
+
+/**
+ * Custom hook to fetch and manage claimable Merkl rewards for an asset.
+ * Handles eligibility checking and reward data fetching.
+ * Uses on-chain contract read for the claimed amount (instant update after claim),
+ * falling back to API-provided claimed value if the on-chain read fails.
+ *
+ * @param options - Hook options
+ * @param options.tokenAddress - The token's contract address
+ * @param options.chainId - The chain ID of the token
+ * @returns Claimable reward amount and refetch function
+ */
+export const useMerklRewards = ({
+  tokenAddress,
+  chainId,
+}: UseMerklRewardsOptions): UseMerklRewardsReturn => {
+  const [claimableReward, setClaimableReward] = useState<string | null>(null);
+
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const selectedAddress = selectedAccount?.address;
+
+  const isEligible = isEligibleForMerklRewards(chainId, tokenAddress);
+
+  const fetchClaimableRewards = useCallback(
+    async (abortController: AbortController) => {
+      if (!tokenAddress || !isEligible || !selectedAddress) {
+        setClaimableReward(null);
+        return;
+      }
+
+      try {
+        const matchingReward = await fetchMerklRewardsForAsset(
+          tokenAddress,
+          chainId,
+          selectedAddress,
+          abortController.signal,
+        );
+
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        if (!matchingReward) {
+          setClaimableReward(null);
+          return;
+        }
+
+        // Get claimed amount from on-chain read for instant update after claims.
+        // The API can lag behind the actual on-chain state.
+        let claimedAmount = matchingReward.claimed;
+
+        const rewardTokenAddress = matchingReward.token.address as Hex;
+        const onChainClaimed = await getClaimedAmountFromContract(
+          selectedAddress,
+          rewardTokenAddress,
+        );
+
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        if (onChainClaimed !== null) {
+          // Use on-chain value — it's always more up-to-date than the API
+          claimedAmount = onChainClaimed;
+        }
+
+        // Calculate unclaimed: total amount from Merkle tree minus what's been claimed
+        const unclaimedBaseUnits =
+          BigInt(matchingReward.amount) - BigInt(claimedAmount);
+        const tokenDecimals = matchingReward.token.decimals ?? 18;
+
+        const displayAmount = formatClaimableAmount(
+          unclaimedBaseUnits,
+          tokenDecimals,
+        );
+
+        if (!abortController.signal.aborted) {
+          setClaimableReward(displayAmount);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+        console.error(
+          'useMerklRewards: Error fetching claimable rewards',
+          error,
+        );
+      }
+    },
+    [tokenAddress, chainId, selectedAddress, isEligible],
+  );
+
+  // Calling refetch just updates a Fetch Key, which in turn triggers a use effect.
+  // This means that we can easily share request aborting logic between the initial
+  // call and later refetches
+  const [fetchKey, setFetchKey] = useState(0);
+  const refetch = useCallback(() => {
+    setFetchKey((k) => k + 1);
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    fetchClaimableRewards(abortController);
+    return () => {
+      abortController.abort();
+    };
+  }, [fetchClaimableRewards, fetchKey]);
+
+  return {
+    claimableReward,
+    refetch,
+  };
+};

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -35,38 +35,6 @@ export const isEligibleForMerklRewards = (
   );
 };
 
-/**
- * Format unclaimed base units into a human-readable display amount.
- * Returns a string with exactly 2 decimal places, or "< 0.01" for very small amounts.
- *
- * @param unclaimedBaseUnits - The unclaimed amount in base units (wei-like)
- * @param tokenDecimals - The number of decimals for the token
- * @returns Formatted display string, or null if amount is zero
- */
-export const formatClaimableAmount = (
-  unclaimedBaseUnits: bigint,
-  tokenDecimals: number,
-): string | null => {
-  if (unclaimedBaseUnits <= 0n) {
-    return null;
-  }
-
-  const divisor = BigInt(10 ** tokenDecimals);
-  const whole = unclaimedBaseUnits / divisor;
-  const remainder = unclaimedBaseUnits % divisor;
-
-  const decimalPart = Number(remainder) / Number(divisor);
-  const totalAmount = Number(whole) + decimalPart;
-
-  if (totalAmount < 0.01) {
-    return '< 0.01';
-  }
-
-  const displayAmount = totalAmount.toFixed(2);
-
-  return displayAmount;
-};
-
 type UseMerklRewardsOptions = {
   tokenAddress: string | undefined;
   chainId: Hex;
@@ -74,7 +42,7 @@ type UseMerklRewardsOptions = {
 };
 
 type UseMerklRewardsReturn = {
-  claimableReward: string | null;
+  hasClaimableReward: boolean;
   refetch: () => void;
 };
 
@@ -88,7 +56,7 @@ type UseMerklRewardsReturn = {
  * @param options.tokenAddress - The token's contract address
  * @param options.chainId - The chain ID of the token
  * @param options.showMerklBadge - whether the token should be shown. If false we don't make a request.
- * @returns Claimable reward amount
+ * @returns Whether there is a claimable reward
  */
 export const useMerklRewards = ({
   tokenAddress,
@@ -97,7 +65,7 @@ export const useMerklRewards = ({
 }: UseMerklRewardsOptions): UseMerklRewardsReturn => {
   const merklRewardsEnabled = useSelector(getMerklRewardsEnabled);
 
-  const [claimableReward, setClaimableReward] = useState<string | null>(null);
+  const [hasClaimableReward, setHasClaimableReward] = useState(false);
 
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
@@ -113,7 +81,7 @@ export const useMerklRewards = ({
   const fetchClaimableRewards = useCallback(
     async (abortController: AbortController) => {
       if (!tokenAddress || !isEligible || !selectedAddress) {
-        setClaimableReward(null);
+        setHasClaimableReward(false);
         return;
       }
 
@@ -130,7 +98,7 @@ export const useMerklRewards = ({
         }
 
         if (!matchingReward) {
-          setClaimableReward(null);
+          setHasClaimableReward(false);
           return;
         }
 
@@ -156,15 +124,9 @@ export const useMerklRewards = ({
         // Calculate unclaimed: total amount from Merkle tree minus what's been claimed
         const unclaimedBaseUnits =
           BigInt(matchingReward.amount) - BigInt(claimedAmount);
-        const tokenDecimals = matchingReward.token.decimals ?? 18;
-
-        const displayAmount = formatClaimableAmount(
-          unclaimedBaseUnits,
-          tokenDecimals,
-        );
 
         if (!abortController.signal.aborted) {
-          setClaimableReward(displayAmount);
+          setHasClaimableReward(unclaimedBaseUnits > 0n);
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
@@ -196,7 +158,7 @@ export const useMerklRewards = ({
   }, [fetchClaimableRewards, fetchKey]);
 
   return {
-    claimableReward,
+    hasClaimableReward,
     refetch,
   };
 };

--- a/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
+++ b/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { MERKL_DISTRIBUTOR_ADDRESS } from '../constants';
+import { useOnMerklClaimConfirmed } from './useOnMerklClaimConfirmed';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const { useSelector } = jest.requireMock('react-redux');
+
+const createMockTransaction = (
+  id: string,
+  status: string,
+  to: string = MERKL_DISTRIBUTOR_ADDRESS,
+) => ({
+  id,
+  status,
+  txParams: { to },
+});
+
+describe('useOnMerklClaimConfirmed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fires callback when pending claim becomes confirmed', () => {
+    const onConfirmed = jest.fn();
+
+    // Start with a pending transaction
+    useSelector.mockReturnValue([
+      createMockTransaction('tx1', TransactionStatus.submitted),
+    ]);
+
+    const { rerender } = renderHook(() =>
+      useOnMerklClaimConfirmed(onConfirmed),
+    );
+
+    // Transaction becomes confirmed
+    useSelector.mockReturnValue([
+      createMockTransaction('tx1', TransactionStatus.confirmed),
+    ]);
+
+    act(() => {
+      rerender();
+    });
+
+    expect(onConfirmed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire callback for already-confirmed transactions', () => {
+    const onConfirmed = jest.fn();
+
+    // Start with already confirmed transaction
+    useSelector.mockReturnValue([
+      createMockTransaction('tx1', TransactionStatus.confirmed),
+    ]);
+
+    renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+  });
+
+  it('does not fire callback for non-Merkl transactions', () => {
+    const onConfirmed = jest.fn();
+
+    // Start with a pending non-Merkl transaction
+    useSelector.mockReturnValue([
+      createMockTransaction(
+        'tx1',
+        TransactionStatus.submitted,
+        '0xOtherAddress',
+      ),
+    ]);
+
+    const { rerender } = renderHook(() =>
+      useOnMerklClaimConfirmed(onConfirmed),
+    );
+
+    // Transaction becomes confirmed
+    useSelector.mockReturnValue([
+      createMockTransaction(
+        'tx1',
+        TransactionStatus.confirmed,
+        '0xOtherAddress',
+      ),
+    ]);
+
+    act(() => {
+      rerender();
+    });
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+  });
+});

--- a/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.ts
+++ b/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { getTransactions } from '../../../../selectors/transactions';
+import { MERKL_DISTRIBUTOR_ADDRESS } from '../constants';
+
+/**
+ * Transaction statuses that indicate a claim is "in flight":
+ * - approved: User confirmed in wallet, waiting for submission
+ * - signed: Transaction signed, waiting for broadcast
+ * - submitted: Transaction submitted to network, waiting for confirmation
+ */
+const IN_FLIGHT_STATUSES: string[] = [
+  TransactionStatus.approved,
+  TransactionStatus.signed,
+  TransactionStatus.submitted,
+];
+
+/**
+ * Check if a transaction is a Merkl claim by matching the distributor address.
+ *
+ * @param tx - The transaction metadata
+ * @returns Whether the transaction is a Merkl claim
+ */
+const isMerklClaimTransaction = (tx: TransactionMeta): boolean =>
+  tx.txParams?.to?.toLowerCase() === MERKL_DISTRIBUTOR_ADDRESS.toLowerCase();
+
+/**
+ * Watches Merkl claim transactions and fires a callback when one confirms.
+ * Tracks in-flight claim IDs so it only fires for transitions from
+ * pending to confirmed, not for transactions that were already confirmed.
+ *
+ * @param onConfirmed - Callback fired when a pending claim is confirmed
+ */
+export const useOnMerklClaimConfirmed = (onConfirmed: () => void): void => {
+  const transactions = useSelector(getTransactions) as TransactionMeta[];
+
+  // Track IDs of pending claims we've seen
+  const pendingClaimIdsRef = useRef<Set<string>>(new Set());
+
+  // Stable callback ref to avoid effect re-running
+  const onConfirmedRef = useRef(onConfirmed);
+  useEffect(() => {
+    onConfirmedRef.current = onConfirmed;
+  }, [onConfirmed]);
+
+  // Detect when a pending claim becomes confirmed
+  useEffect(() => {
+    const merklClaimTxs = transactions.filter(isMerklClaimTransaction);
+
+    const currentPendingIds = new Set(
+      merklClaimTxs
+        .filter((tx) => IN_FLIGHT_STATUSES.includes(tx.status))
+        .map((tx) => tx.id),
+    );
+
+    const confirmedIds = merklClaimTxs
+      .filter((tx) => tx.status === TransactionStatus.confirmed)
+      .map((tx) => tx.id);
+
+    const hadPendingThatConfirmed = confirmedIds.some((id) =>
+      pendingClaimIdsRef.current.has(id),
+    );
+
+    // Update our tracking set
+    pendingClaimIdsRef.current = currentPendingIds;
+
+    // Fire callback if a pending claim was confirmed
+    if (hadPendingThatConfirmed) {
+      onConfirmedRef.current();
+    }
+  }, [transactions]);
+};

--- a/ui/components/app/musd/index.ts
+++ b/ui/components/app/musd/index.ts
@@ -1,6 +1,8 @@
+export { useMerklClaim } from './hooks/useMerklClaim';
 export {
-  useMerklClaim,
+  useMerklRewards,
   isEligibleForMerklRewards,
-} from './hooks/useMerklClaim';
+} from './hooks/useMerklRewards';
+export { useOnMerklClaimConfirmed } from './hooks/useOnMerklClaimConfirmed';
 export { ELIGIBLE_TOKENS, MERKL_FEATURE_FLAG_KEY } from './constants';
 export { ClaimBonusBadge } from './claim-bonus-badge';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This fixes an error in the previous implementation where the claim bonus CTA was always shown. Now we only show the CTA in the case that there is a bonus to claim

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40299?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Only show MUSD claim bonus CTA if there are rewards to claim

## **Related issues**

## **Manual testing steps**


1. Enable the earnMerklCampaignClaiming remote feature flag (e.g. via .manifest-overrides.json)
2. Ensure you have an account holding mUSD on Mainnet or Linea with unclaimed Merkl rewards
3. If there is a bonus, claim it by clicking “Claim bonus”
4. Verify that claim bonus CTA is no longer shown

## **Screenshots/Recordings**

### **Before**


### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new reward-fetching and transaction-watching hooks that affect when claim CTAs render and trigger network/contract reads; errors or selector misuse could incorrectly hide/show the badge or cause extra requests.
> 
> **Overview**
> Updates `TokenCell` to show the Merkl “Claim bonus” CTA **only when the user has claimable rewards**, swapping the previous eligibility/feature-flag check for a new `useMerklRewards` hook and reordering the footer layout to render the badge in the primary slot.
> 
> Adds `useMerklRewards` to fetch reward data (with abort/refetch support) and determine claimability using on-chain claimed amounts as the source of truth (with API fallback), and adds `useOnMerklClaimConfirmed` so `ClaimBonusBadge` can refetch rewards when a pending Merkl claim transaction confirms. Includes new unit tests for both hooks and updates existing `TokenCell` tests to mock the new module API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db6303c2cd128f8e4afdb5d746c9bfb4d34cd8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->