### PR TITLE
feat: add default address metrics

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -782,6 +782,10 @@
       "Reselect: Input stability warnings": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx": {
+      "React: componentWill* lifecycle deprecations": 1,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.test.tsx": {
       "React: componentWill* lifecycle deprecations": 1,
       "warn: ⚠️ React Router Future Flag": 2

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.stories.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { DefaultAddress } from './default-address';
+
+const mockStore = configureStore([]);
+
+const createMockState = (overrides = {}) => ({
+  metamask: {
+    preferences: {
+      showDefaultAddress: true,
+      defaultAddressScope: 'eip155',
+      ...overrides,
+    },
+  },
+});
+
+const meta: Meta<typeof DefaultAddress> = {
+  title: 'Components/MultichainAccounts/DefaultAddress',
+  component: DefaultAddress,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Toggle and label for showing the default address in the account hover menu. Displays the current default scope (e.g. Ethereum) and a link to change it in Settings.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Provider store={mockStore(createMockState())}>
+        <div style={{ width: '380px', padding: '16px' }}>
+          <Story />
+        </div>
+      </Provider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DefaultAddress>;
+
+export const Default: Story = {};

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { DefaultAddress } from './default-address';
+
+const mockStore = configureStore([]);
+
+const createMockState = (overrides = {}) => ({
+  metamask: {
+    preferences: {
+      showDefaultAddress: true,
+      defaultAddressScope: 'eip155',
+      ...overrides,
+    },
+  },
+});
+
+describe('DefaultAddress', () => {
+  it('renders the show default address label', () => {
+    const store = mockStore(createMockState());
+    renderWithProvider(<DefaultAddress />, store);
+
+    expect(screen.getByText('Show default address')).toBeInTheDocument();
+  });
+
+  it('renders the change in settings link', () => {
+    const store = mockStore(createMockState());
+    renderWithProvider(<DefaultAddress />, store);
+
+    expect(screen.getByTestId('change-in-settings-link')).toBeInTheDocument();
+    expect(screen.getByText('Change in Settings')).toBeInTheDocument();
+  });
+
+  it('renders the show default address toggle', () => {
+    const store = mockStore(createMockState());
+    renderWithProvider(<DefaultAddress />, store);
+
+    expect(
+      screen.getByTestId('show-default-address-toggle'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
@@ -80,6 +80,7 @@ describe('DefaultAddress', () => {
       event: MetaMetricsEventName.NavSettingsOpened,
       properties: {
         location: 'account-hover-menu',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         settings_section: 'show-default-address',
       },
     });
@@ -103,8 +104,10 @@ describe('DefaultAddress', () => {
       category: MetaMetricsEventCategory.Settings,
       event: MetaMetricsEventName.SettingsUpdated,
       properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         default_address_network: 'eip155',
         location: 'account-hover-menu',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         show_default_address: false,
       },
     });

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
@@ -79,9 +79,9 @@ describe('DefaultAddress', () => {
       category: MetaMetricsEventCategory.Navigation,
       event: MetaMetricsEventName.NavSettingsOpened,
       properties: {
-        location: 'account-hover-menu',
+        location: 'Account Hover Menu',
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        settings_section: 'show-default-address',
+        settings_type: 'show_default_address',
       },
     });
   });
@@ -106,7 +106,7 @@ describe('DefaultAddress', () => {
       properties: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         default_address_network: 'eip155',
-        location: 'account-hover-menu',
+        location: 'Account Hover Menu',
         // eslint-disable-next-line @typescript-eslint/naming-convention
         show_default_address: false,
       },

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
@@ -24,7 +24,7 @@ describe('DefaultAddress', () => {
     expect(screen.getByText('Show default address')).toBeInTheDocument();
   });
 
-  it('renders the change in settings link', () => {
+  it('renders the Change in Settings link', () => {
     const store = mockStore(createMockState());
     renderWithProvider(<DefaultAddress />, store);
 

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.test.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { DefaultAddress } from './default-address';
+
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  setShowDefaultAddress: (value: boolean) => ({
+    type: 'SET_SHOW_DEFAULT_ADDRESS',
+    value,
+  }),
+}));
 
 const mockStore = configureStore([]);
 
@@ -14,6 +27,13 @@ const createMockState = (overrides = {}) => ({
       ...overrides,
     },
   },
+});
+
+const createMockMetaMetricsContext = (trackEvent = jest.fn()) => ({
+  trackEvent,
+  bufferedTrace: jest.fn().mockResolvedValue(undefined),
+  bufferedEndTrace: jest.fn().mockResolvedValue(undefined),
+  onboardingParentContext: { current: null },
 });
 
 describe('DefaultAddress', () => {
@@ -39,5 +59,54 @@ describe('DefaultAddress', () => {
     expect(
       screen.getByTestId('show-default-address-toggle'),
     ).toBeInTheDocument();
+  });
+
+  it('tracks NavSettingsOpened when Change in Settings is clicked', () => {
+    const mockTrackEvent = jest.fn();
+    const store = mockStore(createMockState());
+    renderWithProvider(
+      <MetaMetricsContext.Provider
+        value={createMockMetaMetricsContext(mockTrackEvent)}
+      >
+        <DefaultAddress />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+
+    fireEvent.click(screen.getByTestId('change-in-settings-link'));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      category: MetaMetricsEventCategory.Navigation,
+      event: MetaMetricsEventName.NavSettingsOpened,
+      properties: {
+        location: 'account-hover-menu',
+        settings_section: 'show-default-address',
+      },
+    });
+  });
+
+  it('tracks SettingsUpdated when show default address toggle is clicked', () => {
+    const mockTrackEvent = jest.fn();
+    const store = mockStore(createMockState());
+    renderWithProvider(
+      <MetaMetricsContext.Provider
+        value={createMockMetaMetricsContext(mockTrackEvent)}
+      >
+        <DefaultAddress />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+
+    fireEvent.click(screen.getByTestId('show-default-address-toggle'));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.SettingsUpdated,
+      properties: {
+        default_address_network: 'eip155',
+        location: 'account-hover-menu',
+        show_default_address: false,
+      },
+    });
   });
 });

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
@@ -78,6 +78,7 @@ export const DefaultAddress = () => {
                   event: MetaMetricsEventName.NavSettingsOpened,
                   properties: {
                     location: METRICS_LOCATION,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     settings_section: SETTINGS_PATH,
                   },
                 });
@@ -98,8 +99,10 @@ export const DefaultAddress = () => {
               category: MetaMetricsEventCategory.Settings,
               event: MetaMetricsEventName.SettingsUpdated,
               properties: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 default_address_network: defaultAddressScope,
                 location: METRICS_LOCATION,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 show_default_address: newValue,
               },
             });

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
@@ -31,7 +31,8 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 
-const METRICS_LOCATION_CHANGE_IN_SETTINGS = 'Account Hover Menu';
+const METRICS_LOCATION = 'account-hover-menu';
+const SETTINGS_PATH = 'show-default-address';
 
 export const DefaultAddress = () => {
   const t = useI18nContext();
@@ -76,11 +77,11 @@ export const DefaultAddress = () => {
                   category: MetaMetricsEventCategory.Navigation,
                   event: MetaMetricsEventName.NavSettingsOpened,
                   properties: {
-                    location: METRICS_LOCATION_CHANGE_IN_SETTINGS,
-                    settings_section: 'show-default-address',
+                    location: METRICS_LOCATION,
+                    settings_section: SETTINGS_PATH,
                   },
                 });
