### PR TITLE
fix: metamask pay native balance validation

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -703,6 +703,10 @@
   "approveButtonText": {
     "message": "Approve"
   },
+  "approveToken": {
+    "message": "Approve $1",
+    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
+  },
   "approveIncreaseAllowance": {
     "message": "Increase $1 spending cap",
     "description": "The token symbol that is being approved"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -703,10 +703,6 @@
   "approveButtonText": {
     "message": "Approve"
   },
-  "approveToken": {
-    "message": "Approve $1",
-    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
-  },
   "approveIncreaseAllowance": {
     "message": "Increase $1 spending cap",
     "description": "The token symbol that is being approved"
@@ -714,6 +710,10 @@
   "approveSpendingCap": {
     "message": "Approve $1 spending cap",
     "description": "The token symbol that is being approved"
+  },
+  "approveToken": {
+    "message": "Approve $1",
+    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
   },
   "approved": {
     "message": "Approved"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -703,6 +703,10 @@
   "approveButtonText": {
     "message": "Approve"
   },
+  "approveToken": {
+    "message": "Approve $1",
+    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
+  },
   "approveIncreaseAllowance": {
     "message": "Increase $1 spending cap",
     "description": "The token symbol that is being approved"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -703,10 +703,6 @@
   "approveButtonText": {
     "message": "Approve"
   },
-  "approveToken": {
-    "message": "Approve $1",
-    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
-  },
   "approveIncreaseAllowance": {
     "message": "Increase $1 spending cap",
     "description": "The token symbol that is being approved"
@@ -714,6 +710,10 @@
   "approveSpendingCap": {
     "message": "Approve $1 spending cap",
     "description": "The token symbol that is being approved"
+  },
+  "approveToken": {
+    "message": "Approve $1",
+    "description": "Used in the transaction details summary to describe an approval transaction. $1 is the symbol of the token being approved."
   },
   "approved": {
     "message": "Approved"

--- a/app/scripts/controller-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/transaction-pay-controller-messenger.ts
@@ -36,6 +36,8 @@ export function getTransactionPayControllerMessenger(
       'TokenListController:getState',
       'TokenRatesController:getState',
       'TokensController:getState',
+      'TransactionController:estimateGas',
+      'TransactionController:estimateGasBatch',
       'TransactionController:getGasFeeTokens',
       'TransactionController:getState',
       'TransactionController:updateTransaction',

--- a/test/jest/console-baseline-integration.json
+++ b/test/jest/console-baseline-integration.json
@@ -4,14 +4,12 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-seaport.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 8,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-single.test.tsx": {
@@ -19,56 +17,48 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 8,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-tradeOrder.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 11,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/personalSign.test.tsx": {
       "Reselect: Identity function warnings": 10,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 4,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/alerts.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 74,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/contract-deployment.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 11,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/contract-interaction.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 16,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/dapp-swap-comparison-banner.test.tsx": {
       "Reselect: Identity function warnings": 9,
       "Reselect: Input stability warnings": 4,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 14,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/erc20-approve.test.tsx": {
@@ -76,14 +66,12 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 39,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/erc721-approve.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 25,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/increase-allowance.test.tsx": {
@@ -91,22 +79,18 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 25,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/set-approval-for-all-revoke.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 4,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/set-approval-for-all.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 1,
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
-      "warn: No tokens found for chainId:": 9,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/defi/defi-positions.test.tsx": {

--- a/test/jest/console-baseline-integration.json
+++ b/test/jest/console-baseline-integration.json
@@ -4,12 +4,14 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-seaport.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 8,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-single.test.tsx": {
@@ -17,48 +19,56 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 8,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit-tradeOrder.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/permit.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 11,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/signatures/personalSign.test.tsx": {
       "Reselect: Identity function warnings": 10,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 4,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/alerts.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 74,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/contract-deployment.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 11,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/contract-interaction.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 16,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/dapp-swap-comparison-banner.test.tsx": {
       "Reselect: Identity function warnings": 9,
       "Reselect: Input stability warnings": 4,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 14,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/erc20-approve.test.tsx": {
@@ -66,12 +76,14 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 39,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/erc721-approve.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 25,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/increase-allowance.test.tsx": {
@@ -79,18 +91,22 @@
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 25,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/set-approval-for-all-revoke.test.tsx": {
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 4,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/confirmations/transactions/set-approval-for-all.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 1,
       "Reselect: Identity function warnings": 11,
       "Reselect: Input stability warnings": 8,
       "error: Error: AggregateError": 1,
+      "warn: No tokens found for chainId:": 9,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "test/integration/defi/defi-positions.test.tsx": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2755,6 +2755,9 @@
     "ui/pages/confirmations/hooks/tokens/useTokenFiatRates.test.ts": {
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/confirmations/hooks/tokens/useTokenWithBalance.test.ts": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapActions.test.ts": {
       "Reselect: Identity function warnings": 4,
       "Reselect: Input stability warnings": 2,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2466,6 +2466,7 @@
       "Reselect: Identity function warnings": 9,
       "Reselect: Input stability warnings": 3,
       "Test errors: Uncaught Errors": 8,
+      "warn: No tokens found for chainId:": 9,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/confirmation/alerts/useAlertActions.test.ts": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2466,7 +2466,6 @@
       "Reselect: Identity function warnings": 9,
       "Reselect: Input stability warnings": 3,
       "Test errors: Uncaught Errors": 8,
-      "warn: No tokens found for chainId:": 9,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/confirmation/alerts/useAlertActions.test.ts": {

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { Text, Box } from '../../../../../components/component-library';
 import {
@@ -11,7 +10,7 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
-import { getTokenByAccountAndAddressAndChainId } from '../../../../../selectors/assets';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TokenIcon } from '../../token-icon';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -22,15 +21,9 @@ export function TransactionDetailsPaidWithRow() {
   const { metamaskPay } = transactionMeta;
   const { chainId, tokenAddress } = metamaskPay || {};
 
-  const token = useSelector((state) =>
-    tokenAddress && chainId
-      ? getTokenByAccountAndAddressAndChainId(
-          state,
-          undefined,
-          tokenAddress as Hex,
-          chainId as Hex,
-        )
-      : null,
+  const token = useTokenWithBalance(
+    (tokenAddress ?? '0x0') as Hex,
+    (chainId ?? '0x0') as Hex,
   );
 
   if (!chainId || !tokenAddress || !token) {

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -116,4 +116,30 @@ describe('TransactionDetailsSummary', () => {
 
     expect(useTokenWithBalanceMock).toHaveBeenCalledWith('0xabc123', '0x89');
   });
+
+  it('renders approve title with token symbol for tokenMethodApprove', () => {
+    useTokenWithBalanceMock.mockReturnValue({
+      address: '0x456',
+      chainId: CHAIN_ID,
+      symbol: 'USDC',
+      decimals: 6,
+      balance: '1',
+      balanceFiat: '$1.00',
+      balanceRaw: '1000000',
+      tokenFiatAmount: 1,
+    });
+
+    const { getByText } = render(TransactionType.tokenMethodApprove);
+    expect(getByText('Approve USDC')).toBeInTheDocument();
+  });
+
+  it('renders approve fallback title when token symbol is not resolved', () => {
+    const { getByText } = render(TransactionType.tokenMethodApprove);
+    expect(getByText('Approve')).toBeInTheDocument();
+  });
+
+  it('uses txParams.to as token address for tokenMethodApprove lookup', () => {
+    render(TransactionType.tokenMethodApprove);
+    expect(useTokenWithBalanceMock).toHaveBeenCalledWith('0x456', CHAIN_ID);
+  });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -5,12 +5,15 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsSummary } from './transaction-details-summary';
 
 const CHAIN_ID = '0x1';
 
 const mockStore = configureMockStore([]);
+
+jest.mock('../../../hooks/tokens/useTokenWithBalance');
 
 const mockState = {
   metamask: {
@@ -34,7 +37,10 @@ const mockState = {
   },
 };
 
-function createMockTransactionMeta(type: TransactionType) {
+function createMockTransactionMeta(
+  type: TransactionType,
+  metamaskPay?: { chainId: string; tokenAddress: string },
+) {
   return {
     id: 'test-id',
     chainId: CHAIN_ID,
@@ -45,13 +51,17 @@ function createMockTransactionMeta(type: TransactionType) {
       from: '0x123',
       to: '0x456',
     },
+    metamaskPay,
   };
 }
 
-function render(type: TransactionType = TransactionType.simpleSend) {
+function render(
+  type: TransactionType = TransactionType.simpleSend,
+  metamaskPay?: { chainId: string; tokenAddress: string },
+) {
   return renderWithProvider(
     <TransactionDetailsProvider
-      transactionMeta={createMockTransactionMeta(type) as never}
+      transactionMeta={createMockTransactionMeta(type, metamaskPay) as never}
     >
       <TransactionDetailsSummary />
     </TransactionDetailsProvider>,
@@ -60,8 +70,11 @@ function render(type: TransactionType = TransactionType.simpleSend) {
 }
 
 describe('TransactionDetailsSummary', () => {
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
+
   beforeEach(() => {
     global.platform = { openTab: jest.fn() } as never;
+    useTokenWithBalanceMock.mockReturnValue(undefined);
   });
 
   it('renders with correct test id', () => {
@@ -82,5 +95,25 @@ describe('TransactionDetailsSummary', () => {
   it('renders swap title for swap transactions', () => {
     const { getByText } = render(TransactionType.swap);
     expect(getByText('Swap')).toBeInTheDocument();
+  });
+
+  it('uses metamaskPay chain for relayDeposit source token lookup', () => {
+    useTokenWithBalanceMock.mockReturnValue({
+      address: '0xabc123',
+      chainId: '0x89',
+      symbol: 'USDC',
+      decimals: 6,
+      balance: '1',
+      balanceFiat: '$1.00',
+      balanceRaw: '1000000',
+      tokenFiatAmount: 1,
+    });
+
+    render(TransactionType.relayDeposit, {
+      chainId: '0x89',
+      tokenAddress: '0xabc123',
+    });
+
+    expect(useTokenWithBalanceMock).toHaveBeenCalledWith('0xabc123', '0x89');
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -23,6 +23,7 @@ import { formatTransactionDateTime } from '../utils';
 import { getTransactions } from '../../../../../selectors/transactions';
 import { getTokenByAccountAndAddressAndChainId } from '../../../../../selectors/assets';
 import { selectNetworkConfigurationByChainId } from '../../../../../selectors';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BlockExplorerLink } from '../block-explorer-link';
 import { TransactionStatusIcon } from '../transaction-status-icon';
 
@@ -54,6 +55,7 @@ export function TransactionDetailsSummary() {
   }, [requiredTransactions, transactionMeta]);
 
   const payTokenAddress = metamaskPay?.tokenAddress as Hex | undefined;
+  const payTokenChainId = metamaskPay?.chainId as Hex | undefined;
 
   return (
     <Box
@@ -73,6 +75,7 @@ export function TransactionDetailsSummary() {
             key={tx.id}
             transactionMeta={tx}
             payTokenAddress={payTokenAddress}
+            payTokenChainId={payTokenChainId}
             isLast={index === transactions.length - 1}
           />
         ))}
@@ -84,10 +87,12 @@ export function TransactionDetailsSummary() {
 function TransactionSummaryLine({
   transactionMeta,
   payTokenAddress,
+  payTokenChainId,
   isLast,
 }: {
   transactionMeta: TransactionMeta;
   payTokenAddress: Hex | undefined;
+  payTokenChainId: Hex | undefined;
   isLast: boolean;
 }) {
   const { type } = transactionMeta;
@@ -97,6 +102,7 @@ function TransactionSummaryLine({
       <RelayDepositSummaryLine
         transactionMeta={transactionMeta}
         tokenAddress={payTokenAddress}
+        tokenChainId={payTokenChainId}
       />
     );
   }
@@ -119,22 +125,18 @@ function TransactionSummaryLine({
 function RelayDepositSummaryLine({
   transactionMeta,
   tokenAddress,
+  tokenChainId,
 }: {
   transactionMeta: TransactionMeta;
   tokenAddress: Hex | undefined;
+  tokenChainId: Hex | undefined;
 }) {
   const t = useI18nContext() as TranslateFunction;
   const { chainId } = transactionMeta;
 
-  const token = useSelector((state) =>
-    tokenAddress && chainId
-      ? getTokenByAccountAndAddressAndChainId(
-          state,
-          undefined,
-          tokenAddress,
-          chainId,
-        )
-      : null,
+  const token = useTokenWithBalance(
+    (tokenAddress ?? '0x0') as Hex,
+    tokenChainId ?? chainId,
   );
 
   const networkConfig = useSelector((state) =>

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -26,6 +26,7 @@ import { selectNetworkConfigurationByChainId } from '../../../../../selectors';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BlockExplorerLink } from '../block-explorer-link';
 import { TransactionStatusIcon } from '../transaction-status-icon';
+import { hasTransactionType } from '../../../utils/transaction-pay';
 
 type TranslateFunction = (key: string, args?: string[]) => string;
 
@@ -97,13 +98,19 @@ function TransactionSummaryLine({
 }) {
   const { type } = transactionMeta;
 
-  if (type === TransactionType.relayDeposit) {
+  if (hasTransactionType(transactionMeta, [TransactionType.relayDeposit])) {
     return (
       <RelayDepositSummaryLine
         transactionMeta={transactionMeta}
         tokenAddress={payTokenAddress}
         tokenChainId={payTokenChainId}
       />
+    );
+  }
+
+  if (type === TransactionType.tokenMethodApprove) {
+    return (
+      <ApprovalSummaryLine transactionMeta={transactionMeta} isLast={isLast} />
     );
   }
 
@@ -159,6 +166,38 @@ function RelayDepositSummaryLine({
       time={transactionMeta.submittedTime ?? transactionMeta.time}
       title={title}
       isLast={false}
+    />
+  );
+}
+
+function ApprovalSummaryLine({
+  transactionMeta,
+  isLast,
+}: {
+  transactionMeta: TransactionMeta;
+  isLast: boolean;
+}) {
+  const t = useI18nContext() as TranslateFunction;
+  const { chainId, txParams } = transactionMeta;
+
+  const tokenAddress = txParams?.to as Hex | undefined;
+
+  const token = useTokenWithBalance((tokenAddress ?? '0x0') as Hex, chainId);
+
+  const tokenSymbol = token?.symbol;
+
+  const title = tokenSymbol
+    ? t('approveToken', [tokenSymbol])
+    : t('approveButtonText');
+
+  return (
+    <SummaryLine
+      chainId={chainId}
+      hash={transactionMeta.hash}
+      status={transactionMeta.status}
+      time={transactionMeta.submittedTime ?? transactionMeta.time}
+      title={title}
+      isLast={isLast}
     />
   );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -8,7 +8,6 @@ import { renderWithProvider } from '../../../../../../test/lib/render-helpers-na
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetails } from './transaction-details';
 
-
 jest.mock('../../../hooks/send/useSendTokens', () => ({
   useSendTokens: () => [],
 }));

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -8,6 +8,11 @@ import { renderWithProvider } from '../../../../../../test/lib/render-helpers-na
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetails } from './transaction-details';
 
+
+jest.mock('../../../hooks/send/useSendTokens', () => ({
+  useSendTokens: () => [],
+}));
+
 const CHAIN_ID = '0x1';
 const TOKEN_ADDRESS = '0xtoken123';
 
@@ -45,6 +50,13 @@ function createMockState(includeToken = false) {
           defaultBlockExplorerUrlIndex: 0,
         },
       },
+      multichainNetworkConfigurationsByChainId: {},
+      accountTree: { wallets: {}, selectedAccountGroup: null },
+      allIgnoredTokens: {},
+      marketData: {},
+      currencyRates: {},
+      currentCurrency: 'usd',
+      accountsByChainId: {},
     },
   };
 }

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -182,7 +182,7 @@ describe('PayWithRow', () => {
 
     expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('pay-with-pill'));
+    fireEvent.click(screen.getByTestId('pay-with-row'));
 
     expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
   });
@@ -191,7 +191,7 @@ describe('PayWithRow', () => {
     const store = mockStore(getMockState());
     renderWithProvider(<PayWithRow />, store);
 
-    fireEvent.click(screen.getByTestId('pay-with-pill'));
+    fireEvent.click(screen.getByTestId('pay-with-row'));
     expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('close-modal'));
@@ -233,24 +233,35 @@ describe('PayWithRow', () => {
     const store = mockStore(getMockState());
     renderWithProvider(<PayWithRow />, store);
 
-    fireEvent.click(screen.getByTestId('pay-with-pill'));
+    fireEvent.click(screen.getByTestId('pay-with-row'));
 
     expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
   });
 
   describe('Default variant', () => {
-    it('renders pill element', () => {
+    it('renders default pill container', () => {
       const store = mockStore(getMockState());
       renderWithProvider(<PayWithRow />, store);
 
-      expect(screen.getByTestId('pay-with-pill')).toBeInTheDocument();
+      expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
     });
 
-    it('hides balance display', () => {
+    it('renders balance display', () => {
       const store = mockStore(getMockState());
       renderWithProvider(<PayWithRow />, store);
 
-      expect(screen.queryByTestId('pay-with-balance')).not.toBeInTheDocument();
+      expect(screen.getByTestId('pay-with-balance')).toHaveTextContent(
+        '$150.00',
+      );
+    });
+
+    it('renders pay with text inside symbol text', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(<PayWithRow />, store);
+
+      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent(
+        'Pay with ETH',
+      );
     });
 
     it('shows arrow icon when editable', () => {
@@ -288,7 +299,8 @@ describe('PayWithRow', () => {
         store,
       );
 
-      expect(screen.queryByTestId('pay-with-pill')).not.toBeInTheDocument();
+      expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
+      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent('ETH');
     });
   });
 });

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -16,8 +16,6 @@ import {
   ConfirmInfoRow,
   ConfirmInfoRowSize,
 } from '../../../../../components/app/confirm/info/row/row';
-import { ConfirmInfoAlertRow } from '../../../../../components/app/confirm/info/row/alert-row/alert-row';
-import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import {
   AlignItems,
   BackgroundColor,
@@ -151,7 +149,7 @@ export function PayWithRow({
       ) : (
         <PayWithRowDefault
           {...contentProps}
-          ownerId={currentConfirmation?.id ?? ''}
+          balanceUsdFormatted={balanceUsdFormatted}
         />
       )}
     </>
@@ -214,58 +212,58 @@ function PayWithRowSmall({
 
 function PayWithRowDefault({
   displayToken,
+  balanceUsdFormatted,
   canEdit,
   from,
   onOpenModal,
-  ownerId,
-}: PayWithRowContentProps & { ownerId: string }) {
+}: PayWithRowContentProps & { balanceUsdFormatted: string }) {
   const t = useI18nContext();
 
   return (
-    <ConfirmInfoAlertRow
-      alertKey={RowAlertKey.PayWith}
-      ownerId={ownerId}
+    <Box
       data-testid="pay-with-row"
-      label={t('payWith')}
-      rowVariant={ConfirmInfoRowSize.Default}
+      onClick={canEdit ? onOpenModal : undefined}
+      backgroundColor={BackgroundColor.backgroundAlternative}
+      borderRadius={BorderRadius.pill}
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      alignItems={AlignItems.center}
+      justifyContent={JustifyContent.center}
+      gap={3}
+      paddingTop={2}
+      paddingBottom={2}
+      paddingLeft={2}
+      paddingRight={4}
+      style={{
+        cursor: canEdit ? 'pointer' : 'default',
+      }}
     >
-      <Box
-        data-testid="pay-with-pill"
-        onClick={canEdit ? onOpenModal : undefined}
-        backgroundColor={
-          canEdit
-            ? BackgroundColor.backgroundMuted
-            : BackgroundColor.transparent
-        }
-        borderRadius={BorderRadius.pill}
-        display={Display.InlineFlex}
-        alignItems={AlignItems.center}
-        gap={1}
-        style={{
-          cursor: canEdit ? 'pointer' : 'default',
-          padding: canEdit ? '4px 8px' : '0px',
-        }}
+      <TokenIcon
+        chainId={displayToken.chainId as `0x${string}`}
+        tokenAddress={displayToken.address as `0x${string}`}
+      />
+      <Text
+        variant={TextVariant.bodyMdMedium}
+        color={TextColor.textDefault}
+        data-testid="pay-with-symbol"
       >
-        <Box
-          display={Display.Flex}
-          alignItems={AlignItems.center}
-          marginRight={1}
-        >
-          <TokenIcon
-            chainId={displayToken.chainId as `0x${string}`}
-            tokenAddress={displayToken.address as `0x${string}`}
-            size="xs"
-          />
-        </Box>
-        <Text data-testid="pay-with-symbol">{displayToken.symbol}</Text>
-        {canEdit && from && (
-          <Icon
-            data-testid="pay-with-arrow"
-            name={IconName.ArrowDown}
-            size={IconSize.Sm}
-          />
-        )}
-      </Box>
-    </ConfirmInfoAlertRow>
+        {`${t('payWith')} ${displayToken.symbol}`}
+      </Text>
+      <Text
+        variant={TextVariant.bodyMdMedium}
+        color={TextColor.textAlternative}
+        data-testid="pay-with-balance"
+      >
+        {balanceUsdFormatted}
+      </Text>
+      {canEdit && from && (
+        <Icon
+          data-testid="pay-with-arrow"
+          name={IconName.ArrowDown}
+          size={IconSize.Sm}
+          color={IconColor.iconAlternative}
+        />
+      )}
+    </Box>
   );
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts
@@ -15,7 +15,7 @@ import {
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../pay/useTransactionPayData';
-import { useMultichainBalances } from '../../../../../hooks/useMultichainBalances';
+import { useTokenWithBalance } from '../../tokens/useTokenWithBalance';
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -23,7 +23,7 @@ import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBa
 
 jest.mock('../../pay/useTransactionPayToken');
 jest.mock('../../pay/useTransactionPayData');
-jest.mock('../../../../../hooks/useMultichainBalances');
+jest.mock('../../tokens/useTokenWithBalance');
 
 const PAY_TOKEN_MOCK = {
   address: '0x123' as Hex,
@@ -74,7 +74,7 @@ function runHook(
 describe('useInsufficientPayTokenBalanceAlert', () => {
   const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useMultichainBalancesMock = jest.mocked(useMultichainBalances);
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
   const useTransactionPayIsMaxAmountMock = jest.mocked(
     useTransactionPayIsMaxAmount,
   );
@@ -99,11 +99,16 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       setPayToken: jest.fn(),
     });
 
-    useMultichainBalancesMock.mockReturnValue({
-      assetsWithBalance: [NATIVE_TOKEN_MOCK],
-      isLoading: false,
-      balanceByChainId: {},
-    } as unknown as ReturnType<typeof useMultichainBalances>);
+    useTokenWithBalanceMock.mockReturnValue({
+      address: NATIVE_TOKEN_MOCK.address,
+      chainId: NATIVE_TOKEN_MOCK.chainId,
+      symbol: 'ETH',
+      decimals: 18,
+      balance: '5',
+      balanceRaw: NATIVE_TOKEN_MOCK.balance,
+      balanceFiat: '$0.00',
+      tokenFiatAmount: 0,
+    });
   });
 
   describe('for input', () => {
@@ -217,16 +222,16 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
   describe('for source network fee', () => {
     it('returns alert if native balance is less than total source network fee', () => {
-      useMultichainBalancesMock.mockReturnValue({
-        assetsWithBalance: [
-          {
-            ...NATIVE_TOKEN_MOCK,
-            balance: '100000000000000',
-          },
-        ],
-        isLoading: false,
-        balanceByChainId: {},
-      } as unknown as ReturnType<typeof useMultichainBalances>);
+      useTokenWithBalanceMock.mockReturnValue({
+        address: NATIVE_TOKEN_MOCK.address,
+        chainId: NATIVE_TOKEN_MOCK.chainId,
+        symbol: 'ETH',
+        decimals: 18,
+        balance: '0.0001',
+        balanceRaw: '100000000000000',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0,
+      });
 
       const { result } = runHook();
 
@@ -243,16 +248,16 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     });
 
     it('returns no alert if pay token is native', () => {
-      useMultichainBalancesMock.mockReturnValue({
-        assetsWithBalance: [
-          {
-            ...NATIVE_TOKEN_MOCK,
-            balance: '100000000000000',
-          },
-        ],
-        isLoading: false,
-        balanceByChainId: {},
-      } as unknown as ReturnType<typeof useMultichainBalances>);
+      useTokenWithBalanceMock.mockReturnValue({
+        address: NATIVE_TOKEN_MOCK.address,
+        chainId: NATIVE_TOKEN_MOCK.chainId,
+        symbol: 'ETH',
+        decimals: 18,
+        balance: '0.0001',
+        balanceRaw: '100000000000000',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0,
+      });
 
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
@@ -270,16 +275,16 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     });
 
     it('returns no alert if source network is using gas fee token', () => {
-      useMultichainBalancesMock.mockReturnValue({
-        assetsWithBalance: [
-          {
-            ...NATIVE_TOKEN_MOCK,
-            balance: '100000000000000',
-          },
-        ],
-        isLoading: false,
-        balanceByChainId: {},
-      } as unknown as ReturnType<typeof useMultichainBalances>);
+      useTokenWithBalanceMock.mockReturnValue({
+        address: NATIVE_TOKEN_MOCK.address,
+        chainId: NATIVE_TOKEN_MOCK.chainId,
+        symbol: 'ETH',
+        decimals: 18,
+        balance: '0.0001',
+        balanceRaw: '100000000000000',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0,
+      });
 
       useTransactionPayTotalsMock.mockReturnValue({
         ...TOTALS_MOCK,
@@ -295,16 +300,16 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
     });
 
     it('returns no alert if pending amount is provided', () => {
-      useMultichainBalancesMock.mockReturnValue({
-        assetsWithBalance: [
-          {
-            ...NATIVE_TOKEN_MOCK,
-            balance: '100000000000000',
-          },
-        ],
-        isLoading: false,
-        balanceByChainId: {},
-      } as unknown as ReturnType<typeof useMultichainBalances>);
+      useTokenWithBalanceMock.mockReturnValue({
+        address: NATIVE_TOKEN_MOCK.address,
+        chainId: NATIVE_TOKEN_MOCK.chainId,
+        symbol: 'ETH',
+        decimals: 18,
+        balance: '0.0001',
+        balanceRaw: '100000000000000',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0,
+      });
 
       const { result } = runHook({ pendingAmountUsd: '1.00' });
 

--- a/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.test.ts
+++ b/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.test.ts
@@ -1,0 +1,133 @@
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import type { Hex } from '@metamask/utils';
+import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { useTokenWithBalance } from './useTokenWithBalance';
+
+const CHAIN_ID = '0x1' as Hex;
+const ACCOUNT_ADDRESS = '0x1111111111111111111111111111111111111111' as Hex;
+const TOKEN_ADDRESS = '0x2222222222222222222222222222222222222222' as Hex;
+
+function createMockState() {
+  return {
+    localeMessages: {
+      currentLocale: 'en_US',
+      current: {},
+      en: {},
+    },
+    metamask: {
+      currentCurrency: 'usd',
+      internalAccounts: {
+        selectedAccount: 'account-id-1',
+        accounts: {
+          'account-id-1': {
+            id: 'account-id-1',
+            address: ACCOUNT_ADDRESS,
+            type: 'eip155:eoa',
+          },
+        },
+      },
+      allTokens: {
+        [CHAIN_ID]: {
+          [ACCOUNT_ADDRESS]: [
+            {
+              address: TOKEN_ADDRESS,
+              symbol: 'T1',
+              decimals: 4,
+              image: '',
+              isNative: false,
+            },
+          ],
+        },
+      },
+      tokenBalances: {
+        [ACCOUNT_ADDRESS]: {
+          [CHAIN_ID]: {
+            [TOKEN_ADDRESS]: '0x64',
+          },
+        },
+      },
+      accountsByChainId: {
+        [CHAIN_ID]: {
+          [ACCOUNT_ADDRESS]: {
+            address: ACCOUNT_ADDRESS,
+            balance: '0x1bc16d674ec80000',
+          },
+        },
+      },
+      marketData: {
+        [CHAIN_ID]: {
+          [TOKEN_ADDRESS]: {
+            tokenAddress: TOKEN_ADDRESS,
+            price: 1,
+          },
+        },
+      },
+      currencyRates: {
+        ETH: {
+          conversionRate: 10000,
+          usdConversionRate: 10000,
+        },
+      },
+      networkConfigurationsByChainId: {
+        [CHAIN_ID]: {
+          chainId: CHAIN_ID,
+          nativeCurrency: 'ETH',
+          name: 'Ethereum',
+          rpcEndpoints: [{ networkClientId: 'mainnet' }],
+          defaultRpcEndpointIndex: 0,
+        },
+      },
+    },
+  };
+}
+
+function runHook(tokenAddress: Hex, chainId: Hex) {
+  return renderHookWithProvider(
+    () => useTokenWithBalance(tokenAddress, chainId),
+    createMockState(),
+  );
+}
+
+describe('useTokenWithBalance', () => {
+  it('returns token and balance properties', () => {
+    const { result } = runHook(TOKEN_ADDRESS, CHAIN_ID);
+
+    expect(result.current).toMatchObject({
+      address: TOKEN_ADDRESS,
+      balance: '0.01',
+      balanceRaw: '100',
+      chainId: CHAIN_ID,
+      decimals: 4,
+      symbol: 'T1',
+      tokenFiatAmount: 100,
+    });
+
+    expect(result.current?.balanceFiat).toContain('100');
+  });
+
+  it('returns native token properties', () => {
+    const nativeTokenAddress = getNativeTokenAddress(CHAIN_ID);
+    const { result } = runHook(nativeTokenAddress, CHAIN_ID);
+
+    expect(result.current).toMatchObject({
+      address: nativeTokenAddress,
+      balance: '2',
+      balanceRaw: '2000000000000000000',
+      chainId: CHAIN_ID,
+      decimals: 18,
+      symbol: 'ETH',
+      tokenFiatAmount: 20000,
+    });
+
+    expect(result.current?.balanceFiat).toContain('20,000');
+  });
+
+  it('returns undefined if no token exists for the given address and chain ID', () => {
+    const { result } = runHook(
+      '0x3333333333333333333333333333333333333333' as Hex,
+      CHAIN_ID,
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -1,0 +1,139 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { BigNumber } from 'bignumber.js';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
+import { getTokenByAccountAndAddressAndChainId } from '../../../../selectors/assets';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import {
+  getNativeTokenCachedBalanceByChainIdSelector,
+  getNativeTokenInfo,
+} from '../../../../selectors';
+import { getTokenBalances } from '../../../../ducks/metamask/metamask';
+import { getNetworkConfigurationsByChainId } from '../../../../../shared/modules/selectors/networks';
+import { useFiatFormatter } from '../../../../hooks/useFiatFormatter';
+import { useTokenFiatRate } from './useTokenFiatRates';
+
+export type TokenWithBalance = {
+  address: Hex;
+  chainId: Hex;
+  symbol: string;
+  decimals: number;
+  balance: string;
+  balanceFiat: string;
+  balanceRaw: string;
+  tokenFiatAmount: number;
+};
+
+export function useTokenWithBalance(
+  tokenAddress: Hex,
+  chainId: Hex,
+): TokenWithBalance | undefined {
+  const fiatFormatter = useFiatFormatter();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const selectedAddress = selectedAccount?.address as Hex | undefined;
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+
+  const nativeTokenInfo = getNativeTokenInfo(
+    networkConfigurationsByChainId,
+    chainId,
+  );
+  const ticker = nativeTokenInfo?.symbol ?? 'ETH';
+
+  const token = useSelector((state) =>
+    getTokenByAccountAndAddressAndChainId(
+      state,
+      selectedAccount,
+      tokenAddress,
+      chainId,
+    ),
+  );
+
+  const nativeBalances = useSelector((state) =>
+    selectedAddress
+      ? (getNativeTokenCachedBalanceByChainIdSelector(
+          state,
+          selectedAddress,
+        ) as Record<Hex, Hex>)
+      : ({} as Record<Hex, Hex>),
+  );
+  const tokenBalances = useSelector(getTokenBalances) as Record<
+    Hex,
+    Record<Hex, Record<Hex, Hex>>
+  >;
+
+  const isNative =
+    tokenAddress.toLowerCase() === getNativeTokenAddress(chainId).toLowerCase();
+
+  const tokenBalanceHex = useMemo(() => {
+    if (isNative) {
+      return nativeBalances?.[chainId] ?? '0x0';
+    }
+
+    if (!selectedAddress) {
+      return '0x0';
+    }
+
+    const tokenBalanceMap = tokenBalances?.[selectedAddress]?.[chainId];
+    if (!tokenBalanceMap) {
+      return '0x0';
+    }
+
+    return (
+      tokenBalanceMap[toChecksumHexAddress(tokenAddress) as Hex] ??
+      tokenBalanceMap[tokenAddress] ??
+      '0x0'
+    );
+  }, [
+    chainId,
+    isNative,
+    nativeBalances,
+    selectedAddress,
+    tokenAddress,
+    tokenBalances,
+  ]);
+
+  const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId, 'USD') ?? 0;
+
+  return useMemo(() => {
+    if (!token && !isNative) {
+      return undefined;
+    }
+
+    const balanceRawValue = new BigNumber(
+      tokenBalanceHex.replace(/^0x/u, '') || '0',
+      16,
+    );
+    const balanceRaw = balanceRawValue.toString(10);
+    const decimals = Number(token?.decimals ?? 18);
+    const divisor = new BigNumber(10).pow(decimals);
+    const balanceValue = balanceRawValue.dividedBy(divisor);
+    const tokenFiatValue = balanceValue.times(tokenFiatRate.toString());
+    const tokenFiatAmount = tokenFiatValue.toNumber();
+    const symbol = token?.symbol ?? ticker;
+    const balanceFiat = fiatFormatter(tokenFiatAmount);
+
+    return {
+      address: tokenAddress,
+      chainId,
+      symbol,
+      decimals,
+      balance: balanceValue.toString(10),
+      balanceFiat,
+      balanceRaw,
+      tokenFiatAmount,
+    };
+  }, [
+    chainId,
+    fiatFormatter,
+    isNative,
+    ticker,
+    token,
+    tokenAddress,
+    tokenBalanceHex,
+    tokenFiatRate,
+  ]);
+}

--- a/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/ui/pages/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -4,7 +4,7 @@ import { BigNumber } from 'bignumber.js';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
-import { getTokenByAccountAndAddressAndChainId } from '../../../../selectors/assets';
+import { selectSingleTokenByAddressAndChainId } from '../../../../selectors/assets';
 import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import {
   getNativeTokenCachedBalanceByChainIdSelector,
@@ -44,12 +44,7 @@ export function useTokenWithBalance(
   const ticker = nativeTokenInfo?.symbol ?? 'ETH';
 
   const token = useSelector((state) =>
-    getTokenByAccountAndAddressAndChainId(
-      state,
-      selectedAccount,
-      tokenAddress,
-      chainId,
-    ),
+    selectSingleTokenByAddressAndChainId(state, tokenAddress, chainId),
   );
 
   const nativeBalances = useSelector((state) =>

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -116,6 +116,55 @@ describe('transaction-pay utils', () => {
         false,
       );
     });
+
+    it('returns true when nested transaction type matches', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.tokenMethodTransfer },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.tokenMethodApprove,
+        ]),
+      ).toBe(true);
+    });
+
+    it('returns false when neither top-level nor nested types match', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        false,
+      );
+    });
+
+    it('returns true for top-level type even with nested transactions', () => {
+      const transactionMeta = {
+        type: TransactionType.swap,
+        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        true,
+      );
+    });
+
+    it('returns false when nestedTransactions is empty', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        false,
+      );
+    });
   });
 
   describe('getTokenTransferData', () => {

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -16,8 +16,18 @@ const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 export function hasTransactionType(
   transactionMeta: TransactionMeta | undefined,
   types: TransactionType[],
-): boolean {
-  return types.includes(transactionMeta?.type as TransactionType);
+) {
+  const { nestedTransactions, type } = transactionMeta ?? {};
+
+  if (types.includes(type as TransactionType)) {
+    return true;
+  }
+
+  return (
+    nestedTransactions?.some((tx) =>
+      types.includes(tx.type as TransactionType),
+    ) ?? false
+  );
 }
 
 export function getTokenTransferData(

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -53,6 +53,7 @@ import { getSelectedInternalAccount } from './accounts';
 import { getMultichainBalances } from './multichain';
 import { EMPTY_OBJECT } from './shared';
 import {
+  getAllTokens,
   getCurrencyRates,
   getCurrentNetwork,
   getIsTokenNetworkFilterEqualCurrentNetwork,
@@ -1351,5 +1352,25 @@ export const getAsset = createSelector(
     const chainAssets = assetsBySelectedAccountGroup[chainId];
 
     return chainAssets?.find((item) => item.assetId === assetId);
+  },
+);
+
+export const selectSingleTokenByAddressAndChainId = createSelector(
+  getAllTokens,
+  (_state: { metamask: TokensControllerState }, tokenAddress: Hex) =>
+    tokenAddress,
+  (
+    _state: { metamask: TokensControllerState },
+    _tokenAddress: Hex,
+    chainId: Hex,
+  ) => chainId,
+  (allTokens, tokenAddress, chainId) => {
+    const chainTokens = Object.values(
+      allTokens[chainId] ?? {},
+    ).flat() as Token[];
+
+    return chainTokens.find(
+      (token) => token.address.toLowerCase() === tokenAddress.toLowerCase(),
+    );
   },
 );


### PR DESCRIPTION
## **Description**

Fix MetaMask Pay balance validation by correctly retrieving native token info.

- Add `useTokenWithBalance` hook.
- Add `selectSingleTokenByAddressAndChainId` selector.
- Handle approve transactions in transaction details summary.
- Fix default variant layout for `PayWithRow` in custom amount confirmations.
- Fix `hasTransactionType` behaviour to check nested transaction types.
- Add missing messenger actions for `TransactionPayController`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40330?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MetaMask Pay balance validation and confirmation rendering logic; risk is moderate due to potential miscomputed balances/labels across chains, but changes are localized and covered by new/updated tests.
> 
> **Overview**
> Fixes MetaMask Pay balance validation by introducing `useTokenWithBalance` (backed by new `selectSingleTokenByAddressAndChainId`) and switching native/token balance lookups in confirmations and alerts to use the correct cached/native sources.
> 
> Improves confirmation UX by reworking the default `PayWithRow` layout (click target + always shows fiat balance) and enhancing the transaction details summary to handle approvals with token-specific titles (`approveToken`) and to resolve relay-deposit source tokens using the MetaMask Pay chain ID.
> 
> Extends `hasTransactionType` to match nested transaction types, adds missing TransactionPayController messenger actions (`estimateGas`, `estimateGasBatch`), and updates/expands unit tests + console baselines accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d71bf92f275b99afcdad05c1f298063dfc2d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->