### PR TITLE
fix: handle evm unsupported chains gracefully in token import flow for custom network cp-13.20.0

### DIFF
--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -11,6 +11,7 @@ import {
   fetchBridgeTokens,
   BridgeClientId,
   type BridgeAsset,
+  getNativeAssetForChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import type {
@@ -141,8 +142,8 @@ export const useTokensWithFiltering = (
     }
     // For Bitcoin chains, we only support native asset
     if (isBitcoinChainId(chainId)) {
-      // Return native asset for Bitcoin chains (safe: returns undefined if not in swaps map)
-      const nativeAsset = getNativeAssetForChainIdSafe(chainId);
+      // Return native asset for Bitcoin chains
+      const nativeAsset = getNativeAssetForChainId(chainId);
       if (nativeAsset) {
         const key = nativeAsset.address ?? '';
         return {
@@ -265,7 +266,6 @@ export const useTokensWithFiltering = (
           }
           if (shouldAddToken(token.symbol, token.address, token.chainId)) {
             if (isNativeAddress(token.address) || token.isNative) {
-              const nativeAsset = getNativeAssetForChainIdSafe(token.chainId);
               yield {
                 symbol: token.symbol,
                 chainId: token.chainId,
@@ -282,12 +282,24 @@ export const useTokensWithFiltering = (
                   MULTICHAIN_TOKEN_IMAGE_MAP[
                     token.chainId as keyof typeof MULTICHAIN_TOKEN_IMAGE_MAP
                   ] ??
-                  nativeAsset?.icon ??
-                  nativeAsset?.iconUrl ??
-                  getAssetImageUrl(
-                    token.address,
-                    formatChainIdToCaip(token.chainId),
-                  ),
+                  (() => {
+                    try {
+                      return (
+                        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
+                        getNativeAssetForChainIdSafe(token.chainId)?.icon ||
+                        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
+                        getNativeAssetForChainIdSafe(token.chainId)?.iconUrl ||
+                        getAssetImageUrl(
+                          token.address,
+                          formatChainIdToCaip(token.chainId),
+                        )
+                      );
+                    } catch {
+                      return '';
+                    }
+                  })(),
                 accountType: token.accountType,
               };
             } else {

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -266,6 +266,16 @@ export const useTokensWithFiltering = (
           }
           if (shouldAddToken(token.symbol, token.address, token.chainId)) {
             if (isNativeAddress(token.address) || token.isNative) {
+              const nativeAsset = getNativeAssetForChainIdSafe(token.chainId);
+              let assetImageUrl: string | undefined;
+              try {
+                assetImageUrl = getAssetImageUrl(
+                  token.address,
+                  formatChainIdToCaip(token.chainId),
+                );
+              } catch (err) {
+                assetImageUrl = undefined;
+              }
               yield {
                 symbol: token.symbol,
                 chainId: token.chainId,
@@ -282,24 +292,8 @@ export const useTokensWithFiltering = (
                   MULTICHAIN_TOKEN_IMAGE_MAP[
                     token.chainId as keyof typeof MULTICHAIN_TOKEN_IMAGE_MAP
                   ] ??
-                  (() => {
-                    try {
-                      return (
-                        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
-                        getNativeAssetForChainIdSafe(token.chainId)?.icon ||
-                        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
-                        getNativeAssetForChainIdSafe(token.chainId)?.iconUrl ||
-                        getAssetImageUrl(
-                          token.address,
-                          formatChainIdToCaip(token.chainId),
-                        )
-                      );
-                    } catch {
-                      return undefined;
-                    }
-                  })(),
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
+                  (nativeAsset?.icon || nativeAsset?.iconUrl || assetImageUrl),
                 accountType: token.accountType,
               };
             } else {

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -282,7 +282,8 @@ export const useTokensWithFiltering = (
                   MULTICHAIN_TOKEN_IMAGE_MAP[
                     token.chainId as keyof typeof MULTICHAIN_TOKEN_IMAGE_MAP
                   ] ??
-                  (nativeAsset?.icon ?? nativeAsset?.iconUrl) ??
+                  nativeAsset?.icon ??
+                  nativeAsset?.iconUrl ??
                   getAssetImageUrl(
                     token.address,
                     formatChainIdToCaip(token.chainId),

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -297,7 +297,7 @@ export const useTokensWithFiltering = (
                         )
                       );
                     } catch {
-                      return '';
+                      return undefined;
                     }
                   })(),
                 accountType: token.accountType,

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -11,7 +11,6 @@ import {
   fetchBridgeTokens,
   BridgeClientId,
   type BridgeAsset,
-  getNativeAssetForChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import type {
@@ -37,7 +36,10 @@ import type {
 } from '../../components/multichain/asset-picker-amount/asset-picker-modal/types';
 import { getAssetImageUrl, toAssetId } from '../../../shared/lib/asset-utils';
 import { MULTICHAIN_TOKEN_IMAGE_MAP } from '../../../shared/constants/multichain/networks';
-import { isTronEnergyOrBandwidthResource } from '../../ducks/bridge/utils';
+import {
+  isTronEnergyOrBandwidthResource,
+  getNativeAssetForChainIdSafe,
+} from '../../ducks/bridge/utils';
 
 // This transforms the token object from the bridge-api into the format expected by the AssetPicker
 const buildTokenData = (
@@ -139,8 +141,8 @@ export const useTokensWithFiltering = (
     }
     // For Bitcoin chains, we only support native asset
     if (isBitcoinChainId(chainId)) {
-      // Return native asset for Bitcoin chains
-      const nativeAsset = getNativeAssetForChainId(chainId);
+      // Return native asset for Bitcoin chains (safe: returns undefined if not in swaps map)
+      const nativeAsset = getNativeAssetForChainIdSafe(chainId);
       if (nativeAsset) {
         const key = nativeAsset.address ?? '';
         return {
@@ -263,6 +265,7 @@ export const useTokensWithFiltering = (
           }
           if (shouldAddToken(token.symbol, token.address, token.chainId)) {
             if (isNativeAddress(token.address) || token.isNative) {
+              const nativeAsset = getNativeAssetForChainIdSafe(token.chainId);
               yield {
                 symbol: token.symbol,
                 chainId: token.chainId,
@@ -279,16 +282,11 @@ export const useTokensWithFiltering = (
                   MULTICHAIN_TOKEN_IMAGE_MAP[
                     token.chainId as keyof typeof MULTICHAIN_TOKEN_IMAGE_MAP
                   ] ??
-                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                  (getNativeAssetForChainId(token.chainId)?.icon ||
-                    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                    getNativeAssetForChainId(token.chainId)?.iconUrl ||
-                    getAssetImageUrl(
-                      token.address,
-                      formatChainIdToCaip(token.chainId),
-                    )),
+                  (nativeAsset?.icon ?? nativeAsset?.iconUrl) ??
+                  getAssetImageUrl(
+                    token.address,
+                    formatChainIdToCaip(token.chainId),
+                  ),
                 accountType: token.accountType,
               };
             } else {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes error when importing tokens on EVM networks with decimal string chainIds (e.g., Injective testnet) using similar strategy to: https://github.com/MetaMask/metamask-extension/pull/39806. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40325?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed error when importing tokens on EVM networks when chainId is provided as decimal string.

## **Related issues**

Related to PR: https://github.com/MetaMask/metamask-extension/pull/39806

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/edb9f332-9d5e-46f4-b04d-528c264f66aa



<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/f8da6e12-12f8-4034-a98e-37ac67a1a436


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in token list/image resolution; main risk is minor regressions in native-asset icon fallback/selection on edge networks.
> 
> **Overview**
> Improves resilience when building native-token entries in `useTokensWithFiltering` for multichain balances.
> 
> The hook now uses `getNativeAssetForChainIdSafe` and guards `getAssetImageUrl` with a `try/catch`, so unsupported/custom EVM chain IDs (including decimal-string chainIds) don’t throw during native token image resolution and instead fall back to available icons/undefined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 779be7dacf53ee4c5b4d064d2cb1049eecee75b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->