-                navigate(`${GENERAL_ROUTE}#show-default-address`);
+                navigate(`${GENERAL_ROUTE}#${SETTINGS_PATH}`);
               }}
               data-testid="change-in-settings-link"
             >
@@ -91,14 +92,15 @@ export const DefaultAddress = () => {
         <ToggleButton
           value={showDefaultAddress}
           onToggle={(value: boolean) => {
-            dispatch(setShowDefaultAddress(!value));
+            const newValue = !value;
+            dispatch(setShowDefaultAddress(newValue));
             trackEvent({
               category: MetaMetricsEventCategory.Settings,
               event: MetaMetricsEventName.SettingsUpdated,
               properties: {
                 default_address_network: defaultAddressScope,
-                location: 'hover-address-menu',
-                show_default_address: value,
+                location: METRICS_LOCATION,
+                show_default_address: newValue,
               },
             });
           }}

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
@@ -1,0 +1,110 @@
+import React, { useContext } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextButton,
+  TextButtonSize,
+  TextColor,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react';
+import { useNavigate } from 'react-router-dom';
+import ToggleButton from '../../ui/toggle-button';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { GENERAL_ROUTE } from '../../../helpers/constants/routes';
+import {
+  DEFAULT_ADDRESS_DISPLAY_KEY_BY_SCOPE,
+  DefaultAddressScope,
+} from '../../../../shared/constants/default-address';
+import {
+  getDefaultAddressScope,
+  getShowDefaultAddress,
+} from '../../../selectors';
+import { setShowDefaultAddress } from '../../../store/actions';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+
+const METRICS_LOCATION_CHANGE_IN_SETTINGS = 'Account Hover Menu';
+
+export const DefaultAddress = () => {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const navigate = useNavigate();
+  const showDefaultAddress = useSelector(getShowDefaultAddress);
+  const defaultAddressScope = useSelector(
+    getDefaultAddressScope,
+  ) as DefaultAddressScope;
+  const defaultScopeDisplayLabel = t(
+    DEFAULT_ADDRESS_DISPLAY_KEY_BY_SCOPE[defaultAddressScope],
+  );
+
+  return (
+    <Box paddingLeft={4} paddingBottom={2}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
+        alignItems={BoxAlignItems.Center}
+      >
+        <Box flexDirection={BoxFlexDirection.Column}>
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+          >
+            {t('showDefaultAddress')}
+          </Text>
+          <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {t('default')}: {defaultScopeDisplayLabel}
+            </Text>
+            <TextButton
+              size={TextButtonSize.BodyXs}
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                trackEvent({
+                  category: MetaMetricsEventCategory.Navigation,
+                  event: MetaMetricsEventName.NavSettingsOpened,
+                  properties: {
+                    location: METRICS_LOCATION_CHANGE_IN_SETTINGS,
+                    settings_section: 'show-default-address',
+                  },
+                });
+                navigate(`${GENERAL_ROUTE}#show-default-address`);
+              }}
+              data-testid="change-in-settings-link"
+            >
+              {t('changeInSettings')}
+            </TextButton>
+          </Box>
+        </Box>
+        <ToggleButton
+          value={showDefaultAddress}
+          onToggle={(value: boolean) => {
+            dispatch(setShowDefaultAddress(!value));
+            trackEvent({
+              category: MetaMetricsEventCategory.Settings,
+              event: MetaMetricsEventName.SettingsUpdated,
+              properties: {
+                default_address_network: defaultAddressScope,
+                location: 'hover-address-menu',
+                show_default_address: value,
+              },
+            });
+          }}
+          dataTestId="show-default-address-toggle"
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/default-address.tsx
@@ -31,8 +31,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 
-const METRICS_LOCATION = 'account-hover-menu';
-const SETTINGS_PATH = 'show-default-address';
+const METRICS_LOCATION = 'Account Hover Menu';
 
 export const DefaultAddress = () => {
   const t = useI18nContext();
@@ -79,10 +78,10 @@ export const DefaultAddress = () => {
                   properties: {
                     location: METRICS_LOCATION,
                     // eslint-disable-next-line @typescript-eslint/naming-convention
-                    settings_section: SETTINGS_PATH,
+                    settings_type: 'show_default_address',
                   },
                 });
-                navigate(`${GENERAL_ROUTE}#${SETTINGS_PATH}`);
+                navigate(`${GENERAL_ROUTE}#show-default-address`);
               }}
               data-testid="change-in-settings-link"
             >

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -5,13 +5,12 @@ import React, {
   useState,
   useEffect,
 } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { type AccountGroupId } from '@metamask/account-api';
 import { CaipChainId } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   Box,
-  BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
   Button,
@@ -19,39 +18,25 @@ import {
   ButtonVariant,
   FontWeight,
   Text,
-  TextButton,
-  TextButtonSize,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import { BackgroundColor } from '../../../helpers/constants/design-system';
 import { Popover, PopoverPosition } from '../../component-library';
-import ToggleButton from '../../ui/toggle-button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import {
   getAllAccountGroups,
   getInternalAccountListSpreadByScopesByGroupId,
 } from '../../../selectors/multichain-accounts/account-tree';
-import {
-  GENERAL_ROUTE,
-  MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE,
-} from '../../../helpers/constants/routes';
-import {
-  DEFAULT_ADDRESS_DISPLAY_KEY_BY_SCOPE,
-  DefaultAddressScope,
-} from '../../../../shared/constants/default-address';
-import {
-  getDefaultAddressScope,
-  getShowDefaultAddress,
-} from '../../../selectors';
-import { setShowDefaultAddress } from '../../../store/actions';
+import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
 import { selectBalanceForAllWallets } from '../../../selectors/assets';
 import { useFormatters } from '../../../hooks/useFormatters';
 // eslint-disable-next-line import/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { MultichainAggregatedAddressListRow } from './multichain-aggregated-list-row';
+import { DefaultAddress } from './default-address';
 
 // Priority networks that should appear first (using CAIP chain IDs)
 const PRIORITY_CHAIN_IDS = new Map<CaipChainId, number>([
@@ -111,18 +96,10 @@ export const MultichainHoveredAddressRowsList = ({
   showDefaultAddressSection = true,
 }: MultichainAddressRowsListProps) => {
   const t = useI18nContext();
-  const dispatch = useDispatch();
 
   // useCopyToClipboard analysis: Copies one of your public addresses
   const [, handleCopy] = useCopyToClipboard({ clearDelayMs: null });
   const navigate = useNavigate();
-  const showDefaultAddress = useSelector(getShowDefaultAddress);
-  const defaultAddressScope = useSelector(
-    getDefaultAddressScope,
-  ) as DefaultAddressScope;
-  const defaultScopeDisplayLabel = t(
-    DEFAULT_ADDRESS_DISPLAY_KEY_BY_SCOPE[defaultAddressScope],
-  );
   const [isHoverOpen, setIsHoverOpen] = useState(false);
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -393,48 +370,7 @@ export const MultichainHoveredAddressRowsList = ({
           {showDefaultAddressSection && (
             <>
               <Divider />
-              <Box paddingLeft={4} paddingBottom={2}>
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  justifyContent={BoxJustifyContent.Between}
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Box flexDirection={BoxFlexDirection.Column}>
-                    <Text
-                      variant={TextVariant.BodySm}
-                      fontWeight={FontWeight.Medium}
-                      color={TextColor.TextDefault}
-                    >
-                      {t('showDefaultAddress')}
-                    </Text>
-                    <Box flexDirection={BoxFlexDirection.Row} gap={2}>
-                      <Text
-                        variant={TextVariant.BodyXs}
-                        color={TextColor.TextAlternative}
-                      >
-                        {t('default')}: {defaultScopeDisplayLabel}
-                      </Text>
-                      <TextButton
-                        size={TextButtonSize.BodyXs}
-                        onClick={(e: React.MouseEvent) => {
-                          e.stopPropagation();
-                          navigate(`${GENERAL_ROUTE}#show-default-address`);
-                        }}
-                        data-testid="change-in-settings-link"
-                      >
-                        {t('changeInSettings')}
-                      </TextButton>
-                    </Box>
-                  </Box>
-                  <ToggleButton
-                    value={showDefaultAddress}
-                    onToggle={(value: boolean) =>
-                      dispatch(setShowDefaultAddress(!value))
-                    }
-                    dataTestId="show-default-address-toggle"
-                  />
-                </Box>
-              </Box>
+              <DefaultAddress />
             </>
           )}
         </Box>

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -209,6 +209,18 @@ export default class SettingsTab extends PureComponent {
     );
   }
 
+  trackShowDefaultAddress(value, networkScope) {
+    this.context.trackEvent({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.SettingsUpdated,
+      properties: {
+        default_address_network: networkScope,
+        location: 'settings-page',
+        show_default_address: value,
+      },
+    });
+  }
+
   renderShowDefaultAddressOptIn() {
     const { t } = this.context;
     const {
@@ -250,7 +262,11 @@ export default class SettingsTab extends PureComponent {
           </div>
           <ToggleButton
             value={showDefaultAddress}
-            onToggle={(value) => setShowDefaultAddress(!value)}
+            onToggle={(value) => {
+              const newValue = !value;
+              setShowDefaultAddress(newValue);
+              this.trackShowDefaultAddress(newValue, defaultAddressScope);
+            }}
             dataTestId="show-default-address-toggle"
           />
         </Box>
@@ -269,6 +285,7 @@ export default class SettingsTab extends PureComponent {
             selectedOption={defaultAddressScope}
             onChange={(value) => {
               setDefaultAddressScope(value);
+              this.trackShowDefaultAddress(true, value);
               if (!showDefaultAddress) {
                 setShowDefaultAddress(true);
               }

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -215,7 +215,7 @@ export default class SettingsTab extends PureComponent {
       event: MetaMetricsEventName.SettingsUpdated,
       properties: {
         default_address_network: networkScope,
-        location: 'settings-page',
+        location: 'Settings Page',
         show_default_address: value,
       },
     });

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -804,17 +804,20 @@ export const getDefaultScopeAndAddressByAccountGroupId =
       }[],
       defaultScope: DefaultAddressScope,
     ): { defaultAddress: string | null; defaultScopes: CaipChainId[] } => {
-      const matching = spreadList.filter((x) =>
-        String(x.scope).startsWith(defaultScope),
-      );
-      if (matching.length === 0) {
-        return { defaultAddress: null, defaultScopes: [] };
+      let defaultAddress: string | null = null;
+      const defaultScopes: CaipChainId[] = [];
+      for (const x of spreadList) {
+        if (!String(x.scope).startsWith(defaultScope)) {
+          continue;
+        }
+        if (defaultAddress === null) {
+          defaultAddress = x.account.address;
+        }
+        if (x.account.address === defaultAddress) {
+          defaultScopes.push(x.scope);
+        }
       }
-      const { address } = matching[0].account;
-      const defaultScopes = matching
-        .filter((x) => x.account.address === address)
-        .map((x) => x.scope);
-      return { defaultAddress: address, defaultScopes };
+      return { defaultAddress, defaultScopes };
     },
   );
 


### PR DESCRIPTION
## **Description**

This PR adds in metrics for default address as follows:

**1. Open Settings by clicking ‘Change in Settings’ from Account hover menu:**
<img width="461" height="318" alt="image" src="https://github.com/user-attachments/assets/91ecdd0d-00e6-45ea-b484-dc49b2639cbb" />


```
{
    "event": "Settings Opened",
    "properties": {
        "location": "Account Hover Menu", // where the user clicked the Settings link
        "settings_type": "show_default_address", // the specific section of Settings opened
        "category": "Navigation",
    },
}
```

**2. Click Show default account toggle within Settings:**
<img width="461" height="158" alt="image" src="https://github.com/user-attachments/assets/e3619390-35df-4d22-adc3-4919c04eda28" />


```
{
    "event": "Settings Updated",
    "properties": {
        "default_address_network": "eip155", // the currently selected default network
        "location": "Settings Page", // where the setting is being updated from
        "show_default_address": true, // the new value of the default address toggle
        "category": "Settings",
    },
}
```

**3. Update default network:**
Same as 2 but show_default_address would always be true. The default_address_network options are: `eip155`, `solana`, `bip122` or `tron`.

**4. Click Show default account toggle from Account hover menu:** 
<img width="461" height="318" alt="image" src="https://github.com/user-attachments/assets/91ecdd0d-00e6-45ea-b484-dc49b2639cbb" />

```
{
    "event": "Settings Updated",
    "properties": {
        "default_address_network": "eip155", // the currently selected default network
        "location": "Account Hover Menu", // where the setting is being updated from
        "show_default_address": false, // the new value of the default address toggle
        "category": "Settings",
    },
}
```

It also refactors the "Show default address" section from the account hover menu into a dedicated `DefaultAddress` component and optimizes the `getDefaultScopeAndAddressByAccountGroupId` selector.

Related segment schema PR: https://github.com/Consensys/segment-schema/pull/473

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40323?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-900

## **Manual testing steps**

Confirm the metrics outlined in the description are seen in the Networks tab when the relevant actions are taken.

## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches metrics instrumentation and settings/hover-menu interactions; low functional risk but event payloads/locations must match analytics expectations.
> 
> **Overview**
> Adds MetaMetrics tracking for the **Default Address** preference, covering both the account hover menu (navigating to Settings and toggling the preference) and the Settings page (toggling the preference and changing the default network scope).
> 
> Refactors the hover menu “Show default address” UI into a dedicated `DefaultAddress` component with Storybook + unit tests, and slightly optimizes `getDefaultScopeAndAddressByAccountGroupId` to avoid extra array allocations when deriving the default address/scopes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63a5264285faff8437d6bc804dce313a7295017. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->